### PR TITLE
⚡ Bolt: Remove intermediate allocations in hot paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,7 +95,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autumn-harvest"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "autumn-harvest-macros",
  "chrono",
@@ -123,7 +123,7 @@ dependencies = [
 
 [[package]]
 name = "autumn-harvest-macros"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -132,7 +132,7 @@ dependencies = [
 
 [[package]]
 name = "autumn-harvest-plugin"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "autumn-harvest",
  "autumn-web",

--- a/autumn-harvest/src/scheduler.rs
+++ b/autumn-harvest/src/scheduler.rs
@@ -534,11 +534,10 @@ async fn execute_dag_run(
         let tasks = level.iter().map(|task_index| {
             // Avoid an unnecessary heap allocation of `DagTask` per task when `&DagTask` works.
             let task = &dag.definition.tasks()[*task_index];
-            let upstream_statuses = task
-                .upstreams
-                .iter()
-                .map(|upstream| statuses[*upstream].clone())
-                .collect::<Vec<_>>();
+            let mut upstream_statuses = Vec::with_capacity(task.upstreams.len());
+            for upstream in &task.upstreams {
+                upstream_statuses.push(statuses[*upstream].clone());
+            }
             let registry = Arc::clone(&registry);
             let task_input = run_input.clone();
             async move { execute_dag_task(&registry, task, &upstream_statuses, &task_input).await }

--- a/autumn-harvest/src/timeout.rs
+++ b/autumn-harvest/src/timeout.rs
@@ -182,25 +182,28 @@ fn find_pending_scheduled_activity(
         })
         .collect::<HashSet<_>>();
 
-    let pending = history
-        .iter()
-        .filter_map(|event| match event {
-            WorkflowEvent::ActivityScheduled {
-                activity_id, name, ..
-            } if name == activity_name && !terminal_ids.contains(activity_id) => Some(*activity_id),
-            _ => None,
-        })
-        .collect::<Vec<_>>();
-
-    match pending.as_slice() {
-        [activity_id] => Ok(*activity_id),
-        [] => Err(HarvestError::NotFound(format!(
-            "no pending scheduled activity '{activity_name}' in workflow history"
-        ))),
-        _ => Err(HarvestError::NonDeterministic(format!(
-            "multiple pending scheduled activities named '{activity_name}' found in history"
-        ))),
+    let mut pending = None;
+    for event in history {
+        if let WorkflowEvent::ActivityScheduled {
+            activity_id, name, ..
+        } = event
+        {
+            if name == activity_name && !terminal_ids.contains(activity_id) {
+                if pending.is_some() {
+                    return Err(HarvestError::NonDeterministic(format!(
+                        "multiple pending scheduled activities named '{activity_name}' found in history"
+                    )));
+                }
+                pending = Some(*activity_id);
+            }
+        }
     }
+
+    pending.ok_or_else(|| {
+        HarvestError::NotFound(format!(
+            "no pending scheduled activity '{activity_name}' in workflow history"
+        ))
+    })
 }
 
 async fn load_workflow_execution(

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -459,25 +459,28 @@ fn find_pending_scheduled_activity(
         })
         .collect::<HashSet<_>>();
 
-    let pending = history
-        .iter()
-        .filter_map(|event| match event {
-            WorkflowEvent::ActivityScheduled {
-                activity_id, name, ..
-            } if name == activity_name && !terminal_ids.contains(activity_id) => Some(*activity_id),
-            _ => None,
-        })
-        .collect::<Vec<_>>();
-
-    match pending.as_slice() {
-        [activity_id] => Ok(*activity_id),
-        [] => Err(HarvestError::NotFound(format!(
-            "no pending scheduled activity '{activity_name}' in workflow history"
-        ))),
-        _ => Err(HarvestError::NonDeterministic(format!(
-            "multiple pending scheduled activities named '{activity_name}' found in history"
-        ))),
+    let mut pending = None;
+    for event in history {
+        if let WorkflowEvent::ActivityScheduled {
+            activity_id, name, ..
+        } = event
+        {
+            if name == activity_name && !terminal_ids.contains(activity_id) {
+                if pending.is_some() {
+                    return Err(HarvestError::NonDeterministic(format!(
+                        "multiple pending scheduled activities named '{activity_name}' found in history"
+                    )));
+                }
+                pending = Some(*activity_id);
+            }
+        }
     }
+
+    pending.ok_or_else(|| {
+        HarvestError::NotFound(format!(
+            "no pending scheduled activity '{activity_name}' in workflow history"
+        ))
+    })
 }
 
 async fn load_workflow_execution(


### PR DESCRIPTION
💡 **What**: Removed intermediate `.collect::<Vec<_>>()` allocations in `find_pending_scheduled_activity` (`worker.rs` and `timeout.rs`) and replaced `.collect()` with `Vec::with_capacity` in `execute_dag_run` (`scheduler.rs`).
🎯 **Why**: The intermediate `Vec` allocations in hot paths (like checking for pending activities, which runs on many workflow events) cause unnecessary heap allocations and pressure the allocator. Using `Vec::with_capacity` avoids resizing.
📊 **Impact**: Eliminates a heap allocation per workflow task processing when checking pending activities. Reduces vector reallocations during DAG task scheduling, making the hot paths cleaner and more allocation-friendly.
🔬 **Measurement**: Observe reduced heap allocations during heavy workflow task processing. Tests pass locally.

---
*PR created automatically by Jules for task [9658868871827964138](https://jules.google.com/task/9658868871827964138) started by @madmax983*