### PR TITLE
⚡ Bolt: Remove intermediate vector allocation for DAG task trigger evaluation

### DIFF
--- a/autumn-harvest/src/policy.rs
+++ b/autumn-harvest/src/policy.rs
@@ -184,7 +184,7 @@ pub enum TriggerRule {
 }
 
 impl TriggerRule {
-    /// Evaluates the trigger rule against a list of upstream task statuses.
+    /// Evaluates the trigger rule against a list (or iterator) of upstream task statuses.
     ///
     /// Returns `true` if the downstream task should be executed, `false` otherwise.
     ///
@@ -198,17 +198,24 @@ impl TriggerRule {
     /// assert!(rule.should_run(&statuses));
     /// ```
     #[must_use]
-    pub fn should_run(&self, upstream_statuses: &[TaskStatus]) -> bool {
+    pub fn should_run<'a>(
+        &self,
+        upstream_statuses: impl IntoIterator<Item = &'a TaskStatus>,
+    ) -> bool {
         match self {
             Self::AllSuccess => upstream_statuses
-                .iter()
+                .into_iter()
                 .all(|s| *s == TaskStatus::Succeeded),
             Self::AllDone => true,
-            Self::OneSuccess => upstream_statuses.contains(&TaskStatus::Succeeded),
-            Self::OneFailed => upstream_statuses.contains(&TaskStatus::Failed),
+            Self::OneSuccess => upstream_statuses
+                .into_iter()
+                .any(|s| *s == TaskStatus::Succeeded),
+            Self::OneFailed => upstream_statuses
+                .into_iter()
+                .any(|s| *s == TaskStatus::Failed),
             Self::AllFailed => {
-                !upstream_statuses.is_empty()
-                    && upstream_statuses.iter().all(|s| *s == TaskStatus::Failed)
+                let mut iter = upstream_statuses.into_iter().peekable();
+                iter.peek().is_some() && iter.all(|s| *s == TaskStatus::Failed)
             }
             Self::Manual => false,
         }

--- a/autumn-harvest/src/scheduler.rs
+++ b/autumn-harvest/src/scheduler.rs
@@ -535,14 +535,18 @@ async fn execute_dag_run(
         let tasks = level.iter().map(|task_index| {
             // Avoid an unnecessary heap allocation of `DagTask` per task when `&DagTask` works.
             let task = &dag.definition.tasks()[*task_index];
-            let upstream_statuses: Vec<_> = task
-                .upstreams
-                .iter()
-                .map(|upstream| statuses[*upstream])
-                .collect();
             let registry = Arc::clone(&registry);
             let task_input = Arc::clone(&run_input);
-            async move { execute_dag_task(&registry, task, &upstream_statuses, &task_input).await }
+
+            // ⚡ Bolt: Remove an intermediate `.collect::<Vec<_>>()` when fetching upstream
+            // statuses by passing an Iterator into `execute_dag_task`. This avoids an
+            // unnecessary heap allocation per DAG task inside this loop.
+            let statuses_ref = &statuses;
+            let upstream_statuses = task
+                .upstreams
+                .iter()
+                .map(move |upstream| &statuses_ref[*upstream]);
+            async move { execute_dag_task(&registry, task, upstream_statuses, &task_input).await }
         });
         let results = futures::future::join_all(tasks).await;
         for (task_index, result) in level.iter().zip(results) {
@@ -571,10 +575,10 @@ async fn execute_dag_run(
     Ok(())
 }
 
-async fn execute_dag_task(
+async fn execute_dag_task<'a>(
     registry: &HandlerRegistry,
     task: &crate::dag::DagTask,
-    upstream_statuses: &[TaskStatus],
+    upstream_statuses: impl IntoIterator<Item = &'a TaskStatus>,
     conf: &Value,
 ) -> TaskStatus {
     if !task.trigger_rule.should_run(upstream_statuses) {


### PR DESCRIPTION
💡 **What**: Refactored `TriggerRule::should_run` and `execute_dag_task` to accept an iterator over upstream task statuses instead of a materialized slice.
🎯 **Why**: Previously, `execute_dag_run` in the scheduler loop would allocate a new `Vec` to map `TaskStatus` for every single task being evaluated inside a DAG level, just to pass it to the trigger evaluation.
📊 **Impact**: This removes a `Vec::collect()` heap allocation per task evaluated in a DAG, reducing GC pressure and accelerating the scheduler hot-path.
🔬 **Measurement**: Verify by running `cargo test -p autumn-harvest --lib`. The existing `policy` tests pass perfectly since slices coerce into iterators.

---
*PR created automatically by Jules for task [8883583475907672023](https://jules.google.com/task/8883583475907672023) started by @madmax983*