### PR TITLE
Add workflow list filtering by state, name, and search attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ runtime-owned behavior stay behind the same API surface your service exposes.
 ```bash
 cargo run -p autumn-harvest-cli -- health
 cargo run -p autumn-harvest-cli -- workflow list --limit 25
+cargo run -p autumn-harvest-cli -- workflow list --state RUNNING --search-attr tenant=acme
 cargo run -p autumn-harvest-cli -- workflow get <execution-id>
 cargo run -p autumn-harvest-cli -- workflow start approval_workflow --input-json '{"request_id":"42"}'
 cargo run -p autumn-harvest-cli -- workflow signal <execution-id> approved --payload-json '{"approved":true}'
@@ -125,6 +126,29 @@ a bearer token. Successful responses are printed as pretty JSON by default; use
 `--output json` for compact script-friendly output. JSON request payloads accept
 inline `--*-json` values or `--*-file PATH`; use `-` as the file path to read
 from stdin.
+
+### Filtering the workflow list
+
+`workflow list` (and `GET /workflows`) accept three additional filter knobs on
+top of `limit`:
+
+| CLI flag | Query param | Behavior |
+|---|---|---|
+| `--state RUNNING` (repeatable, also accepts `RUNNING,FAILED`) | `?state=RUNNING,FAILED` (repeatable) | Exact match on the workflow execution state. Allowed values: `RUNNING`, `COMPLETED`, `FAILED`, `CANCELLED`, `TIMED_OUT`. |
+| `--workflow-name onboarding` | `?workflow_name=onboarding` | Exact match on the registered workflow name. |
+| `--search-attr tenant=acme` (repeatable) | `?search_attr=tenant:acme` (repeatable) | JSONB containment predicate on `search_attrs`. Multiple flags AND together; repeating a key narrows. Hits the existing `idx_harvest_we_search` GIN index. |
+
+Invalid values (unknown state, malformed `search_attr` missing the `:`
+separator) return `400 Bad Request` instead of silently matching nothing.
+
+Triage example — find the running onboarding workflows for a single tenant:
+
+```bash
+cargo run -p autumn-harvest-cli -- workflow list \
+    --state RUNNING \
+    --workflow-name onboarding \
+    --search-attr tenant=acme
+```
 
 ## Requirements
 

--- a/autumn-harvest-cli/src/lib.rs
+++ b/autumn-harvest-cli/src/lib.rs
@@ -134,6 +134,13 @@ pub enum CliError {
     /// JSON output could not be serialized.
     #[error("failed to serialize response JSON: {0}")]
     SerializeResponse(serde_json::Error),
+
+    /// A `--search-attr` flag was missing the `=` separator.
+    #[error("invalid --search-attr '{value}': expected 'key=value'")]
+    InvalidSearchAttr {
+        /// Original CLI argument value.
+        value: String,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -167,6 +174,17 @@ enum WorkflowCommand {
         /// Maximum number of rows to return.
         #[arg(long, value_parser = clap::value_parser!(i64).range(1..=200))]
         limit: Option<i64>,
+        /// Filter by workflow execution state. Repeat the flag or pass a
+        /// comma-separated list to match any of several states.
+        #[arg(long, value_delimiter = ',')]
+        state: Vec<String>,
+        /// Filter by registered workflow name (exact match).
+        #[arg(long)]
+        workflow_name: Option<String>,
+        /// Filter by a `search_attrs` key/value pair (`key=value`). Repeat to
+        /// AND multiple predicates together.
+        #[arg(long = "search-attr", value_name = "KEY=VALUE")]
+        search_attr: Vec<String>,
     },
     /// Get one workflow execution and event history.
     Get {
@@ -399,12 +417,20 @@ pub fn format_output(value: &Value, output: OutputFormat) -> Result<String, CliE
     }
 }
 
+#[allow(clippy::too_many_lines)]
 fn workflow_request(command: &WorkflowCommand) -> Result<ApiRequest, CliError> {
     match command {
-        WorkflowCommand::List { limit } => Ok(ApiRequest::get(path_with_limit(
-            "/workflows",
-            limit.map(|value| ("limit", value)),
-        ))),
+        WorkflowCommand::List {
+            limit,
+            state,
+            workflow_name,
+            search_attr,
+        } => Ok(ApiRequest::get(build_workflow_list_path(
+            *limit,
+            state,
+            workflow_name.as_deref(),
+            search_attr,
+        )?)),
         WorkflowCommand::Get { execution_id } => Ok(ApiRequest::get(format!(
             "/workflows/{}",
             path_segment(execution_id)
@@ -615,4 +641,55 @@ fn path_with_limit(base: &str, limit: Option<(&str, i64)>) -> String {
         .collect::<Vec<_>>()
         .join("&");
     format!("{base}?{query}")
+}
+
+fn build_workflow_list_path(
+    limit: Option<i64>,
+    states: &[String],
+    workflow_name: Option<&str>,
+    search_attrs: &[String],
+) -> Result<String, CliError> {
+    let mut params: Vec<(&'static str, String)> = Vec::new();
+    if let Some(value) = limit {
+        params.push(("limit", value.to_string()));
+    }
+    if !states.is_empty() {
+        // Use comma-separated values to match the management API's documented
+        // canonical form. The server also accepts repeated `state=` params.
+        params.push(("state", states.join(",")));
+    }
+    if let Some(name) = workflow_name {
+        params.push(("workflow_name", name.to_string()));
+    }
+    for raw in search_attrs {
+        let (key, value) = raw
+            .split_once('=')
+            .ok_or_else(|| CliError::InvalidSearchAttr { value: raw.clone() })?;
+        params.push(("search_attr", format!("{key}:{value}")));
+    }
+
+    if params.is_empty() {
+        return Ok("/workflows".to_string());
+    }
+    let encoded = params
+        .iter()
+        .map(|(key, value)| format!("{key}={}", query_encode(value)))
+        .collect::<Vec<_>>()
+        .join("&");
+    Ok(format!("/workflows?{encoded}"))
+}
+
+fn query_encode(input: &str) -> String {
+    // RFC 3986 query-component encoding. We intentionally leave `:` unencoded
+    // so the management API sees `search_attr=key:value` as a stable shape.
+    let mut out = String::with_capacity(input.len());
+    for byte in input.bytes() {
+        if byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_' | b'.' | b'~' | b':' | b',') {
+            out.push(byte as char);
+        } else {
+            use std::fmt::Write as _;
+            let _ = write!(out, "%{byte:02X}");
+        }
+    }
+    out
 }

--- a/autumn-harvest-cli/tests/request_mapping.rs
+++ b/autumn-harvest-cli/tests/request_mapping.rs
@@ -70,6 +70,65 @@ fn workflow_list_and_query_use_get_requests() {
 }
 
 #[test]
+fn workflow_list_filters_map_to_query_string() {
+    let list = Cli::try_parse_from([
+        "harvest",
+        "workflow",
+        "list",
+        "--state",
+        "RUNNING",
+        "--workflow-name",
+        "onboarding",
+        "--search-attr",
+        "tenant=acme",
+        "--search-attr",
+        "customer_id=42",
+    ])
+    .expect("filtered list args should parse");
+    let request = list.api_request().expect("list request should build");
+
+    assert_eq!(request.method, ApiMethod::Get);
+    assert_eq!(
+        request.path,
+        "/workflows?state=RUNNING&workflow_name=onboarding\
+         &search_attr=tenant:acme&search_attr=customer_id:42"
+    );
+    assert_eq!(request.body, None);
+}
+
+#[test]
+fn workflow_list_supports_repeated_and_comma_states() {
+    let list = Cli::try_parse_from([
+        "harvest",
+        "workflow",
+        "list",
+        "--state",
+        "RUNNING,FAILED",
+        "--state",
+        "TIMED_OUT",
+    ])
+    .expect("multi-state list args should parse");
+    let request = list.api_request().expect("list request should build");
+
+    assert_eq!(request.path, "/workflows?state=RUNNING,FAILED,TIMED_OUT");
+}
+
+#[test]
+fn workflow_list_rejects_search_attr_without_equals() {
+    let list = Cli::try_parse_from(["harvest", "workflow", "list", "--search-attr", "tenant"])
+        .expect("malformed search-attr args should still parse at clap level");
+
+    let err = list
+        .api_request()
+        .expect_err("malformed search-attr should fail to map");
+    let message = err.to_string();
+    assert!(
+        message.contains("invalid --search-attr"),
+        "unexpected error: {message}"
+    );
+}
+
+#[test]
 fn workflow_signal_and_cancel_use_post_bodies() {
     let signal = Cli::try_parse_from([
         "harvest",

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -230,9 +230,27 @@ struct DagPauseRequest {
     paused: bool,
 }
 
-#[derive(Debug, Deserialize)]
-struct WorkflowListQuery {
-    limit: Option<i64>,
+/// Workflow execution states that the management API recognises in `state=`
+/// filters. Anything outside this list is rejected with `400 Bad Request`.
+pub(crate) const KNOWN_WORKFLOW_STATES: &[&str] =
+    &["RUNNING", "COMPLETED", "FAILED", "CANCELLED", "TIMED_OUT"];
+
+const DEFAULT_WORKFLOW_LIMIT: i64 = 50;
+const MAX_WORKFLOW_LIMIT: i64 = 200;
+
+#[derive(Debug, Default, Clone)]
+pub(crate) struct WorkflowFilters {
+    pub(crate) limit: i64,
+    pub(crate) states: Vec<String>,
+    pub(crate) workflow_name: Option<String>,
+    pub(crate) search_attrs: Vec<Value>,
+}
+
+impl WorkflowFilters {
+    pub(crate) const fn with_limit(mut self, limit: i64) -> Self {
+        self.limit = limit;
+        self
+    }
 }
 
 #[derive(Debug, Deserialize)]
@@ -263,11 +281,82 @@ pub fn harvest_api_router(api_state: HarvestApiState) -> Router<AppState> {
 
 async fn list_workflows(
     Extension(api_state): Extension<HarvestApiState>,
-    Query(query): Query<WorkflowListQuery>,
+    Query(pairs): Query<Vec<(String, String)>>,
 ) -> Result<Json<Vec<WorkflowExecution>>, AutumnError> {
-    let limit = query.limit.unwrap_or(50).clamp(1, 200);
-    let workflows = load_workflows_from_shards(&api_state, None, limit).await?;
+    let filters = parse_workflow_filters(&pairs)?;
+    let workflows = load_workflows_from_shards(&api_state, &filters).await?;
     Ok(Json(workflows))
+}
+
+/// Parse the management-API query string into a `WorkflowFilters`.
+///
+/// State values are comma-separated (or repeated `state=`) and validated
+/// against `KNOWN_WORKFLOW_STATES`. `search_attr=` values must be `key:value`
+/// and are repeatable; each entry contributes a separate JSONB containment
+/// predicate so repeats narrow rather than widen.
+pub(crate) fn parse_workflow_filters(
+    pairs: &[(String, String)],
+) -> Result<WorkflowFilters, AutumnError> {
+    let mut limit_raw: Option<i64> = None;
+    let mut filters = WorkflowFilters::default();
+
+    for (key, value) in pairs {
+        match key.as_str() {
+            "limit" => {
+                let parsed = value.parse::<i64>().map_err(|_| {
+                    AutumnError::bad_request_msg(format!("invalid limit '{value}'"))
+                })?;
+                limit_raw = Some(parsed);
+            }
+            "state" => {
+                for raw in value.split(',') {
+                    let trimmed = raw.trim();
+                    if trimmed.is_empty() {
+                        continue;
+                    }
+                    if !KNOWN_WORKFLOW_STATES.contains(&trimmed) {
+                        return Err(AutumnError::bad_request_msg(format!(
+                            "unknown workflow state '{trimmed}'; expected one of {KNOWN_WORKFLOW_STATES:?}"
+                        )));
+                    }
+                    let owned = trimmed.to_string();
+                    if !filters.states.contains(&owned) {
+                        filters.states.push(owned);
+                    }
+                }
+            }
+            "workflow_name" => {
+                let trimmed = value.trim();
+                if !trimmed.is_empty() {
+                    filters.workflow_name = Some(trimmed.to_string());
+                }
+            }
+            "search_attr" => {
+                let (raw_key, raw_val) = value.split_once(':').ok_or_else(|| {
+                    AutumnError::bad_request_msg(format!(
+                        "invalid search_attr '{value}'; expected 'key:value'"
+                    ))
+                })?;
+                let attr_key = raw_key.trim();
+                if attr_key.is_empty() {
+                    return Err(AutumnError::bad_request_msg(format!(
+                        "search_attr '{value}' is missing a key"
+                    )));
+                }
+                let mut object = serde_json::Map::with_capacity(1);
+                object.insert(attr_key.to_string(), Value::String(raw_val.to_string()));
+                filters.search_attrs.push(Value::Object(object));
+            }
+            _ => {
+                // Ignore unknown query parameters so future additions stay non-breaking.
+            }
+        }
+    }
+
+    let limit = limit_raw
+        .unwrap_or(DEFAULT_WORKFLOW_LIMIT)
+        .clamp(1, MAX_WORKFLOW_LIMIT);
+    Ok(filters.with_limit(limit))
 }
 
 async fn get_workflow(
@@ -637,15 +726,26 @@ async fn db_conn_for_dag(
 
 pub(crate) async fn load_workflows(
     conn: &mut AsyncPgConnection,
-    state_filter: Option<&str>,
-    limit: i64,
+    filters: &WorkflowFilters,
 ) -> HarvestResult<Vec<WorkflowExecution>> {
+    use diesel::dsl::sql;
+    use diesel::sql_types::{Bool, Jsonb};
+
     let mut query = harvest_workflow_executions::table
         .into_boxed()
         .order(harvest_workflow_executions::created_at.desc())
-        .limit(limit);
-    if let Some(state) = state_filter {
-        query = query.filter(harvest_workflow_executions::state.eq(state.to_string()));
+        .limit(filters.limit);
+    if !filters.states.is_empty() {
+        query = query.filter(harvest_workflow_executions::state.eq_any(filters.states.clone()));
+    }
+    if let Some(name) = &filters.workflow_name {
+        query = query.filter(harvest_workflow_executions::workflow_name.eq(name.clone()));
+    }
+    // Each search_attr filter contributes its own `search_attrs @> {...}` predicate.
+    // The `@>` operator hits the existing `idx_harvest_we_search` GIN index on
+    // `search_attrs`; ANDing predicates means repeated keys narrow the result set.
+    for predicate in &filters.search_attrs {
+        query = query.filter(sql::<Bool>("search_attrs @> ").bind::<Jsonb, _>(predicate.clone()));
     }
     query
         .select(WorkflowExecution::as_select())
@@ -656,15 +756,14 @@ pub(crate) async fn load_workflows(
 
 pub(crate) async fn load_workflows_from_shards(
     api_state: &HarvestApiState,
-    state_filter: Option<&str>,
-    limit: i64,
+    filters: &WorkflowFilters,
 ) -> Result<Vec<WorkflowExecution>, AutumnError> {
     let pool = api_state.storage_pool().map_err(map_error)?;
     let mut workflows = Vec::new();
 
     for (_shard, shard_pool) in pool.iter_shards() {
         let mut conn = acquire_conn(shard_pool).await?;
-        let mut rows = load_workflows(&mut conn, state_filter, limit)
+        let mut rows = load_workflows(&mut conn, filters)
             .await
             .map_err(map_error)?;
         workflows.append(&mut rows);
@@ -676,7 +775,7 @@ pub(crate) async fn load_workflows_from_shards(
             .cmp(&left.created_at)
             .then_with(|| right.id.cmp(&left.id))
     });
-    workflows.truncate(usize::try_from(limit).unwrap_or(usize::MAX));
+    workflows.truncate(usize::try_from(filters.limit).unwrap_or(usize::MAX));
     Ok(workflows)
 }
 
@@ -773,5 +872,102 @@ pub(crate) fn map_error(error: HarvestError) -> AutumnError {
         } => AutumnError::bad_request_msg(message),
         HarvestError::Database(message) => AutumnError::service_unavailable_msg(message),
         other => AutumnError::service_unavailable_msg(other.to_string()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn pairs(values: &[(&str, &str)]) -> Vec<(String, String)> {
+        values
+            .iter()
+            .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn parse_workflow_filters_defaults_to_empty_filters_with_default_limit() {
+        let filters = parse_workflow_filters(&[]).expect("no params should parse");
+        assert_eq!(filters.limit, DEFAULT_WORKFLOW_LIMIT);
+        assert!(filters.states.is_empty());
+        assert!(filters.workflow_name.is_none());
+        assert!(filters.search_attrs.is_empty());
+    }
+
+    #[test]
+    fn parse_workflow_filters_accepts_comma_and_repeated_states() {
+        let filters = parse_workflow_filters(&pairs(&[
+            ("state", "RUNNING,FAILED"),
+            ("state", "TIMED_OUT"),
+        ]))
+        .expect("multi-state should parse");
+        assert_eq!(
+            filters.states,
+            vec![
+                "RUNNING".to_string(),
+                "FAILED".to_string(),
+                "TIMED_OUT".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn parse_workflow_filters_rejects_unknown_state() {
+        let err = parse_workflow_filters(&pairs(&[("state", "BOGUS")]))
+            .expect_err("unknown state must error");
+        assert!(err.to_string().contains("unknown workflow state"));
+    }
+
+    #[test]
+    fn parse_workflow_filters_builds_search_attr_predicates() {
+        let filters = parse_workflow_filters(&pairs(&[
+            ("search_attr", "tenant:acme"),
+            ("search_attr", "customer_id:42"),
+        ]))
+        .expect("search_attr pairs should parse");
+        assert_eq!(filters.search_attrs.len(), 2);
+        assert_eq!(filters.search_attrs[0]["tenant"], "acme");
+        assert_eq!(filters.search_attrs[1]["customer_id"], "42");
+    }
+
+    #[test]
+    fn parse_workflow_filters_rejects_search_attr_without_separator() {
+        let err = parse_workflow_filters(&pairs(&[("search_attr", "tenant")]))
+            .expect_err("missing separator must error");
+        assert!(err.to_string().contains("invalid search_attr"));
+    }
+
+    #[test]
+    fn parse_workflow_filters_rejects_search_attr_with_empty_key() {
+        let err = parse_workflow_filters(&pairs(&[("search_attr", ":acme")]))
+            .expect_err("empty key must error");
+        assert!(err.to_string().contains("missing a key"));
+    }
+
+    #[test]
+    fn parse_workflow_filters_clamps_limit_to_documented_range() {
+        let filters = parse_workflow_filters(&pairs(&[("limit", "9001")]))
+            .expect("oversize limit should clamp");
+        assert_eq!(filters.limit, MAX_WORKFLOW_LIMIT);
+
+        let filters =
+            parse_workflow_filters(&pairs(&[("limit", "0")])).expect("zero limit should clamp");
+        assert_eq!(filters.limit, 1);
+    }
+
+    #[test]
+    fn parse_workflow_filters_rejects_non_numeric_limit() {
+        let err = parse_workflow_filters(&pairs(&[("limit", "abc")]))
+            .expect_err("non-numeric limit must error");
+        assert!(err.to_string().contains("invalid limit"));
+    }
+
+    #[test]
+    fn parse_workflow_filters_ignores_unknown_query_keys() {
+        let filters = parse_workflow_filters(&pairs(&[("ignored", "value")]))
+            .expect("unknown keys should be skipped");
+        assert!(filters.states.is_empty());
+        assert!(filters.workflow_name.is_none());
     }
 }

--- a/autumn-harvest-plugin/src/ui.rs
+++ b/autumn-harvest-plugin/src/ui.rs
@@ -24,14 +24,14 @@ use autumn_harvest::models::WorkflowExecution;
 use autumn_harvest::store;
 
 use crate::api::{
-    HarvestApiState, db_conn_for_execution, load_execution, load_workflows_from_shards, map_error,
-    parse_execution_id,
+    HarvestApiState, KNOWN_WORKFLOW_STATES, WorkflowFilters, db_conn_for_execution, load_execution,
+    load_workflows_from_shards, map_error, parse_execution_id,
 };
 
 const DEFAULT_PAGE_SIZE: i64 = 25;
 const MAX_PAGE_SIZE: i64 = 200;
 
-const KNOWN_STATES: &[&str] = &["RUNNING", "COMPLETED", "FAILED", "CANCELLED"];
+const KNOWN_STATES: &[&str] = KNOWN_WORKFLOW_STATES;
 
 const STYLE: &str = r#"
 *,*::before,*::after{box-sizing:border-box}
@@ -90,6 +90,12 @@ pub(crate) struct WorkflowListParams {
     limit: Option<i64>,
     #[serde(default)]
     state: Option<String>,
+    #[serde(default)]
+    workflow_name: Option<String>,
+    #[serde(default)]
+    search_attr_key: Option<String>,
+    #[serde(default)]
+    search_attr_value: Option<String>,
 }
 
 /// Build the Vantage dashboard router.
@@ -123,9 +129,43 @@ async fn list_workflows_ui(
         .filter(|value| !value.is_empty())
         .map(str::to_string);
 
+    let workflow_name_filter = params
+        .workflow_name
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
+
+    let search_attr_key = params
+        .search_attr_key
+        .as_deref()
+        .map(str::trim)
+        .filter(|value| !value.is_empty())
+        .map(str::to_string);
+    let search_attr_value = params
+        .search_attr_value
+        .as_deref()
+        .map(str::to_string)
+        .unwrap_or_default();
+    // Only enforce the search_attr predicate when the user supplied a key.
+    // The value may legitimately be the empty string.
+    let search_attr_pair = search_attr_key
+        .as_ref()
+        .map(|key| (key.clone(), search_attr_value.clone()));
+
     let fetch_limit = offset.saturating_add(limit).saturating_add(1);
-    let workflows =
-        load_workflows_from_shards(&api_state, state_filter.as_deref(), fetch_limit).await?;
+    let mut filters = WorkflowFilters::default().with_limit(fetch_limit);
+    if let Some(state) = state_filter.as_deref() {
+        filters.states.push(state.to_string());
+    }
+    filters.workflow_name.clone_from(&workflow_name_filter);
+    if let Some((key, value)) = search_attr_pair.clone() {
+        let mut object = serde_json::Map::with_capacity(1);
+        object.insert(key, Value::String(value));
+        filters.search_attrs.push(Value::Object(object));
+    }
+
+    let workflows = load_workflows_from_shards(&api_state, &filters).await?;
     let limit_usize = usize::try_from(limit).unwrap_or(usize::MAX);
     let offset_usize = usize::try_from(offset).unwrap_or(usize::MAX);
     let has_next = workflows.len() > offset_usize.saturating_add(limit_usize);
@@ -141,6 +181,8 @@ async fn list_workflows_ui(
         limit,
         has_next,
         state_filter.as_deref(),
+        workflow_name_filter.as_deref(),
+        search_attr_pair.as_ref(),
     )))
 }
 
@@ -172,10 +214,17 @@ fn render_workflow_list(
     limit: i64,
     has_next: bool,
     state_filter: Option<&str>,
+    workflow_name_filter: Option<&str>,
+    search_attr_filter: Option<&(String, String)>,
 ) -> String {
     let mut body = String::new();
     body.push_str("<h2>Workflows</h2>");
-    body.push_str(&render_filters(state_filter, limit));
+    body.push_str(&render_filters(
+        state_filter,
+        workflow_name_filter,
+        search_attr_filter,
+        limit,
+    ));
 
     if workflows.is_empty() {
         body.push_str("<div class=\"card empty\">No workflows match this filter.</div>");
@@ -206,12 +255,24 @@ fn render_workflow_list(
         body.push_str("</tbody></table>");
     }
 
-    body.push_str(&render_pagination(page, limit, has_next, state_filter));
+    body.push_str(&render_pagination(
+        page,
+        limit,
+        has_next,
+        state_filter,
+        workflow_name_filter,
+        search_attr_filter,
+    ));
 
     layout("Workflows · Vantage", &body)
 }
 
-fn render_filters(state_filter: Option<&str>, limit: i64) -> String {
+fn render_filters(
+    state_filter: Option<&str>,
+    workflow_name_filter: Option<&str>,
+    search_attr_filter: Option<&(String, String)>,
+    limit: i64,
+) -> String {
     let mut out = String::new();
     out.push_str("<form class=\"filters\" method=\"get\" action=\"workflows\">");
     out.push_str("<label>State<select name=\"state\">");
@@ -227,6 +288,23 @@ fn render_filters(state_filter: Option<&str>, limit: i64) -> String {
     out.push_str("</select></label>");
     let _ = write!(
         out,
+        "<label>Workflow name<input type=\"text\" name=\"workflow_name\" value=\"{value}\" placeholder=\"e.g. onboarding\"></label>",
+        value = html_escape(workflow_name_filter.unwrap_or("")),
+    );
+    let (attr_key, attr_value) =
+        search_attr_filter.map_or(("", ""), |(k, v)| (k.as_str(), v.as_str()));
+    let _ = write!(
+        out,
+        "<label>Search attr key<input type=\"text\" name=\"search_attr_key\" value=\"{key}\" placeholder=\"e.g. tenant\"></label>",
+        key = html_escape(attr_key),
+    );
+    let _ = write!(
+        out,
+        "<label>Search attr value<input type=\"text\" name=\"search_attr_value\" value=\"{value}\" placeholder=\"e.g. acme\"></label>",
+        value = html_escape(attr_value),
+    );
+    let _ = write!(
+        out,
         "<label>Per page<input type=\"number\" name=\"limit\" min=\"1\" max=\"{MAX_PAGE_SIZE}\" value=\"{limit}\"></label>"
     );
     out.push_str("<button type=\"submit\">Apply</button>");
@@ -235,11 +313,23 @@ fn render_filters(state_filter: Option<&str>, limit: i64) -> String {
     out
 }
 
-fn render_pagination(page: i64, limit: i64, has_next: bool, state_filter: Option<&str>) -> String {
+fn render_pagination(
+    page: i64,
+    limit: i64,
+    has_next: bool,
+    state_filter: Option<&str>,
+    workflow_name_filter: Option<&str>,
+    search_attr_filter: Option<&(String, String)>,
+) -> String {
     let mut out = String::new();
     out.push_str("<div class=\"pagination\">");
 
-    let base_query = build_query_string(limit, state_filter);
+    let base_query = build_query_string(
+        limit,
+        state_filter,
+        workflow_name_filter,
+        search_attr_filter,
+    );
 
     if page > 0 {
         let _ = write!(
@@ -268,13 +358,25 @@ fn render_pagination(page: i64, limit: i64, has_next: bool, state_filter: Option
     out
 }
 
-fn build_query_string(limit: i64, state_filter: Option<&str>) -> String {
+fn build_query_string(
+    limit: i64,
+    state_filter: Option<&str>,
+    workflow_name_filter: Option<&str>,
+    search_attr_filter: Option<&(String, String)>,
+) -> String {
     let mut out = String::new();
     if limit != DEFAULT_PAGE_SIZE {
         let _ = write!(out, "&limit={limit}");
     }
     if let Some(state) = state_filter {
         let _ = write!(out, "&state={}", url_encode(state));
+    }
+    if let Some(name) = workflow_name_filter {
+        let _ = write!(out, "&workflow_name={}", url_encode(name));
+    }
+    if let Some((key, value)) = search_attr_filter {
+        let _ = write!(out, "&search_attr_key={}", url_encode(key));
+        let _ = write!(out, "&search_attr_value={}", url_encode(value));
     }
     out
 }
@@ -521,15 +623,24 @@ mod tests {
 
     #[test]
     fn build_query_string_omits_default_limit() {
-        assert_eq!(build_query_string(DEFAULT_PAGE_SIZE, None), "");
-        assert_eq!(build_query_string(10, None), "&limit=10");
+        assert_eq!(build_query_string(DEFAULT_PAGE_SIZE, None, None, None), "");
+        assert_eq!(build_query_string(10, None, None, None), "&limit=10");
         assert_eq!(
-            build_query_string(DEFAULT_PAGE_SIZE, Some("FAILED")),
+            build_query_string(DEFAULT_PAGE_SIZE, Some("FAILED"), None, None),
             "&state=FAILED"
         );
         assert_eq!(
-            build_query_string(50, Some("with space")),
+            build_query_string(50, Some("with space"), None, None),
             "&limit=50&state=with%20space"
+        );
+        assert_eq!(
+            build_query_string(
+                DEFAULT_PAGE_SIZE,
+                None,
+                Some("onboarding"),
+                Some(&("tenant".to_string(), "acme".to_string())),
+            ),
+            "&workflow_name=onboarding&search_attr_key=tenant&search_attr_value=acme"
         );
     }
 }

--- a/autumn-harvest-plugin/tests/workflow_filter_integration.rs
+++ b/autumn-harvest-plugin/tests/workflow_filter_integration.rs
@@ -1,0 +1,476 @@
+//! Integration tests for the new workflow-list filter knobs on
+//! `GET /workflows` (issue #83). Seeds three workflows with distinct
+//! `search_attrs` and asserts each filter combination returns exactly the
+//! expected subset, including against a sharded deployment. Also verifies the
+//! GIN index `idx_harvest_we_search` covers the search-attribute predicate via
+//! `EXPLAIN`.
+
+use std::collections::BTreeMap;
+
+use autumn_harvest::schema::harvest_workflow_executions;
+use autumn_harvest::shard::ShardedDbPool;
+use autumn_harvest::types::{ExecutionId, ShardId};
+use autumn_harvest::worker::DbPool;
+use autumn_harvest::{StartWorkflowParams, start_or_load_workflow_execution};
+use autumn_harvest_plugin::HarvestDbPool;
+use autumn_harvest_plugin::api::{HarvestApiState, harvest_api_router};
+use autumn_web::AppState;
+use autumn_web::reexports::axum;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use diesel::ExpressionMethods;
+use diesel::QueryDsl;
+use diesel::QueryableByName;
+use diesel_async::AsyncConnection;
+use diesel_async::AsyncPgConnection;
+use diesel_async::RunQueryDsl;
+use diesel_async::SimpleAsyncConnection;
+use diesel_async::pooled_connection::AsyncDieselConnectionManager;
+use serde_json::{Value, json};
+use testcontainers::ContainerAsync;
+use testcontainers_modules::postgres::Postgres;
+use testcontainers_modules::testcontainers::runners::AsyncRunner;
+use tower::ServiceExt;
+
+const INIT_SQL: &str = concat!(
+    include_str!("../../autumn-harvest/migrations/20260409000000_harvest_initial/up.sql"),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260424000001_harvest_trace_context/up.sql"),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260427000000_harvest_continue_as_new/up.sql"),
+);
+
+type HarvestApiApp = axum::Router;
+
+fn test_app_state_without_database() -> AppState {
+    AppState::for_test().with_profile("test")
+}
+
+async fn setup_single_database() -> (String, ContainerAsync<Postgres>) {
+    let container = Postgres::default()
+        .with_init_sql(INIT_SQL.to_string().into_bytes())
+        .start()
+        .await
+        .expect("failed to start Postgres container");
+
+    let host = container
+        .get_host()
+        .await
+        .expect("failed to get container host");
+    let port = container
+        .get_host_port_ipv4(5432)
+        .await
+        .expect("failed to get container port");
+    let database_url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+
+    (database_url, container)
+}
+
+async fn setup_sharded_databases() -> ((String, String), ContainerAsync<Postgres>) {
+    let container = Postgres::default()
+        .start()
+        .await
+        .expect("failed to start Postgres container");
+
+    let host = container
+        .get_host()
+        .await
+        .expect("failed to get container host");
+    let port = container
+        .get_host_port_ipv4(5432)
+        .await
+        .expect("failed to get container port");
+    let admin_url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+    let shard0_db = format!("harvest_shard_{}", uuid::Uuid::new_v4().simple());
+    let shard1_db = format!("harvest_shard_{}", uuid::Uuid::new_v4().simple());
+
+    let mut admin_conn = <AsyncPgConnection as AsyncConnection>::establish(&admin_url)
+        .await
+        .expect("failed to connect to admin database");
+    diesel::sql_query(format!("CREATE DATABASE {shard0_db}"))
+        .execute(&mut admin_conn)
+        .await
+        .expect("failed to create shard 0 database");
+    diesel::sql_query(format!("CREATE DATABASE {shard1_db}"))
+        .execute(&mut admin_conn)
+        .await
+        .expect("failed to create shard 1 database");
+
+    let shard0_url = format!("postgres://postgres:postgres@{host}:{port}/{shard0_db}");
+    let shard1_url = format!("postgres://postgres:postgres@{host}:{port}/{shard1_db}");
+
+    for shard_url in [&shard0_url, &shard1_url] {
+        let mut conn = <AsyncPgConnection as AsyncConnection>::establish(shard_url)
+            .await
+            .expect("failed to connect to shard database");
+        conn.batch_execute(INIT_SQL)
+            .await
+            .expect("failed to apply harvest migrations to shard database");
+    }
+
+    ((shard0_url, shard1_url), container)
+}
+
+fn build_pool(database_url: &str) -> DbPool {
+    let manager = AsyncDieselConnectionManager::<AsyncPgConnection>::new(database_url);
+    deadpool::managed::Pool::builder(manager)
+        .max_size(4)
+        .build()
+        .expect("failed to build test pool")
+}
+
+fn build_two_shard_pool(shard0_url: &str, shard1_url: &str) -> HarvestDbPool {
+    let mut pools = BTreeMap::new();
+    pools.insert(ShardId::new(0), build_pool(shard0_url));
+    pools.insert(ShardId::new(1), build_pool(shard1_url));
+    HarvestDbPool::sharded(ShardedDbPool::from_map(pools, ShardId::new(0)))
+}
+
+async fn seed_workflow(
+    database_url: &str,
+    shard: ShardId,
+    workflow_name: &str,
+    workflow_id: &str,
+    search_attrs: Option<Value>,
+) -> ExecutionId {
+    let exec_id = ExecutionId::new_for_shard(shard);
+    let mut conn = <AsyncPgConnection as AsyncConnection>::establish(database_url)
+        .await
+        .expect("failed to connect to seed workflow");
+    start_or_load_workflow_execution(
+        &mut conn,
+        StartWorkflowParams {
+            workflow_name,
+            workflow_id,
+            exec_id,
+            input: json!({ "workflow_id": workflow_id }),
+            parent_id: None,
+            queue_name: "default",
+            execution_timeout: None,
+            memo: None,
+            search_attrs,
+        },
+    )
+    .await
+    .expect("seed workflow should succeed");
+    exec_id
+}
+
+async fn mark_state(database_url: &str, exec_id: ExecutionId, new_state: &str) {
+    let mut conn = <AsyncPgConnection as AsyncConnection>::establish(database_url)
+        .await
+        .expect("failed to connect to update state");
+    diesel::update(harvest_workflow_executions::table.find(exec_id.as_uuid()))
+        .set(harvest_workflow_executions::state.eq(new_state.to_string()))
+        .execute(&mut conn)
+        .await
+        .expect("state update should succeed");
+}
+
+async fn get_json(app: &HarvestApiApp, uri: impl Into<String>) -> (StatusCode, Value) {
+    let uri = uri.into();
+    let response = app
+        .clone()
+        .oneshot(Request::builder().uri(&uri).body(Body::empty()).unwrap())
+        .await
+        .expect("GET request failed");
+    let status = response.status();
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("failed to read response body");
+    let json: Value = if body.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&body).expect("response must be JSON")
+    };
+    (status, json)
+}
+
+fn workflow_ids(value: &Value) -> Vec<String> {
+    value
+        .as_array()
+        .expect("workflow list must be an array")
+        .iter()
+        .map(|row| {
+            row["workflow_id"]
+                .as_str()
+                .expect("workflow_id must be a string")
+                .to_string()
+        })
+        .collect()
+}
+
+#[tokio::test]
+#[allow(clippy::too_many_lines)]
+async fn workflow_list_filters_match_expected_subsets() {
+    let (database_url, _container) = setup_single_database().await;
+    let pool = build_pool(&database_url);
+    let api_state = HarvestApiState::new();
+    api_state.install_storage_pool(HarvestDbPool::from(pool.clone()));
+    let app = harvest_api_router(api_state).with_state(test_app_state_without_database());
+
+    let onboarding_acme = seed_workflow(
+        &database_url,
+        ShardId::new(0),
+        "onboarding",
+        "wf-onboarding-acme",
+        Some(json!({ "tenant": "acme", "customer_id": "42" })),
+    )
+    .await;
+    let onboarding_beta = seed_workflow(
+        &database_url,
+        ShardId::new(0),
+        "onboarding",
+        "wf-onboarding-beta",
+        Some(json!({ "tenant": "beta", "customer_id": "99" })),
+    )
+    .await;
+    let billing_acme = seed_workflow(
+        &database_url,
+        ShardId::new(0),
+        "billing",
+        "wf-billing-acme",
+        Some(json!({ "tenant": "acme", "customer_id": "42" })),
+    )
+    .await;
+
+    // Mark one workflow as FAILED so we can exercise multi-state filters.
+    mark_state(&database_url, billing_acme, "FAILED").await;
+
+    // No filters -> all three rows visible (order is created_at desc).
+    let (status, json) = get_json(&app, "/workflows").await;
+    assert_eq!(status, StatusCode::OK);
+    let mut ids = workflow_ids(&json);
+    ids.sort();
+    assert_eq!(
+        ids,
+        vec![
+            "wf-billing-acme".to_string(),
+            "wf-onboarding-acme".to_string(),
+            "wf-onboarding-beta".to_string(),
+        ]
+    );
+
+    // workflow_name only.
+    let (_, json) = get_json(&app, "/workflows?workflow_name=onboarding").await;
+    let mut ids = workflow_ids(&json);
+    ids.sort();
+    assert_eq!(
+        ids,
+        vec![
+            "wf-onboarding-acme".to_string(),
+            "wf-onboarding-beta".to_string(),
+        ]
+    );
+
+    // search_attr (single key).
+    let (_, json) = get_json(&app, "/workflows?search_attr=tenant:acme").await;
+    let mut ids = workflow_ids(&json);
+    ids.sort();
+    assert_eq!(
+        ids,
+        vec![
+            "wf-billing-acme".to_string(),
+            "wf-onboarding-acme".to_string(),
+        ]
+    );
+
+    // workflow_name + search_attr narrows to a single row.
+    let (_, json) = get_json(
+        &app,
+        "/workflows?workflow_name=onboarding&search_attr=tenant:acme",
+    )
+    .await;
+    assert_eq!(workflow_ids(&json), vec!["wf-onboarding-acme".to_string()]);
+
+    // Multiple search_attr predicates AND together.
+    let (_, json) = get_json(
+        &app,
+        "/workflows?search_attr=tenant:acme&search_attr=customer_id:42",
+    )
+    .await;
+    let mut ids = workflow_ids(&json);
+    ids.sort();
+    assert_eq!(
+        ids,
+        vec![
+            "wf-billing-acme".to_string(),
+            "wf-onboarding-acme".to_string(),
+        ]
+    );
+
+    // Repeating the same key with a different value narrows to zero rows.
+    let (_, json) = get_json(
+        &app,
+        "/workflows?search_attr=tenant:acme&search_attr=tenant:beta",
+    )
+    .await;
+    assert!(
+        json.as_array().expect("array").is_empty(),
+        "contradictory predicates should match nothing"
+    );
+
+    // state filter -- multiple values via comma-separated form.
+    let (_, json) = get_json(&app, "/workflows?state=RUNNING,FAILED").await;
+    let mut ids = workflow_ids(&json);
+    ids.sort();
+    assert_eq!(
+        ids,
+        vec![
+            "wf-billing-acme".to_string(),
+            "wf-onboarding-acme".to_string(),
+            "wf-onboarding-beta".to_string(),
+        ]
+    );
+
+    // state filter -- repeated key form is also accepted.
+    let (_, json) = get_json(&app, "/workflows?state=FAILED&state=CANCELLED").await;
+    assert_eq!(workflow_ids(&json), vec!["wf-billing-acme".to_string()]);
+
+    // Combined: state + workflow_name + search_attr = 1 row.
+    let (_, json) = get_json(
+        &app,
+        "/workflows?state=RUNNING&workflow_name=onboarding&search_attr=tenant:acme",
+    )
+    .await;
+    assert_eq!(workflow_ids(&json), vec!["wf-onboarding-acme".to_string()]);
+
+    // Reference the unused exec ids so dead-code lints stay quiet.
+    let _ = (onboarding_acme, onboarding_beta);
+}
+
+#[tokio::test]
+async fn workflow_list_invalid_filters_return_400() {
+    let (database_url, _container) = setup_single_database().await;
+    let pool = build_pool(&database_url);
+    let api_state = HarvestApiState::new();
+    api_state.install_storage_pool(HarvestDbPool::from(pool));
+    let app = harvest_api_router(api_state).with_state(test_app_state_without_database());
+
+    let (status, body) = get_json(&app, "/workflows?state=NOT_A_STATE").await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(
+        body.to_string().contains("unknown workflow state"),
+        "expected helpful error, got {body}"
+    );
+
+    let (status, body) = get_json(&app, "/workflows?search_attr=tenant").await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(
+        body.to_string().contains("invalid search_attr"),
+        "expected helpful error, got {body}"
+    );
+
+    let (status, body) = get_json(&app, "/workflows?search_attr=:acme").await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(
+        body.to_string().contains("missing a key"),
+        "expected helpful error, got {body}"
+    );
+
+    let (status, _) = get_json(&app, "/workflows?limit=not-a-number").await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn workflow_list_filters_apply_across_shards() {
+    let ((shard0_url, shard1_url), _container) = setup_sharded_databases().await;
+    let api_state = HarvestApiState::new();
+    api_state.install_storage_pool(build_two_shard_pool(&shard0_url, &shard1_url));
+    let app = harvest_api_router(api_state).with_state(test_app_state_without_database());
+
+    let _ = seed_workflow(
+        &shard0_url,
+        ShardId::new(0),
+        "onboarding",
+        "wf-on-zero-acme",
+        Some(json!({ "tenant": "acme" })),
+    )
+    .await;
+    let _ = seed_workflow(
+        &shard1_url,
+        ShardId::new(1),
+        "onboarding",
+        "wf-on-one-acme",
+        Some(json!({ "tenant": "acme" })),
+    )
+    .await;
+    let _ = seed_workflow(
+        &shard1_url,
+        ShardId::new(1),
+        "billing",
+        "wf-on-one-beta",
+        Some(json!({ "tenant": "beta" })),
+    )
+    .await;
+
+    let (status, json) = get_json(
+        &app,
+        "/workflows?workflow_name=onboarding&search_attr=tenant:acme&limit=10",
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let mut ids = workflow_ids(&json);
+    ids.sort();
+    assert_eq!(
+        ids,
+        vec!["wf-on-one-acme".to_string(), "wf-on-zero-acme".to_string()],
+        "filter must apply to results from every shard"
+    );
+
+    // Shard merge respects the limit cap.
+    let (_, json) = get_json(&app, "/workflows?search_attr=tenant:acme&limit=1").await;
+    assert_eq!(
+        json.as_array().map(Vec::len),
+        Some(1),
+        "limit must clamp the merged shard result set"
+    );
+}
+
+#[derive(QueryableByName)]
+struct ExplainRow {
+    #[diesel(sql_type = diesel::sql_types::Text, column_name = "QUERY PLAN")]
+    plan: String,
+}
+
+#[tokio::test]
+async fn workflow_search_attr_predicate_uses_gin_index() {
+    let (database_url, _container) = setup_single_database().await;
+
+    let _onboarding = seed_workflow(
+        &database_url,
+        ShardId::new(0),
+        "onboarding",
+        "wf-on-acme",
+        Some(json!({ "tenant": "acme", "customer_id": "42" })),
+    )
+    .await;
+
+    let mut conn = <AsyncPgConnection as AsyncConnection>::establish(&database_url)
+        .await
+        .expect("failed to connect for EXPLAIN");
+    // Force the planner to consider the GIN index even though the test table
+    // is tiny; otherwise the seq scan will always win on cost and obscure the
+    // index plan we want to assert on.
+    conn.batch_execute("SET enable_seqscan = off")
+        .await
+        .expect("disable seqscan should succeed");
+
+    let plans: Vec<ExplainRow> = diesel::sql_query(
+        "EXPLAIN SELECT id FROM harvest_workflow_executions \
+         WHERE search_attrs @> '{\"tenant\":\"acme\"}'::jsonb",
+    )
+    .load(&mut conn)
+    .await
+    .expect("EXPLAIN should succeed");
+
+    let plan_text = plans
+        .into_iter()
+        .map(|row| row.plan)
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        plan_text.contains("idx_harvest_we_search"),
+        "expected EXPLAIN plan to use idx_harvest_we_search, got:\n{plan_text}"
+    );
+}


### PR DESCRIPTION
## Summary

Implements comprehensive filtering capabilities for the workflow list endpoint (`GET /workflows`) and CLI command, allowing users to filter by execution state, workflow name, and search attributes. This addresses issue #83 and includes extensive integration tests validating filter behavior across single and sharded deployments.

## Key Changes

- **Management API filtering** (`autumn-harvest-plugin/src/api.rs`):
  - Added `WorkflowFilters` struct to encapsulate limit, states, workflow_name, and search_attrs
  - Implemented `parse_workflow_filters()` to parse and validate query parameters with helpful error messages
  - Updated `load_workflows()` to apply filters using Diesel query builder, including JSONB containment (`@>`) for search attributes
  - Updated `load_workflows_from_shards()` to merge filtered results from all shards and respect the limit cap
  - Added `KNOWN_WORKFLOW_STATES` constant for validation
  - Comprehensive unit tests for filter parsing logic

- **CLI support** (`autumn-harvest-cli/src/lib.rs`):
  - Added `--state`, `--workflow-name`, and `--search-attr` flags to `workflow list` command
  - Implemented `build_workflow_list_path()` to construct query strings with proper encoding
  - Added `query_encode()` for RFC 3986 compliant URL encoding (preserving `:` for search_attr format)
  - Added `InvalidSearchAttr` error variant for malformed search attribute arguments

- **UI enhancements** (`autumn-harvest-plugin/src/ui.rs`):
  - Extended `WorkflowListParams` with workflow_name and search_attr_key/value fields
  - Updated filter rendering to include text inputs for workflow name and search attributes
  - Integrated new filters into pagination query string building

- **Integration tests** (`autumn-harvest-plugin/tests/workflow_filter_integration.rs`):
  - Comprehensive test suite with 476 lines covering:
    - Single and multi-value state filtering
    - Workflow name filtering
    - Search attribute filtering with AND semantics for repeated keys
    - Combined filter interactions
    - Invalid filter rejection with helpful error messages
    - Cross-shard filtering with proper limit handling
    - GIN index usage verification via `EXPLAIN` analysis

## Notable Implementation Details

- **Search attributes use JSONB containment**: Each `search_attr=key:value` filter generates a `search_attrs @> '{"key":"value"}'::jsonb` predicate, leveraging the existing `idx_harvest_we_search` GIN index for efficient queries
- **Multiple search_attr filters AND together**: Repeated keys narrow results (e.g., `tenant=acme&tenant=beta` matches nothing)
- **State values are comma-separated or repeated**: Both `?state=RUNNING,FAILED` and `?state=RUNNING&state=FAILED` are accepted
- **Sharded deployment support**: Filters apply to each shard independently, results are merged and re-sorted by creation time, then truncated to the limit
- **Backward compatible**: Unknown query parameters are silently ignored for future extensibility

https://claude.ai/code/session_01BzbTpugzWjo38dpRVnJFBS