### PR TITLE
👹 Havoc: Fuzzing harnesses for parsers and time logic

### DIFF
--- a/autumn-harvest/tests/havoc_tests.rs
+++ b/autumn-harvest/tests/havoc_tests.rs
@@ -1,5 +1,7 @@
 use autumn_harvest::policy::compute_retry_delay;
+use autumn_harvest::types::*;
 use proptest::prelude::*;
+use std::str::FromStr;
 use std::time::Duration;
 
 proptest! {
@@ -13,5 +15,29 @@ proptest! {
         let initial = Duration::from_secs(initial_secs);
         let max_interval = Duration::from_secs(max_interval_secs);
         let _delay = compute_retry_delay(initial, backoff, max_interval, attempt);
+    }
+}
+
+proptest! {
+    #[test]
+    fn havoc_task_duration_does_not_panic(s in "\\PC*") {
+        let _ = autumn_harvest::task_duration(&s);
+    }
+}
+
+proptest! {
+    #[test]
+    fn havoc_types_do_not_panic(s in "\\PC*") {
+        let _ = ExecutionId::from_str(&s);
+        let _ = ActivityExecId::from_str(&s);
+        let _ = TimerId::new(&s);
+    }
+}
+
+#[cfg(feature = "db")]
+proptest! {
+    #[test]
+    fn havoc_cron_schedule_does_not_panic(s in "\\PC*") {
+        let _ = croner::Cron::new(&s).parse();
     }
 }


### PR DESCRIPTION
* 🧊 **The Trigger:** Fuzzing string parsers (`task_duration`, `ExecutionId`, `ActivityExecId`, `TimerId`, `croner` schedules) and numeric overflow points (`compute_retry_delay`).
* 📉 **The Stack Trace:** (None! The codebase correctly bounded all math with saturating/clamping logic and properly implemented string parsers via checked ops or wrapped primitives, returning Results/Options instead of panicking.)
* 🧪 **Reproduction:** Run `cargo test -p autumn-harvest --test havoc_tests`
* 😈 **Comment:** I tried my absolute hardest to crash this using garbage strings and extreme boundaries (like testing exponential backoff with negative backoffs or `u32::MAX` attempts). Unfortunately for me, the application successfully guards against overflows and parse panics. I am submitting this harness anyway so that my future chaos brethren can catch you slipping when you refactor. (Note: concurrency torture via `loom` is blocked due to `tokio::net` mocking incompatibility in `hyper-util` upstream).

---
*PR created automatically by Jules for task [99892833085977733](https://jules.google.com/task/99892833085977733) started by @madmax983*