### PR TITLE
chore(plugin): use published autumn-web 0.2 + add CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,71 @@
+name: CI
+
+on:
+  push:
+    branches: [trunk]
+  pull_request:
+    branches: [trunk]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+      - uses: Swatinem/rust-cache@v2
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+      - name: Clippy autumn-harvest
+        run: cargo clippy -p autumn-harvest --all-features --tests -- -D warnings
+      - name: Clippy autumn-harvest-plugin
+        run: cargo clippy -p autumn-harvest-plugin --all-targets -- -D warnings
+      - name: Clippy autumn-harvest-macros
+        run: cargo clippy -p autumn-harvest-macros -- -D warnings
+
+  test:
+    name: Test (${{ matrix.os }})
+    needs: lint
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, macos-latest, windows-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Run no-db tests
+        run: cargo test -p autumn-harvest --no-default-features
+      - name: Compile db-backed tests
+        run: cargo test -p autumn-harvest --all-features --tests --no-run
+      - name: Run all-features lib tests
+        run: cargo test -p autumn-harvest --all-features --lib
+      - name: Run plugin lib tests
+        run: cargo test -p autumn-harvest-plugin --lib
+      - name: Run macros tests
+        run: cargo test -p autumn-harvest-macros
+      - name: Compile plugin integration tests
+        run: cargo test -p autumn-harvest-plugin --test api_scheduler_integration --no-run
+      - name: Run Docker-backed integration tests
+        if: runner.os == 'Linux'
+        run: cargo test -p autumn-harvest --test integration_e2e -- --test-threads=1
+      - name: Run plugin API and scheduler integration tests
+        if: runner.os == 'Linux'
+        run: cargo test -p autumn-harvest-plugin --test api_scheduler_integration -- --test-threads=1
+
+  msrv:
+    name: MSRV (1.86.0)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@1.86.0
+      - uses: Swatinem/rust-cache@v2
+      - name: Check MSRV compiles
+        run: cargo check --workspace

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,58 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v[0-9]+.*"
+
+permissions:
+  contents: write
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  validate:
+    name: Validate release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+      - name: Clippy
+        run: cargo clippy --workspace --all-targets -- -D warnings
+      - name: Run tests
+        run: cargo test --workspace
+
+  release:
+    name: Create GitHub Release
+    needs: validate
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install git-cliff
+        uses: taiki-e/install-action@git-cliff
+      - name: Generate release notes
+        id: release-notes
+        run: |
+          git-cliff --config cliff.toml --latest --strip header > RELEASE_NOTES.md
+      - name: Update CHANGELOG.md
+        run: |
+          git-cliff --config cliff.toml --output CHANGELOG.md
+      - name: Commit changelog to trunk
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add CHANGELOG.md
+          git commit -m "docs: update CHANGELOG.md for ${{ github.ref_name }}"
+          git push origin HEAD:trunk
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v3
+        with:
+          body_path: RELEASE_NOTES.md
+          draft: false
+          prerelease: ${{ contains(github.ref, '-alpha') || contains(github.ref, '-beta') || contains(github.ref, '-rc') }}

