### PR TITLE
Add opt-in retention janitor with API/CLI controls and builder integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,10 @@ async fn main() {
   polling backoff.
 - **Dead letter queue** for tasks that exhaust their retry policy, with
   management endpoints to inspect and replay entries.
+- **Retention janitor** (opt-in) to prune completed workflow histories older
+  than a configured max age, with status and run-now controls on the admin API.
+  Running workflows are unaffected because only terminal-state executions with
+  `completed_at` older than the retention window are eligible.
 - **Separate worker/web connection pools** with a shared ceiling so worker
   bursts can't starve HTTP request handling.
 
@@ -118,6 +122,8 @@ cargo run -p autumn-harvest-cli -- dag trigger daily_pipeline --conf-json '{"dat
 cargo run -p autumn-harvest-cli -- dag pause daily_pipeline
 cargo run -p autumn-harvest-cli -- dlq list --limit 25
 cargo run -p autumn-harvest-cli -- dlq replay <dead-letter-id>
+cargo run -p autumn-harvest-cli -- retention status
+cargo run -p autumn-harvest-cli -- retention run-now
 ```
 
 Configure the API mount with `--base-url` or `HARVEST_URL` (default:

--- a/autumn-harvest-cli/src/lib.rs
+++ b/autumn-harvest-cli/src/lib.rs
@@ -163,6 +163,11 @@ enum Commands {
         #[command(subcommand)]
         command: DeadLetterCommand,
     },
+    /// Retention janitor operations.
+    Retention {
+        #[command(subcommand)]
+        command: RetentionCommand,
+    },
     /// Open the TUI dashboard to monitor workflows.
     Tui,
 }
@@ -286,6 +291,14 @@ enum DagCommand {
 }
 
 #[derive(Debug, Subcommand)]
+enum RetentionCommand {
+    /// Show retention config and last tick results.
+    Status,
+    /// Trigger a retention tick immediately.
+    RunNow,
+}
+
+#[derive(Debug, Subcommand)]
 enum DeadLetterCommand {
     /// List dead-lettered tasks.
     List {
@@ -313,6 +326,7 @@ impl Cli {
             Commands::Workflow { command } => workflow_request(command),
             Commands::Dag { command } => dag_request(command),
             Commands::Dlq { command } => Ok(dead_letter_request(command)),
+            Commands::Retention { command } => Ok(retention_request(command)),
             Commands::Tui => unreachable!("Tui command handles its own requests"),
         }
     }
@@ -556,6 +570,13 @@ fn dag_request(command: &DagCommand) -> Result<ApiRequest, CliError> {
             format!("/dags/{}", path_segment(dag_name)),
             json!({ "paused": false }),
         )),
+    }
+}
+
+fn retention_request(command: &RetentionCommand) -> ApiRequest {
+    match command {
+        RetentionCommand::Status => ApiRequest::get("/admin/retention"),
+        RetentionCommand::RunNow => ApiRequest::post("/admin/retention/run-now", None),
     }
 }
 

--- a/autumn-harvest-cli/tests/request_mapping.rs
+++ b/autumn-harvest-cli/tests/request_mapping.rs
@@ -245,3 +245,20 @@ fn path_segments_are_percent_encoded() {
         "/workflows/tenant%2Fworkflow%20with%20spaces/start"
     );
 }
+
+#[test]
+fn retention_commands_match_management_routes() {
+    let status = Cli::try_parse_from(["harvest", "retention", "status"])
+        .expect("retention status args should parse");
+    let status_request = status.api_request().expect("status request should build");
+    assert_eq!(status_request.method, ApiMethod::Get);
+    assert_eq!(status_request.path, "/admin/retention");
+    assert_eq!(status_request.body, None);
+
+    let run_now = Cli::try_parse_from(["harvest", "retention", "run-now"])
+        .expect("retention run-now args should parse");
+    let run_now_request = run_now.api_request().expect("run-now request should build");
+    assert_eq!(run_now_request.method, ApiMethod::Post);
+    assert_eq!(run_now_request.path, "/admin/retention/run-now");
+    assert_eq!(run_now_request.body, None);
+}

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -24,6 +24,7 @@ use autumn_harvest::context::WorkflowContext;
 use autumn_harvest::dlq;
 use autumn_harvest::error::{HarvestError, HarvestResult, database_error};
 use autumn_harvest::models::{DagRun, DeadLetter, HarvestSchedule, WorkflowExecution};
+use autumn_harvest::retention::{RetentionConfig, RetentionMonitor, RetentionStatus};
 use autumn_harvest::scheduler::{
     DagCatalog, RegisteredDag, SchedulerMonitor, SchedulerSnapshot, trigger_dag,
 };
@@ -46,6 +47,9 @@ pub struct HarvestApiRuntime {
     worker_id: Option<String>,
     queues: Vec<String>,
     scheduler: SchedulerMonitor,
+    retention_config: RetentionConfig,
+    retention: Option<RetentionMonitor>,
+    retention_trigger: Option<tokio::sync::mpsc::UnboundedSender<()>>,
     router: ShardRouter,
 }
 
@@ -59,6 +63,9 @@ impl HarvestApiRuntime {
         worker_id: Option<String>,
         queues: Vec<String>,
         scheduler: SchedulerMonitor,
+        retention_config: RetentionConfig,
+        retention: Option<RetentionMonitor>,
+        retention_trigger: Option<tokio::sync::mpsc::UnboundedSender<()>>,
         router: ShardRouter,
     ) -> Self {
         Self {
@@ -67,6 +74,9 @@ impl HarvestApiRuntime {
             worker_id,
             queues,
             scheduler,
+            retention_config,
+            retention,
+            retention_trigger,
             router,
         }
     }
@@ -276,6 +286,8 @@ pub fn harvest_api_router(api_state: HarvestApiState) -> Router<AppState> {
         .route("/dead-letters", get(list_dead_letters))
         .route("/dead-letters/{id}/replay", post(replay_dead_letter))
         .route("/health", get(health))
+        .route("/admin/retention", get(retention_status))
+        .route("/admin/retention/run-now", post(retention_run_now))
         .layer(Extension(api_state))
 }
 
@@ -648,6 +660,30 @@ async fn replay_dead_letter(
             task_id: task_id.to_string(),
         }),
     ))
+}
+
+async fn retention_status(
+    Extension(api_state): Extension<HarvestApiState>,
+) -> Result<Json<RetentionStatus>, AutumnError> {
+    let runtime = api_state.runtime().map_err(map_error)?;
+    let status = runtime.retention.as_ref().map_or_else(
+        || RetentionStatus {
+            config: runtime.retention_config.clone(),
+            per_shard: Vec::new(),
+        },
+        RetentionMonitor::snapshot,
+    );
+    Ok(Json(status))
+}
+
+async fn retention_run_now(
+    Extension(api_state): Extension<HarvestApiState>,
+) -> Result<Json<BasicAck>, AutumnError> {
+    let runtime = api_state.runtime().map_err(map_error)?;
+    if let Some(trigger) = &runtime.retention_trigger {
+        let _ = trigger.send(());
+    }
+    Ok(Json(BasicAck { ok: true }))
 }
 
 async fn health(

--- a/autumn-harvest-plugin/src/plugin.rs
+++ b/autumn-harvest-plugin/src/plugin.rs
@@ -245,7 +245,9 @@ fn start_harvest_runtime(
         ));
     };
 
-    let built = builder.build();
+    let built = builder
+        .try_build()
+        .map_err(|error| AutumnError::service_unavailable_msg(error.to_string()))?;
     state.insert_extension(harvest_config.outbox.clone());
     state.insert_extension(router.clone());
     let mut runner_resources = HarvestRunnerResources::new(harvest_pool)

--- a/autumn-harvest-plugin/src/runner.rs
+++ b/autumn-harvest-plugin/src/runner.rs
@@ -6,6 +6,7 @@ use std::sync::Arc;
 
 use autumn_harvest::BuiltHarvest;
 use autumn_harvest::context::SharedStateMap;
+use autumn_harvest::retention::{RetentionConfig, RetentionRuntime};
 use autumn_harvest::scheduler::{
     DagCatalog, SchedulerMonitor, SchedulerRuntime, compile_dag_catalog,
 };
@@ -76,6 +77,7 @@ struct PreparedHarvestRuntime {
     worker_runtime_config: WorkerRuntimeConfig,
     storage_pool: HarvestDbPool,
     shard_router: ShardRouter,
+    retention_config: RetentionConfig,
 }
 
 impl PreparedHarvestRuntime {
@@ -84,6 +86,7 @@ impl PreparedHarvestRuntime {
         resources: HarvestRunnerResources,
     ) -> autumn_web::AutumnResult<Self> {
         let shard_router = resources.shard_router.clone().unwrap_or_default();
+        let retention_config = built.retention().clone();
         let (registry, dags, worker_config) =
             built.into_worker_parts_with_extra_state(injected_runtime_state(
                 resources.app_state,
@@ -102,6 +105,7 @@ impl PreparedHarvestRuntime {
             worker_runtime_config: WorkerRuntimeConfig::from(worker_config),
             storage_pool: HarvestDbPool::from(resources.harvest_pool),
             shard_router,
+            retention_config,
         })
     }
 }
@@ -117,6 +121,7 @@ pub struct HarvestRunner {
     worker: Option<Arc<Worker>>,
     worker_handle: Option<JoinHandle<()>>,
     scheduler: Option<SchedulerRuntime>,
+    retention: Option<RetentionRuntime>,
 }
 
 impl HarvestRunner {
@@ -180,12 +185,22 @@ impl HarvestRunner {
         let scheduler_monitor = scheduler
             .as_ref()
             .map_or_else(SchedulerMonitor::offline, SchedulerRuntime::monitor);
+        let retention = RetentionRuntime::spawn(
+            prepared.storage_pool.sharded_pool().clone(),
+            prepared.retention_config.clone(),
+            Arc::clone(&registry.telemetry().metrics),
+        );
+        let retention_monitor = retention.as_ref().map(RetentionRuntime::monitor);
+        let retention_trigger = retention.as_ref().map(RetentionRuntime::trigger_sender);
         let api_runtime = HarvestApiRuntime::new(
             registry,
             dag_catalog,
             worker_id,
             queues,
             scheduler_monitor,
+            prepared.retention_config,
+            retention_monitor,
+            retention_trigger,
             shard_router,
         );
 
@@ -195,6 +210,7 @@ impl HarvestRunner {
             worker,
             worker_handle,
             scheduler,
+            retention,
         })
     }
 
@@ -218,6 +234,7 @@ impl HarvestRunner {
             worker,
             worker_handle,
             scheduler,
+            retention,
         } = self;
 
         if let Some(worker) = worker {
@@ -227,6 +244,12 @@ impl HarvestRunner {
             scheduler.shutdown();
             if let Err(error) = scheduler.join().await {
                 tracing::warn!(error = %error, "harvest scheduler task failed during shutdown");
+            }
+        }
+        if let Some(retention) = retention {
+            retention.shutdown();
+            if let Err(error) = retention.join().await {
+                tracing::warn!(error = %error, "harvest retention task failed during shutdown");
             }
         }
         if let Some(worker_handle) = worker_handle

--- a/autumn-harvest-plugin/tests/api_scheduler_integration.rs
+++ b/autumn-harvest-plugin/tests/api_scheduler_integration.rs
@@ -21,7 +21,8 @@ use autumn_harvest::shard::{ShardRouter, ShardedDbPool};
 use autumn_harvest::types::{ExecutionId, ShardId};
 use autumn_harvest::worker::{DbPool, HandlerRegistry, Worker, WorkerRuntimeConfig};
 use autumn_harvest::{
-    ActivityContext, StartWorkflowParams, WorkflowContext, start_or_load_workflow_execution,
+    ActivityContext, RetentionConfig, StartWorkflowParams, WorkflowContext,
+    start_or_load_workflow_execution,
 };
 use autumn_harvest_plugin::HarvestDbPool;
 use autumn_harvest_plugin::api::{HarvestApiRuntime, HarvestApiState, harvest_api_router};
@@ -55,6 +56,12 @@ const INIT_SQL: &str = concat!(
     include_str!("../../autumn-harvest/migrations/20260427000000_harvest_continue_as_new/up.sql"),
 );
 type HarvestApiApp = axum::Router;
+
+#[derive(diesel::QueryableByName)]
+struct CountByName {
+    #[diesel(sql_type = diesel::sql_types::BigInt)]
+    count: i64,
+}
 
 async fn setup_test_database_url() -> (String, ContainerAsync<Postgres>) {
     let container = Postgres::default()
@@ -471,6 +478,9 @@ fn build_sharded_dag_api_app(
         Some("scheduler-sharded".to_string()),
         vec!["default".to_string()],
         SchedulerMonitor::offline(),
+        autumn_harvest::RetentionConfig::default(),
+        None,
+        None,
         router,
     ));
     harvest_api_router(api_state).with_state(test_app_state_without_database())
@@ -837,6 +847,9 @@ async fn harvest_api_uses_installed_storage_pool_when_app_state_has_no_database(
         Some("test-worker".to_string()),
         vec!["default".to_string()],
         SchedulerMonitor::offline(),
+        autumn_harvest::RetentionConfig::default(),
+        None,
+        None,
         ShardRouter::single(),
     ));
 
@@ -922,6 +935,9 @@ async fn harvest_api_duplicate_start_reuses_existing_execution() {
         Some("test-worker".to_string()),
         vec!["default".to_string()],
         SchedulerMonitor::offline(),
+        autumn_harvest::RetentionConfig::default(),
+        None,
+        None,
         ShardRouter::single(),
     ));
     let app = harvest_api_router(api_state).with_state(test_app_state(pool));
@@ -979,6 +995,9 @@ async fn harvest_api_cancels_workflows_and_rejects_late_signals() {
         Some("test-worker".to_string()),
         vec!["default".to_string()],
         SchedulerMonitor::offline(),
+        autumn_harvest::RetentionConfig::default(),
+        None,
+        None,
         ShardRouter::single(),
     ));
     let app = harvest_api_router(api_state).with_state(test_app_state(pool));
@@ -1136,6 +1155,195 @@ async fn external_runner_processes_workflows_started_via_management_api() {
 }
 
 #[tokio::test]
+async fn retention_janitor_deletes_only_rows_older_than_max_age_and_cascades_children() {
+    let (database_url, _container) = setup_test_database_url().await;
+    let pool = build_test_pool(&database_url);
+    let api_state = HarvestApiState::new();
+
+    let runner = HarvestRunner::start(
+        autumn_harvest::HarvestBuilder::new()
+            .retention(RetentionConfig {
+                max_age_secs: Some(7 * 24 * 60 * 60),
+                tick_interval_secs: 60 * 60,
+                batch_size: 1000,
+                dry_run: false,
+            })
+            .build(),
+        &HarvestRuntimeConfig {
+            mode: HarvestMode::External,
+            worker_enabled: false,
+            scheduler_enabled: false,
+            database: autumn_harvest_plugin::HarvestDatabaseConfig {
+                url: Some(database_url.clone()),
+            },
+            outbox: autumn_harvest_plugin::HarvestOutboxConfig::default(),
+        },
+        HarvestRunnerResources::new(pool.clone()),
+    )
+    .expect("runner with retention should start");
+
+    let old_exec_a = uuid::Uuid::new_v4();
+    let old_exec_b = uuid::Uuid::new_v4();
+    let recent_exec = uuid::Uuid::new_v4();
+    let inflight_exec = uuid::Uuid::new_v4();
+    let mut conn = <AsyncPgConnection as AsyncConnection>::establish(&database_url)
+        .await
+        .expect("failed to connect for retention fixture");
+    for (exec_id, workflow_id, state, completed_at_expr) in [
+        (
+            old_exec_a,
+            "retention-old-a",
+            "COMPLETED",
+            "NOW() - INTERVAL '10 days'",
+        ),
+        (
+            old_exec_b,
+            "retention-old-b",
+            "FAILED",
+            "NOW() - INTERVAL '9 days'",
+        ),
+        (
+            recent_exec,
+            "retention-recent",
+            "COMPLETED",
+            "NOW() - INTERVAL '2 days'",
+        ),
+        (inflight_exec, "retention-inflight", "RUNNING", "NULL"),
+    ] {
+        diesel::sql_query(format!(
+            "INSERT INTO harvest_workflow_executions (
+                id, workflow_name, workflow_id, run_id, shard_id, state, input, queue_name, started_at, completed_at, created_at
+            ) VALUES (
+                $1, 'retention_fixture', '{workflow_id}', gen_random_uuid(), 0, '{state}', '{{}}'::jsonb, 'default',
+                NOW() - INTERVAL '11 days', {completed_at_expr}, NOW() - INTERVAL '11 days'
+            )"
+        ))
+        .bind::<diesel::sql_types::Uuid, _>(exec_id)
+        .execute(&mut conn)
+        .await
+        .expect("failed to insert fixture workflow execution");
+
+        if state != "RUNNING" {
+            diesel::sql_query(
+                "INSERT INTO harvest_events (workflow_exec_id, event_id, event_type, event_data, timestamp)
+                 VALUES ($1, 0, 'WorkflowCompleted', '{}'::jsonb, NOW() - INTERVAL '10 days')",
+            )
+            .bind::<diesel::sql_types::Uuid, _>(exec_id)
+            .execute(&mut conn)
+            .await
+            .expect("failed to insert fixture event");
+
+            diesel::sql_query(
+                "INSERT INTO harvest_task_queue (
+                    id, queue_name, task_type, workflow_exec_id, input, state, priority, max_attempts, scheduled_at
+                 ) VALUES (
+                    gen_random_uuid(), 'default', 'workflow', $1, '{}'::jsonb, 'COMPLETED', 0, 1, NOW() - INTERVAL '10 days'
+                 )",
+            )
+            .bind::<diesel::sql_types::Uuid, _>(exec_id)
+            .execute(&mut conn)
+            .await
+            .expect("failed to insert fixture task");
+
+            diesel::sql_query(
+                "INSERT INTO harvest_timers (workflow_exec_id, timer_id, fires_at, fired)
+                 VALUES ($1, 'fixture-timer', NOW() - INTERVAL '10 days', TRUE)",
+            )
+            .bind::<diesel::sql_types::Uuid, _>(exec_id)
+            .execute(&mut conn)
+            .await
+            .expect("failed to insert fixture timer");
+
+            diesel::sql_query(
+                "INSERT INTO harvest_signals (workflow_exec_id, signal_name, payload, consumed)
+                 VALUES ($1, 'fixture-signal', '{}'::jsonb, TRUE)",
+            )
+            .bind::<diesel::sql_types::Uuid, _>(exec_id)
+            .execute(&mut conn)
+            .await
+            .expect("failed to insert fixture signal");
+
+            diesel::sql_query(
+                "INSERT INTO harvest_dead_letters (
+                    id, original_task_id, queue_name, task_type, workflow_exec_id, input, error, attempts, failed_at
+                 ) VALUES (
+                    gen_random_uuid(), gen_random_uuid(), 'default', 'workflow', $1, '{}'::jsonb, 'fixture', 1, NOW() - INTERVAL '10 days'
+                 )",
+            )
+            .bind::<diesel::sql_types::Uuid, _>(exec_id)
+            .execute(&mut conn)
+            .await
+            .expect("failed to insert fixture dead letter");
+        }
+    }
+
+    api_state.install_storage_pool(runner.storage_pool());
+    api_state.install(runner.api_runtime());
+    let app = harvest_api_router(api_state).with_state(test_app_state_without_database());
+
+    let (run_now_status, run_now_json) =
+        post_json(&app, "/admin/retention/run-now", json!({})).await;
+    assert_eq!(run_now_status, StatusCode::OK);
+    assert_eq!(run_now_json["ok"], true);
+
+    for _ in 0..40 {
+        let (_status, status_json) = get_json(&app, "/admin/retention").await;
+        let deleted_total: u64 = status_json["per_shard"]
+            .as_array()
+            .unwrap_or(&Vec::new())
+            .iter()
+            .filter_map(|tick| tick["deleted_count"].as_u64())
+            .sum();
+        if deleted_total >= 2 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+
+    let mut verify_conn = <AsyncPgConnection as AsyncConnection>::establish(&database_url)
+        .await
+        .expect("failed to reconnect for verification");
+    async fn count_execution_rows(conn: &mut AsyncPgConnection, exec_id: uuid::Uuid) -> i64 {
+        diesel::sql_query("SELECT COUNT(*) AS count FROM harvest_workflow_executions WHERE id = $1")
+            .bind::<diesel::sql_types::Uuid, _>(exec_id)
+            .get_result::<CountByName>(conn)
+            .await
+            .expect("count query should succeed")
+            .count
+    }
+
+    assert_eq!(count_execution_rows(&mut verify_conn, old_exec_a).await, 0);
+    assert_eq!(count_execution_rows(&mut verify_conn, old_exec_b).await, 0);
+    assert_eq!(count_execution_rows(&mut verify_conn, recent_exec).await, 1);
+    assert_eq!(
+        count_execution_rows(&mut verify_conn, inflight_exec).await,
+        1
+    );
+
+    for table in [
+        "harvest_events",
+        "harvest_task_queue",
+        "harvest_timers",
+        "harvest_signals",
+        "harvest_dead_letters",
+    ] {
+        for deleted_exec in [old_exec_a, old_exec_b] {
+            let count = diesel::sql_query(format!(
+                "SELECT COUNT(*) AS count FROM {table} WHERE workflow_exec_id = $1"
+            ))
+            .bind::<diesel::sql_types::Uuid, _>(deleted_exec)
+            .get_result::<CountByName>(&mut verify_conn)
+            .await
+            .expect("child count query should succeed")
+            .count;
+            assert_eq!(count, 0, "cascade should clear {table} for {deleted_exec}");
+        }
+    }
+
+    runner.stop().await;
+}
+
+#[tokio::test]
 async fn harvest_api_signal_does_not_wake_timer_waits_early() {
     let (database_url, _container) = setup_test_database_url().await;
     let pool = build_test_pool(&database_url);
@@ -1148,6 +1356,9 @@ async fn harvest_api_signal_does_not_wake_timer_waits_early() {
         Some("test-worker".to_string()),
         vec!["default".to_string()],
         SchedulerMonitor::offline(),
+        autumn_harvest::RetentionConfig::default(),
+        None,
+        None,
         ShardRouter::single(),
     ));
 
@@ -1416,6 +1627,9 @@ async fn harvest_api_lists_and_triggers_manual_dags() {
         Some("scheduler-only".to_string()),
         vec!["default".to_string()],
         SchedulerMonitor::offline(),
+        autumn_harvest::RetentionConfig::default(),
+        None,
+        None,
         ShardRouter::single(),
     ));
     let app = harvest_api_router(api_state).with_state(test_app_state(pool.clone()));

--- a/autumn-harvest-plugin/tests/ui_integration.rs
+++ b/autumn-harvest-plugin/tests/ui_integration.rs
@@ -259,6 +259,9 @@ async fn ui_root_redirects_to_workflows() {
         Some("ui-test-worker".to_string()),
         vec!["default".to_string()],
         SchedulerMonitor::offline(),
+        autumn_harvest::RetentionConfig::default(),
+        None,
+        None,
         ShardRouter::single(),
     ));
 
@@ -291,6 +294,9 @@ async fn ui_lists_workflows_and_renders_detail_page() {
         Some("ui-test-worker".to_string()),
         vec!["default".to_string()],
         SchedulerMonitor::offline(),
+        autumn_harvest::RetentionConfig::default(),
+        None,
+        None,
         ShardRouter::single(),
     ));
 
@@ -368,6 +374,9 @@ async fn ui_lists_workflows_across_shards() {
         Some("ui-test-worker".to_string()),
         vec!["default".to_string()],
         SchedulerMonitor::offline(),
+        autumn_harvest::RetentionConfig::default(),
+        None,
+        None,
         ShardRouter::new(
             vec![ShardId::new(0), ShardId::new(1)],
             vec![ShardId::new(0), ShardId::new(1)],

--- a/autumn-harvest/src/builder.rs
+++ b/autumn-harvest/src/builder.rs
@@ -6,6 +6,7 @@ use std::time::Duration;
 
 use crate::context::SharedStateMap;
 use crate::info::{ActivityInfo, DagInfo, WorkflowInfo};
+use crate::retention::RetentionConfig;
 use crate::telemetry::TelemetryConfig;
 use crate::types::ShardId;
 
@@ -22,6 +23,7 @@ pub struct HarvestBuilder {
     worker_config: WorkerConfig,
     state: SharedStateMap,
     telemetry: Option<TelemetryConfig>,
+    retention: RetentionConfig,
 }
 
 impl std::fmt::Debug for HarvestBuilder {
@@ -45,6 +47,7 @@ pub struct BuiltHarvest {
     worker_config: WorkerConfig,
     state: SharedStateMap,
     telemetry: Arc<TelemetryConfig>,
+    retention: RetentionConfig,
 }
 
 impl std::fmt::Debug for BuiltHarvest {
@@ -56,8 +59,17 @@ impl std::fmt::Debug for BuiltHarvest {
             .field("worker_config", &self.worker_config)
             .field("state_count", &self.state.len())
             .field("telemetry", &self.telemetry)
+            .field("retention", &self.retention)
             .finish()
     }
+}
+
+/// Builder-time configuration errors.
+#[derive(Debug, Clone, thiserror::Error, PartialEq, Eq)]
+pub enum HarvestBuilderError {
+    /// Retention configuration validation failed.
+    #[error("invalid retention configuration: {0}")]
+    InvalidRetention(String),
 }
 
 impl BuiltHarvest {
@@ -101,6 +113,12 @@ impl BuiltHarvest {
     #[must_use]
     pub const fn telemetry(&self) -> &Arc<TelemetryConfig> {
         &self.telemetry
+    }
+
+    /// Retention janitor configuration.
+    #[must_use]
+    pub const fn retention(&self) -> &RetentionConfig {
+        &self.retention
     }
 
     /// Convert the built harvest registration into worker-ready parts.
@@ -196,6 +214,13 @@ impl HarvestBuilder {
         self
     }
 
+    /// Configure retention janitor behavior for completed workflow history.
+    #[must_use]
+    pub fn retention(mut self, retention: RetentionConfig) -> Self {
+        self.retention = retention;
+        self
+    }
+
     /// Number of registered workflows (used in tests and diagnostics).
     #[must_use]
     pub const fn workflow_count(&self) -> usize {
@@ -215,16 +240,35 @@ impl HarvestBuilder {
     }
 
     /// Finalize the builder into a reusable harvest registration set.
+    ///
+    /// # Panics
+    ///
+    /// Panics when retention settings are invalid. Prefer [`Self::try_build`]
+    /// if you want startup errors instead.
     #[must_use]
     pub fn build(self) -> BuiltHarvest {
-        BuiltHarvest {
+        self.try_build()
+            .expect("HarvestBuilder::build failed validation")
+    }
+
+    /// Finalize the builder into a reusable harvest registration set.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HarvestBuilderError`] when retention settings are invalid.
+    pub fn try_build(self) -> Result<BuiltHarvest, HarvestBuilderError> {
+        self.retention
+            .validate()
+            .map_err(HarvestBuilderError::InvalidRetention)?;
+        Ok(BuiltHarvest {
             workflows: self.workflows,
             activities: self.activities,
             dags: self.dags,
             worker_config: self.worker_config,
             state: self.state,
             telemetry: Arc::new(self.telemetry.unwrap_or_default()),
-        }
+            retention: self.retention,
+        })
     }
 }
 

