### PR TITLE
⚒️ Forge: Refactor manual loops to idiomatic iterators

### DIFF
--- a/autumn-harvest/src/scheduler.rs
+++ b/autumn-harvest/src/scheduler.rs
@@ -535,10 +535,11 @@ async fn execute_dag_run(
         let tasks = level.iter().map(|task_index| {
             // Avoid an unnecessary heap allocation of `DagTask` per task when `&DagTask` works.
             let task = &dag.definition.tasks()[*task_index];
-            let mut upstream_statuses = Vec::with_capacity(task.upstreams.len());
-            for upstream in &task.upstreams {
-                upstream_statuses.push(statuses[*upstream].clone());
-            }
+            let upstream_statuses: Vec<_> = task
+                .upstreams
+                .iter()
+                .map(|upstream| statuses[*upstream].clone())
+                .collect();
             let registry = Arc::clone(&registry);
             let task_input = Arc::clone(&run_input);
             async move { execute_dag_task(&registry, task, &upstream_statuses, &task_input).await }

--- a/autumn-harvest/src/store.rs
+++ b/autumn-harvest/src/store.rs
@@ -129,11 +129,10 @@ pub async fn load_history(
 
     let next_event_id = rows.last().map_or(0, |r| r.event_id.saturating_add(1));
 
-    let mut events = Vec::with_capacity(rows.len());
-    for row in rows {
-        let event: WorkflowEvent = serde_json::from_value(row.event_data)?;
-        events.push(event);
-    }
+    let events = rows
+        .into_iter()
+        .map(|row| serde_json::from_value(row.event_data))
+        .collect::<Result<Vec<WorkflowEvent>, _>>()?;
 
     Ok(EventHistory {
         exec_id,

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -967,16 +967,18 @@ async fn ingest_pending_signals(
         return Ok(());
     }
 
-    let mut signal_events = Vec::with_capacity(pending_signals.len());
-    let mut signal_ids = Vec::with_capacity(pending_signals.len());
-
-    for signal in pending_signals {
-        signal_ids.push(signal.id);
-        signal_events.push(WorkflowEvent::SignalReceived {
-            signal_name: signal.signal_name,
-            payload: signal.payload,
-        });
-    }
+    let (signal_ids, signal_events): (Vec<_>, Vec<_>) = pending_signals
+        .into_iter()
+        .map(|signal| {
+            (
+                signal.id,
+                WorkflowEvent::SignalReceived {
+                    signal_name: signal.signal_name,
+                    payload: signal.payload,
+                },
+            )
+        })
+        .unzip();
 
     conn.transaction::<(), HarvestError, _>(|conn| {
         async move {
@@ -1014,15 +1016,17 @@ async fn ingest_fired_timers(
         return Ok(());
     }
 
-    let mut timer_events = Vec::with_capacity(due_timers.len());
-    let mut timer_row_ids = Vec::with_capacity(due_timers.len());
-
-    for timer in due_timers {
-        timer_row_ids.push(timer.id);
-        timer_events.push(WorkflowEvent::TimerFired {
-            timer_id: TimerId::new(timer.timer_id),
-        });
-    }
+    let (timer_row_ids, timer_events): (Vec<_>, Vec<_>) = due_timers
+        .into_iter()
+        .map(|timer| {
+            (
+                timer.id,
+                WorkflowEvent::TimerFired {
+                    timer_id: TimerId::new(timer.timer_id),
+                },
+            )
+        })
+        .unzip();
 
     conn.transaction::<(), HarvestError, _>(|conn| {
         async move {


### PR DESCRIPTION
🚮 Smell: Several areas of the codebase used manual `for` loops to instantiate empty `Vec::with_capacity()` instances, iterate over collections, and manually `push()` items. This is verbose and less idiomatic in Rust.

✨ Solution: Refactored these loops into clean, functional iterator chains:
- In `worker.rs`, replaced dual `push()` loops for signals and timers with `into_iter().map().unzip()`.
- In `store.rs`, replaced JSON parsing loop with `into_iter().map().collect::<Result<_, _>>()?`.
- In `scheduler.rs`, replaced the status collection loop with `iter().map().collect()`.

🧼 Benefit: Considerably reduces boilerplate and cognitive load. The intent of mapping and collecting data is now explicit and declaratively stated via iterators, embracing standard Rust idioms. It strictly preserves the zero-allocation performance traits of the previous code since the size bounds flow cleanly through the `ExactSizeIterator` trait during collection.

🛡️ Verification: Tests passed. No logic changed. Code successfully compiles and perfectly passes existing test suites under `cargo test` and `cargo clippy`.

---
*PR created automatically by Jules for task [14356710954139326228](https://jules.google.com/task/14356710954139326228) started by @madmax983*