### PR TITLE
🌟 Nova: Diagnostic Report Generator

### DIFF
--- a/autumn-harvest/src/diagnostic.rs
+++ b/autumn-harvest/src/diagnostic.rs
@@ -1,0 +1,108 @@
+use crate::analyzer::{AnalyzerWarning, HistoryAnalyzer};
+use crate::history_export::export_mermaid_sequence;
+use crate::simulator::SimulatorResult;
+use serde_json::Value;
+use std::fmt::Write;
+
+/// A diagnostic report generated from a simulated workflow execution.
+#[derive(Debug, Clone)]
+pub struct DiagnosticReport {
+    pub final_output: Result<Value, String>,
+    pub event_count: usize,
+    pub analyzer_warnings: Vec<AnalyzerWarning>,
+    pub mermaid_sequence: String,
+}
+
+impl DiagnosticReport {
+    /// Render the diagnostic report as a Markdown string.
+    #[must_use]
+    pub fn to_markdown(&self) -> String {
+        let mut out = String::new();
+        out.push_str("# Diagnostic Report\n\n");
+
+        out.push_str("## Execution Result\n");
+        match &self.final_output {
+            Ok(val) => {
+                out.push_str("**Status:** Success\n");
+                let _ = write!(out, "**Output:** `{val}`\n\n");
+            }
+            Err(err) => {
+                out.push_str("**Status:** Failure\n");
+                let _ = write!(out, "**Error:** `{err}`\n\n");
+            }
+        }
+
+        let _ = write!(out, "**Total Events:** {}\n\n", self.event_count);
+
+        if !self.analyzer_warnings.is_empty() {
+            out.push_str("## Analyzer Warnings\n");
+            for warning in &self.analyzer_warnings {
+                let _ = writeln!(out, "- **{}**: {}", warning.rule_name, warning.message);
+            }
+            out.push('\n');
+        }
+
+        out.push_str("## Sequence Diagram\n");
+        out.push_str("```mermaid\n");
+        out.push_str(&self.mermaid_sequence);
+        if !self.mermaid_sequence.ends_with('\n') {
+            out.push('\n');
+        }
+        out.push_str("```\n");
+
+        out
+    }
+}
+
+/// Extension trait for generating diagnostic reports from a `SimulatorResult`.
+pub trait SimulatorResultExt {
+    /// Generate a diagnostic report.
+    fn diagnostic_report(&self) -> DiagnosticReport;
+}
+
+impl SimulatorResultExt for SimulatorResult {
+    fn diagnostic_report(&self) -> DiagnosticReport {
+        let analyzer = HistoryAnalyzer::new();
+        let warnings = analyzer.analyze(&self.history);
+        let sequence = export_mermaid_sequence(&self.history).unwrap_or_default();
+
+        DiagnosticReport {
+            final_output: self.final_output.clone(),
+            event_count: self.history.len(),
+            analyzer_warnings: warnings,
+            mermaid_sequence: sequence,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::event::WorkflowEvent;
+    use chrono::Utc;
+
+    #[test]
+    fn test_diagnostic_report_generation() {
+        let history = vec![
+            WorkflowEvent::WorkflowStarted {
+                input: serde_json::json!({}),
+                timestamp: Utc::now(),
+            },
+            WorkflowEvent::WorkflowCompleted {
+                output: serde_json::json!({"status": "ok"}),
+            },
+        ];
+
+        let result = SimulatorResult {
+            final_output: Ok(serde_json::json!({"status": "ok"})),
+            history,
+        };
+
+        let report = result.diagnostic_report();
+        let markdown = report.to_markdown();
+
+        assert!(markdown.contains("Diagnostic Report"));
+        assert!(markdown.contains("Success"));
+        assert!(markdown.contains("sequenceDiagram"));
+    }
+}

--- a/autumn-harvest/src/lib.rs
+++ b/autumn-harvest/src/lib.rs
@@ -25,6 +25,7 @@ pub mod dag_export;
 pub mod dag_linter;
 #[cfg(any(test, feature = "testing"))]
 pub mod dag_simulator;
+pub mod diagnostic;
 pub mod error;
 pub mod event;
 #[cfg(feature = "db")]
@@ -97,6 +98,7 @@ pub use dag_linter::{
 };
 #[cfg(any(test, feature = "testing"))]
 pub use dag_simulator::{DagSimulator, DagSimulatorResult};
+pub use diagnostic::{DiagnosticReport, SimulatorResultExt};
 pub use error::{HarvestError, HarvestResult, TimeoutType};
 pub use event::WorkflowEvent;
 #[cfg(feature = "db")]


### PR DESCRIPTION
💡 **The Spark:** We have an in-memory `WorkflowSimulator`, a `HistoryAnalyzer` for linting events, and a Mermaid diagram exporter (`export_mermaid_sequence`). However, they are disjointed. What if we mash them together to automatically generate beautiful Markdown reports after a test finishes?

🚀 **The Feature:** Implemented `SimulatorResultExt` and `DiagnosticReport` in a new `diagnostic` module. It consumes a `SimulatorResult`, runs it through the analyzer, and appends a Mermaid sequence diagram, spitting out a formatted Markdown string.

🔮 **The Potential:** Can be used in CI/CD logs to instantly visualize why a local workflow simulation failed, making debugging complex state transitions incredibly easy. It bridges the gap between raw event history and human-readable feedback.

⚠️ **Risk:** Low. Strictly additive. The new `diagnostic.rs` file does not touch core executor logic, and it only exposes a new trait that tests/developers can opt into using. All tests pass and the code is formatted properly.

---
*PR created automatically by Jules for task [2293492319202641026](https://jules.google.com/task/2293492319202641026) started by @madmax983*