--- a/autumn-harvest/src/lib.rs
+++ b/autumn-harvest/src/lib.rs
@@ -38,6 +38,8 @@ pub mod prelude;
 /// Types and definitions for querying workflow state and metadata.
 pub mod query;
 pub mod replay;
+#[cfg(feature = "db")]
+pub mod retention;
 pub mod saga;
 pub mod shard;
 pub mod simulator;
@@ -106,6 +108,10 @@ pub use policy::{RetryPolicy, Schedule, TaskStatus, TriggerRule};
 pub use pool::{HarvestPoolConfig, compute_pool_sizes};
 pub use query::QueryRegistry;
 pub use replay::{HistoryMatch, HistoryMatcher};
+#[cfg(feature = "db")]
+pub use retention::{
+    RetentionConfig, RetentionMonitor, RetentionRuntime, RetentionStatus, RetentionTickResult,
+};
 pub use saga::Saga;
 #[cfg(feature = "db")]
 pub use scheduler::{

--- a/autumn-harvest/src/lib.rs
+++ b/autumn-harvest/src/lib.rs
@@ -38,7 +38,6 @@ pub mod prelude;
 /// Types and definitions for querying workflow state and metadata.
 pub mod query;
 pub mod replay;
-#[cfg(feature = "db")]
 pub mod retention;
 pub mod saga;
 pub mod shard;
@@ -108,10 +107,9 @@ pub use policy::{RetryPolicy, Schedule, TaskStatus, TriggerRule};
 pub use pool::{HarvestPoolConfig, compute_pool_sizes};
 pub use query::QueryRegistry;
 pub use replay::{HistoryMatch, HistoryMatcher};
+pub use retention::RetentionConfig;
 #[cfg(feature = "db")]
-pub use retention::{
-    RetentionConfig, RetentionMonitor, RetentionRuntime, RetentionStatus, RetentionTickResult,
-};
+pub use retention::{RetentionMonitor, RetentionRuntime, RetentionStatus, RetentionTickResult};
 pub use saga::Saga;
 #[cfg(feature = "db")]
 pub use scheduler::{

--- a/autumn-harvest/src/retention.rs
+++ b/autumn-harvest/src/retention.rs
@@ -1,0 +1,455 @@
+//! Time-based retention janitor for completed workflow history.
+
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use chrono::{DateTime, Utc};
+use diesel::prelude::*;
+use diesel::sql_types::{BigInt, Nullable, Text, Timestamptz, Uuid as SqlUuid};
+use diesel_async::{AsyncConnection, RunQueryDsl};
+use futures::future::join_all;
+use serde::Serialize;
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+use crate::error::{HarvestError, HarvestResult, database_error};
+use crate::schema::harvest_workflow_executions;
+use crate::schema::{harvest_dag_runs, harvest_signals, harvest_task_queue, harvest_timers};
+use crate::shard::ShardedDbPool;
+use crate::telemetry::MetricsRecorder;
+use crate::types::ShardId;
+
+const DEFAULT_TICK_INTERVAL: Duration = Duration::from_secs(60 * 60);
+const DEFAULT_BATCH_SIZE: usize = 1_000;
+const MIN_MAX_AGE: Duration = Duration::from_secs(1);
+const MAX_MAX_AGE: Duration = Duration::from_secs(60 * 60 * 24 * 365 * 10);
+const TERMINAL_STATES: [&str; 5] = [
+    "COMPLETED",
+    "FAILED",
+    "CANCELLED",
+    "TIMED_OUT",
+    "CONTINUED_AS_NEW",
+];
+
+#[derive(Debug, Clone, Serialize)]
+pub struct RetentionConfig {
+    pub max_age_secs: Option<u64>,
+    pub tick_interval_secs: u64,
+    pub batch_size: usize,
+    pub dry_run: bool,
+}
+
+impl Default for RetentionConfig {
+    fn default() -> Self {
+        Self {
+            max_age_secs: None,
+            tick_interval_secs: DEFAULT_TICK_INTERVAL.as_secs(),
+            batch_size: DEFAULT_BATCH_SIZE,
+            dry_run: false,
+        }
+    }
+}
+
+impl RetentionConfig {
+    #[must_use]
+    pub fn with_max_age(max_age: Duration) -> Self {
+        Self {
+            max_age_secs: Some(max_age.as_secs()),
+            ..Self::default()
+        }
+    }
+
+    #[must_use]
+    pub fn max_age(&self) -> Option<Duration> {
+        self.max_age_secs.map(Duration::from_secs)
+    }
+
+    #[must_use]
+    pub const fn tick_interval(&self) -> Duration {
+        Duration::from_secs(self.tick_interval_secs)
+    }
+
+    pub fn validate(&self) -> Result<(), String> {
+        if self.tick_interval_secs == 0 {
+            return Err("tick_interval must be >= 1s".to_string());
+        }
+        if self.batch_size == 0 {
+            return Err("batch_size must be >= 1".to_string());
+        }
+        if let Some(max_age) = self.max_age() {
+            if !(MIN_MAX_AGE..=MAX_MAX_AGE).contains(&max_age) {
+                return Err(format!(
+                    "max_age must be between {}s and {}s",
+                    MIN_MAX_AGE.as_secs(),
+                    MAX_MAX_AGE.as_secs()
+                ));
+            }
+        }
+        Ok(())
+    }
+
+    #[must_use]
+    pub const fn enabled(&self) -> bool {
+        self.max_age_secs.is_some()
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct RetentionTickResult {
+    pub shard: u16,
+    pub ran_at: Option<DateTime<Utc>>,
+    pub candidate_count: usize,
+    pub deleted_count: usize,
+    pub oldest_age_secs_skipped: Option<u64>,
+    pub duration_ms: u128,
+    pub last_error: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct RetentionStatus {
+    pub config: RetentionConfig,
+    pub per_shard: Vec<RetentionTickResult>,
+}
+
+#[derive(Debug, Clone)]
+pub struct RetentionMonitor {
+    inner: Arc<Mutex<RetentionStatus>>,
+}
+
+impl RetentionMonitor {
+    #[must_use]
+    pub fn new(config: RetentionConfig, shards: impl Iterator<Item = ShardId>) -> Self {
+        let per_shard = shards
+            .map(|shard| RetentionTickResult {
+                shard: u16::try_from(shard.as_i32()).unwrap_or(0),
+                ..RetentionTickResult::default()
+            })
+            .collect();
+        Self {
+            inner: Arc::new(Mutex::new(RetentionStatus { config, per_shard })),
+        }
+    }
+
+    #[must_use]
+    pub fn snapshot(&self) -> RetentionStatus {
+        self.inner
+            .lock()
+            .expect("retention monitor lock poisoned")
+            .clone()
+    }
+
+    fn update(&self, shard: ShardId, result: RetentionTickResult) {
+        let mut guard = self.inner.lock().expect("retention monitor lock poisoned");
+        if let Some(existing) = guard
+            .per_shard
+            .iter_mut()
+            .find(|x| x.shard == u16::try_from(shard.as_i32()).unwrap_or(0))
+        {
+            *existing = result;
+        }
+    }
+}
+
+pub struct RetentionRuntime {
+    shutdown: CancellationToken,
+    trigger_tx: mpsc::UnboundedSender<()>,
+    handle: JoinHandle<()>,
+    monitor: RetentionMonitor,
+}
+
+impl RetentionRuntime {
+    #[must_use]
+    pub fn spawn(
+        pools: ShardedDbPool,
+        config: RetentionConfig,
+        metrics: Arc<dyn MetricsRecorder>,
+    ) -> Option<Self> {
+        if !config.enabled() {
+            return None;
+        }
+        let monitor = RetentionMonitor::new(config.clone(), pools.shard_ids().into_iter());
+        let shutdown = CancellationToken::new();
+        let shutdown_task = shutdown.clone();
+        let monitor_task = monitor.clone();
+        let (trigger_tx, mut trigger_rx) = mpsc::unbounded_channel();
+        let handle = tokio::spawn(async move {
+            loop {
+                tokio::select! {
+                    () = shutdown_task.cancelled() => break,
+                    _ = tokio::time::sleep(config.tick_interval()) => {},
+                    Some(_) = trigger_rx.recv() => {
+                        while trigger_rx.try_recv().is_ok() {}
+                    }
+                }
+
+                let cutoff = Utc::now()
+                    - chrono::Duration::from_std(
+                        config.max_age().expect("enabled config has max_age"),
+                    )
+                    .unwrap_or_default();
+                let tick_futures = pools.iter_shards().map(|(shard, pool)| {
+                    let pool = pool.clone();
+                    let config = config.clone();
+                    let metrics = Arc::clone(&metrics);
+                    async move {
+                        let started = Instant::now();
+                        let tick =
+                            run_shard_tick(pool, shard, cutoff, &config, Arc::clone(&metrics))
+                                .await;
+                        (shard, started, tick)
+                    }
+                });
+
+                for (shard, started, tick) in join_all(tick_futures).await {
+                    let mut result = RetentionTickResult {
+                        shard: u16::try_from(shard.as_i32()).unwrap_or(0),
+                        ran_at: Some(Utc::now()),
+                        duration_ms: started.elapsed().as_millis(),
+                        ..RetentionTickResult::default()
+                    };
+                    match tick {
+                        Ok(ok) => {
+                            result.candidate_count = ok.candidate_count;
+                            result.deleted_count = ok.deleted_count;
+                            result.oldest_age_secs_skipped = ok.oldest_age_secs_skipped;
+                            tracing::info!(
+                                shard = %shard,
+                                candidates = ok.candidate_count,
+                                deleted = ok.deleted_count,
+                                oldest_age_secs_skipped = ok.oldest_age_secs_skipped,
+                                duration_ms = result.duration_ms,
+                                dry_run = config.dry_run,
+                                "harvest retention tick completed"
+                            );
+                            metrics.record_retention_tick(
+                                u16::try_from(shard.as_i32()).unwrap_or(0),
+                                ok.candidate_count as u64,
+                                ok.deleted_count as u64,
+                                result.duration_ms as f64 / 1000.0,
+                            );
+                        }
+                        Err(error) => {
+                            result.last_error = Some(error.to_string());
+                            tracing::warn!(shard = %shard, error = %error, "harvest retention tick failed");
+                        }
+                    }
+                    monitor_task.update(shard, result);
+                }
+            }
+        });
+
+        Some(Self {
+            shutdown,
+            trigger_tx,
+            handle,
+            monitor,
+        })
+    }
+
+    #[must_use]
+    pub fn monitor(&self) -> RetentionMonitor {
+        self.monitor.clone()
+    }
+
+    pub fn run_now(&self) {
+        let _ = self.trigger_tx.send(());
+    }
+
+    #[must_use]
+    pub fn trigger_sender(&self) -> mpsc::UnboundedSender<()> {
+        self.trigger_tx.clone()
+    }
+
+    pub fn shutdown(&self) {
+        self.shutdown.cancel();
+    }
+
+    pub async fn join(self) -> Result<(), tokio::task::JoinError> {
+        self.handle.await
+    }
+}
+
+#[derive(Debug, Default)]
+struct ShardTickOutcome {
+    candidate_count: usize,
+    deleted_count: usize,
+    oldest_age_secs_skipped: Option<u64>,
+}
+
+#[derive(Debug, QueryableByName)]
+struct CandidateExecution {
+    #[diesel(sql_type = SqlUuid)]
+    id: uuid::Uuid,
+    #[diesel(sql_type = Text)]
+    workflow_name: String,
+    #[diesel(sql_type = Text)]
+    workflow_id: String,
+    #[diesel(sql_type = Nullable<Timestamptz>) ]
+    completed_at: Option<DateTime<Utc>>,
+}
+
+async fn run_shard_tick(
+    pool: crate::worker::DbPool,
+    shard: ShardId,
+    cutoff: DateTime<Utc>,
+    config: &RetentionConfig,
+    _metrics: Arc<dyn MetricsRecorder>,
+) -> HarvestResult<ShardTickOutcome> {
+    let mut conn = pool
+        .get()
+        .await
+        .map_err(|error| HarvestError::Database(error.to_string()))?;
+    let candidates = diesel::sql_query(
+        "SELECT id, workflow_name, workflow_id, completed_at
+         FROM harvest_workflow_executions
+         WHERE state = ANY($1)
+           AND completed_at IS NOT NULL
+           AND completed_at < $2
+         ORDER BY completed_at ASC
+         LIMIT $3",
+    )
+    .bind::<diesel::sql_types::Array<Text>, _>(TERMINAL_STATES.to_vec())
+    .bind::<Timestamptz, _>(cutoff)
+    .bind::<BigInt, _>(config.batch_size as i64)
+    .load::<CandidateExecution>(&mut conn)
+    .await
+    .map_err(database_error)?;
+
+    let mut outcome = ShardTickOutcome {
+        candidate_count: candidates.len(),
+        ..ShardTickOutcome::default()
+    };
+
+    for candidate in candidates {
+        if should_skip_candidate(&mut conn, &candidate, cutoff).await? {
+            if let Some(completed_at) = candidate.completed_at {
+                let age = (Utc::now() - completed_at).num_seconds().max(0) as u64;
+                outcome.oldest_age_secs_skipped = Some(
+                    outcome
+                        .oldest_age_secs_skipped
+                        .map_or(age, |existing| existing.max(age)),
+                );
+            }
+            continue;
+        }
+
+        if config.dry_run {
+            outcome.deleted_count += 1;
+            continue;
+        }
+
+        conn.transaction::<_, HarvestError, _>(|conn| {
+            Box::pin(async move {
+                diesel::delete(
+                    harvest_workflow_executions::table
+                        .filter(harvest_workflow_executions::id.eq(candidate.id)),
+                )
+                .execute(conn)
+                .await
+                .map_err(database_error)?;
+                Ok(())
+            })
+        })
+        .await?;
+        outcome.deleted_count += 1;
+    }
+
+    tracing::debug!(shard = %shard, candidates = outcome.candidate_count, deleted = outcome.deleted_count, "retention shard tick");
+    Ok(outcome)
+}
+
+async fn should_skip_candidate(
+    conn: &mut diesel_async::AsyncPgConnection,
+    candidate: &CandidateExecution,
+    cutoff: DateTime<Utc>,
+) -> HarvestResult<bool> {
+    let active_parent_ref_count = diesel::sql_query(
+        "SELECT COUNT(*) AS count
+         FROM harvest_workflow_executions
+         WHERE parent_id = $1
+           AND state NOT IN ('COMPLETED','FAILED','CANCELLED','TIMED_OUT','CONTINUED_AS_NEW')",
+    )
+    .bind::<SqlUuid, _>(candidate.id)
+    .get_result::<CountRow>(conn)
+    .await
+    .map_err(database_error)?
+    .count;
+
+    if active_parent_ref_count > 0 {
+        return Ok(true);
+    }
+
+    let inflight_dag_run_count = harvest_dag_runs::table
+        .filter(harvest_dag_runs::workflow_exec_id.eq(Some(candidate.id)))
+        .filter(harvest_dag_runs::state.eq_any(["QUEUED", "RUNNING"]))
+        .count()
+        .get_result::<i64>(conn)
+        .await
+        .map_err(database_error)?;
+    if inflight_dag_run_count > 0 {
+        return Ok(true);
+    }
+
+    let inflight_task_count = harvest_task_queue::table
+        .filter(harvest_task_queue::workflow_exec_id.eq(Some(candidate.id)))
+        .filter(harvest_task_queue::state.eq_any(["PENDING", "RUNNING"]))
+        .count()
+        .get_result::<i64>(conn)
+        .await
+        .map_err(database_error)?;
+    if inflight_task_count > 0 {
+        return Ok(true);
+    }
+
+    let pending_signal_count = harvest_signals::table
+        .filter(harvest_signals::workflow_exec_id.eq(candidate.id))
+        .filter(harvest_signals::consumed.eq(false))
+        .count()
+        .get_result::<i64>(conn)
+        .await
+        .map_err(database_error)?;
+    if pending_signal_count > 0 {
+        return Ok(true);
+    }
+
+    let pending_timer_count = harvest_timers::table
+        .filter(harvest_timers::workflow_exec_id.eq(candidate.id))
+        .filter(harvest_timers::fired.eq(false))
+        .count()
+        .get_result::<i64>(conn)
+        .await
+        .map_err(database_error)?;
+    if pending_timer_count > 0 {
+        return Ok(true);
+    }
+
+    let chain_link_count = diesel::sql_query(
+        "SELECT COUNT(*) AS count
+         FROM harvest_workflow_executions
+         WHERE workflow_name = $1
+           AND workflow_id = $2
+           AND id <> $3
+           AND (
+               state NOT IN ('COMPLETED','FAILED','CANCELLED','TIMED_OUT','CONTINUED_AS_NEW')
+               OR completed_at IS NULL
+               OR completed_at >= $4
+           )",
+    )
+    .bind::<Text, _>(&candidate.workflow_name)
+    .bind::<Text, _>(&candidate.workflow_id)
+    .bind::<SqlUuid, _>(candidate.id)
+    .bind::<Timestamptz, _>(cutoff)
+    .get_result::<CountRow>(conn)
+    .await
+    .map_err(database_error)?
+    .count;
+
+    Ok(chain_link_count > 0)
+}
+
+#[derive(QueryableByName)]
+struct CountRow {
+    #[diesel(sql_type = BigInt)]
+    count: i64,
+}

--- a/autumn-harvest/src/retention.rs
+++ b/autumn-harvest/src/retention.rs
@@ -1,22 +1,36 @@
 //! Time-based retention janitor for completed workflow history.
 
 use std::sync::{Arc, Mutex};
-use std::time::{Duration, Instant};
+use std::time::Duration;
+#[cfg(feature = "db")]
+use std::time::Instant;
 
 use chrono::{DateTime, Utc};
+#[cfg(feature = "db")]
 use diesel::prelude::*;
+#[cfg(feature = "db")]
 use diesel::sql_types::{BigInt, Nullable, Text, Timestamptz, Uuid as SqlUuid};
+#[cfg(feature = "db")]
 use diesel_async::{AsyncConnection, RunQueryDsl};
+#[cfg(feature = "db")]
 use futures::future::join_all;
 use serde::Serialize;
+#[cfg(feature = "db")]
 use tokio::sync::mpsc;
+#[cfg(feature = "db")]
 use tokio::task::JoinHandle;
+#[cfg(feature = "db")]
 use tokio_util::sync::CancellationToken;
 
+#[cfg(feature = "db")]
 use crate::error::{HarvestError, HarvestResult, database_error};
+#[cfg(feature = "db")]
 use crate::schema::harvest_workflow_executions;
+#[cfg(feature = "db")]
 use crate::schema::{harvest_dag_runs, harvest_signals, harvest_task_queue, harvest_timers};
+#[cfg(feature = "db")]
 use crate::shard::ShardedDbPool;
+#[cfg(feature = "db")]
 use crate::telemetry::MetricsRecorder;
 use crate::types::ShardId;
 
@@ -24,6 +38,7 @@ const DEFAULT_TICK_INTERVAL: Duration = Duration::from_secs(60 * 60);
 const DEFAULT_BATCH_SIZE: usize = 1_000;
 const MIN_MAX_AGE: Duration = Duration::from_secs(1);
 const MAX_MAX_AGE: Duration = Duration::from_secs(60 * 60 * 24 * 365 * 10);
+#[cfg(feature = "db")]
 const TERMINAL_STATES: [&str; 5] = [
     "COMPLETED",
     "FAILED",
@@ -139,6 +154,7 @@ impl RetentionMonitor {
             .clone()
     }
 
+    #[cfg(feature = "db")]
     fn update(&self, shard: ShardId, result: RetentionTickResult) {
         let mut guard = self.inner.lock().expect("retention monitor lock poisoned");
         if let Some(existing) = guard
@@ -151,6 +167,7 @@ impl RetentionMonitor {
     }
 }
 
+#[cfg(feature = "db")]
 pub struct RetentionRuntime {
     shutdown: CancellationToken,
     trigger_tx: mpsc::UnboundedSender<()>,
@@ -158,6 +175,7 @@ pub struct RetentionRuntime {
     monitor: RetentionMonitor,
 }
 
+#[cfg(feature = "db")]
 impl RetentionRuntime {
     #[must_use]
     pub fn spawn(
@@ -270,6 +288,7 @@ impl RetentionRuntime {
     }
 }
 
+#[cfg(feature = "db")]
 #[derive(Debug, Default)]
 struct ShardTickOutcome {
     candidate_count: usize,
@@ -277,6 +296,7 @@ struct ShardTickOutcome {
     oldest_age_secs_skipped: Option<u64>,
 }
 
+#[cfg(feature = "db")]
 #[derive(Debug, QueryableByName)]
 struct CandidateExecution {
     #[diesel(sql_type = SqlUuid)]
@@ -289,6 +309,7 @@ struct CandidateExecution {
     completed_at: Option<DateTime<Utc>>,
 }
 
+#[cfg(feature = "db")]
 async fn run_shard_tick(
     pool: crate::worker::DbPool,
     shard: ShardId,
@@ -359,6 +380,7 @@ async fn run_shard_tick(
     Ok(outcome)
 }
 
+#[cfg(feature = "db")]
 async fn should_skip_candidate(
     conn: &mut diesel_async::AsyncPgConnection,
     candidate: &CandidateExecution,
@@ -367,8 +389,7 @@ async fn should_skip_candidate(
     let active_parent_ref_count = diesel::sql_query(
         "SELECT COUNT(*) AS count
          FROM harvest_workflow_executions
-         WHERE parent_id = $1
-           AND state NOT IN ('COMPLETED','FAILED','CANCELLED','TIMED_OUT','CONTINUED_AS_NEW')",
+         WHERE parent_id = $1",
     )
     .bind::<SqlUuid, _>(candidate.id)
     .get_result::<CountRow>(conn)
@@ -448,6 +469,7 @@ async fn should_skip_candidate(
     Ok(chain_link_count > 0)
 }
 
+#[cfg(feature = "db")]
 #[derive(QueryableByName)]
 struct CountRow {
     #[diesel(sql_type = BigInt)]

--- a/autumn-harvest/src/telemetry.rs
+++ b/autumn-harvest/src/telemetry.rs
@@ -237,6 +237,17 @@ pub trait MetricsRecorder: Send + Sync {
     fn record_queue_depth(&self, queue_name: &str, depth: u64) {
         let _ = (queue_name, depth);
     }
+
+    /// Results of one retention-janitor tick on a shard.
+    fn record_retention_tick(
+        &self,
+        shard: u16,
+        candidate_count: u64,
+        deleted_count: u64,
+        duration_secs: f64,
+    ) {
+        let _ = (shard, candidate_count, deleted_count, duration_secs);
+    }
 }
 
 /// Default metrics recorder that discards every sample.

--- a/docs/autumn-workflow-architecture.md
+++ b/docs/autumn-workflow-architecture.md
@@ -888,27 +888,15 @@ CREATE TABLE harvest_events_p1 PARTITION OF harvest_events FOR VALUES WITH (MODU
 
 The `harvest_task_queue` table is also partitioned by `queue_name` using list partitioning, enabling queue-specific vacuum and index tuning.
 
-### 8.3 History Archival
+### 8.3 History Retention
 
-Completed workflow histories should be archived to prevent unbounded table growth. A background janitor task (running on the scheduler tick) moves completed workflows older than `history_retention` (default: 30 days) to `harvest_archived_events` (or deletes them if `archive = false`).
+Harvest ships an opt-in retention janitor for completed workflow histories. Operators configure `RetentionConfig` on `HarvestBuilder`; default behavior is disabled (`max_age = None`), so upgrading does not delete any rows until explicitly enabled.
 
-```sql
--- Archive old completed events
-INSERT INTO harvest_archived_events
-SELECT * FROM harvest_events
-WHERE workflow_exec_id IN (
-    SELECT id FROM harvest_workflow_executions
-    WHERE state IN ('COMPLETED', 'FAILED', 'CANCELLED')
-      AND completed_at < NOW() - INTERVAL '30 days'
-);
+When enabled, each tick selects terminal workflow executions older than `max_age` and deletes the parent row from `harvest_workflow_executions`; child rows in `harvest_events`, `harvest_task_queue`, `harvest_timers`, `harvest_signals`, and `harvest_dead_letters` are removed by existing `ON DELETE CASCADE` foreign keys.
 
-DELETE FROM harvest_events
-WHERE workflow_exec_id IN (
-    SELECT id FROM harvest_workflow_executions
-    WHERE state IN ('COMPLETED', 'FAILED', 'CANCELLED')
-      AND completed_at < NOW() - INTERVAL '30 days'
-);
-```
+In-flight workflows are never eligible because retention only targets terminal states with `completed_at` older than the configured window.
+
+The management API exposes retention introspection and control via `GET /admin/retention` and `POST /admin/retention/run-now`.
 
 ---
 
@@ -1310,11 +1298,9 @@ Activities that need their own connections use `ctx.db()` which draws from the s
 
 For long-running deployments, the event history table will be the largest table. Harvest provides three retention strategies:
 
-**Time-based deletion** (default): Completed workflow histories older than `history_retention` are deleted.
+**Time-based deletion** (implemented): Configure `RetentionConfig { max_age, tick_interval, batch_size, dry_run }` on `HarvestBuilder` to prune terminal workflow history older than a fixed age.
 
-**Archival to cold storage:** Completed histories are serialized to JSONL and written to a configurable storage backend (local filesystem, S3 via optional feature flag) before deletion.
-
-**Infinite retention:** No cleanup. Suitable for compliance-heavy workloads. Requires partitioning and pg_partman for automated partition management.
+**Infinite retention** (default): Leave `max_age = None` to keep append-only history forever.
 
 ---
 
@@ -1350,9 +1336,7 @@ default_retry_policy.backoff_coefficient = 2.0
 default_retry_policy.max_interval = "5m"
 
 # History management
-history_retention = "30d"
-archive_enabled = false
-archive_path = "./harvest-archive"
+# configured via `HarvestBuilder::retention(RetentionConfig { ... })`
 
 # Management API
 api_enabled = true


### PR DESCRIPTION
### Motivation

- Provide an opt-in retention janitor to prune completed workflow histories older than a configured max age while leaving in-flight workflows untouched.
- Expose management controls to inspect status and trigger a tick immediately from the management API and CLI.
- Make retention configuration part of the builder/runtime so operators can enable, tune, or dry-run retention safely.

### Description

- Implement a new retention subsystem in `autumn-harvest::retention` with `RetentionConfig`, `RetentionRuntime`, `RetentionMonitor`, and per-shard tick logic that selects terminal executions older than the cutoff and deletes parent rows while skipping candidates with active children, inflight DAG runs, pending tasks/signals/timers, or chain links that would make deletion unsafe.
- Wire retention into the runtime: `BuiltHarvest` carries `retention`, `HarvestBuilder` exposes `.retention(...)` and `try_build()` validates retention settings, and `HarvestRunner` spawns `RetentionRuntime` and exposes its monitor/trigger to the API runtime.
- Add management API endpoints `GET /admin/retention` and `POST /admin/retention/run-now` and surface them in the plugin (`autumn-harvest-plugin::api`) with snapshotting and trigger behavior.
- Add CLI subcommands `retention status` and `retention run-now` and map them to the new management routes in `autumn-harvest-cli`.
- Add telemetry hook `record_retention_tick` to record retention metrics, update docs/README to describe the feature and default opt-out behavior, and update many tests to provide a default `RetentionConfig` where API runtime construction requires it.
- Add tests and integration coverage: CLI request mapping test for retention commands and an integration test (`retention_janitor_deletes_only_rows_older_than_max_age_and_cascades_children`) that seeds DB fixtures and asserts proper deletion/cascade behavior and that recent/inflight executions are preserved.

### Testing

- Ran the test suite with the new additions: `cargo test` across `autumn-harvest`, `autumn-harvest-plugin`, and `autumn-harvest-cli`, including the new tests `retention_commands_match_management_routes` and `retention_janitor_deletes_only_rows_older_than_max_age_and_cascades_children`, and all tests completed successfully.
- Exercise of API surface and integration behavior was covered by existing and new integration tests that instantiate `HarvestRunner` with retention enabled and assert API responses and DB state changes.
- CLI mapping checks were validated by the unit test in `autumn-harvest-cli/tests/request_mapping.rs`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f00f4b37d0832a887fcde3ca1f4614)