### PR TITLE
fix(plugin): explicitly enable autumn-harvest db feature for publish verify

### DIFF
--- a/autumn-harvest-plugin/Cargo.toml
+++ b/autumn-harvest-plugin/Cargo.toml
@@ -12,7 +12,7 @@ keywords = ["workflow", "durable", "postgres", "orchestration", "autumn"]
 categories = ["asynchronous", "database"]
 
 [dependencies]
-autumn-harvest = { version = "0.1.0", path = "../autumn-harvest" }
+autumn-harvest = { version = "0.1.0", path = "../autumn-harvest", features = ["db"] }
 autumn-web = "0.2"
 tokio = { workspace = true }
 tokio-util = { version = "0.7", features = ["rt"] }


### PR DESCRIPTION
## Summary
Unblocks \`cargo publish --workspace\` which was failing with:

\`\`\`
error[E0425]: cannot find value \`MIGRATIONS\` in crate \`autumn_harvest\`
  --> src\plugin.rs:25:64
\`\`\`

## Root cause
\`autumn_harvest::MIGRATIONS\` is gated by \`#[cfg(feature = "db")]\`. autumn-harvest's default features include \`db\`, so default-features inference *should* activate it. Under \`cargo check --workspace\` it does. Under \`cargo publish\`'s isolated verify-build (compiling the packaged plugin tarball against autumn-harvest pulled from \`target/package/tmp-registry\`), it doesn't — \`db\` isn't activated and the const is invisible.

Probable cargo feature-unification quirk when verifying isolated tarballs via \`tmp-registry\` under \`resolver = "3"\`. Explicit \`features = ["db"]\` on the dep bypasses the inference and works reliably.

## Change
\`\`\`diff
 [dependencies]
-autumn-harvest = { version = "0.1.0", path = "../autumn-harvest" }
+autumn-harvest = { version = "0.1.0", path = "../autumn-harvest", features = ["db"] }
\`\`\`

## Verification
\`cargo publish --workspace --dry-run --allow-dirty\` reproduced the MIGRATIONS error before the change, and after the change the error is gone.

A separate \`STATUS_ACCESS_VIOLATION\` rustc crash surfaced during the next verify step. That's a transient Windows-specific issue unrelated to this fix — retry usually clears it, or fall back to \`--no-verify\`.

## Follow-up
Worth filing upstream: default-features propagation not activating the same features under \`cargo publish\` verify as under regular \`cargo check\` is a real inconsistency. Will dig into whether it's a \`resolver = "3"\` interaction with tmp-registry or something more general, once the publish is unblocked.

## Test plan
- [ ] CI passes
- [ ] After merge: \`cargo publish --workspace\` gets past the MIGRATIONS verify step

🤖 Generated with [Claude Code](https://claude.com/claude-code)