### PR TITLE
🌟 Nova: DAG Exporter for Mermaid and DOT

### DIFF
--- a/autumn-harvest/src/dag_export.rs
+++ b/autumn-harvest/src/dag_export.rs
@@ -1,0 +1,110 @@
+use crate::dag::DagDefinition;
+use std::fmt::Write;
+
+/// Exports the DAG definition to a Mermaid.js flowchart.
+#[must_use]
+pub fn export_mermaid(dag: &DagDefinition) -> String {
+    let mut out = String::new();
+    writeln!(out, "graph TD").unwrap();
+
+    let tasks = dag.tasks();
+
+    for (i, task) in tasks.iter().enumerate() {
+        writeln!(out, "    t{i}[\"{}\"]", task.activity_name).unwrap();
+    }
+
+    for (i, task) in tasks.iter().enumerate() {
+        for &upstream in &task.upstreams {
+            writeln!(out, "    t{upstream} --> t{i}").unwrap();
+        }
+    }
+
+    out
+}
+
+/// Exports the DAG definition to Graphviz DOT format.
+#[must_use]
+pub fn export_dot(dag: &DagDefinition) -> String {
+    let mut out = String::new();
+    writeln!(out, "digraph DAG {{").unwrap();
+
+    let tasks = dag.tasks();
+
+    for (i, task) in tasks.iter().enumerate() {
+        writeln!(out, "    t{i} [label=\"{}\"];", task.activity_name).unwrap();
+    }
+
+    for (i, task) in tasks.iter().enumerate() {
+        for &upstream in &task.upstreams {
+            writeln!(out, "    t{upstream} -> t{i};").unwrap();
+        }
+    }
+
+    writeln!(out, "}}").unwrap();
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dag::DagBuilder;
+
+    fn dummy_activity() {}
+    fn dummy_activity2() {}
+    fn dummy_activity3() {}
+
+    #[test]
+    fn test_export_empty_dag() {
+        let builder = DagBuilder::new();
+        let dag = builder.build().unwrap();
+
+        let mermaid = export_mermaid(&dag);
+        assert_eq!(mermaid, "graph TD\n");
+
+        let dot = export_dot(&dag);
+        assert_eq!(dot, "digraph DAG {\n}\n");
+    }
+
+    #[test]
+    fn test_export_simple_dag() {
+        let mut builder = DagBuilder::new();
+        let a = builder.activity(dummy_activity);
+        let b1 = builder.activity(dummy_activity2).upstream(&a);
+        let b2 = builder.activity(dummy_activity2).upstream(&a);
+        let _c = builder
+            .activity(dummy_activity3)
+            .upstream(&b1)
+            .upstream(&b2);
+
+        let dag = builder.build().unwrap();
+
+        let mermaid = export_mermaid(&dag);
+        let expected_mermaid = "\
+graph TD
+    t0[\"dummy_activity\"]
+    t1[\"dummy_activity2\"]
+    t2[\"dummy_activity2\"]
+    t3[\"dummy_activity3\"]
+    t0 --> t1
+    t0 --> t2
+    t1 --> t3
+    t2 --> t3
+";
+        assert_eq!(mermaid, expected_mermaid);
+
+        let dot = export_dot(&dag);
+        let expected_dot = "\
+digraph DAG {
+    t0 [label=\"dummy_activity\"];
+    t1 [label=\"dummy_activity2\"];
+    t2 [label=\"dummy_activity2\"];
+    t3 [label=\"dummy_activity3\"];
+    t0 -> t1;
+    t0 -> t2;
+    t1 -> t3;
+    t2 -> t3;
+}
+";
+        assert_eq!(dot, expected_dot);
+    }
+}

--- a/autumn-harvest/src/lib.rs
+++ b/autumn-harvest/src/lib.rs
@@ -18,6 +18,7 @@ pub mod builder;
 pub mod cache;
 pub mod context;
 pub mod dag;
+pub mod dag_export;
 pub mod error;
 pub mod event;
 #[cfg(feature = "db")]
@@ -70,6 +71,7 @@ pub use builder::{BuiltHarvest, HarvestBuilder, WorkerConfig};
 pub use cache::{CachedWorkflowState, WorkflowCache};
 pub use context::{ActivityContext, WorkflowCommand, WorkflowContext};
 pub use dag::{DagBuildError, DagBuilder, DagDefinition, DagTask, DagTaskRef};
+pub use dag_export::{export_dot, export_mermaid};
 pub use error::{HarvestError, HarvestResult, TimeoutType};
 pub use event::WorkflowEvent;
 #[cfg(feature = "db")]


### PR DESCRIPTION
💡 **The Spark:** I noticed we define complex DAGs using `DagBuilder` and compile them into `DagDefinition`, but there's no way to visually inspect the dependency graph before it runs in production or documentation.

🚀 **The Feature:** Implemented `export_mermaid` and `export_dot` functions in a new `dag_export` module. They take a `DagDefinition` and output valid Mermaid.js and Graphviz DOT strings.

🔮 **The Potential:** Could be used to auto-generate documentation for orchestration pipelines, or integrated into a future TUI/Web Dashboard to visualize workflow DAGs live.

⚠️ **Risk:** Low. Isolated purely as an additive feature in `src/dag_export.rs` and exposed through `src/lib.rs`. It does not modify existing scheduler or DAG execution logic.

---
*PR created automatically by Jules for task [9207136269533833064](https://jules.google.com/task/9207136269533833064) started by @madmax983*