### PR TITLE
🎸 Bard: [documentation update]

### DIFF
--- a/autumn-harvest-macros/src/lib.rs
+++ b/autumn-harvest-macros/src/lib.rs
@@ -1,3 +1,8 @@
+//! Procedural macros for the `autumn-harvest` workflow engine.
+//!
+//! This crate provides attribute macros to define workflows, activities, and DAGs,
+//! as well as collection macros to bundle them for registration.
+
 use proc_macro::TokenStream;
 
 mod activity;
@@ -5,31 +10,66 @@ mod collect;
 mod dag;
 mod workflow;
 
+/// Marks an async function as a Harvest workflow.
+///
+/// This macro generates a companion function that returns a `WorkflowInfo`
+/// struct describing the workflow, which is used for registration.
 #[proc_macro_attribute]
 pub fn workflow(attr: TokenStream, item: TokenStream) -> TokenStream {
     workflow::workflow_macro(attr.into(), item.into()).into()
 }
 
+/// Marks an async function as a Harvest activity.
+///
+/// This macro generates a companion function that returns an `ActivityInfo`
+/// struct describing the activity, which is used for registration.
+///
+/// Supports attributes like `start_to_close`, `heartbeat_timeout`, and `retry`.
 #[proc_macro_attribute]
 pub fn activity(attr: TokenStream, item: TokenStream) -> TokenStream {
     activity::activity_macro(attr.into(), item.into()).into()
 }
 
+/// Marks a function as a Harvest DAG builder.
+///
+/// This macro generates a companion function that returns a `DagInfo`
+/// struct describing the DAG, which is used for registration.
 #[proc_macro_attribute]
 pub fn dag(attr: TokenStream, item: TokenStream) -> TokenStream {
     dag::dag_macro(attr.into(), item.into()).into()
 }
 
+/// Collects multiple workflow functions into a `Vec<WorkflowInfo>`.
+///
+/// # Examples
+///
+/// ```ignore
+/// let w = workflows![my_workflow, another_workflow];
+/// ```
 #[proc_macro]
 pub fn workflows(input: TokenStream) -> TokenStream {
     collect::workflows_macro(input.into()).into()
 }
 
+/// Collects multiple activity functions into a `Vec<ActivityInfo>`.
+///
+/// # Examples
+///
+/// ```ignore
+/// let a = activities![my_activity, another_activity];
+/// ```
 #[proc_macro]
 pub fn activities(input: TokenStream) -> TokenStream {
     collect::activities_macro(input.into()).into()
 }
 
