### PR TITLE
🛡️ Sentry: [test coverage improvement] Enhance Error, Info, and Saga test suites

### DIFF
--- a/autumn-harvest/src/error.rs
+++ b/autumn-harvest/src/error.rs
@@ -156,4 +156,31 @@ mod tests {
         assert_eq!(r?, 42);
         Ok(())
     }
+    #[test]
+    fn harvest_error_saga_compensation_failed() {
+        let e = HarvestError::SagaCompensationFailed {
+            original: "network timeout".into(),
+            compensation_errors: vec!["db locked".into(), "disk full".into()],
+        };
+        assert!(e.to_string().contains("network timeout"));
+        assert!(e.to_string().contains("db locked"));
+        assert!(e.to_string().contains("disk full"));
+    }
+
+    #[test]
+    fn timeout_type_display_is_correct() {
+        assert_eq!(TimeoutType::StartToClose.to_string(), "StartToClose");
+        assert_eq!(TimeoutType::ScheduleToStart.to_string(), "ScheduleToStart");
+        assert_eq!(TimeoutType::ScheduleToClose.to_string(), "ScheduleToClose");
+        assert_eq!(TimeoutType::Heartbeat.to_string(), "Heartbeat");
+    }
+
+    #[test]
+    fn database_error_conversion() {
+        let err = database_error("connection refused");
+        match err {
+            HarvestError::Database(msg) => assert_eq!(msg, "connection refused"),
+            _ => panic!("Expected Database error"),
+        }
+    }
 }

--- a/autumn-harvest/src/info.rs
+++ b/autumn-harvest/src/info.rs
@@ -190,4 +190,42 @@ mod tests {
         assert_eq!(definition.tasks()[0].queue.as_deref(), Some("etl-workers"));
         assert_eq!(definition.tasks()[1].trigger_rule, TriggerRule::AllSuccess);
     }
+    #[test]
+    fn info_debug_formats_correctly() {
+        let workflow_info = WorkflowInfo {
+            name: "test_wf",
+            module: "test_mod",
+            handler: |_ctx, input| Box::pin(async move { Ok(input) }),
+        };
+        let debug_str = format!("{workflow_info:?}");
+        assert!(debug_str.contains("WorkflowInfo"));
+        assert!(debug_str.contains("test_wf"));
+
+        let activity_info = ActivityInfo {
+            name: "test_act",
+            module: "test_mod",
+            default_retry_policy: None,
+            default_start_to_close: None,
+            default_heartbeat_timeout: None,
+            default_schedule_to_start: None,
+            default_queue: None,
+            handler: |_ctx, input| Box::pin(async move { Ok(input) }),
+        };
+        let debug_str = format!("{activity_info:?}");
+        assert!(debug_str.contains("ActivityInfo"));
+        assert!(debug_str.contains("test_act"));
+
+        let dag_info = DagInfo {
+            name: "test_dag",
+            module: "test_mod",
+            schedule: None,
+            catchup: false,
+            max_active_runs: 1,
+            default_queue: None,
+            builder: |_| {},
+        };
+        let debug_str = format!("{dag_info:?}");
+        assert!(debug_str.contains("DagInfo"));
+        assert!(debug_str.contains("test_dag"));
+    }
 }

--- a/autumn-harvest/tests/saga_tests.rs
+++ b/autumn-harvest/tests/saga_tests.rs
@@ -285,3 +285,44 @@ async fn saga_reports_compensation_failures_with_original_error_and_keeps_unwind
     );
     assert_eq!(saga.pending_compensation_count(), 0);
 }
+
+#[tokio::test]
+async fn saga_compensate_all_reports_failures_when_compensations_fail() {
+    let ctx = test_context();
+    let mut saga = Saga::new(&ctx);
+
+    saga.step(
+        || async move { Ok::<_, HarvestError>("step1") },
+        |_| async move { Err::<(), _>(workflow_failed("comp_fail_1")) },
+    )
+    .await
+    .expect("step should succeed");
+
+    saga.step(
+        || async move { Ok::<_, HarvestError>("step2") },
+        |_| async move { Err::<(), _>(workflow_failed("comp_fail_2")) },
+    )
+    .await
+    .expect("step should succeed");
+
+    let error = saga.compensate_all().await.expect_err("should fail");
+    let HarvestError::SagaCompensationFailed {
+        original,
+        compensation_errors,
+    } = error
+    else {
+        panic!("expected SagaCompensationFailed, got {error:?}");
+    };
+
+    assert_eq!(original, "manual compensation requested");
+    assert_eq!(compensation_errors.len(), 2);
+    assert!(compensation_errors[0].contains("comp_fail_2"));
+    assert!(compensation_errors[1].contains("comp_fail_1"));
+}
+
+#[tokio::test]
+async fn saga_context_returns_provided_context() {
+    let ctx = test_context();
+    let saga = Saga::new(&ctx);
+    assert_eq!(saga.context().version("test", 1, 1), 1);
+}


### PR DESCRIPTION
🎯 Target: `autumn-harvest/src/error.rs`, `autumn-harvest/src/info.rs`, `autumn-harvest/src/saga.rs`, and `autumn-harvest/tests/saga_tests.rs`
💣 Risk: Previously missing basic Display/Debug sanity format tests, as well as an edge-case test for nested error propagation from Saga compensations logic.
🧪 Strategy: Standard inline Unit tests inside `#[cfg(test)] mod tests` checking basic struct outputs and the `HarvestError` enum payload mappings.
🔬 Verification: Run `cargo test -p autumn-harvest --lib --features testing`

---
*PR created automatically by Jules for task [14380052290190863443](https://jules.google.com/task/14380052290190863443) started by @madmax983*