### PR TITLE
⚒️ Forge: Flatten persist_workflow_outcome and simplify match patterns

### DIFF
--- a/autumn-harvest-cli/src/tui.rs
+++ b/autumn-harvest-cli/src/tui.rs
@@ -19,6 +19,11 @@ use serde_json::Value;
 use crate::Cli;
 use crate::CliError;
 
+/// Runs the TUI dashboard.
+///
+/// # Errors
+///
+/// Returns an error if the terminal setup fails, or if rendering encounters an error.
 pub async fn run_tui(cli: &Cli) -> Result<(), CliError> {
     // Setup terminal
     enable_raw_mode().map_err(|e| CliError::ReadJson {

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -1616,56 +1616,54 @@ async fn persist_workflow_outcome(
 ) -> HarvestResult<()> {
     let parent_exec_id = execution.parent_id.map(execution_id_from_uuid);
 
-    match outcome {
-        WorkflowOutcome::Completed { output } => {
-            if let Some(parent_id) = parent_exec_id {
-                persist_child_workflow_completion(
-                    conn,
-                    persistence.task.id,
-                    persistence.exec_id,
-                    persistence.next_event_id,
-                    persistence.worker_id,
-                    parent_id,
-                    output,
-                )
-                .await
-            } else {
-                persist_workflow_completion(
-                    conn,
-                    persistence.task.id,
-                    persistence.exec_id,
-                    persistence.next_event_id,
-                    persistence.worker_id,
-                    output,
-                )
-                .await
-            }
+    match (outcome, parent_exec_id) {
+        (WorkflowOutcome::Completed { output }, Some(parent_id)) => {
+            persist_child_workflow_completion(
+                conn,
+                persistence.task.id,
+                persistence.exec_id,
+                persistence.next_event_id,
+                persistence.worker_id,
+                parent_id,
+                output,
+            )
+            .await
         }
-        WorkflowOutcome::Failed { error } => {
-            if let Some(parent_id) = parent_exec_id {
-                persist_child_workflow_failure(
-                    conn,
-                    persistence.task.id,
-                    persistence.exec_id,
-                    persistence.next_event_id,
-                    persistence.worker_id,
-                    parent_id,
-                    &error,
-                )
-                .await
-            } else {
-                persist_workflow_failure(
-                    conn,
-                    persistence.task.id,
-                    persistence.exec_id,
-                    persistence.next_event_id,
-                    persistence.worker_id,
-                    &error,
-                )
-                .await
-            }
+        (WorkflowOutcome::Completed { output }, None) => {
+            persist_workflow_completion(
+                conn,
+                persistence.task.id,
+                persistence.exec_id,
+                persistence.next_event_id,
+                persistence.worker_id,
+                output,
+            )
+            .await
         }
-        WorkflowOutcome::Suspended { commands } => {
+        (WorkflowOutcome::Failed { error }, Some(parent_id)) => {
+            persist_child_workflow_failure(
+                conn,
+                persistence.task.id,
+                persistence.exec_id,
+                persistence.next_event_id,
+                persistence.worker_id,
+                parent_id,
+                &error,
+            )
+            .await
+        }
+        (WorkflowOutcome::Failed { error }, None) => {
+            persist_workflow_failure(
+                conn,
+                persistence.task.id,
+                persistence.exec_id,
+                persistence.next_event_id,
+                persistence.worker_id,
+                &error,
+            )
+            .await
+        }
+        (WorkflowOutcome::Suspended { commands }, _) => {
             handle_suspended_workflow(
                 conn,
                 registry,
@@ -1759,12 +1757,7 @@ async fn process_task(
     cancellation_grace_period: Duration,
     sticky_timeout: Duration,
 ) -> HarvestResult<()> {
-    let mut conn = match pool.get().await {
-        Ok(conn) => conn,
-        Err(error) => {
-            return Err(crate::error::database_error(error));
-        }
-    };
+    let mut conn = pool.get().await.map_err(crate::error::database_error)?;
 
     match ClaimedTaskKind::from_db(&task.task_type)? {
         ClaimedTaskKind::Workflow => {


### PR DESCRIPTION
🚮 Smell:
- `process_task` had an unnecessary manual `match pool.get().await` expanding 6 lines just to propagate an error.
- `persist_workflow_outcome` was deeply nested (a "Pyramid of Doom") with `match outcome` containing inner `if let Some(parent_id) = parent_exec_id` branches across 60 lines.
- `autumn-harvest-cli/src/tui.rs` failed clippy because `run_tui` lacked the `# Errors` section in its documentation.

✨ Solution:
- In `process_task`, simplified the `pool.get()` connection retrieval to `pool.get().await.map_err(crate::error::database_error)?`.
- In `persist_workflow_outcome`, flattened the logic by matching on a tuple `(outcome, parent_exec_id)`.
- Added missing documentation comments in `tui.rs`.

🧼 Benefit:
- Reduced cognitive load by replacing nested branching with a clean, flat 1D matching structure.
- Removed boilerplate error conversions.
- Code conforms strictly to idiomatic Rust standards and clippy requirements.

🛡️ Verification:
- Tests passed (`cargo test -p autumn-harvest --lib`). No logic changed.
- Clippy warnings cleared.

---
*PR created automatically by Jules for task [1410813970903774366](https://jules.google.com/task/1410813970903774366) started by @madmax983*