### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/autumn-harvest-plugin/src/plugin.rs
+++ b/autumn-harvest-plugin/src/plugin.rs
@@ -1,4 +1,4 @@
-//! `HarvestPlugin` — the [`Plugin`](autumn_web::Plugin) implementation that wires
+//! `HarvestPlugin` — the [`Plugin`] implementation that wires
 //! the Harvest workflow engine into an Autumn [`AppBuilder`].
 
 use std::any::Any;

--- a/autumn-harvest/src/queue.rs
+++ b/autumn-harvest/src/queue.rs
@@ -107,7 +107,7 @@ impl EnqueueParams {
 ///
 /// # Errors
 ///
-/// Returns [`HarvestError::Database`] on insert failure.
+/// Returns [`crate::error::HarvestError::Database`] on insert failure.
 pub async fn enqueue(conn: &mut AsyncPgConnection, params: &EnqueueParams) -> HarvestResult<Uuid> {
     use crate::schema::harvest_task_queue;
 
@@ -147,7 +147,7 @@ pub async fn enqueue(conn: &mut AsyncPgConnection, params: &EnqueueParams) -> Ha
 ///
 /// # Errors
 ///
-/// Returns [`HarvestError::Database`] on query failure.
+/// Returns [`crate::error::HarvestError::Database`] on query failure.
 pub async fn claim_task(
     conn: &mut AsyncPgConnection,
     queues: &[String],
@@ -176,7 +176,7 @@ pub async fn claim_task(
 ///
 /// # Errors
 ///
-/// Returns [`HarvestError::Database`] on update failure.
+/// Returns [`crate::error::HarvestError::Database`] on update failure.
 pub async fn complete_task(
     conn: &mut AsyncPgConnection,
     task_id: Uuid,
@@ -211,7 +211,7 @@ pub async fn complete_task(
 ///
 /// # Errors
 ///
-/// Returns [`HarvestError::Database`] on update failure.
+/// Returns [`crate::error::HarvestError::Database`] on update failure.
 pub async fn fail_task(
     conn: &mut AsyncPgConnection,
     task_id: Uuid,
@@ -246,7 +246,7 @@ pub async fn fail_task(
 ///
 /// # Errors
 ///
-/// Returns [`HarvestError::Database`] on update failure.
+/// Returns [`crate::error::HarvestError::Database`] on update failure.
 pub async fn record_heartbeat(conn: &mut AsyncPgConnection, task_id: Uuid) -> HarvestResult<()> {
     use crate::schema::harvest_task_queue::dsl;
 
@@ -273,7 +273,7 @@ pub async fn record_heartbeat(conn: &mut AsyncPgConnection, task_id: Uuid) -> Ha
 ///
 /// # Errors
 ///
-/// Returns [`HarvestError::Database`] on update failure.
+/// Returns [`crate::error::HarvestError::Database`] on update failure.
 pub async fn requeue_for_retry(
     conn: &mut AsyncPgConnection,
     task_id: Uuid,
@@ -287,7 +287,7 @@ pub async fn requeue_for_retry(
 ///
 /// # Errors
 ///
-/// Returns [`HarvestError::Database`] on update failure.
+/// Returns [`crate::error::HarvestError::Database`] on update failure.
 pub async fn reschedule_task(
     conn: &mut AsyncPgConnection,
     task_id: Uuid,
@@ -329,7 +329,7 @@ pub async fn reschedule_task(
 ///
 /// # Errors
 ///
-/// Returns [`HarvestError::Database`] on update failure.
+/// Returns [`crate::error::HarvestError::Database`] on update failure.
 pub async fn park_workflow_task(conn: &mut AsyncPgConnection, task_id: Uuid) -> HarvestResult<()> {
     use crate::schema::harvest_task_queue::dsl;
 
@@ -366,7 +366,7 @@ pub async fn park_workflow_task(conn: &mut AsyncPgConnection, task_id: Uuid) -> 
 ///
 /// # Errors
 ///
-/// Returns [`HarvestError::Database`] on update failure.
+/// Returns [`crate::error::HarvestError::Database`] on update failure.
 pub async fn wake_workflow_task(
     conn: &mut AsyncPgConnection,
     exec_id: ExecutionId,

--- a/autumn-harvest/src/store.rs
+++ b/autumn-harvest/src/store.rs
@@ -74,13 +74,13 @@ pub fn events_to_insert_rows_from(
 /// Append events to a workflow's history in a single INSERT.
 ///
 /// Returns the number of events inserted. Fails with a unique constraint
-/// violation (wrapped as [`HarvestError::Database`]) if `start_id` conflicts --
+/// violation (wrapped as [`crate::error::HarvestError::Database`]) if `start_id` conflicts --
 /// this indicates a concurrency conflict where two workers tried to advance
 /// the same workflow simultaneously.
 ///
 /// # Errors
 ///
-/// Returns [`HarvestError::Database`] if the INSERT fails (e.g. unique
+/// Returns [`crate::error::HarvestError::Database`] if the INSERT fails (e.g. unique
 /// constraint violation on `(workflow_exec_id, event_id)` or connection error).
 pub async fn append_events(
     conn: &mut AsyncPgConnection,
@@ -110,8 +110,8 @@ pub async fn append_events(
 ///
 /// # Errors
 ///
-/// Returns [`HarvestError::Database`] on connection or query errors, or
-/// [`HarvestError::Serialization`] if a stored JSON value can't be deserialized
+/// Returns [`crate::error::HarvestError::Database`] on connection or query errors, or
+/// [`crate::error::HarvestError::Serialization`] if a stored JSON value can't be deserialized
 /// into `WorkflowEvent`.
 pub async fn load_history(
     conn: &mut AsyncPgConnection,


### PR DESCRIPTION
📖 Chapter: `autumn-harvest::queue`, `autumn-harvest::store`, and `autumn-harvest-plugin::plugin` modules.
🔦 Insight: Resolved broken intra-doc links for `HarvestError::Database` and `HarvestError::Serialization` which were failing to resolve during `cargo doc`, ensuring the documentation now properly links to the error types. Fixed a redundant link for `Plugin` trait in the plugin macro documentation.
🧪 Example: No new examples added, but `cargo doc` now runs successfully without generating warnings about unresolved paths.
🖼️ Preview: Documentation is now fully linked and warning-free.

---
*PR created automatically by Jules for task [3830070539040855941](https://jules.google.com/task/3830070539040855941) started by @madmax983*