### PR TITLE
⚡ Bolt: Make TaskStatus Copy to avoid allocations

### DIFF
--- a/autumn-harvest/src/dag_simulator.rs
+++ b/autumn-harvest/src/dag_simulator.rs
@@ -81,7 +81,7 @@ impl DagSimulator {
                 let upstream_statuses: Vec<TaskStatus> = task
                     .upstreams
                     .iter()
-                    .map(|&up_idx| task_states[up_idx].clone())
+                    .map(|&up_idx| task_states[up_idx])
                     .collect();
 
                 // Evaluate trigger rule

--- a/autumn-harvest/src/policy.rs
+++ b/autumn-harvest/src/policy.rs
@@ -144,7 +144,7 @@ impl Default for RetryPolicy {
 /// let status = TaskStatus::Succeeded;
 /// assert_eq!(status, TaskStatus::Succeeded);
 /// ```
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TaskStatus {
     /// The task executed and returned success.
     Succeeded,

--- a/autumn-harvest/src/scheduler.rs
+++ b/autumn-harvest/src/scheduler.rs
@@ -538,7 +538,7 @@ async fn execute_dag_run(
             let upstream_statuses: Vec<_> = task
                 .upstreams
                 .iter()
-                .map(|upstream| statuses[*upstream].clone())
+                .map(|upstream| statuses[*upstream])
                 .collect();
             let registry = Arc::clone(&registry);
             let task_input = Arc::clone(&run_input);


### PR DESCRIPTION
💡 What: Derived `Copy` on `TaskStatus` and removed unnecessary `.clone()` calls during DAG evaluation.
🎯 Why: `TaskStatus` is a small unit enum that fits perfectly in registers. Cloning it in a hot loop (DAG task upstream resolution) introduces unnecessary overhead and prevents treating it like primitive data.
📊 Impact: Eliminates `.clone()` calls and potential extra operations when mapping upstream statuses in the scheduler execution loop, ensuring zero-cost abstraction for simple state matching.
🔬 Measurement: Observe standard scheduler execution; unit tests for `TriggerRule` continue to pass seamlessly.

---
*PR created automatically by Jules for task [3249702506175992457](https://jules.google.com/task/3249702506175992457) started by @madmax983*