+/// Collects multiple DAG builder functions into a `Vec<DagInfo>`.
+///
+/// # Examples
+///
+/// ```ignore
+/// let d = dags![my_dag, another_dag];
+/// ```
 #[proc_macro]
 pub fn dags(input: TokenStream) -> TokenStream {
     collect::dags_macro(input.into()).into()

--- a/autumn-harvest/src/event.rs
+++ b/autumn-harvest/src/event.rs
@@ -19,83 +19,133 @@ use crate::types::{ActivityExecId, ExecutionId, TimerId, WorkerId};
 #[serde(tag = "type", content = "data")]
 pub enum WorkflowEvent {
     // ── Lifecycle ──────────────────────────────────────────────────
+    /// A new workflow execution has started.
     WorkflowStarted {
+        /// The JSON payload used to start the workflow.
         input: serde_json::Value,
+        /// Time when the workflow was initiated.
         timestamp: DateTime<Utc>,
     },
+    /// The workflow ran to completion without an error.
     WorkflowCompleted {
+        /// The JSON result returned by the workflow function.
         output: serde_json::Value,
     },
+    /// The workflow panicked or returned a non-recoverable error.
     WorkflowFailed {
+        /// String representation of the failure.
         error: String,
     },
+    /// The workflow was intentionally cancelled (e.g., via API or parent workflow).
     WorkflowCancelled {
+        /// The reason given for cancellation.
         reason: String,
     },
 
     // ── Activities ────────────────────────────────────────────────
+    /// An activity was requested by the workflow.
     ActivityScheduled {
+        /// Unique ID for this specific activity attempt.
         activity_id: ActivityExecId,
+        /// The name of the registered activity handler.
         name: String,
+        /// JSON input for the activity.
         input: serde_json::Value,
+        /// Target worker queue.
         queue: String,
     },
+    /// A worker picked up the activity and began executing it.
     ActivityStarted {
+        /// Unique ID for this specific activity attempt.
         activity_id: ActivityExecId,
+        /// The worker instance running the activity.
         worker_id: WorkerId,
     },
+    /// The activity finished executing successfully.
     ActivityCompleted {
+        /// Unique ID for this specific activity attempt.
         activity_id: ActivityExecId,
+        /// The JSON result returned by the activity.
         output: serde_json::Value,
     },
+    /// The activity returned an error or panicked.
     ActivityFailed {
+        /// Unique ID for this specific activity attempt.
         activity_id: ActivityExecId,
+        /// String representation of the failure.
         error: String,
+        /// How many times the activity has failed so far.
         attempt: u32,
     },
+    /// The activity exceeded its allocated `start_to_close` or `heartbeat` timeout.
     ActivityTimedOut {
+        /// Unique ID for this specific activity attempt.
         activity_id: ActivityExecId,
+        /// Which timeout triggered the failure.
         timeout_type: TimeoutType,
     },
+    /// The activity successfully sent a heartbeat.
     ActivityHeartbeat {
+        /// Unique ID for this specific activity attempt.
         activity_id: ActivityExecId,
+        /// JSON payload attached to the heartbeat, used to resume progress after failures.
         details: serde_json::Value,
     },
 
     // ── Timers ────────────────────────────────────────────────────
+    /// The workflow requested a durable sleep/timer.
     TimerStarted {
+        /// The ID used to wake the workflow later.
         timer_id: TimerId,
         /// Duration in seconds (Duration is not JSON-serializable natively).
         duration_secs: u64,
     },
+    /// The requested timer elapsed and the workflow can wake up.
     TimerFired {
+        /// The ID that just finished waiting.
         timer_id: TimerId,
     },
 
     // ── Signals ───────────────────────────────────────────────────
+    /// An external signal arrived while the workflow was waiting.
     SignalReceived {
+        /// Name of the signal channel.
         signal_name: String,
+        /// JSON payload delivered by the signal.
         payload: serde_json::Value,
     },
 
     // ── Child workflows ───────────────────────────────────────────
+    /// A sub-workflow was scheduled by a parent workflow.
     ChildWorkflowStarted {
+        /// The ID of the spawned execution.
         child_id: ExecutionId,
+        /// The target child workflow handler.
         workflow_name: String,
+        /// The input passed to the child workflow.
         input: serde_json::Value,
     },
+    /// The spawned sub-workflow completed successfully.
     ChildWorkflowCompleted {
+        /// The ID of the spawned execution.
         child_id: ExecutionId,
+        /// Result of the completed workflow.
         output: serde_json::Value,
     },
+    /// The spawned sub-workflow encountered a fatal error.
     ChildWorkflowFailed {
+        /// The ID of the spawned execution.
         child_id: ExecutionId,
+        /// The reason the child failed.
         error: String,
     },
 
     // ── Markers ───────────────────────────────────────────────────
+    /// An explicit version change or side-effect marker was recorded.
     MarkerRecorded {
+        /// The name of the recorded side effect (e.g. version block name).
         name: String,
+        /// Arbitrary data recorded with the marker.
         details: serde_json::Value,
     },
 }

--- a/autumn-harvest/src/executor.rs
+++ b/autumn-harvest/src/executor.rs
@@ -22,12 +22,21 @@ use crate::types::ExecutionId;
 #[derive(Debug)]
 pub enum WorkflowOutcome {
     /// The workflow ran to completion and returned a value.
-    Completed { output: Value },
+    Completed {
+        /// The final result serialized as JSON.
+        output: Value,
+    },
     /// The workflow function returned an error.
-    Failed { error: String },
+    Failed {
+        /// The string description of the error encountered.
+        error: String,
+    },
     /// The workflow suspended awaiting activity results or timer firings.
     /// The accumulated commands describe what the worker needs to schedule.
-    Suspended { commands: Vec<WorkflowCommand> },
+    Suspended {
+        /// A list of commands representing the side effects (e.g. activities) requested.
+        commands: Vec<WorkflowCommand>,
+    },
 }
 
 /// Default timeout for detecting suspension -- if the workflow hasn't completed

--- a/autumn-harvest/src/policy.rs
+++ b/autumn-harvest/src/policy.rs
@@ -95,8 +95,11 @@ impl Default for RetryPolicy {
 /// Status of a completed DAG task, used by trigger rules.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TaskStatus {
+    /// The task executed and returned success.
     Succeeded,
+    /// The task returned an error or exhausted its retries.
     Failed,
+    /// The task was skipped (e.g., due to a trigger rule evaluating to false).
     Skipped,
 }
 
@@ -121,6 +124,9 @@ pub enum TriggerRule {
 }
 
 impl TriggerRule {
+    /// Evaluates the trigger rule against a list of upstream task statuses.
+    ///
+    /// Returns `true` if the downstream task should be executed, `false` otherwise.
     #[must_use]
     pub fn should_run(&self, upstream_statuses: &[TaskStatus]) -> bool {
         match self {

--- a/autumn-harvest/src/query.rs
+++ b/autumn-harvest/src/query.rs
@@ -5,19 +5,23 @@ use serde_json::Value;
 
 use crate::error::{HarvestError, HarvestResult};
 
+/// A thread-safe, sync function that returns a JSON-serializable query result.
 pub type QueryHandler = Arc<dyn Fn() -> Value + Send + Sync>;
 
+/// Holds all registered query handlers for a running workflow.
 #[derive(Default)]
 pub struct QueryRegistry {
     handlers: HashMap<String, QueryHandler>,
 }
 
 impl QueryRegistry {
+    /// Creates a new, empty query registry.
     #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Registers a query handler under the given name.
     pub fn register(&mut self, name: &str, handler: QueryHandler) {
         self.handlers.insert(name.to_string(), handler);
     }

--- a/autumn-harvest/src/replay.rs
+++ b/autumn-harvest/src/replay.rs
@@ -19,16 +19,32 @@ use crate::event::WorkflowEvent;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum HistoryMatch {
     /// History contains a completed result for this command.
-    Matched { output: Value },
+    Matched {
+        /// The JSON result value returned by the matched event.
+        output: Value,
+    },
     /// History contains a failure for this command.
-    Failed { error: String, attempt: u32 },
+    Failed {
+        /// String representation of the failure.
+        error: String,
+        /// Attempt number for the failed action.
+        attempt: u32,
+    },
     /// History contains a timeout for this command.
-    TimedOut { timeout_type: TimeoutType },
+    TimedOut {
+        /// The type of timeout that occurred.
+        timeout_type: TimeoutType,
+    },
     /// Cursor is past the end of history — this is a new command.
     NoMatch,
     /// The command does not match what was recorded at this position,
     /// indicating non-determinism in the workflow code.
-    Diverged { expected: String, actual: String },
+    Diverged {
+        /// What the history matcher expected to find based on recorded events.
+        expected: String,
+        /// What the workflow actually requested.
+        actual: String,
+    },
 }
 
 /// Walks through recorded workflow events during replay, matching

--- a/autumn-harvest/src/scheduler.rs
+++ b/autumn-harvest/src/scheduler.rs
@@ -27,39 +27,55 @@ use crate::worker::{DbPool, HandlerRegistry};
 
 const DEFAULT_SCHEDULER_TICK_INTERVAL: Duration = Duration::from_secs(1);
 
+/// Represents a fully registered and compiled DAG definition.
 #[derive(Debug, Clone)]
 pub struct RegisteredDag {
+    /// The name of the DAG.
     pub name: String,
+    /// The Rust module path where the DAG is defined.
     pub module: String,
+    /// Optional schedule for automatic execution.
     pub schedule: Option<Schedule>,
+    /// Whether to run missed executions sequentially if the scheduler was down.
     pub catchup: bool,
+    /// Maximum number of concurrent executions for this DAG.
     pub max_active_runs: u32,
+    /// The compiled task and dependency definition.
     pub definition: crate::dag::DagDefinition,
 }
 
 impl RegisteredDag {
+    /// Returns the number of tasks in this DAG.
     #[must_use]
     pub fn task_count(&self) -> usize {
         self.definition.tasks().len()
     }
 }
 
+/// A collection of registered DAGs mapped by name.
 pub type DagCatalog = HashMap<String, RegisteredDag>;
 
+/// A point-in-time diagnostic snapshot of the scheduler's state.
 #[derive(Debug, Clone, Serialize)]
 pub struct SchedulerSnapshot {
+    /// True if the scheduler loop is currently running.
     pub running: bool,
+    /// Number of DAGs registered with the scheduler.
     pub dag_count: usize,
+    /// Interval in milliseconds between scheduler ticks.
     pub tick_interval_ms: u64,
+    /// UTC timestamp of the last executed tick.
     pub last_tick_at: Option<DateTime<Utc>>,
 }
 
+/// Provides diagnostic visibility into a running scheduler.
 #[derive(Debug, Clone)]
 pub struct SchedulerMonitor {
     inner: Arc<Mutex<SchedulerSnapshot>>,
 }
 
 impl SchedulerMonitor {
+    /// Creates a new monitor initialized for the given number of DAGs.
     #[must_use]
     pub fn new(dag_count: usize) -> Self {
         Self {
@@ -75,6 +91,7 @@ impl SchedulerMonitor {
         }
     }
 
+    /// Creates a dummy offline monitor for contexts where the scheduler isn't running.
     #[must_use]
     pub fn offline() -> Self {
         Self {
@@ -117,6 +134,7 @@ impl SchedulerMonitor {
     }
 }
 
+/// The background runtime that drives DAG scheduling.
 pub struct SchedulerRuntime {
     shutdown: CancellationToken,
     handle: JoinHandle<()>,
@@ -124,6 +142,9 @@ pub struct SchedulerRuntime {
 }
 
 impl SchedulerRuntime {
+    /// Spawns the scheduler loop on a new Tokio task.
+    ///
+    /// It wakes up at a fixed interval to evaluate schedules and trigger runs.
     #[must_use]
     pub fn spawn(pool: DbPool, registry: Arc<HandlerRegistry>, dags: Arc<DagCatalog>) -> Self {
         let shutdown = CancellationToken::new();
@@ -165,11 +186,13 @@ impl SchedulerRuntime {
         }
     }
 
+    /// Returns a diagnostic monitor for the scheduler.
     #[must_use]
     pub fn monitor(&self) -> SchedulerMonitor {
         self.monitor.clone()
     }
 
+    /// Requests that the background scheduler loop shut down gracefully.
     pub fn shutdown(&self) {
         self.shutdown.cancel();
     }

--- a/autumn-harvest/src/types.rs
+++ b/autumn-harvest/src/types.rs
@@ -20,11 +20,13 @@ use uuid::Uuid;
 pub struct WorkflowId(String);
 
 impl WorkflowId {
+    /// Creates a new `WorkflowId` from a string-like value.
     #[must_use]
     pub fn new(id: impl Into<String>) -> Self {
         Self(id.into())
     }
 
+    /// Returns the underlying string slice.
     #[must_use]
     pub fn as_str(&self) -> &str {
         &self.0
@@ -44,16 +46,19 @@ impl fmt::Display for WorkflowId {
 pub struct ExecutionId(Uuid);
 
 impl ExecutionId {
+    /// Creates a new, random `ExecutionId` using a v4 UUID.
     #[must_use]
     pub fn new() -> Self {
         Self(Uuid::new_v4())
     }
 
+    /// Wraps an existing `Uuid` into an `ExecutionId`.
     #[must_use]
     pub const fn from_uuid(id: Uuid) -> Self {
         Self(id)
     }
 
+    /// Returns the underlying `Uuid` for database storage or serialization.
     #[must_use]
     pub const fn as_uuid(&self) -> Uuid {
         self.0
@@ -84,11 +89,13 @@ impl FromStr for ExecutionId {
 pub struct ActivityExecId(Uuid);
 
 impl ActivityExecId {
+    /// Creates a new, random `ActivityExecId` using a v4 UUID.
     #[must_use]
     pub fn new() -> Self {
         Self(Uuid::new_v4())
     }
 
+    /// Returns the underlying `Uuid`.
     #[must_use]
     pub const fn as_uuid(&self) -> Uuid {
         self.0
@@ -119,11 +126,13 @@ impl FromStr for ActivityExecId {
 pub struct TimerId(String);
 
 impl TimerId {
+    /// Creates a new `TimerId` from a string-like value.
     #[must_use]
     pub fn new(id: impl Into<String>) -> Self {
         Self(id.into())
     }
 
+    /// Returns the underlying string slice.
     #[must_use]
     pub fn as_str(&self) -> &str {
         &self.0
@@ -141,11 +150,13 @@ impl fmt::Display for TimerId {
 pub struct WorkerId(String);
 
 impl WorkerId {
+    /// Creates a new `WorkerId` from a string-like value.
     #[must_use]
     pub fn new(id: impl Into<String>) -> Self {
         Self(id.into())
     }
 
+    /// Returns the underlying string slice.
     #[must_use]
     pub fn as_str(&self) -> &str {
         &self.0


### PR DESCRIPTION
📖 Chapter: `cargo doc` generation for core types, macros, and variants in `autumn-harvest`
🔦 Insight: Cleared up missing documentation on `WorkflowEvent`, `HistoryMatch`, DAG scheduling components (`RegisteredDag`, `SchedulerRuntime`), `WorkflowOutcome`, internal IDs (`ExecutionId`, `WorkflowId`), and proc macros (`#[workflow]`, `dags!`, etc). Explained *why* and *what* each variant/field does.
🧪 Example: Provided `ignore` doctests showing how the proc macros are used (avoiding unnecessary dummy workflows inside macro docs).
🖼️ Preview: `cargo doc --open` should now properly render without `missing_docs` clippy warnings.

---
*PR created automatically by Jules for task [14149145948570599923](https://jules.google.com/task/14149145948570599923) started by @madmax983*