### PR TITLE
🎸 Bard: [documentation update]

### DIFF
--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -79,39 +79,61 @@ fn should_check_durable_cancellation(
 pub enum WorkflowCommand {
     /// Schedule an activity for execution on a task queue.
     ScheduleActivity {
+        /// The unique execution ID of the activity.
         activity_id: ActivityExecId,
+        /// The name of the activity to execute.
         name: String,
+        /// The input payload for the activity.
         input: Value,
+        /// The queue to schedule the activity on.
         queue: String,
         /// The worker sends the result back through this channel.
         result_tx: oneshot::Sender<Result<Value, String>>,
     },
     /// Start a durable timer.
     StartTimer {
+        /// The unique ID of the timer.
         timer_id: TimerId,
+        /// The duration to wait before firing the timer, in seconds.
         duration_secs: u64,
         /// Fires when the timer completes.
         result_tx: oneshot::Sender<()>,
     },
     /// Start a child workflow execution.
     StartChildWorkflow {
+        /// The unique execution ID of the child workflow.
         child_id: ExecutionId,
+        /// The name of the workflow to execute.
         workflow_name: String,
+        /// The input payload for the child workflow.
         input: Value,
         /// The worker sends the terminal child result back through this channel.
         result_tx: oneshot::Sender<Result<Value, String>>,
     },
     /// Record an opaque marker (used by version gates, side-effect-free notes).
-    RecordMarker { name: String, details: Value },
+    RecordMarker {
+        /// The name of the marker.
+        name: String,
+        /// Optional details or payload associated with the marker.
+        details: Value,
+    },
     /// Suspend until a named signal is delivered.
     WaitForSignal {
+        /// The name of the signal to wait for.
         signal_name: String,
+        /// The worker sends the signal payload back through this channel.
         result_tx: oneshot::Sender<Value>,
     },
     /// The workflow function returned `Ok(output)`.
-    Complete { output: Value },
+    Complete {
+        /// The final output payload of the workflow.
+        output: Value,
+    },
     /// The workflow function returned `Err(error)`.
-    Fail { error: String },
+    Fail {
+        /// The string representation of the error that caused the failure.
+        error: String,
+    },
 }
 
 // Manual Debug because oneshot::Sender is not Debug.

--- a/autumn-harvest/src/dag.rs
+++ b/autumn-harvest/src/dag.rs
@@ -25,11 +25,17 @@ struct PendingDagTask {
 /// Immutable task definition produced by [`DagBuilder::build`].
 #[derive(Debug, Clone)]
 pub struct DagTask {
+    /// The name of the activity.
     pub activity_name: String,
+    /// Indices of upstream tasks that must complete before this task.
     pub upstreams: Vec<usize>,
+    /// The trigger rule for this task.
     pub trigger_rule: TriggerRule,
+    /// The retry policy for this task.
     pub retry_policy: Option<RetryPolicy>,
+    /// The start-to-close timeout for this task.
     pub start_to_close: Option<Duration>,
+    /// The optional specific queue to schedule this task on.
     pub queue: Option<String>,
 }
 
@@ -54,11 +60,14 @@ pub struct DagDefinition {
 }
 
 impl DagDefinition {
+    /// Returns the linearised list of all tasks in the DAG.
     #[must_use]
     pub fn tasks(&self) -> &[DagTask] {
         &self.tasks
     }
 
+    /// Returns the DAG execution levels, where each level contains indices
+    /// of tasks that can be executed concurrently.
     #[must_use]
     pub fn execution_levels(&self) -> &[Vec<usize>] {
         &self.execution_levels
@@ -68,6 +77,7 @@ impl DagDefinition {
 /// Error returned when a DAG cannot be compiled.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DagBuildError {
+    /// The DAG contains a cyclic dependency, which prevents execution.
     CycleDetected,
 }
 
@@ -91,18 +101,19 @@ pub struct DagTaskRef {
 }
 
 impl DagTaskRef {
+    /// The numerical index of this task within the [`DagBuilder`].
     #[must_use]
     pub const fn index(&self) -> usize {
         self.index
     }
 
-    #[must_use]
     /// Declare that this task depends on `upstream`.
     ///
     /// # Panics
     ///
     /// Panics if `self` and `upstream` were created by different
     /// [`DagBuilder`] instances.
+    #[must_use]
     pub fn upstream(self, upstream: &Self) -> Self {
         assert!(
             Rc::ptr_eq(&self.tasks, &upstream.tasks),
@@ -115,21 +126,25 @@ impl DagTaskRef {
         })
     }
 
+    /// Set a custom trigger rule for this task.
     #[must_use]
     pub fn trigger_rule(self, trigger_rule: TriggerRule) -> Self {
         self.mutate(|task| task.trigger_rule = trigger_rule)
     }
 
+    /// Attach a specific retry policy to this task.
     #[must_use]
     pub fn retry(self, retry_policy: RetryPolicy) -> Self {
         self.mutate(|task| task.retry_policy = Some(retry_policy))
     }
 
+    /// Set a maximum start-to-close timeout duration for this task.
     #[must_use]
     pub fn start_to_close(self, timeout: Duration) -> Self {
         self.mutate(|task| task.start_to_close = Some(timeout))
     }
 
+    /// Assign this task to a specific task queue.
     #[must_use]
     pub fn queue(self, queue: impl Into<String>) -> Self {
         self.mutate(|task| task.queue = Some(queue.into()))
@@ -161,11 +176,29 @@ impl Default for DagBuilder {
 }
 
 impl DagBuilder {
+    /// Create a new, empty DAG builder.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// use autumn_harvest::dag::DagBuilder;
+    ///
+    /// let mut builder = DagBuilder::new();
+    /// ```
     #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
 
+    /// Create a new DAG builder that schedules tasks on `queue` by default.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// use autumn_harvest::dag::DagBuilder;
+    ///
+    /// let mut builder = DagBuilder::with_default_queue("my-queue");
+    /// ```
     #[must_use]
     pub fn with_default_queue(queue: impl Into<String>) -> Self {
         Self {
@@ -174,6 +207,18 @@ impl DagBuilder {
         }
     }
 
+    /// Add an activity task to the DAG.
+    ///
+    /// ## Examples
+    ///
+    /// ```rust
+    /// use autumn_harvest::dag::DagBuilder;
+    ///
+    /// fn my_activity() {}
+    ///
+    /// let mut builder = DagBuilder::new();
+    /// let task = builder.activity(my_activity);
+    /// ```
     #[must_use]
     pub fn activity<F>(&mut self, activity: F) -> DagTaskRef
     where

--- a/autumn-harvest/src/error.rs
+++ b/autumn-harvest/src/error.rs
@@ -53,49 +53,77 @@ impl std::fmt::Display for TimeoutType {
 /// ```
 #[derive(Debug, thiserror::Error)]
 pub enum HarvestError {
+    /// An activity execution failed and exhausted its retries (if any).
     #[error("activity failed: {name} (attempt {attempt}): {source}")]
     ActivityFailed {
+        /// The name of the failed activity.
         name: String,
+        /// The attempt number that failed.
         attempt: u32,
+        /// The underlying error source.
         #[source]
         source: Box<dyn std::error::Error + Send + Sync>,
     },
 
+    /// A workflow execution failed permanently.
     #[error("workflow failed: {name}: {reason}")]
-    WorkflowFailed { name: String, reason: String },
+    WorkflowFailed {
+        /// The name of the failed workflow.
+        name: String,
+        /// The reason string describing the failure.
+        reason: String,
+    },
 
+    /// The engine detected non-deterministic behavior during workflow replay.
     #[error("non-deterministic replay: {0}")]
     NonDeterministic(String),
 
+    /// The workflow was explicitly cancelled.
     #[error("workflow cancelled: {0}")]
     Cancelled(String),
 
+    /// A Saga compensation sequence failed while trying to rollback.
     #[error(
         "saga compensation failed after original error: {original}; compensation errors: {compensation_errors:?}"
     )]
     SagaCompensationFailed {
+        /// The original error that triggered the compensation.
         original: String,
+        /// The list of errors encountered during compensation steps.
         compensation_errors: Vec<String>,
     },
 
+    /// A timeout occurred for a workflow, activity, or execution component.
     #[error("timeout: {timeout_type} for {task_name}")]
     Timeout {
+        /// The specific type of timeout that occurred.
         timeout_type: TimeoutType,
+        /// The name of the task or entity that timed out.
         task_name: String,
     },
 
+    /// A payload could not be serialized or deserialized.
     #[error("serialization error: {0}")]
     Serialization(#[from] serde_json::Error),
 
+    /// A database operation failed.
     #[error("database error: {0}")]
     Database(String),
 
+    /// A task queue reached its maximum capacity.
     #[error("task queue is full (queue: {queue}, depth: {depth})")]
-    QueueFull { queue: String, depth: usize },
+    QueueFull {
+        /// The name of the full task queue.
+        queue: String,
+        /// The current depth/size of the queue.
+        depth: usize,
+    },
 
+    /// The requested workflow execution could not be found.
     #[error("workflow execution not found: {0}")]
     NotFound(String),
 
+    /// Invalid configuration provided to the engine.
     #[error("invalid configuration: {0}")]
     Config(String),
 }

--- a/autumn-harvest/src/lib.rs
+++ b/autumn-harvest/src/lib.rs
@@ -18,6 +18,7 @@ pub mod builder;
 pub mod cache;
 pub mod context;
 pub mod dag;
+/// Export format types for Directed Acyclic Graphs (DAGs) representing workflows.
 pub mod dag_export;
 pub mod error;
 pub mod event;
@@ -30,6 +31,7 @@ pub mod info;
 pub mod policy;
 pub mod pool;
 pub mod prelude;
+/// Types and definitions for querying workflow state and metadata.
 pub mod query;
 pub mod replay;
 pub mod saga;

--- a/autumn-harvest/src/replay.rs
+++ b/autumn-harvest/src/replay.rs
@@ -559,6 +559,14 @@ impl HistoryMatcher {
         }
     }
 
+    /// Versioning mechanism for safe workflow code changes.
+    ///
+    /// Checks the recorded history for a version marker. If the marker is present
+    /// in history, returns the recorded version. If not in history (first execution
+    /// or unversioned branch), records `max_version` as a marker and returns it.
+    ///
+    /// This ensures that existing non-deterministic executions continue correctly,
+    /// while new executions start on the new `max_version` path.
     pub fn match_version(&mut self, change_id: &str, min_version: u32, max_version: u32) -> u32 {
         self.advance_to_next_unconsumed_event();
         let marker_name = format!("version:{change_id}");


### PR DESCRIPTION
📖 Chapter: Documented core engine structs and enums (`WorkflowCommand`, `HarvestError`, `DagTask`, `DagBuilder`, and `match_version`).
💡 Insight: Clarified the purpose of workflow commands, detailed error variants and their contents, and explained how the deterministic version matcher handles historical replays safely.
🧪 Example: Added executable doctests for `DagBuilder::new`, `DagBuilder::with_default_queue`, and `DagBuilder::activity`.
🖼️ Preview: Documentation builds cleanly without warnings via `cargo rustdoc -p autumn-harvest -- -D missing_docs`.

---
*PR created automatically by Jules for task [13017535056574540847](https://jules.google.com/task/13017535056574540847) started by @madmax983*