### PR TITLE
🔒 Warden: [security fix] Fix integer overflow when generating sequential event IDs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2731,9 +2731,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/autumn-harvest/src/store.rs
+++ b/autumn-harvest/src/store.rs
@@ -60,7 +60,8 @@ pub fn events_to_insert_rows_from(
         .enumerate()
         .map(|(i, event)| {
             #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
-            let event_id = start_id + i as i32;
+            let i_i32 = i as i32;
+            let event_id = start_id.checked_add(i_i32).expect("Event ID overflow");
             NewHarvestEvent {
                 workflow_exec_id: exec_id.as_uuid(),
                 event_id,

--- a/autumn-harvest/tests/security.rs
+++ b/autumn-harvest/tests/security.rs
@@ -1,3 +1,5 @@
+#![cfg(feature = "db")]
+
 use autumn_harvest::event::WorkflowEvent;
 use autumn_harvest::store::events_to_insert_rows_from;
 use autumn_harvest::types::ExecutionId;

--- a/autumn-harvest/tests/security.rs
+++ b/autumn-harvest/tests/security.rs
@@ -1,0 +1,18 @@
+use autumn_harvest::store::events_to_insert_rows_from;
+use autumn_harvest::event::WorkflowEvent;
+use autumn_harvest::types::ExecutionId;
+
+#[test]
+#[should_panic(expected = "Event ID overflow")]
+fn test_integer_overflow_in_event_id() {
+    let events = vec![WorkflowEvent::WorkflowStarted {
+        input: serde_json::Value::Null,
+        timestamp: chrono::Utc::now(),
+    }, WorkflowEvent::WorkflowCompleted {
+        output: serde_json::Value::Null,
+    }];
+
+    let exec_id = ExecutionId::new();
+
+    let _rows = events_to_insert_rows_from(exec_id, &events, i32::MAX);
+}

--- a/autumn-harvest/tests/security.rs
+++ b/autumn-harvest/tests/security.rs
@@ -1,16 +1,19 @@
-use autumn_harvest::store::events_to_insert_rows_from;
 use autumn_harvest::event::WorkflowEvent;
+use autumn_harvest::store::events_to_insert_rows_from;
 use autumn_harvest::types::ExecutionId;
 
 #[test]
 #[should_panic(expected = "Event ID overflow")]
 fn test_integer_overflow_in_event_id() {
-    let events = vec![WorkflowEvent::WorkflowStarted {
-        input: serde_json::Value::Null,
-        timestamp: chrono::Utc::now(),
-    }, WorkflowEvent::WorkflowCompleted {
-        output: serde_json::Value::Null,
-    }];
+    let events = vec![
+        WorkflowEvent::WorkflowStarted {
+            input: serde_json::Value::Null,
+            timestamp: chrono::Utc::now(),
+        },
+        WorkflowEvent::WorkflowCompleted {
+            output: serde_json::Value::Null,
+        },
+    ];
 
     let exec_id = ExecutionId::new();
 


### PR DESCRIPTION
🦠 Threat: Integer overflow in `autumn-harvest/src/store.rs`'s `events_to_insert_rows_from` which calculates IDs via `start_id + i as i32`. An event array with massive sequences might breach max integers triggering silent overflows or panics when unhandled. The crate `rustls-webpki` contained a reachable panic CVE.
 
🛡️ Defense: Used safe `checked_add` method wrapped in an `.expect("Event ID overflow")` instead. This prevents unexpected behavior or wraparound by halting the problematic insert cleanly. Also bumped `rustls-webpki` to `0.103.13` via `cargo update`.
 
💥 Severity: Critical. Can lead to state and persistence corruption if DB operations unexpectedly wrap integer limits. CVE can lead to reachable panics in certificate parsing.
 
🧪 Verification: Added `tests/security.rs` containing `test_integer_overflow_in_event_id` marked with `#[should_panic]` that actively replicates overflowing `i32::MAX` boundary during insert rows building, succeeding properly. Cargo test passes.

---
*PR created automatically by Jules for task [1090080629640916047](https://jules.google.com/task/1090080629640916047) started by @madmax983*