### PR TITLE
👺 Havoc: Fix Panic in Retry Backoff Calculation on Negative Floats

### DIFF
--- a/autumn-harvest/Cargo.toml
+++ b/autumn-harvest/Cargo.toml
@@ -47,6 +47,8 @@ tokio-postgres = { version = "0.7", optional = true }
 tokio = { workspace = true, features = ["test-util"] }
 testcontainers = { workspace = true }
 testcontainers-modules = { workspace = true }
+proptest = "1.11.0"
+loom = "0.7.2"
 
 [lints]
 workspace = true

--- a/autumn-harvest/src/policy.rs
+++ b/autumn-harvest/src/policy.rs
@@ -16,7 +16,15 @@ pub fn compute_retry_delay(
 ) -> Duration {
     let exp = i32::try_from(attempt.saturating_sub(1)).unwrap_or(i32::MAX);
     let secs = initial.as_secs_f64() * backoff_coefficient.powi(exp);
-    Duration::from_secs_f64(secs.min(max_interval.as_secs_f64()))
+
+    // Protect against negative floats and NaN, which would cause from_secs_f64 to panic
+    let clamped_secs = if secs.is_nan() || secs < 0.0 {
+        0.0
+    } else {
+        secs
+    };
+
+    Duration::from_secs_f64(clamped_secs.min(max_interval.as_secs_f64()))
 }
 
 /// How an activity failure is retried.

--- a/autumn-harvest/tests/havoc_tests.rs
+++ b/autumn-harvest/tests/havoc_tests.rs
@@ -1,0 +1,17 @@
+use autumn_harvest::policy::compute_retry_delay;
+use proptest::prelude::*;
+use std::time::Duration;
+
+proptest! {
+    #[test]
+    fn havoc_compute_retry_delay_does_not_panic(
+        initial_secs in 1u64..u64::MAX,
+        backoff in -100.0f64..100.0f64,
+        max_interval_secs in 1u64..u64::MAX,
+        attempt in 1u32..u32::MAX
+    ) {
+        let initial = Duration::from_secs(initial_secs);
+        let max_interval = Duration::from_secs(max_interval_secs);
+        let _delay = compute_retry_delay(initial, backoff, max_interval, attempt);
+    }
+}


### PR DESCRIPTION
🧨 **The Trigger:** Passing a negative `backoff_coefficient` or `f64::NAN` to `compute_retry_delay` causes it to evaluate to a negative float value.
📉 **The Stack Trace:** 
```
thread 'main' panicked at library/core/src/time.rs:964:23:
cannot convert float seconds to Duration: value is negative
```
🧪 **Reproduction:** Run `cargo test -p autumn-harvest --test havoc_tests`.
😈 **Comment:** You assumed the user would play nice and pass positive floats. You were wrong. I clamped your variables so it doesn't panic anymore.

---
*PR created automatically by Jules for task [1121090333060253426](https://jules.google.com/task/1121090333060253426) started by @madmax983*