### PR TITLE
Add sticky cross-worker routing for workflow task affinity

### DIFF
--- a/autumn-harvest/migrations/20260409000000_harvest_initial/up.sql
+++ b/autumn-harvest/migrations/20260409000000_harvest_initial/up.sql
@@ -70,7 +70,18 @@ CREATE TABLE harvest_task_queue (
     schedule_to_start   INTERVAL,
     retry_policy        JSONB,
     output              JSONB,
-    error               TEXT
+    error               TEXT,
+    -- Sticky cross-worker routing: optional affinity to a specific worker that
+    -- already holds workflow state in its LRU cache. `sticky_until` is the
+    -- grace period during which only the pinned worker preferentially claims;
+    -- once elapsed, any worker may claim, so a crashed sticky worker never
+    -- blocks progress. `sticky_timeout` captures the refresh interval so wakes
+    -- can extend the window by a consistent amount.
+    sticky_worker_id    TEXT,
+    sticky_until        TIMESTAMPTZ,
+    sticky_timeout      INTERVAL,
+    CONSTRAINT harvest_tq_sticky_pair_ck
+        CHECK ((sticky_worker_id IS NULL) = (sticky_until IS NULL))
 );
 
 CREATE INDEX idx_harvest_tq_poll ON harvest_task_queue
@@ -80,6 +91,9 @@ CREATE INDEX idx_harvest_tq_running ON harvest_task_queue
     (state, last_heartbeat_at)
     WHERE state = 'RUNNING';
 CREATE INDEX idx_harvest_tq_workflow ON harvest_task_queue (workflow_exec_id);
+CREATE INDEX idx_harvest_tq_sticky_poll ON harvest_task_queue
+    (sticky_worker_id, queue_name, priority DESC, scheduled_at)
+    WHERE state = 'PENDING' AND sticky_worker_id IS NOT NULL;
 
 -- DAG runs
 CREATE TABLE harvest_dag_runs (

--- a/autumn-harvest/migrations/20260424000000_harvest_sticky_routing/down.sql
+++ b/autumn-harvest/migrations/20260424000000_harvest_sticky_routing/down.sql
@@ -1,0 +1,9 @@
+DROP INDEX IF EXISTS idx_harvest_tq_sticky_poll;
+
+ALTER TABLE harvest_task_queue
+    DROP CONSTRAINT IF EXISTS harvest_tq_sticky_pair_ck;
+
+ALTER TABLE harvest_task_queue
+    DROP COLUMN IF EXISTS sticky_timeout,
+    DROP COLUMN IF EXISTS sticky_until,
+    DROP COLUMN IF EXISTS sticky_worker_id;

--- a/autumn-harvest/migrations/20260424000000_harvest_sticky_routing/up.sql
+++ b/autumn-harvest/migrations/20260424000000_harvest_sticky_routing/up.sql
@@ -1,0 +1,32 @@
+-- Add sticky cross-worker routing columns to harvest_task_queue for legacy
+-- databases that were created before the initial migration was amended to
+-- include them. Fresh installs applying the updated initial migration already
+-- have these columns; this migration is a no-op there.
+--
+-- Sticky routing lets workflow follow-up tasks preferentially land on the
+-- worker whose in-process LRU cache holds the workflow state. When the pinned
+-- worker does not claim the task before `sticky_until` elapses, any worker may
+-- claim it, so a crashed or slow sticky worker never blocks progress.
+
+ALTER TABLE harvest_task_queue
+    ADD COLUMN IF NOT EXISTS sticky_worker_id TEXT,
+    ADD COLUMN IF NOT EXISTS sticky_until     TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS sticky_timeout   INTERVAL;
+
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conrelid = 'harvest_task_queue'::regclass
+          AND conname = 'harvest_tq_sticky_pair_ck'
+    ) THEN
+        ALTER TABLE harvest_task_queue
+            ADD CONSTRAINT harvest_tq_sticky_pair_ck
+            CHECK ((sticky_worker_id IS NULL) = (sticky_until IS NULL));
+    END IF;
+END $$;
+
+CREATE INDEX IF NOT EXISTS idx_harvest_tq_sticky_poll ON harvest_task_queue
+    (sticky_worker_id, queue_name, priority DESC, scheduled_at)
+    WHERE state = 'PENDING' AND sticky_worker_id IS NOT NULL;

--- a/autumn-harvest/src/models.rs
+++ b/autumn-harvest/src/models.rs
@@ -124,6 +124,9 @@ pub struct TaskQueueItem {
     pub retry_policy: Option<serde_json::Value>,
     pub output: Option<serde_json::Value>,
     pub error: Option<String>,
+    pub sticky_worker_id: Option<String>,
+    pub sticky_until: Option<DateTime<Utc>>,
+    pub sticky_timeout: Option<chrono::Duration>,
 }
 
 /// Insert struct for enqueuing a new task.
@@ -143,6 +146,9 @@ pub struct NewTaskQueueItem<'a> {
     pub start_to_close: Option<chrono::Duration>,
     pub schedule_to_start: Option<chrono::Duration>,
     pub retry_policy: Option<serde_json::Value>,
+    pub sticky_worker_id: Option<&'a str>,
+    pub sticky_until: Option<DateTime<Utc>>,
+    pub sticky_timeout: Option<chrono::Duration>,
 }
 
 // ── DagRun ────────────────────────────────────────────────────────────────────

--- a/autumn-harvest/src/queue.rs
+++ b/autumn-harvest/src/queue.rs
@@ -138,22 +138,19 @@ pub async fn enqueue(conn: &mut AsyncPgConnection, params: &EnqueueParams) -> Ha
 
     // Sticky pin: only valid when both worker_id and timeout are present so the
     // check constraint `sticky_worker_id IS NULL <=> sticky_until IS NULL` holds.
