### PR TITLE
🔭 Vantage: Spec for OpenTelemetry Integration

### DIFF
--- a/docs/plans/vantage-spec-cancellation-semantics.md
+++ b/docs/plans/vantage-spec-cancellation-semantics.md
@@ -1,0 +1,26 @@
+# 🔭 Vantage: Spec for Cancellation Semantics
+
+## 👤 User Story
+As a Developer building long-running workflows, I want to explicitly cancel running workflows and have that cancellation propagate to running activities, so that I don't waste compute resources or create unwanted side-effects when a business process is aborted.
+
+## 📈 The "So What?" (Business Value)
+When a user aborts an operation (e.g., cancels an order, stops a data pipeline), the workflow engine must stop immediately. Right now, workflows just run to completion or fail. If we can't cancel them, we waste worker CPU cycles, database IO, and potentially make external API calls that cost money and cause state inconsistencies. By providing robust cancellation semantics, we allow businesses to halt expensive or erroneous operations gracefully, saving money and preventing incorrect side-effects.
+
+**Metric Definition:**
+- Success = 99% of cancelled workflows stop execution and clean up resources within 5 seconds of the cancellation signal.
+- Cost savings on worker compute and external API charges for aborted processes.
+
+## 🕵️ Gap Analysis
+- **Temporal/Cadence:** First-class support for cancellation scopes and propagation to activities.
+- **Current State (`autumn-harvest`):** Workflows can only be stopped by failing or finishing. Activities cannot be interrupted mid-flight.
+
+## ✅ Acceptance Criteria
+- Must allow operators to trigger a cancellation on a workflow execution via the Management API.
+- Must propagate the cancellation signal to the workflow coroutine, allowing it to perform cleanup before exiting.
+- Must propagate cancellation to currently executing activities (e.g., via a cancellation token or context).
+- Must gracefully handle the case where an activity ignores the cancellation (enforcing a hard timeout if necessary).
+- Must record a `WorkflowCancelled` event in the history log.
+
+## 🚫 Out of Scope
+- Rolling back already completed activities (that is the job of Saga primitives).
+- Preemptive OS-level thread killing of activities (cancellation is cooperative).

--- a/docs/plans/vantage-spec-opentelemetry.md
+++ b/docs/plans/vantage-spec-opentelemetry.md
@@ -1,0 +1,26 @@
+# 🔭 Vantage: Spec for OpenTelemetry Integration
+
+## 👤 User Story
+As an Operator monitoring production workloads, I want our workflows and activities to emit standard OpenTelemetry spans and metrics, so that I can visualize distributed traces across our microservices and quickly diagnose performance bottlenecks or failures.
+
+## 📈 The "So What?" (Business Value)
+What business problem does this solve? Currently, developers have to rely on custom logs or database queries to trace workflows. This siloed approach increases Mean Time to Resolution (MTTR) when debugging complex, multi-service orchestrations. By standardizing on OpenTelemetry, we integrate seamlessly with existing observability stacks (Datadog, Jaeger, Grafana), reducing debugging time and saving engineering costs.
+
+**Metric Definition:**
+- Success = 100% of workflow and activity executions emit standard traces.
+- 95% of operators can trace a request from their frontend through our durable workflows using their existing APM tools.
+
+## 🕵️ Gap Analysis
+- **Temporal/Cadence:** Offers built-in OpenTelemetry SDK integration and context propagation.
+- **Current State (`autumn-harvest`):** No tracing support. Logging is standard text, making it difficult to correlate a specific web request to the background activities it spawns across different workers.
+
+## ✅ Acceptance Criteria
+- Must automatically create spans for workflow executions, activity executions, and timer delays.
+- Must propagate trace context (Trace ID, Span ID) correctly across the Postgres task queue boundary (via headers or payload).
+- Must emit standard metrics (e.g., active workflow count, activity duration, task queue depth).
+- Must not enforce a specific OTel backend (the exporter must be configurable by the application developer).
+
+## 🚫 Out of Scope
+- Building a custom UI for tracing (users will use their existing tools like Jaeger, Datadog, etc.).
+- Implementing our own logging framework.
+- Adding auto-instrumentation to external third-party crates beyond our own execution context.


### PR DESCRIPTION
* 👤 **User Story:** As an Operator monitoring production workloads, I want our workflows and activities to emit standard OpenTelemetry spans and metrics, so that I can visualize distributed traces across our microservices and quickly diagnose performance bottlenecks or failures.
* ✅ **Acceptance Criteria:**
  - Must automatically create spans for workflow executions, activity executions, and timer delays.
  - Must propagate trace context (Trace ID, Span ID) correctly across the Postgres task queue boundary (via headers or payload).
  - Must emit standard metrics (e.g., active workflow count, activity duration, task queue depth).
  - Must not enforce a specific OTel backend (the exporter must be configurable by the application developer).
* 🚫 **Out of Scope:** Building a custom UI for tracing, implementing our own logging framework, or adding auto-instrumentation to external third-party crates beyond our own execution context.

---
*PR created automatically by Jules for task [1075757701553082188](https://jules.google.com/task/1075757701553082188) started by @madmax983*