### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/autumn-harvest-cli/src/tui.rs
+++ b/autumn-harvest-cli/src/tui.rs
@@ -19,6 +19,12 @@ use serde_json::Value;
 use crate::Cli;
 use crate::CliError;
 
+/// Runs the interactive terminal UI dashboard.
+///
+/// # Errors
+///
+/// Returns `CliError` if terminal setup fails, if HTTP requests to the
+/// engine fail, or if reading user input fails.
 pub async fn run_tui(cli: &Cli) -> Result<(), CliError> {
     // Setup terminal
     enable_raw_mode().map_err(|e| CliError::ReadJson {

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -1845,6 +1845,20 @@ mod tests {
     }
 
     #[test]
+    fn context_cancellation_check_success_cases() {
+        let ctx = WorkflowContext::new_test();
+        assert!(ctx.check_cancellation().is_ok());
+    }
+
+    #[test]
+    fn context_is_cancelled_live_mode() {
+        let ctx = WorkflowContext::new_test();
+        assert!(!ctx.is_cancelled());
+        assert!(ctx.cancellation_reason().is_none());
+        assert!(ctx.check_cancellation().is_ok());
+    }
+
+    #[test]
     fn context_reports_cancellation_from_history() {
         let events = vec![
             WorkflowEvent::WorkflowStarted {

--- a/autumn-harvest/src/store.rs
+++ b/autumn-harvest/src/store.rs
@@ -260,6 +260,23 @@ mod tests {
     }
 
     #[test]
+    #[should_panic(expected = "Event ID overflow")]
+    fn events_to_insert_rows_from_panics_on_event_id_overflow() {
+        let exec_id = ExecutionId::new();
+        let events = vec![
+            WorkflowEvent::WorkflowStarted {
+                input: serde_json::Value::Null,
+                timestamp: Utc::now(),
+            },
+            WorkflowEvent::WorkflowCompleted {
+                output: serde_json::Value::Null,
+            },
+        ];
+
+        let _rows = events_to_insert_rows_from(exec_id, &events, i32::MAX);
+    }
+
+    #[test]
     fn history_from_rows_deserializes_events() -> Result<(), serde_json::Error> {
         let exec_id = ExecutionId::new();
         let events = vec![


### PR DESCRIPTION
🎯 Target: `autumn-harvest-cli/src/tui.rs`, `autumn-harvest/src/store.rs`, and `autumn-harvest/src/context.rs`.
💣 Risk: 
- `run_tui` function was missing an `# Errors` documentation section, triggering a warning in `clippy` when run with `-D warnings`.
- Untested edge case around integer overflow in `events_to_insert_rows_from` in `store.rs`, which is handled with `.expect("Event ID overflow")`. 
- Missing test coverage on `WorkflowContext::check_cancellation` logic.
🧪 Strategy: 
- Updated `run_tui` doc comment to include the `# Errors` section to satisfy Clippy.
- Added `#[should_panic]` test to verify the `checked_add` bounds check triggers properly.
- Added test coverage for `WorkflowContext::check_cancellation` using `new_test` in live mode.
🔬 Verification: Run `cargo test --lib --features testing` to execute the internal module tests. Run `cargo clippy --all-targets --all-features -- -D warnings` to verify warning cleanup.

---
*PR created automatically by Jules for task [4934796227673649374](https://jules.google.com/task/4934796227673649374) started by @madmax983*