-    let (sticky_worker_id, sticky_until, sticky_timeout) =
-        match (params.sticky_worker_id.as_deref(), params.sticky_timeout) {
-            (Some(worker), Some(timeout)) => {
-                let chrono_timeout = chrono::Duration::from_std(timeout).map_err(|_| {
-                    crate::error::HarvestError::Config(
-                        "sticky_timeout exceeds chrono duration range".to_string(),
-                    )
-                })?;
-                (
-                    Some(worker),
-                    Some(Utc::now() + chrono_timeout),
-                    Some(chrono_timeout),
+    // sticky_until is computed below via DB NOW() in a follow-up UPDATE so it
+    // agrees with the clock used by `claim_task` and `wake_workflow_task`.
+    let sticky = match (params.sticky_worker_id.as_deref(), params.sticky_timeout) {
+        (Some(worker), Some(timeout)) => {
+            let chrono_timeout = chrono::Duration::from_std(timeout).map_err(|_| {
+                crate::error::HarvestError::Config(
+                    "sticky_timeout exceeds chrono duration range".to_string(),
                 )
-            }
-            _ => (None, None, None),
-        };
+            })?;
+            Some((worker, chrono_timeout))
+        }
+        _ => None,
+    };
 
     let row = NewTaskQueueItem {
         id: task_id,
@@ -169,9 +166,9 @@ pub async fn enqueue(conn: &mut AsyncPgConnection, params: &EnqueueParams) -> Ha
         start_to_close: params.start_to_close,
         schedule_to_start: params.schedule_to_start,
         retry_policy: params.retry_policy.clone(),
-        sticky_worker_id,
-        sticky_until,
-        sticky_timeout,
+        sticky_worker_id: None,
+        sticky_until: None,
+        sticky_timeout: None,
     };
 
     diesel::insert_into(harvest_task_queue::table)
@@ -179,6 +176,22 @@ pub async fn enqueue(conn: &mut AsyncPgConnection, params: &EnqueueParams) -> Ha
         .execute(conn)
         .await
         .map_err(crate::error::database_error)?;
+
+    if let Some((worker_id, timeout)) = sticky {
+        diesel::sql_query(
+            "UPDATE harvest_task_queue \
+             SET sticky_worker_id = $2, \
+                 sticky_until = NOW() + $3, \
+                 sticky_timeout = $3 \
+             WHERE id = $1",
+        )
+        .bind::<diesel::sql_types::Uuid, _>(task_id)
+        .bind::<diesel::sql_types::Text, _>(worker_id)
+        .bind::<diesel::sql_types::Interval, _>(timeout)
+        .execute(conn)
+        .await
+        .map_err(crate::error::database_error)?;
+    }
 
     crate::notify::notify_task_enqueued(conn, &params.queue_name, task_id).await?;
 
@@ -462,21 +475,26 @@ pub async fn set_task_sticky_affinity(
     task_id: Uuid,
     sticky: Option<StickyHint<'_>>,
 ) -> HarvestResult<()> {
-    use crate::schema::harvest_task_queue::dsl;
-
+    // Use DB NOW() for sticky_until so all rows agree on a single clock with
+    // `claim_task` and `wake_workflow_task`. See `park_workflow_task` for the
+    // rationale.
     let updated = if let Some(hint) = sticky {
         let timeout = hint.chrono_timeout()?;
-        let sticky_until = Utc::now() + timeout;
-        diesel::update(dsl::harvest_task_queue.find(task_id))
-            .set((
-                dsl::sticky_worker_id.eq(Some(hint.worker_id.to_string())),
-                dsl::sticky_until.eq(Some(sticky_until)),
-                dsl::sticky_timeout.eq(Some(timeout)),
-            ))
-            .execute(conn)
-            .await
-            .map_err(crate::error::database_error)?
+        diesel::sql_query(
+            "UPDATE harvest_task_queue \
+             SET sticky_worker_id = $2, \
+                 sticky_until = NOW() + $3, \
+                 sticky_timeout = $3 \
+             WHERE id = $1",
+        )
+        .bind::<diesel::sql_types::Uuid, _>(task_id)
+        .bind::<diesel::sql_types::Text, _>(hint.worker_id)
+        .bind::<diesel::sql_types::Interval, _>(timeout)
+        .execute(conn)
+        .await
+        .map_err(crate::error::database_error)?
     } else {
+        use crate::schema::harvest_task_queue::dsl;
         diesel::update(dsl::harvest_task_queue.find(task_id))
             .set((
                 dsl::sticky_worker_id.eq(None::<String>),
@@ -516,36 +534,44 @@ pub async fn park_workflow_task(
     task_id: Uuid,
     sticky: Option<StickyHint<'_>>,
 ) -> HarvestResult<()> {
-    use crate::schema::harvest_task_queue::dsl;
-
-    let base_query = dsl::harvest_task_queue
-        .find(task_id)
-        .filter(dsl::task_type.eq(TaskType::Workflow.as_str()))
-        .filter(dsl::state.eq("RUNNING"));
-
+    // Use raw SQL when applying a sticky hint so `sticky_until` is computed
+    // from Postgres `NOW()` -- the same clock used by `wake_workflow_task` and
+    // `claim_task`. Mixing host-clock and DB-clock timestamps on the same row
+    // breaks comparisons under testcontainers / cross-host clock skew.
     let updated = if let Some(hint) = sticky {
         let timeout = hint.chrono_timeout()?;
-        let sticky_until = Utc::now() + timeout;
-        diesel::update(base_query)
-            .set((
-                dsl::worker_id.eq(None::<String>),
-                dsl::started_at.eq(None::<chrono::DateTime<Utc>>),
-                dsl::sticky_worker_id.eq(Some(hint.worker_id.to_string())),
-                dsl::sticky_until.eq(Some(sticky_until)),
-                dsl::sticky_timeout.eq(Some(timeout)),
-            ))
-            .execute(conn)
-            .await
-            .map_err(crate::error::database_error)?
+        diesel::sql_query(
+            "UPDATE harvest_task_queue \
+             SET worker_id = NULL, \
+                 started_at = NULL, \
+                 sticky_worker_id = $2, \
+                 sticky_until = NOW() + $3, \
+                 sticky_timeout = $3 \
+             WHERE id = $1 \
+               AND task_type = 'workflow' \
+               AND state = 'RUNNING'",
+        )
+        .bind::<diesel::sql_types::Uuid, _>(task_id)
+        .bind::<diesel::sql_types::Text, _>(hint.worker_id)
+        .bind::<diesel::sql_types::Interval, _>(timeout)
+        .execute(conn)
+        .await
+        .map_err(crate::error::database_error)?
     } else {
-        diesel::update(base_query)
-            .set((
-                dsl::worker_id.eq(None::<String>),
-                dsl::started_at.eq(None::<chrono::DateTime<Utc>>),
-            ))
-            .execute(conn)
-            .await
-            .map_err(crate::error::database_error)?
+        use crate::schema::harvest_task_queue::dsl;
+        diesel::update(
+            dsl::harvest_task_queue
+                .find(task_id)
+                .filter(dsl::task_type.eq(TaskType::Workflow.as_str()))
+                .filter(dsl::state.eq("RUNNING")),
+        )
+        .set((
+            dsl::worker_id.eq(None::<String>),
+            dsl::started_at.eq(None::<chrono::DateTime<Utc>>),
+        ))
+        .execute(conn)
+        .await
+        .map_err(crate::error::database_error)?
     };
 
     if updated == 0 {

--- a/autumn-harvest/src/queue.rs
+++ b/autumn-harvest/src/queue.rs
@@ -4,8 +4,9 @@
 //! moves a `PENDING` row to `RUNNING` using `FOR UPDATE SKIP LOCKED` --
 //! no two workers will ever claim the same task.
 
+use std::time::Duration as StdDuration;
+
 use chrono::{Duration, Utc};
-use diesel::BoolExpressionMethods;
 use diesel::ExpressionMethods;
 use diesel::OptionalExtension;
 use diesel::QueryDsl;
@@ -70,6 +71,16 @@ pub struct EnqueueParams {
     pub start_to_close: Option<Duration>,
     pub schedule_to_start: Option<Duration>,
     pub retry_policy: Option<serde_json::Value>,
+    /// Pin this task to a specific worker for best-effort cache locality.
+    ///
+    /// When set together with [`Self::sticky_timeout`], the task is offered to
+    /// this worker preferentially for `sticky_timeout` after it becomes
+    /// claimable. Once the window expires, any worker may claim it.
+    pub sticky_worker_id: Option<String>,
+    /// Duration of the sticky preference window. Stored on the row so that
+    /// [`wake_workflow_task()`] can refresh `sticky_until` to the same value
+    /// on each transition back to PENDING without needing external config.
+    pub sticky_timeout: Option<StdDuration>,
 }
 
 impl EnqueueParams {
@@ -95,7 +106,19 @@ impl EnqueueParams {
             start_to_close: None,
             schedule_to_start: None,
             retry_policy: None,
+            sticky_worker_id: None,
+            sticky_timeout: None,
         }
+    }
+
+    /// Pin this task to the given worker for the duration of `timeout`.
+    ///
+    /// Both fields are required together -- passing either alone is a no-op.
+    #[must_use]
+    pub fn with_sticky(mut self, worker_id: impl Into<String>, timeout: StdDuration) -> Self {
+        self.sticky_worker_id = Some(worker_id.into());
+        self.sticky_timeout = Some(timeout);
+        self
     }
 }
 
@@ -113,6 +136,25 @@ pub async fn enqueue(conn: &mut AsyncPgConnection, params: &EnqueueParams) -> Ha
 
     let task_id = Uuid::new_v4();
 
+    // Sticky pin: only valid when both worker_id and timeout are present so the
+    // check constraint `sticky_worker_id IS NULL <=> sticky_until IS NULL` holds.
+    let (sticky_worker_id, sticky_until, sticky_timeout) =
+        match (params.sticky_worker_id.as_deref(), params.sticky_timeout) {
+            (Some(worker), Some(timeout)) => {
+                let chrono_timeout = chrono::Duration::from_std(timeout).map_err(|_| {
+                    crate::error::HarvestError::Config(
+                        "sticky_timeout exceeds chrono duration range".to_string(),
+                    )
+                })?;
+                (
+                    Some(worker),
+                    Some(Utc::now() + chrono_timeout),
+                    Some(chrono_timeout),
+                )
+            }
+            _ => (None, None, None),
+        };
+
     let row = NewTaskQueueItem {
         id: task_id,
         queue_name: &params.queue_name,
@@ -127,6 +169,9 @@ pub async fn enqueue(conn: &mut AsyncPgConnection, params: &EnqueueParams) -> Ha
         start_to_close: params.start_to_close,
         schedule_to_start: params.schedule_to_start,
         retry_policy: params.retry_policy.clone(),
+        sticky_worker_id,
+        sticky_until,
+        sticky_timeout,
     };
 
     diesel::insert_into(harvest_task_queue::table)
@@ -145,6 +190,14 @@ pub async fn enqueue(conn: &mut AsyncPgConnection, params: &EnqueueParams) -> Ha
 /// Uses `FOR UPDATE SKIP LOCKED` so concurrent workers never contend on the
 /// same row. Returns `None` if no eligible task is available.
 ///
+/// # Sticky routing
+///
+/// When a row has `sticky_worker_id` set and `sticky_until > NOW()`, only that
+/// worker may claim it. Once `sticky_until` elapses, any worker becomes
+/// eligible, so a crashed or slow sticky worker never blocks progress.
+/// Within the eligible set, rows pinned to the caller are sorted ahead of
+/// unpinned rows to maximize cache locality.
+///
 /// # Errors
 ///
 /// Returns [`crate::error::HarvestError::Database`] on query failure.
@@ -158,8 +211,19 @@ pub async fn claim_task(
          SET state = 'RUNNING', worker_id = $1, started_at = NOW(), attempt = attempt + 1 \
          WHERE id = ( \
              SELECT id FROM harvest_task_queue \
-             WHERE queue_name = ANY($2) AND state = 'PENDING' AND scheduled_at <= NOW() \
-             ORDER BY priority DESC, scheduled_at ASC \
+             WHERE queue_name = ANY($2) \
+               AND state = 'PENDING' \
+               AND scheduled_at <= NOW() \
+               AND ( \
+                   sticky_worker_id IS NULL \
+                   OR sticky_worker_id = $1 \
+                   OR sticky_until IS NULL \
+                   OR sticky_until <= NOW() \
+               ) \
+             ORDER BY \
+                 (sticky_worker_id = $1 AND sticky_until > NOW()) DESC NULLS LAST, \
+                 priority DESC, \
+                 scheduled_at ASC \
              LIMIT 1 FOR UPDATE SKIP LOCKED \
          ) RETURNING *",
     )
@@ -353,31 +417,136 @@ pub async fn reschedule_task(
     Ok(())
 }
 
+/// Hint for sticky cross-worker routing when parking or enqueueing a task.
+///
+/// When both fields are set, the task is pinned to `worker_id` for `timeout`
+/// so the worker's in-process LRU cache can service follow-up replays without
+/// reloading history from Postgres. A `None` hint leaves the task unpinned.
+#[derive(Debug, Clone, Copy)]
+pub struct StickyHint<'a> {
+    pub worker_id: &'a str,
+    pub timeout: StdDuration,
+}
+
+impl<'a> StickyHint<'a> {
+    /// Create a new sticky hint.
+    #[must_use]
+    pub const fn new(worker_id: &'a str, timeout: StdDuration) -> Self {
+        Self { worker_id, timeout }
+    }
+
+    fn chrono_timeout(self) -> HarvestResult<chrono::Duration> {
+        chrono::Duration::from_std(self.timeout).map_err(|_| {
+            crate::error::HarvestError::Config(
+                "sticky_timeout exceeds chrono duration range".to_string(),
+            )
+        })
+    }
+}
+
+/// Pin a task row to a specific worker for best-effort sticky routing.
+///
+/// Overwrites any existing sticky affinity on the row with the new worker
+/// and a fresh `sticky_until = NOW() + hint.timeout`. Use this after calls
+/// like [`reschedule_task()`] or [`enqueue()`] when the caller wants the
+/// target worker to preferentially claim the task once it becomes due.
+///
+/// Passing `None` clears any existing pin.
+///
+/// # Errors
+///
+/// Returns [`crate::error::HarvestError::Database`] on update failure or
+/// [`crate::error::HarvestError::NotFound`] if the row does not exist.
+pub async fn set_task_sticky_affinity(
+    conn: &mut AsyncPgConnection,
+    task_id: Uuid,
+    sticky: Option<StickyHint<'_>>,
+) -> HarvestResult<()> {
+    use crate::schema::harvest_task_queue::dsl;
+
+    let updated = if let Some(hint) = sticky {
+        let timeout = hint.chrono_timeout()?;
+        let sticky_until = Utc::now() + timeout;
+        diesel::update(dsl::harvest_task_queue.find(task_id))
+            .set((
+                dsl::sticky_worker_id.eq(Some(hint.worker_id.to_string())),
+                dsl::sticky_until.eq(Some(sticky_until)),
+                dsl::sticky_timeout.eq(Some(timeout)),
+            ))
+            .execute(conn)
+            .await
+            .map_err(crate::error::database_error)?
+    } else {
+        diesel::update(dsl::harvest_task_queue.find(task_id))
+            .set((
+                dsl::sticky_worker_id.eq(None::<String>),
+                dsl::sticky_until.eq(None::<chrono::DateTime<Utc>>),
+                dsl::sticky_timeout.eq(None::<chrono::Duration>),
+            ))
+            .execute(conn)
+            .await
+            .map_err(crate::error::database_error)?
+    };
+
+    if updated == 0 {
+        return Err(crate::error::HarvestError::NotFound(format!(
+            "task queue item {task_id} does not exist"
+        )));
+    }
+
+    Ok(())
+}
+
 /// Mark a running workflow task as parked while it waits on an external event.
 ///
 /// Parked tasks stay in `RUNNING` state so they remain attached to the same
 /// workflow execution, but their worker ownership and start timestamp are cleared
 /// so wake-up paths can distinguish them from actively executing workflow tasks.
 ///
+/// If `sticky` is supplied, the row is pinned to the given worker for the
+/// configured duration. This lets the next wake-up preferentially land back on
+/// the worker that just produced the park -- the same worker whose in-process
+/// LRU cache holds the workflow state.
+///
 /// # Errors
 ///
 /// Returns [`crate::error::HarvestError::Database`] on update failure.
-pub async fn park_workflow_task(conn: &mut AsyncPgConnection, task_id: Uuid) -> HarvestResult<()> {
+pub async fn park_workflow_task(
+    conn: &mut AsyncPgConnection,
+    task_id: Uuid,
+    sticky: Option<StickyHint<'_>>,
+) -> HarvestResult<()> {
     use crate::schema::harvest_task_queue::dsl;
 
-    let updated = diesel::update(
-        dsl::harvest_task_queue
-            .find(task_id)
-            .filter(dsl::task_type.eq(TaskType::Workflow.as_str()))
-            .filter(dsl::state.eq("RUNNING")),
-    )
-    .set((
-        dsl::worker_id.eq(None::<String>),
-        dsl::started_at.eq(None::<chrono::DateTime<Utc>>),
-    ))
-    .execute(conn)
-    .await
-    .map_err(crate::error::database_error)?;
+    let base_query = dsl::harvest_task_queue
+        .find(task_id)
+        .filter(dsl::task_type.eq(TaskType::Workflow.as_str()))
+        .filter(dsl::state.eq("RUNNING"));
+
+    let updated = if let Some(hint) = sticky {
+        let timeout = hint.chrono_timeout()?;
+        let sticky_until = Utc::now() + timeout;
+        diesel::update(base_query)
+            .set((
+                dsl::worker_id.eq(None::<String>),
+                dsl::started_at.eq(None::<chrono::DateTime<Utc>>),
+                dsl::sticky_worker_id.eq(Some(hint.worker_id.to_string())),
+                dsl::sticky_until.eq(Some(sticky_until)),
+                dsl::sticky_timeout.eq(Some(timeout)),
+            ))
+            .execute(conn)
+            .await
+            .map_err(crate::error::database_error)?
+    } else {
+        diesel::update(base_query)
+            .set((
+                dsl::worker_id.eq(None::<String>),
+                dsl::started_at.eq(None::<chrono::DateTime<Utc>>),
+            ))
+            .execute(conn)
+            .await
+            .map_err(crate::error::database_error)?
+    };
 
     if updated == 0 {
         return Err(crate::error::HarvestError::NotFound(format!(
@@ -396,6 +565,11 @@ pub async fn park_workflow_task(conn: &mut AsyncPgConnection, task_id: Uuid) -> 
 /// rows (e.g. timer-scheduled tasks) are intentionally excluded. If no parked
 /// workflow task exists, this is a no-op.
 ///
+/// If the parked row carries a `sticky_timeout`, `sticky_until` is refreshed
+/// to `NOW() + sticky_timeout` so the pinned worker gets a fresh grace period
+/// each time the task becomes claimable. Rows without a stored timeout keep
+/// their existing `sticky_until` value (which will simply expire if stale).
+///
 /// # Errors
 ///
 /// Returns [`crate::error::HarvestError::Database`] on update failure.
@@ -403,29 +577,45 @@ pub async fn wake_workflow_task(
     conn: &mut AsyncPgConnection,
     exec_id: ExecutionId,
 ) -> HarvestResult<()> {
-    use crate::schema::harvest_task_queue::dsl;
+    // Use raw SQL so we can refresh `sticky_until` from the row's own
+    // `sticky_timeout` column atomically in a single UPDATE. Doing this in
+    // two trips (SELECT then UPDATE) would race with other wake paths.
+    let queue_names: Vec<String> = {
+        use diesel::deserialize::QueryableByName;
+        use diesel::sql_types::Text;
 
-    let queue_names = diesel::update(
-        dsl::harvest_task_queue
-            .filter(dsl::workflow_exec_id.eq(Some(exec_id.as_uuid())))
-            .filter(dsl::task_type.eq(TaskType::Workflow.as_str()))
-            .filter(
-                dsl::state
-                    .eq("RUNNING")
-                    .and(dsl::worker_id.is_null())
-                    .and(dsl::started_at.is_null()),
-            ),
-    )
-    .set((
-        dsl::state.eq("PENDING"),
-        dsl::worker_id.eq(None::<String>),
-        dsl::started_at.eq(None::<chrono::DateTime<Utc>>),
-        dsl::scheduled_at.eq(Utc::now() - IMMEDIATE_SCHEDULE_SKEW_ALLOWANCE),
-    ))
-    .returning(dsl::queue_name)
-    .get_results::<String>(conn)
-    .await
-    .map_err(crate::error::database_error)?;
+        #[derive(QueryableByName)]
+        struct QueueNameRow {
+            #[diesel(sql_type = Text)]
+            queue_name: String,
+        }
+
+        let rows: Vec<QueueNameRow> = diesel::sql_query(
+            "UPDATE harvest_task_queue \
+             SET state = 'PENDING', \
+                 worker_id = NULL, \
+                 started_at = NULL, \
+                 scheduled_at = $2, \
+                 sticky_until = CASE \
+                     WHEN sticky_worker_id IS NOT NULL AND sticky_timeout IS NOT NULL \
+                     THEN NOW() + sticky_timeout \
+                     ELSE sticky_until \
+                 END \
+             WHERE workflow_exec_id = $1 \
+               AND task_type = 'workflow' \
+               AND state = 'RUNNING' \
+               AND worker_id IS NULL \
+               AND started_at IS NULL \
+             RETURNING queue_name",
+        )
+        .bind::<diesel::sql_types::Uuid, _>(exec_id.as_uuid())
+        .bind::<diesel::sql_types::Timestamptz, _>(Utc::now() - IMMEDIATE_SCHEDULE_SKEW_ALLOWANCE)
+        .load(conn)
+        .await
+        .map_err(crate::error::database_error)?;
+
+        rows.into_iter().map(|r| r.queue_name).collect()
+    };
 
     let mut queue_names = queue_names;
     queue_names.sort();
@@ -485,5 +675,33 @@ mod tests {
         assert_eq!(params.priority, 10);
         assert_eq!(params.max_attempts, 5);
         assert!(params.workflow_exec_id.is_some());
+    }
+
+    #[test]
+    fn enqueue_params_defaults_have_no_sticky_pin() {
+        let params = EnqueueParams::new("default", TaskType::Workflow, serde_json::json!(null));
+        assert!(params.sticky_worker_id.is_none());
+        assert!(params.sticky_timeout.is_none());
+    }
+
+    #[test]
+    fn enqueue_params_with_sticky_sets_both_fields() {
+        let params = EnqueueParams::new("default", TaskType::Workflow, serde_json::json!(null))
+            .with_sticky("worker-42", StdDuration::from_secs(7));
+        assert_eq!(params.sticky_worker_id.as_deref(), Some("worker-42"));
+        assert_eq!(params.sticky_timeout, Some(StdDuration::from_secs(7)));
+    }
+
+    #[test]
+    fn sticky_hint_constructs_with_fields() {
+        let hint = StickyHint::new("w1", StdDuration::from_secs(3));
+        assert_eq!(hint.worker_id, "w1");
+        assert_eq!(hint.timeout, StdDuration::from_secs(3));
+    }
+
+    #[test]
+    fn sticky_hint_rejects_out_of_range_duration() {
+        let hint = StickyHint::new("w1", StdDuration::from_secs(u64::MAX));
+        assert!(hint.chrono_timeout().is_err());
     }
 }

--- a/autumn-harvest/src/schema.rs
+++ b/autumn-harvest/src/schema.rs
@@ -65,6 +65,9 @@ diesel::table! {
         retry_policy -> Nullable<Jsonb>,
         output -> Nullable<Jsonb>,
         error -> Nullable<Text>,
+        sticky_worker_id -> Nullable<Text>,
+        sticky_until -> Nullable<Timestamptz>,
+        sticky_timeout -> Nullable<Interval>,
     }
 }
 

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -66,6 +66,10 @@ pub struct WorkerRuntimeConfig {
     pub poll_interval: Duration,
     /// Maximum time to wait for in-flight tasks during shutdown.
     pub shutdown_timeout: Duration,
+    /// Grace period during which subsequent tasks for a workflow are offered
+    /// preferentially to this worker so its in-process LRU cache stays warm.
+    /// Zero disables sticky routing entirely.
+    pub sticky_timeout: Duration,
 }
 
 impl WorkerRuntimeConfig {
@@ -94,6 +98,7 @@ impl From<WorkerConfig> for WorkerRuntimeConfig {
             max_concurrent_activities: cfg.max_concurrent_activities,
             poll_interval: Duration::from_millis(500),
             shutdown_timeout: cfg.shutdown_timeout,
+            sticky_timeout: cfg.sticky_timeout,
         }
     }
 }
@@ -280,6 +285,21 @@ struct WorkflowTaskPersistence<'a> {
     worker_id: &'a str,
     exec_id: ExecutionId,
     next_event_id: i32,
+    /// Grace window for pinning follow-up tasks to this worker's LRU cache.
+    /// Zero disables sticky routing entirely.
+    sticky_timeout: Duration,
+}
+
+impl<'a> WorkflowTaskPersistence<'a> {
+    /// Build a sticky hint bound to this worker, or `None` when sticky routing
+    /// is disabled (timeout == 0).
+    const fn sticky_hint(&self) -> Option<queue::StickyHint<'a>> {
+        if self.sticky_timeout.is_zero() {
+            None
+        } else {
+            Some(queue::StickyHint::new(self.worker_id, self.sticky_timeout))
+        }
+    }
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -661,6 +681,7 @@ async fn persist_signal_wait_park(
     exec_id: ExecutionId,
     next_event_id: i32,
     marker_events: &[WorkflowEvent],
+    sticky: Option<queue::StickyHint<'_>>,
 ) -> HarvestResult<()> {
     // Park the workflow task (state=RUNNING, worker cleared) so it is not
     // confused with a timer-waiting task (state=PENDING). This ensures that
@@ -670,7 +691,7 @@ async fn persist_signal_wait_park(
     conn.transaction::<(), HarvestError, _>(|conn| {
         async move {
             store::append_events(conn, exec_id, marker_events, next_event_id).await?;
-            queue::park_workflow_task(conn, task_id).await
+            queue::park_workflow_task(conn, task_id, sticky).await
         }
         .scope_boxed()
     })
@@ -691,6 +712,7 @@ async fn persist_signal_wait_park(
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn persist_scheduled_activity(
     conn: &mut AsyncPgConnection,
     registry: &HandlerRegistry,
@@ -699,6 +721,7 @@ async fn persist_scheduled_activity(
     next_event_id: i32,
     commands: &[WorkflowCommand],
     scheduled: &ScheduledActivityCommand,
+    sticky: Option<queue::StickyHint<'_>>,
 ) -> HarvestResult<()> {
     let activity = registry.activities.get(&scheduled.name).ok_or_else(|| {
         HarvestError::Config(format!(
@@ -758,7 +781,7 @@ async fn persist_scheduled_activity(
         async move {
             store::append_events(conn, exec_id, &events, next_event_id).await?;
             queue::enqueue(conn, &params).await?;
-            queue::park_workflow_task(conn, task_id).await?;
+            queue::park_workflow_task(conn, task_id, sticky).await?;
             Ok(())
         }
         .scope_boxed()
@@ -773,6 +796,7 @@ async fn persist_started_timer(
     task_id: uuid::Uuid,
     commands: &[WorkflowCommand],
     timer: &StartedTimerCommand,
+    sticky: Option<queue::StickyHint<'_>>,
 ) -> HarvestResult<()> {
     let marker_events = marker_events_from_commands(commands);
     let fire_delay = chrono_duration_from_secs(timer.duration_secs, "timer duration")?;
@@ -798,13 +822,18 @@ async fn persist_started_timer(
                 .execute(conn)
                 .await
                 .map_err(crate::error::database_error)?;
-            queue::reschedule_task(conn, task_id, fires_at).await
+            queue::reschedule_task(conn, task_id, fires_at).await?;
+            if sticky.is_some() {
+                queue::set_task_sticky_affinity(conn, task_id, sticky).await?;
+            }
+            Ok(())
         }
         .scope_boxed()
     })
     .await
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn persist_started_child_workflow(
     conn: &mut AsyncPgConnection,
     registry: &HandlerRegistry,
@@ -813,6 +842,7 @@ async fn persist_started_child_workflow(
     next_event_id: i32,
     commands: &[WorkflowCommand],
     child: &StartedChildWorkflowCommand,
+    sticky: Option<queue::StickyHint<'_>>,
 ) -> HarvestResult<()> {
     if !registry.workflows.contains_key(&child.workflow_name) {
         return Err(HarvestError::Config(format!(
@@ -864,7 +894,7 @@ async fn persist_started_child_workflow(
                 .map_err(crate::error::database_error)?;
             store::append_events(conn, child.child_id, &[child_started_event], 0).await?;
             queue::enqueue(conn, &params).await?;
-            queue::park_workflow_task(conn, task_id).await?;
+            queue::park_workflow_task(conn, task_id, sticky).await?;
             Ok(())
         }
         .scope_boxed()
@@ -1222,6 +1252,8 @@ async fn handle_suspended_workflow(
     context: SuspendedWorkflowContext<'_>,
     commands: &[WorkflowCommand],
 ) -> HarvestResult<()> {
+    let sticky = context.persistence.sticky_hint();
+
     if should_requeue_signal_wait(commands) {
         let marker_events = marker_events_from_commands(commands);
         let result = persist_signal_wait_park(
@@ -1230,6 +1262,7 @@ async fn handle_suspended_workflow(
             context.persistence.exec_id,
             context.persistence.next_event_id,
             &marker_events,
+            sticky,
         )
         .await;
         return fail_execution_on_error(
@@ -1250,6 +1283,7 @@ async fn handle_suspended_workflow(
             context.persistence.next_event_id,
             commands,
             &scheduled,
+            sticky,
         )
         .await;
         return fail_execution_on_error(
@@ -1269,6 +1303,7 @@ async fn handle_suspended_workflow(
             context.persistence.task.id,
             commands,
             &timer,
+            sticky,
         )
         .await;
         return fail_execution_on_error(
@@ -1289,6 +1324,7 @@ async fn handle_suspended_workflow(
             context.persistence.next_event_id,
             commands,
             &child,
+            sticky,
         )
         .await;
         return fail_execution_on_error(
@@ -1473,6 +1509,7 @@ async fn process_workflow_task(
     registry: &HandlerRegistry,
     task: &TaskQueueItem,
     worker_id: &str,
+    sticky_timeout: Duration,
 ) -> HarvestResult<()> {
     let prepared = prepare_workflow_task(conn, task, worker_id).await?;
     let Some(workflow) = registry.workflows.get(&prepared.execution.workflow_name) else {
@@ -1502,6 +1539,7 @@ async fn process_workflow_task(
             worker_id,
             exec_id: prepared.exec_id,
             next_event_id: prepared.next_event_id,
+            sticky_timeout,
         },
         outcome,
     )
@@ -1513,6 +1551,7 @@ async fn process_task(
     registry: Arc<HandlerRegistry>,
     task: TaskQueueItem,
     worker_id: &str,
+    sticky_timeout: Duration,
 ) -> HarvestResult<()> {
     let mut conn = match pool.get().await {
         Ok(conn) => conn,
@@ -1523,7 +1562,14 @@ async fn process_task(
 
     match ClaimedTaskKind::from_db(&task.task_type)? {
         ClaimedTaskKind::Workflow => {
-            process_workflow_task(&mut conn, registry.as_ref(), &task, worker_id).await
+            process_workflow_task(
+                &mut conn,
+                registry.as_ref(),
+                &task,
+                worker_id,
+                sticky_timeout,
+            )
+            .await
         }
         ClaimedTaskKind::Activity => {
             process_activity_task(pool, &mut conn, registry.as_ref(), &task, worker_id).await
@@ -1723,6 +1769,7 @@ impl Worker {
         let task_id = task.id;
         let task_type = task.task_type.clone();
         let worker_id = self.config.worker_id.clone();
+        let sticky_timeout = self.config.sticky_timeout;
 
         tokio::spawn(async move {
             // Acquire semaphore permit — blocks if at concurrency limit.
@@ -1738,7 +1785,9 @@ impl Worker {
                 "executing task"
             );
 
-            if let Err(error) = process_task(&pool, registry, task, &worker_id).await {
+            if let Err(error) =
+                process_task(&pool, registry, task, &worker_id, sticky_timeout).await
+            {
                 tracing::error!(
                     task_id = %task_id,
                     task_type = %task_type,
@@ -1807,6 +1856,7 @@ mod tests {
             max_concurrent_activities: 20,
             poll_interval: Duration::from_millis(100),
             shutdown_timeout: Duration::from_secs(5),
+            sticky_timeout: Duration::from_secs(5),
         }
     }
 

--- a/autumn-harvest/tests/cancellation_tests.rs
+++ b/autumn-harvest/tests/cancellation_tests.rs
@@ -389,6 +389,7 @@ async fn running_activity_heartbeat_observes_workflow_cancellation() {
                 max_concurrent_activities: 1,
                 poll_interval: Duration::from_millis(25),
                 shutdown_timeout: Duration::from_secs(1),
+                sticky_timeout: Duration::from_secs(5),
             },
             registry,
         )

--- a/autumn-harvest/tests/integration_e2e.rs
+++ b/autumn-harvest/tests/integration_e2e.rs
@@ -2258,16 +2258,18 @@ async fn claim_task_falls_back_to_any_worker_after_sticky_expires() {
     let (mut conn, _container) = setup_test_db().await;
     let exec_id = insert_workflow_execution(&mut conn).await;
 
-    // Pin with a 1ms window so we can observe fallback without sleeping long.
+    // Pin with a short window so we can observe fallback without sleeping long.
+    // The sleep is generously larger than the window to tolerate DB/host clock
+    // skew inside testcontainers on CI runners.
     let mut pinned = EnqueueParams::new("default", TaskType::Workflow, serde_json::json!({}))
-        .with_sticky("crashed-worker", Duration::from_millis(1));
+        .with_sticky("crashed-worker", Duration::from_millis(100));
     pinned.workflow_exec_id = Some(exec_id.as_uuid());
     queue::enqueue(&mut conn, &pinned)
         .await
         .expect("enqueue should succeed");
 
-    // Allow the sticky window to elapse.
-    tokio::time::sleep(Duration::from_millis(50)).await;
+    // Allow the sticky window to elapse comfortably.
+    tokio::time::sleep(Duration::from_millis(800)).await;
 
     let queues = vec!["default".to_string()];
     let claimed = queue::claim_task(&mut conn, &queues, "rescue-worker")
@@ -2334,19 +2336,33 @@ async fn wake_workflow_task_refreshes_sticky_until() {
     let _claimed = queue::claim_task(&mut conn, &queues, "wake-refresh-worker")
         .await
         .expect("claim should succeed");
+    // Use a 5s window so both the park's sticky_until and the wake's refreshed
+    // sticky_until land comfortably in the future even under DB/host clock skew
+    // on CI runners. The test asserts the value was REFRESHED by comparing
+    // before/after timestamps, not by waiting for expiry.
     queue::park_workflow_task(
         &mut conn,
         task_id,
         Some(StickyHint::new(
             "wake-refresh-worker",
-            Duration::from_millis(50),
+            Duration::from_secs(5),
         )),
     )
     .await
     .expect("park should succeed");
 
-    // Simulate a long-running activity: let the original sticky window expire.
-    tokio::time::sleep(Duration::from_millis(120)).await;
+    let parked_until = harvest_task_queue::table
+        .find(task_id)
+        .select(TaskQueueItem::as_select())
+        .first(&mut conn)
+        .await
+        .expect("parked row should exist")
+        .sticky_until
+        .expect("sticky_until should be set at park");
+
+    // Wait long enough that NOW() has moved noticeably (well above typical
+    // sub-millisecond timer resolution) before triggering the refresh.
+    tokio::time::sleep(Duration::from_millis(250)).await;
 
     queue::wake_workflow_task(&mut conn, exec_id)
         .await
@@ -2363,7 +2379,8 @@ async fn wake_workflow_task_refreshes_sticky_until() {
     assert_eq!(row.sticky_worker_id.as_deref(), Some("wake-refresh-worker"));
     let refreshed_until = row.sticky_until.expect("sticky_until should be refreshed");
     assert!(
-        refreshed_until > Utc::now(),
-        "sticky_until should be refreshed into the future on wake (got {refreshed_until})",
+        refreshed_until > parked_until,
+        "sticky_until should be pushed forward on wake (parked_until={parked_until}, \
+         refreshed_until={refreshed_until})",
     );
 }

--- a/autumn-harvest/tests/integration_e2e.rs
+++ b/autumn-harvest/tests/integration_e2e.rs
@@ -2146,9 +2146,12 @@ async fn enqueue_with_sticky_pin_stores_worker_and_expiry() {
     let (mut conn, _container) = setup_test_db().await;
     let exec_id = insert_workflow_execution(&mut conn).await;
 
-    let params =
-        EnqueueParams::new("default", TaskType::Workflow, serde_json::json!({"go": true}))
-            .with_sticky("worker-sticky-1", Duration::from_secs(3));
+    let params = EnqueueParams::new(
+        "default",
+        TaskType::Workflow,
+        serde_json::json!({"go": true}),
+    )
+    .with_sticky("worker-sticky-1", Duration::from_secs(3));
     let mut enqueue = params.clone();
     enqueue.workflow_exec_id = Some(exec_id.as_uuid());
 
@@ -2244,7 +2247,10 @@ async fn claim_task_excludes_other_workers_while_sticky_active() {
         .await
         .expect("owner claim should succeed")
         .expect("owner should be able to claim its pinned task");
-    assert_eq!(owner_claim.sticky_worker_id.as_deref(), Some("owner-worker"));
+    assert_eq!(
+        owner_claim.sticky_worker_id.as_deref(),
+        Some("owner-worker")
+    );
 }
 
 #[tokio::test]

--- a/autumn-harvest/tests/integration_e2e.rs
+++ b/autumn-harvest/tests/integration_e2e.rs
@@ -2168,18 +2168,45 @@ async fn enqueue_with_sticky_pin_stores_worker_and_expiry() {
 
     assert_eq!(row.sticky_worker_id.as_deref(), Some("worker-sticky-1"));
     assert!(row.sticky_until.is_some(), "sticky_until should be set");
+    let stored_timeout = row.sticky_timeout.expect("sticky_timeout should be set");
     assert_eq!(
-        row.sticky_timeout,
-        Some(chrono::Duration::seconds(3)),
-        "sticky_timeout interval should be stored on the row",
+        stored_timeout.num_seconds(),
+        3,
+        "sticky_timeout interval should round-trip as 3 seconds (got {stored_timeout})",
     );
+}
+
+async fn insert_named_workflow_execution(
+    conn: &mut AsyncPgConnection,
+    workflow_id: &str,
+) -> ExecutionId {
+    let exec_id = ExecutionId::new();
+    let row = NewWorkflowExecution {
+        id: exec_id.as_uuid(),
+        workflow_name: "e2e_sticky_test",
+        workflow_id,
+        run_id: Uuid::new_v4(),
+        shard_id: 0,
+        input: serde_json::json!({}),
+        parent_id: None,
+        queue_name: "default",
+        execution_timeout: None,
+        memo: None,
+        search_attrs: None,
+    };
+    diesel::insert_into(harvest_workflow_executions::table)
+        .values(&row)
+        .execute(conn)
+        .await
+        .expect("failed to insert sticky test workflow execution");
+    exec_id
 }
 
 #[tokio::test]
 async fn claim_task_prefers_sticky_worker_within_window() {
     let (mut conn, _container) = setup_test_db().await;
-    let exec_pinned = insert_workflow_execution(&mut conn).await;
-    let exec_free = insert_workflow_execution(&mut conn).await;
+    let exec_pinned = insert_named_workflow_execution(&mut conn, "pinned-1").await;
+    let exec_free = insert_named_workflow_execution(&mut conn, "free-1").await;
 
     // Free task is higher priority AND enqueued first so it would ordinarily be
     // claimed ahead of the pinned task by any worker. Sticky routing must
@@ -2318,7 +2345,12 @@ async fn park_workflow_task_with_sticky_hint_pins_to_worker() {
     assert!(row.worker_id.is_none(), "worker ownership cleared on park");
     assert_eq!(row.sticky_worker_id.as_deref(), Some("park-worker"));
     assert!(row.sticky_until.is_some());
-    assert_eq!(row.sticky_timeout, Some(chrono::Duration::seconds(10)));
+    let stored_timeout = row.sticky_timeout.expect("sticky_timeout should be set");
+    assert_eq!(
+        stored_timeout.num_seconds(),
+        10,
+        "sticky_timeout should round-trip as 10 seconds (got {stored_timeout})",
+    );
 }
 
 #[tokio::test]

--- a/autumn-harvest/tests/integration_e2e.rs
+++ b/autumn-harvest/tests/integration_e2e.rs
@@ -12,7 +12,7 @@ use autumn_harvest::info::{ActivityInfo, WorkflowInfo};
 use autumn_harvest::models::{
     HarvestTimer, NewWorkflowExecution, TaskQueueItem, WorkflowExecution,
 };
-use autumn_harvest::queue::{EnqueueParams, TaskType};
+use autumn_harvest::queue::{EnqueueParams, StickyHint, TaskType};
 use autumn_harvest::schema::{harvest_task_queue, harvest_timers, harvest_workflow_executions};
 use autumn_harvest::store;
 use autumn_harvest::types::{ActivityExecId, ExecutionId};
@@ -337,6 +337,7 @@ fn build_runtime_worker(
                 max_concurrent_activities,
                 poll_interval: Duration::from_millis(25),
                 shutdown_timeout: Duration::from_secs(1),
+                sticky_timeout: Duration::from_secs(5),
             },
             registry,
         )
@@ -734,6 +735,7 @@ async fn worker_completes_workflow_task_and_persists_result() {
                 max_concurrent_activities: 1,
                 poll_interval: Duration::from_millis(25),
                 shutdown_timeout: Duration::from_secs(1),
+                sticky_timeout: Duration::from_secs(5),
             },
             registry,
         )
@@ -823,6 +825,7 @@ async fn worker_marks_workflow_failed_when_handler_errors() {
                 max_concurrent_activities: 1,
                 poll_interval: Duration::from_millis(25),
                 shutdown_timeout: Duration::from_secs(1),
+                sticky_timeout: Duration::from_secs(5),
             },
             registry,
         )
@@ -934,6 +937,7 @@ async fn worker_completes_workflow_with_activity_round_trip() {
                 max_concurrent_activities: 1,
                 poll_interval: Duration::from_millis(25),
                 shutdown_timeout: Duration::from_secs(1),
+                sticky_timeout: Duration::from_secs(5),
             },
             registry,
         )
@@ -1021,6 +1025,7 @@ async fn worker_fails_orphaned_activity_task_without_scheduled_event() {
                 max_concurrent_activities: 1,
                 poll_interval: Duration::from_millis(25),
                 shutdown_timeout: Duration::from_secs(1),
+                sticky_timeout: Duration::from_secs(5),
             },
             Arc::new(HandlerRegistry::new(
                 vec![],
@@ -1134,7 +1139,7 @@ async fn timeout_enforcement_fails_pending_activity_and_wakes_workflow() {
         .expect("workflow task should be claimable");
     assert_eq!(claimed_workflow.id, workflow_task_id);
     assert_eq!(claimed_workflow.state, "RUNNING");
-    queue::park_workflow_task(&mut conn, workflow_task_id)
+    queue::park_workflow_task(&mut conn, workflow_task_id, None)
         .await
         .expect("park workflow task failed");
 
@@ -1221,6 +1226,7 @@ async fn worker_fails_workflow_when_activity_start_to_close_timeout_elapses() {
                 max_concurrent_activities: 1,
                 poll_interval: Duration::from_millis(25),
                 shutdown_timeout: Duration::from_secs(1),
+                sticky_timeout: Duration::from_secs(5),
             },
             Arc::new(HandlerRegistry::new(
                 vec![WorkflowInfo {
@@ -1333,6 +1339,7 @@ async fn worker_completes_workflow_with_timer_round_trip() {
                 max_concurrent_activities: 1,
                 poll_interval: Duration::from_millis(25),
                 shutdown_timeout: Duration::from_secs(1),
+                sticky_timeout: Duration::from_secs(5),
             },
             Arc::new(HandlerRegistry::new(
                 vec![WorkflowInfo {
@@ -1651,7 +1658,7 @@ async fn wake_workflow_task_emits_notification() {
         .expect("claim should succeed")
         .expect("workflow task should be claimable");
     assert_eq!(claimed.id, task_id);
-    queue::park_workflow_task(&mut conn, task_id)
+    queue::park_workflow_task(&mut conn, task_id, None)
         .await
         .expect("park workflow task should succeed");
 
@@ -2128,4 +2135,229 @@ async fn duplicate_event_id_is_rejected() {
     let result = store::append_events(&mut conn, exec_id, &events, 0).await;
     assert!(result.is_err());
     assert!(matches!(result.unwrap_err(), HarvestError::Database(_)));
+}
+
+// ---------------------------------------------------------------------------
+// Sticky cross-worker routing tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn enqueue_with_sticky_pin_stores_worker_and_expiry() {
+    let (mut conn, _container) = setup_test_db().await;
+    let exec_id = insert_workflow_execution(&mut conn).await;
+
+    let params =
+        EnqueueParams::new("default", TaskType::Workflow, serde_json::json!({"go": true}))
+            .with_sticky("worker-sticky-1", Duration::from_secs(3));
+    let mut enqueue = params.clone();
+    enqueue.workflow_exec_id = Some(exec_id.as_uuid());
+
+    let task_id = queue::enqueue(&mut conn, &enqueue)
+        .await
+        .expect("enqueue should succeed");
+
+    let row = harvest_task_queue::table
+        .find(task_id)
+        .select(TaskQueueItem::as_select())
+        .first(&mut conn)
+        .await
+        .expect("row should exist");
+
+    assert_eq!(row.sticky_worker_id.as_deref(), Some("worker-sticky-1"));
+    assert!(row.sticky_until.is_some(), "sticky_until should be set");
+    assert_eq!(
+        row.sticky_timeout,
+        Some(chrono::Duration::seconds(3)),
+        "sticky_timeout interval should be stored on the row",
+    );
+}
+
+#[tokio::test]
+async fn claim_task_prefers_sticky_worker_within_window() {
+    let (mut conn, _container) = setup_test_db().await;
+    let exec_pinned = insert_workflow_execution(&mut conn).await;
+    let exec_free = insert_workflow_execution(&mut conn).await;
+
+    // Free task is higher priority AND enqueued first so it would ordinarily be
+    // claimed ahead of the pinned task by any worker. Sticky routing must
+    // reshuffle the order so the pinned worker sees its pinned row first.
+    let mut free = EnqueueParams::new("default", TaskType::Workflow, serde_json::json!({}));
+    free.priority = 10;
+    free.workflow_exec_id = Some(exec_free.as_uuid());
+    let free_id = queue::enqueue(&mut conn, &free)
+        .await
+        .expect("enqueue free task failed");
+
+    let mut pinned = EnqueueParams::new("default", TaskType::Workflow, serde_json::json!({}))
+        .with_sticky("sticky-worker", Duration::from_secs(30));
+    pinned.priority = 0;
+    pinned.workflow_exec_id = Some(exec_pinned.as_uuid());
+    let pinned_id = queue::enqueue(&mut conn, &pinned)
+        .await
+        .expect("enqueue pinned task failed");
+
+    let queues = vec!["default".to_string()];
+    let claimed = queue::claim_task(&mut conn, &queues, "sticky-worker")
+        .await
+        .expect("claim should succeed")
+        .expect("sticky worker should get its pinned task");
+    assert_eq!(
+        claimed.id, pinned_id,
+        "sticky worker should claim its pinned task ahead of the higher-priority free task",
+    );
+
+    let claimed_other = queue::claim_task(&mut conn, &queues, "other-worker")
+        .await
+        .expect("second claim should succeed")
+        .expect("other worker should pick up the free task");
+    assert_eq!(
+        claimed_other.id, free_id,
+        "other worker should still claim the unpinned free task",
+    );
+}
+
+#[tokio::test]
+async fn claim_task_excludes_other_workers_while_sticky_active() {
+    let (mut conn, _container) = setup_test_db().await;
+    let exec_id = insert_workflow_execution(&mut conn).await;
+
+    let pinned = EnqueueParams::new("default", TaskType::Workflow, serde_json::json!({}))
+        .with_sticky("owner-worker", Duration::from_secs(30));
+    let mut pinned = pinned;
+    pinned.workflow_exec_id = Some(exec_id.as_uuid());
+    queue::enqueue(&mut conn, &pinned)
+        .await
+        .expect("enqueue should succeed");
+
+    let queues = vec!["default".to_string()];
+    // Different worker must not steal a fresh sticky pin.
+    let claimed = queue::claim_task(&mut conn, &queues, "interloper")
+        .await
+        .expect("claim should succeed");
+    assert!(
+        claimed.is_none(),
+        "non-sticky worker should not claim a pinned task while sticky_until is in the future",
+    );
+
+    // The owner can still claim it.
+    let owner_claim = queue::claim_task(&mut conn, &queues, "owner-worker")
+        .await
+        .expect("owner claim should succeed")
+        .expect("owner should be able to claim its pinned task");
+    assert_eq!(owner_claim.sticky_worker_id.as_deref(), Some("owner-worker"));
+}
+
+#[tokio::test]
+async fn claim_task_falls_back_to_any_worker_after_sticky_expires() {
+    let (mut conn, _container) = setup_test_db().await;
+    let exec_id = insert_workflow_execution(&mut conn).await;
+
+    // Pin with a 1ms window so we can observe fallback without sleeping long.
+    let mut pinned = EnqueueParams::new("default", TaskType::Workflow, serde_json::json!({}))
+        .with_sticky("crashed-worker", Duration::from_millis(1));
+    pinned.workflow_exec_id = Some(exec_id.as_uuid());
+    queue::enqueue(&mut conn, &pinned)
+        .await
+        .expect("enqueue should succeed");
+
+    // Allow the sticky window to elapse.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+
+    let queues = vec!["default".to_string()];
+    let claimed = queue::claim_task(&mut conn, &queues, "rescue-worker")
+        .await
+        .expect("claim should succeed")
+        .expect("any worker may claim after sticky_until expires");
+    assert_eq!(
+        claimed.worker_id.as_deref(),
+        Some("rescue-worker"),
+        "fallback worker should own the row after expiry",
+    );
+}
+
+#[tokio::test]
+async fn park_workflow_task_with_sticky_hint_pins_to_worker() {
+    let (mut conn, _container) = setup_test_db().await;
+    let exec_id = insert_workflow_execution(&mut conn).await;
+
+    // Seed and claim a workflow task so the row is in RUNNING state.
+    let mut params = EnqueueParams::new("default", TaskType::Workflow, serde_json::json!({}));
+    params.workflow_exec_id = Some(exec_id.as_uuid());
+    let task_id = queue::enqueue(&mut conn, &params)
+        .await
+        .expect("enqueue should succeed");
+    let queues = vec!["default".to_string()];
+    let _claimed = queue::claim_task(&mut conn, &queues, "park-worker")
+        .await
+        .expect("claim should succeed")
+        .expect("row should be claimable");
+
+    queue::park_workflow_task(
+        &mut conn,
+        task_id,
+        Some(StickyHint::new("park-worker", Duration::from_secs(10))),
+    )
+    .await
+    .expect("park with sticky should succeed");
+
+    let row = harvest_task_queue::table
+        .find(task_id)
+        .select(TaskQueueItem::as_select())
+        .first(&mut conn)
+        .await
+        .expect("row should exist");
+    assert_eq!(row.state, "RUNNING", "parked row keeps RUNNING state");
+    assert!(row.worker_id.is_none(), "worker ownership cleared on park");
+    assert_eq!(row.sticky_worker_id.as_deref(), Some("park-worker"));
+    assert!(row.sticky_until.is_some());
+    assert_eq!(row.sticky_timeout, Some(chrono::Duration::seconds(10)));
+}
+
+#[tokio::test]
+async fn wake_workflow_task_refreshes_sticky_until() {
+    let (mut conn, _container) = setup_test_db().await;
+    let exec_id = insert_workflow_execution(&mut conn).await;
+
+    // Seed, claim, and park a workflow task with a short sticky window.
+    let mut params = EnqueueParams::new("default", TaskType::Workflow, serde_json::json!({}));
+    params.workflow_exec_id = Some(exec_id.as_uuid());
+    let task_id = queue::enqueue(&mut conn, &params)
+        .await
+        .expect("enqueue should succeed");
+    let queues = vec!["default".to_string()];
+    let _claimed = queue::claim_task(&mut conn, &queues, "wake-refresh-worker")
+        .await
+        .expect("claim should succeed");
+    queue::park_workflow_task(
+        &mut conn,
+        task_id,
+        Some(StickyHint::new(
+            "wake-refresh-worker",
+            Duration::from_millis(50),
+        )),
+    )
+    .await
+    .expect("park should succeed");
+
+    // Simulate a long-running activity: let the original sticky window expire.
+    tokio::time::sleep(Duration::from_millis(120)).await;
+
+    queue::wake_workflow_task(&mut conn, exec_id)
+        .await
+        .expect("wake should succeed");
+
+    let row = harvest_task_queue::table
+        .find(task_id)
+        .select(TaskQueueItem::as_select())
+        .first(&mut conn)
+        .await
+        .expect("row should exist");
+
+    assert_eq!(row.state, "PENDING");
+    assert_eq!(row.sticky_worker_id.as_deref(), Some("wake-refresh-worker"));
+    let refreshed_until = row.sticky_until.expect("sticky_until should be refreshed");
+    assert!(
+        refreshed_until > Utc::now(),
+        "sticky_until should be refreshed into the future on wake (got {refreshed_until})",
+    );
 }


### PR DESCRIPTION
## Summary

Implements sticky cross-worker routing to improve cache locality for workflow tasks. When a workflow task is parked or enqueued, it can be pinned to a specific worker for a configurable grace period. During this window, only the pinned worker preferentially claims the task, allowing its in-process LRU cache to service follow-up replays without reloading from the database. Once the window expires, any worker may claim the task, ensuring crashed or slow workers never block progress.

## Key Changes

- **Database schema**: Added three new columns to `harvest_task_queue`:
  - `sticky_worker_id`: Optional worker ID for task affinity
  - `sticky_until`: Expiration timestamp for the sticky window
  - `sticky_timeout`: Stored interval for refreshing `sticky_until` on task wake
  - Added check constraint ensuring `sticky_worker_id` and `sticky_until` are both NULL or both set

- **Queue API enhancements**:
  - `EnqueueParams` now supports `.with_sticky(worker_id, timeout)` builder method
  - New `StickyHint` struct for passing sticky affinity to park/wake operations
  - `park_workflow_task()` now accepts optional `StickyHint` to pin parked tasks
  - `wake_workflow_task()` refreshes `sticky_until` from stored `sticky_timeout` atomically
  - New `set_task_sticky_affinity()` function to update sticky pins on existing tasks

- **Task claiming logic**: Modified `claim_task()` SQL query to:
  - Filter out tasks pinned to other workers while sticky window is active
  - Sort pinned tasks ahead of unpinned tasks for the owning worker
  - Fall back to any worker once `sticky_until` elapses

- **Worker runtime**: Added `sticky_timeout` configuration to `WorkerRuntimeConfig` and `WorkflowTaskPersistence` to enable sticky routing during workflow execution

- **Migrations**: 
  - Updated initial migration to include sticky columns
  - Added separate migration for legacy databases to add columns idempotently

- **Tests**: Added comprehensive test coverage for sticky routing behavior including preference ordering, window expiration, and sticky hint refresh on wake

## Implementation Details

- Sticky routing is entirely optional; tasks without a sticky pin behave as before
- The `sticky_timeout` is stored on the row so `wake_workflow_task()` can refresh the window without external configuration
- Uses raw SQL in `wake_workflow_task()` to atomically refresh `sticky_until` from the row's own `sticky_timeout` column, avoiding race conditions
- Sticky window expiration is checked at claim time; no background cleanup needed

https://claude.ai/code/session_018maDNkreRE96R9MDmHJxim