### PR TITLE
🔒 Warden: Fix integer overflow vulnerability in task_duration parsing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -95,7 +95,7 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "autumn-harvest"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "autumn-harvest-macros",
  "chrono",
@@ -123,7 +123,7 @@ dependencies = [
 
 [[package]]
 name = "autumn-harvest-macros"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -132,7 +132,7 @@ dependencies = [
 
 [[package]]
 name = "autumn-harvest-plugin"
-version = "0.1.1"
+version = "0.2.0"
 dependencies = [
  "autumn-harvest",
  "autumn-web",

--- a/autumn-harvest/src/lib.rs
+++ b/autumn-harvest/src/lib.rs
@@ -118,10 +118,10 @@ pub fn task_duration(s: &str) -> Option<std::time::Duration> {
             let num: u64 = current_num.parse().ok()?;
             current_num.clear();
             match ch {
-                's' => total_secs += num,
-                'm' => total_secs += num * 60,
-                'h' => total_secs += num * 3600,
-                'd' => total_secs += num * 86400,
+                's' => total_secs = total_secs.checked_add(num)?,
+                'm' => total_secs = total_secs.checked_add(num.checked_mul(60)?)?,
+                'h' => total_secs = total_secs.checked_add(num.checked_mul(3600)?)?,
+                'd' => total_secs = total_secs.checked_add(num.checked_mul(86400)?)?,
                 _ => return None,
             }
         } else if ch != ' ' {
@@ -172,5 +172,13 @@ mod tests {
         assert_eq!(task_duration(""), None);
         assert_eq!(task_duration("5"), None);
         assert_eq!(task_duration("5x"), None);
+    }
+
+    #[test]
+    fn task_duration_rejects_overflow() {
+        assert_eq!(task_duration("18446744073709551615d"), None); // u64::MAX
+        assert_eq!(task_duration("18446744073709551615h"), None); // u64::MAX
+        assert_eq!(task_duration("18446744073709551615m"), None); // u64::MAX
+        assert_eq!(task_duration("18446744073709551614s 2s"), None); // Add overflow
     }
 }


### PR DESCRIPTION
🦠 **Threat:** Integer overflow vulnerability in `autumn-harvest/src/lib.rs` inside the `task_duration` string parsing logic. Attackers or edge-case payloads could provide an extremely large numeric string (e.g. `"18446744073709551615d"`) which would cause an uncontrolled panic via arithmetic overflow when multiplying by time constants (like `* 86400`) or accumulating the `total_secs`.

🛡️ **Defense:** Replaced standard arithmetic operators (`+=`, `*`) with safe checked math methods (`checked_add` and `checked_mul`) using the `?` operator. Now, if an overflow occurs, the function gracefully returns `None` as intended for an invalid parse, rather than detonating.

💥 **Severity:** Medium / High - Unchecked parsing of user or macro inputs that panics upon extreme values acts as an application crash/Denial of Service (DoS) vector.

🧪 **Verification:**
- Ran `cargo audit` to confirm 0 known dependency CVEs.
- Inserted `task_duration_rejects_overflow` exploit test to prove integer limits are safely discarded without crashing.
- Verified test suite passes locally with `cargo test --lib`.
- Ran `cargo clippy --all-targets --all-features -- -D warnings` and `cargo fmt --all`.

---
*PR created automatically by Jules for task [870480353636247695](https://jules.google.com/task/870480353636247695) started by @madmax983*