--- a/README.md
+++ b/README.md
@@ -1,0 +1,132 @@
+# autumn-harvest
+
+[![Crates.io](https://img.shields.io/crates/v/autumn-harvest.svg)](https://crates.io/crates/autumn-harvest)
+[![License](https://img.shields.io/badge/license-MIT%2FApache--2.0-blue.svg)](#license)
+[![CI](https://github.com/madmax983/autumn-harvest/actions/workflows/ci.yml/badge.svg)](https://github.com/madmax983/autumn-harvest/actions/workflows/ci.yml)
+
+Postgres-backed durable workflow engine for Rust, designed as a companion to the
+[Autumn](https://github.com/madmax983/autumn) web framework. Provides
+event-sourced workflow execution with activities, signals, timers, child
+workflows, and DAG scheduling — Temporal-style durability semantics with a
+single-Postgres operational footprint.
+
+## Why
+
+Most Rust async work is fire-and-forget. autumn-harvest is for the work that
+*can't* be: long-running orchestrations that survive process restarts, retries
+with exactly-once semantics, multi-step business processes with rollback, and
+scheduled DAGs. If you've reached for Temporal, Cadence, or Inngest from a Rust
+service, this is the same shape with one fewer service to operate.
+
+## Quick example
+
+```rust
+use autumn_harvest::prelude::*;
+
+#[workflow]
+async fn onboarding(ctx: &WorkflowContext, user_id: i64) -> HarvestResult<()> {
+    ctx.execute_activity_raw(
+        "send_welcome_email",
+        serde_json::json!({ "user_id": user_id }),
+        "default",
+    )
+    .await?;
+    Ok(())
+}
+
+#[activity(start_to_close = "30s", retry = RetryPolicy::exponential(3, std::time::Duration::from_secs(1)))]
+async fn send_welcome_email(_ctx: &ActivityContext, input: serde_json::Value)
+    -> HarvestResult<serde_json::Value>
+{
+    // … real I/O. Failure here is retried per the policy above.
+    Ok(serde_json::json!({ "sent": true }))
+}
+```
+
+Wired into an Autumn app via the plugin:
+
+```rust
+use autumn_web::prelude::*;
+use autumn_harvest_plugin::HarvestPlugin;
+
+#[autumn_web::main]
+async fn main() {
+    autumn_web::app()
+        .plugin(
+            HarvestPlugin::new()
+                .workflows(workflows![onboarding])
+                .activities(activities![send_welcome_email])
+                .api("/api/harvest"),
+        )
+        .run()
+        .await;
+}
+```
+
+## What you get
+
+- **Event-sourced execution.** Workflows are deterministic functions; their
+  history is a Postgres event log. Restart the process, replay the history, end
+  up at the same state.
+- **Activities with retries.** Side effects live in `#[activity]` functions
+  with configurable `start_to_close`, `heartbeat_timeout`, and `retry` policies.
+- **Signals & queries.** Send a signal into a running workflow, query its
+  state, or block on a timer.
+- **Child workflows.** Compose orchestrations from smaller workflows; parent
+  failures cascade or compensate per your design.
+- **DAG scheduling.** Declare DAGs of activities with trigger rules and
+  cron/interval schedules; built-in scheduler dispatches them.
+- **Management API.** Optional HTTP surface for inspecting executions, sending
+  signals, querying state, and triggering DAG runs.
+- **SKIP LOCKED task queue + LISTEN/NOTIFY** for low-latency dispatch without
+  polling backoff.
+- **Dead letter queue** for tasks that exhaust their retry policy.
+- **Separate worker/web connection pools** with a shared ceiling so worker
+  bursts can't starve HTTP request handling.
+
+## Workspace
+
+| Crate | Purpose |
+|-------|---------|
+| [`autumn-harvest`](autumn-harvest/) | Core engine — types, executor, replay, queue, worker runtime |
+| [`autumn-harvest-plugin`](autumn-harvest-plugin/) | `HarvestPlugin` — wires the engine into an Autumn `AppBuilder`, mounts the management API, owns the runtime lifecycle |
+| [`autumn-harvest-macros`](autumn-harvest-macros/) | `#[workflow]`, `#[activity]`, `#[dag]`, `workflows![]`, `activities![]` proc macros |
+
+Use `autumn-harvest-plugin` if you're building an Autumn app. Use the bare
+`autumn-harvest` crate if you want to embed the engine in another framework or
+a non-web context.
+
+## Requirements
+
+- Rust 1.86.0 or newer (MSRV)
+- Postgres 12+
+- The `db` feature is enabled by default and pulls Diesel + diesel-async; build
+  with `--no-default-features` for pure compile-checks on systems without
+  libpq.
+
+## Status
+
+Phase 3 (DAG scheduling, signals, queries, management API) is implemented and
+exercised by integration tests. Phase 4 (cancellation/saga semantics, sticky
+cross-worker routing, richer observability, dashboard UI) is the next focus.
+
+API stability: pre-1.0. Breaking changes happen in minor versions per Cargo's
+0.x semver convention. Each release notes the migration where applicable.
+
+## Architecture in one paragraph
+
+Workflows are deterministic Rust async functions. When they hit
+`ctx.execute_activity(...)` for the first time, the activity is enqueued to a
+Postgres task queue and the workflow suspends. A worker claims the activity
+(`SELECT … FOR UPDATE SKIP LOCKED`), runs it, and writes the result as an event
+in the workflow's history. The workflow then resumes — on the *same* worker if
+cached, or by replaying its history from scratch on any other worker. Replay is
+deterministic because every non-deterministic decision (activity result, timer
+fire, signal arrival, version branch) is recorded as an event the first time
+and read back from history on subsequent invocations. This is the same model as
+Temporal and Cadence; the operational difference is that you only need
+Postgres, not a separate service.
+
+## License
+
+Dual-licensed under MIT or Apache 2.0 at your option.

--- a/autumn-harvest-macros/Cargo.toml
+++ b/autumn-harvest-macros/Cargo.toml
@@ -5,6 +5,11 @@ version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
+repository.workspace = true
+homepage = "https://github.com/madmax983/autumn-harvest"
+readme = "../README.md"
+keywords = ["workflow", "durable", "postgres", "orchestration", "autumn"]
+categories = ["asynchronous", "database"]
 
 [lib]
 proc-macro = true

--- a/autumn-harvest-plugin/Cargo.toml
+++ b/autumn-harvest-plugin/Cargo.toml
@@ -9,7 +9,7 @@ repository.workspace = true
 
 [dependencies]
 autumn-harvest = { path = "../autumn-harvest" }
-autumn-web = { path = "../../autumn" }
+autumn-web = "0.2"
 tokio = { workspace = true }
 tokio-util = { version = "0.7", features = ["rt"] }
 serde = { workspace = true }

--- a/autumn-harvest-plugin/Cargo.toml
+++ b/autumn-harvest-plugin/Cargo.toml
@@ -6,6 +6,10 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
+homepage = "https://github.com/madmax983/autumn-harvest"
+readme = "../README.md"
+keywords = ["workflow", "durable", "postgres", "orchestration", "autumn"]
+categories = ["asynchronous", "database"]
 
 [dependencies]
 autumn-harvest = { path = "../autumn-harvest" }

--- a/autumn-harvest/Cargo.toml
+++ b/autumn-harvest/Cargo.toml
@@ -6,6 +6,10 @@ edition.workspace = true
 rust-version.workspace = true
 license.workspace = true
 repository.workspace = true
+homepage = "https://github.com/madmax983/autumn-harvest"
+readme = "../README.md"
+keywords = ["workflow", "durable", "postgres", "orchestration", "autumn"]
+categories = ["asynchronous", "database"]
 
 [features]
 default = ["db"]

--- a/cliff.toml
+++ b/cliff.toml
@@ -1,0 +1,55 @@
+[changelog]
+header = """
+# Changelog
+
+All notable changes to autumn-harvest will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).\n
+"""
+body = """
+{%- macro remote_url() -%}
+  https://github.com/madmax983/autumn-harvest
+{%- endmacro -%}
+
+{% if version -%}
+  ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+{% else -%}
+  ## [Unreleased]
+{% endif -%}
+
+{% for group, commits in commits | group_by(attribute="group") %}
+  ### {{ group | striptags | trim | upper_first }}
+  {% for commit in commits %}
+    - {% if commit.scope %}**{{ commit.scope }}:** {% endif %}\
+      {{ commit.message | upper_first }}\
+      {% if commit.breaking %} [**BREAKING**]{% endif %}\
+      ([{{ commit.id | truncate(length=7, end="") }}]({{ self::remote_url() }}/commit/{{ commit.id }}))\
+  {% endfor %}
+{% endfor %}
+"""
+footer = ""
+trim = true
+
+[git]
+conventional_commits = true
+filter_unconventional = true
+split_commits = false
+protect_breaking_commits = true
+filter_commits = false
+tag_pattern = "v[0-9].*"
+sort_commits = "newest"
+
+commit_parsers = [
+  { message = "^feat", group = "<!-- 0 -->Added" },
+  { message = "^fix", group = "<!-- 1 -->Fixed" },
+  { message = "^perf", group = "<!-- 2 -->Performance" },
+  { message = "^refactor", group = "<!-- 3 -->Changed" },
+  { message = "^docs", group = "<!-- 4 -->Documentation" },
+  { message = "^style", group = "<!-- 5 -->Styling" },
+  { message = "^test", group = "<!-- 6 -->Testing" },
+  { message = "^chore\\(release\\)", skip = true },
+  { message = "^chore|^ci", group = "<!-- 7 -->Miscellaneous" },
+  { body = ".*security", group = "<!-- 8 -->Security" },
+  { message = "^revert", group = "<!-- 9 -->Reverted" },
+]


### PR DESCRIPTION
## Summary
First PR in this repo. Two changes:

1. **`autumn-harvest-plugin` switches from path dep to published `autumn-web = "0.2"`.** The path was a temporary workaround during the harvest extraction window. Now that autumn-web 0.2.0 is on crates.io with the Plugin trait, the plugin crate becomes a normal downstream user.
2. **CI and release infrastructure**, lifted from autumn's pre-extraction setup.

## CI workflow (`.github/workflows/ci.yml`)
- **Lint:** `cargo fmt --all -- --check` + 3 per-crate clippy invocations preserving the original feature-flag splits (autumn-harvest with `--all-features --tests`, autumn-harvest-plugin with `--all-targets`, autumn-harvest-macros bare)
- **Test matrix:** ubuntu / macos / windows running the no-db / all-features-lib / plugin-lib / macros / plugin-integration-compile sequence, plus Linux-only Docker-backed integration tests for both the core engine and the plugin
- **MSRV:** `cargo check --workspace` on Rust 1.86.0
- **Coverage:** intentionally omitted for v0; will add Codecov in a follow-up

## Release workflow (`.github/workflows/release.yml`)
Tag-driven (`v[0-9]+.*`). Validates, generates release notes via git-cliff, commits the regenerated `CHANGELOG.md` back to trunk, creates a GitHub Release. `cargo publish` stays manual (workspace-root convention).

## cliff.toml
Standard conventional-commits config, `chore(release)` commits skipped, repo URL pointed at this repo. `CHANGELOG.md` is auto-generated on first tag push, so no seed file is needed.

## Local verification
- `cargo check --workspace --tests` — clean (plugin resolves against autumn-web 0.2 from crates.io, lockfile shows `source = "registry+..."` with checksum `c214525...`)
- `cargo fmt --all -- --check` — clean
- All 3 clippy invocations from the new CI — clean (run on local stable 1.95)

## After merge
Tag `v0.1.0` on trunk → release workflow fires → manual `cargo publish --workspace` from the repo root publishes autumn-harvest-macros, autumn-harvest, and autumn-harvest-plugin in dep order.

## Test plan
- [ ] CI passes (lint + test matrix + MSRV)
- [ ] After merge: tag and watch release workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)