### PR TITLE
👺 Havoc: Fix f64 to Duration panic in compute_retry_delay

### DIFF
--- a/autumn-harvest/src/policy.rs
+++ b/autumn-harvest/src/policy.rs
@@ -24,7 +24,8 @@ pub fn compute_retry_delay(
         secs
     };
 
-    Duration::from_secs_f64(clamped_secs.min(max_interval.as_secs_f64()))
+    let delay = Duration::try_from_secs_f64(clamped_secs).unwrap_or(Duration::MAX);
+    delay.min(max_interval)
 }
 
 /// How an activity failure is retried.


### PR DESCRIPTION
🧨 **The Trigger:**
When `max_interval` is large enough (like `Duration::from_secs(u64::MAX)`), `max_interval.as_secs_f64()` loses precision and becomes `18446744073709552000.0`. When `clamped_secs` takes this value via `.min()` and is passed to `Duration::from_secs_f64`, it exceeds the internal safe max bound of the function (`18446744073709551616.0`) and immediately panics.

📉 **The Stack Trace:**
```
thread 'main' panicked at library/core/src/time.rs:964:23:
cannot convert float seconds to Duration: value is either too big or NaN
```

🧪 **Reproduction:**
Run the `havoc_tests` with an extremely large `attempt` that evaluates to an out-of-bounds interval and `u64::MAX` as `max_interval_secs`. The test previously failed by panicking in the property test suite.

😈 **Comment:**
You assumed floats would perfectly map back into 64-bit bounds without precision loss. You were wrong. Using `try_from_secs_f64` protects against these invisible edge cases where precision loss artificially pushes values outside representable bounds.

---
*PR created automatically by Jules for task [443097489743151703](https://jules.google.com/task/443097489743151703) started by @madmax983*