### PR TITLE
👺 Havoc: Fix OOM Bomb and Panic in WorkflowCache

### DIFF
--- a/autumn-harvest/src/cache.rs
+++ b/autumn-harvest/src/cache.rs
@@ -42,6 +42,11 @@ impl WorkflowCache {
     /// The maximum size is also capped at 1,000,000 entries to prevent OOM
     /// conditions when large, arbitrary sizes are requested.
     ///
+    /// # Panics
+    ///
+    /// Panics if the clamped capacity somehow becomes zero (which should be
+    /// mathematically impossible due to the clamping bounds).
+    ///
     /// ## Examples
     ///
     /// ```rust

--- a/autumn-harvest/src/cache.rs
+++ b/autumn-harvest/src/cache.rs
@@ -38,9 +38,9 @@ pub struct WorkflowCache {
 impl WorkflowCache {
     /// Create a new cache with the given maximum number of entries.
     ///
-    /// # Panics
-    ///
-    /// Panics if `max_size` is zero.
+    /// If `max_size` is zero, it defaults to a capacity of 1.
+    /// The maximum size is also capped at 1,000,000 entries to prevent OOM
+    /// conditions when large, arbitrary sizes are requested.
     ///
     /// ## Examples
     ///
@@ -52,7 +52,9 @@ impl WorkflowCache {
     /// ```
     #[must_use]
     pub fn new(max_size: usize) -> Self {
-        let cap = NonZeroUsize::new(max_size).expect("cache max_size must be > 0");
+        // Havoc prevention: Cap max capacity to prevent OOM, and floor at 1 to prevent panic.
+        let safe_size = max_size.clamp(1, 1_000_000);
+        let cap = NonZeroUsize::new(safe_size).expect("clamp ensures size >= 1");
         Self {
             inner: LruCache::new(cap),
         }
@@ -228,6 +230,18 @@ mod tests {
     fn cache_get_missing_returns_none() {
         let mut cache = WorkflowCache::new(5);
         assert!(cache.get(&Uuid::new_v4()).is_none());
+    }
+
+    #[test]
+    fn cache_handles_zero_size_safely() {
+        let cache = WorkflowCache::new(0);
+        assert_eq!(cache.len(), 0);
+    }
+
+    #[test]
+    fn cache_handles_max_size_without_oom() {
+        let cache = WorkflowCache::new(usize::MAX);
+        assert_eq!(cache.len(), 0);
     }
 
     #[test]


### PR DESCRIPTION
🧨 **The Trigger:** 
A payload requesting an excessively large cache size (e.g. `usize::MAX` or even `1222220002` found via `cargo fuzz`) passed directly into `WorkflowCache::new(n)` causes `lru::LruCache` to attempt an astronomical memory allocation (`0x880000010` bytes). 
Additionally, passing `0` explicitly triggered an `expect` panic.

📉 **The Stack Trace:**
```
==57790==ERROR: AddressSanitizer: out of memory: allocator is trying to allocate 0x880000010 bytes
    #0 0x5631e97fa994  (/app/autumn-harvest/fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_target_32+0xea994)
    #1 0x5631e982c724  (/app/autumn-harvest/fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_target_32+0x11c724)
...
SUMMARY: AddressSanitizer: out-of-memory (/app/autumn-harvest/fuzz/target/x86_64-unknown-linux-gnu/release/fuzz_target_32+0xea994)
```

And for the panic on `0`:
```
thread '<unnamed>' (56139) panicked at /app/autumn-harvest/src/cache.rs:55:47:
cache max_size must be > 0
```

🧪 **Reproduction:**
```rust
use autumn_harvest::cache::WorkflowCache;

// Detonation 1: Panic
let _ = WorkflowCache::new(0);

// Detonation 2: Out of Memory
let _ = WorkflowCache::new(usize::MAX);
```

😈 **Comment:**
You assumed memory was infinite and zero meant "unlimited." You were wrong on both counts. I capped your cache at 1,000,000 items and floored it at 1. Next time, validate your bounds before the OS OOM killer validates them for you.

---
*PR created automatically by Jules for task [13514514957130377382](https://jules.google.com/task/13514514957130377382) started by @madmax983*