### PR TITLE
fix(manifests): add version to internal workspace path deps

### DIFF
--- a/autumn-harvest-plugin/Cargo.toml
+++ b/autumn-harvest-plugin/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["workflow", "durable", "postgres", "orchestration", "autumn"]
 categories = ["asynchronous", "database"]
 
 [dependencies]
-autumn-harvest = { path = "../autumn-harvest" }
+autumn-harvest = { version = "0.1.0", path = "../autumn-harvest" }
 autumn-web = "0.2"
 tokio = { workspace = true }
 tokio-util = { version = "0.7", features = ["rt"] }

--- a/autumn-harvest/Cargo.toml
+++ b/autumn-harvest/Cargo.toml
@@ -24,7 +24,7 @@ db = [
 testing = []
 
 [dependencies]
-autumn-harvest-macros = { path = "../autumn-harvest-macros" }
+autumn-harvest-macros = { version = "0.1.0", path = "../autumn-harvest-macros" }
 tokio = { workspace = true }
 tokio-util = { version = "0.7", features = ["rt"] }
 serde = { workspace = true }


### PR DESCRIPTION
## Summary
`cargo publish --workspace` failed during the v0.1.0 publish attempt:

\`\`\`
error: failed to verify manifest at autumn-harvest/Cargo.toml
Caused by:
  all dependencies must have a version requirement specified when publishing.
  dependency \`autumn-harvest-macros\` does not specify a version
\`\`\`

## Fix
Added \`version = "0.1.0"\` alongside the existing \`path\` for the two internal workspace deps:
- \`autumn-harvest\` → \`autumn-harvest-macros\`
- \`autumn-harvest-plugin\` → \`autumn-harvest\`

The path stays for local builds; crates.io strips it on upload. Mirrors how \`autumn-web\` depends on \`autumn-macros\` (\`{ version = "0.2.0", path = "..." }\`).

## Verification
- \`cargo publish -p autumn-harvest-macros --dry-run --allow-dirty\` — full verify, clean
- \`cargo publish -p autumn-harvest --dry-run --allow-dirty --no-verify\` — manifest accepted (build-verify fails because \`autumn-harvest-macros\` isn't on crates.io yet, expected; will resolve when published in dep order)
- Same pattern for \`autumn-harvest-plugin\`

## After merge
\`cargo publish --workspace\` from repo root should now succeed. Cargo handles dep order: macros → core → plugin.

## Note on the v0.1.0 tag
The \`v0.1.0\` tag points at the pre-fix commit. The published artifacts will reflect this fix, so the git tag and crates.io source will differ by one commit. Two reasonable resolutions:
- Leave it (the difference is a non-functional manifest cleanup; minor drift)
- Move the tag to this commit after merge (\`git tag -f v0.1.0 <new-sha> && git push -f origin v0.1.0\`) — would re-fire the release workflow

Recommend leaving it. The release notes and GitHub Release are already published; re-firing would generate a duplicate or no-op CHANGELOG commit.

## Test plan
- [ ] CI passes (lint + test matrix + MSRV)
- [ ] After merge: \`cargo publish --workspace\` from repo root succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)