### PR TITLE
Add WorkflowIdReusePolicy to control duplicate workflow starts

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,61 @@ a bearer token. Successful responses are printed as pretty JSON by default; use
 inline `--*-json` values or `--*-file PATH`; use `-` as the file path to read
 from stdin.
 
+### Controlling duplicate workflow starts
+
+By default, starting a workflow with a `(workflow_name, workflow_id)` pair that already exists returns the existing execution. This "allow duplicate" behaviour is correct for upstream services that retry a start whose response was lost. It is **not** correct when you need at-most-one, retry-after-failure, or terminate-and-replace semantics.
+
+Pass `reuse_policy` in the HTTP body (or `--reuse-policy` on the CLI) to override the default:
+
+| Value | Behaviour |
+|---|---|
+| `allow_duplicate` (default) | Return the existing execution unconditionally. |
+| `reject_duplicate` | Return **409 Conflict** with `existing_execution_id` and `existing_state` in the body. Use for at-most-one semantics. |
+| `allow_duplicate_failed_only` | Start fresh if the prior execution is FAILED or CANCELLED; return the existing execution if RUNNING or COMPLETED. Use for retry-after-failure. |
+| `terminate_if_running` | Cancel a RUNNING prior execution and start a fresh run; start fresh unconditionally for any terminal prior state. |
+
+An unknown `reuse_policy` value returns `400 Bad Request` with the offending value echoed in the error body; it does not silently fall back to the default.
+
+**Retry-after-failure**: pass `reuse_policy: "allow_duplicate_failed_only"` so an upstream retry against a failed run gets a fresh execution while a successful or in-progress run is not superseded. Pass `reuse_policy: "reject_duplicate"` for strict at-most-one semantics.
+
+```bash
+# Retry-after-failure: start fresh only if the prior run failed or was cancelled
+cargo run -p autumn-harvest-cli -- workflow start billing_workflow \
+    --workflow-id "order-42" \
+    --reuse-policy allow_duplicate_failed_only \
+    --input-json '{"order_id": 42}'
+
+# At-most-one: reject a second start with 409 while the workflow is still running
+cargo run -p autumn-harvest-cli -- workflow start billing_workflow \
+    --workflow-id "order-42" \
+    --reuse-policy reject_duplicate
+
+# Terminate-and-replace: cancel a stuck run and immediately start fresh
+cargo run -p autumn-harvest-cli -- workflow start billing_workflow \
+    --workflow-id "order-42" \
+    --reuse-policy terminate_if_running
+```
+
+Via the HTTP API directly:
+
+```json
+POST /api/harvest/workflows/billing_workflow/start
+{
+  "workflow_id": "order-42",
+  "reuse_policy": "allow_duplicate_failed_only",
+  "input": {"order_id": 42}
+}
+```
+
+A 409 response body looks like:
+
+```json
+{
+  "existing_execution_id": "01234567-...",
+  "existing_state": "RUNNING"
+}
+```
+
 ### Filtering the workflow list
 
 `workflow list` (and `GET /workflows`) accept three additional filter knobs on

--- a/autumn-harvest-cli/src/lib.rs
+++ b/autumn-harvest-cli/src/lib.rs
@@ -227,6 +227,11 @@ enum WorkflowCommand {
         /// Execution timeout in seconds.
         #[arg(long)]
         execution_timeout_secs: Option<i64>,
+        /// How to handle a duplicate `(workflow_name, workflow_id)` start.
+        /// One of: `allow_duplicate` (default), `reject_duplicate`,
+        /// `allow_duplicate_failed_only`, `terminate_if_running`.
+        #[arg(long, value_name = "POLICY")]
+        reuse_policy: Option<String>,
     },
     /// Cancel a workflow execution.
     Cancel {
@@ -460,6 +465,7 @@ fn workflow_request(command: &WorkflowCommand) -> Result<ApiRequest, CliError> {
             search_attrs_json,
             search_attrs_file,
             execution_timeout_secs,
+            reuse_policy,
         } => {
             let mut body = Map::new();
             insert_string(&mut body, "workflow_id", workflow_id.as_deref());
@@ -490,6 +496,7 @@ fn workflow_request(command: &WorkflowCommand) -> Result<ApiRequest, CliError> {
             if let Some(timeout) = execution_timeout_secs {
                 body.insert("execution_timeout_secs".to_string(), json!(timeout));
             }
+            insert_string(&mut body, "reuse_policy", reuse_policy.as_deref());
 
             Ok(ApiRequest::post(
                 format!("/workflows/{}/start", path_segment(workflow_name)),
@@ -713,4 +720,98 @@ fn query_encode(input: &str) -> String {
         }
     }
     out
+}
+
+#[cfg(test)]
+mod reuse_policy_tests {
+    use super::*;
+
+    fn parse(args: &[&str]) -> Cli {
+        Cli::try_parse_from(std::iter::once("harvest").chain(args.iter().copied()))
+            .expect("CLI should parse successfully")
+    }
+
+    fn start_request(args: &[&str]) -> ApiRequest {
+        parse(args)
+            .api_request()
+            .expect("request mapping should succeed")
+    }
+
+    #[test]
+    fn start_omitting_reuse_policy_sends_no_field() {
+        let req = start_request(&["workflow", "start", "my_wf"]);
+        let body = req.body.as_ref().expect("start should have a body");
+        assert!(
+            body.get("reuse_policy").is_none(),
+            "omitting --reuse-policy must not send the field"
+        );
+    }
+
+    #[test]
+    fn start_allow_duplicate_sends_correct_value() {
+        let req = start_request(&[
+            "workflow",
+            "start",
+            "my_wf",
+            "--reuse-policy",
+            "allow_duplicate",
+        ]);
+        let body = req.body.as_ref().unwrap();
+        assert_eq!(body["reuse_policy"], "allow_duplicate");
+    }
+
+    #[test]
+    fn start_reject_duplicate_sends_correct_value() {
+        let req = start_request(&[
+            "workflow",
+            "start",
+            "my_wf",
+            "--reuse-policy",
+            "reject_duplicate",
+        ]);
+        let body = req.body.as_ref().unwrap();
+        assert_eq!(body["reuse_policy"], "reject_duplicate");
+    }
+
+    #[test]
+    fn start_allow_duplicate_failed_only_sends_correct_value() {
+        let req = start_request(&[
+            "workflow",
+            "start",
+            "my_wf",
+            "--reuse-policy",
+            "allow_duplicate_failed_only",
+        ]);
+        let body = req.body.as_ref().unwrap();
+        assert_eq!(body["reuse_policy"], "allow_duplicate_failed_only");
+    }
+
+    #[test]
+    fn start_terminate_if_running_sends_correct_value() {
+        let req = start_request(&[
+            "workflow",
+            "start",
+            "my_wf",
+            "--reuse-policy",
+            "terminate_if_running",
+        ]);
+        let body = req.body.as_ref().unwrap();
+        assert_eq!(body["reuse_policy"], "terminate_if_running");
+    }
+
+    #[test]
+    fn start_preserves_other_fields_alongside_reuse_policy() {
+        let req = start_request(&[
+            "workflow",
+            "start",
+            "my_wf",
+            "--workflow-id",
+            "wf-123",
+            "--reuse-policy",
+            "reject_duplicate",
+        ]);
+        let body = req.body.as_ref().unwrap();
+        assert_eq!(body["workflow_id"], "wf-123");
+        assert_eq!(body["reuse_policy"], "reject_duplicate");
+    }
 }

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -32,7 +32,7 @@ use autumn_harvest::schema::{harvest_dag_runs, harvest_schedules, harvest_workfl
 use autumn_harvest::shard::ShardRouter;
 use autumn_harvest::signal;
 use autumn_harvest::store;
-use autumn_harvest::types::{ExecutionId, ShardId};
+use autumn_harvest::types::{ExecutionId, ShardId, WorkflowIdReusePolicy};
 use autumn_harvest::worker::{DbPool, HandlerRegistry};
 use autumn_harvest::{
     StartWorkflowParams, cancel_workflow_execution, start_or_load_workflow_execution,
@@ -244,6 +244,17 @@ struct StartWorkflowRequest {
     memo: Option<Value>,
     search_attrs: Option<Value>,
     execution_timeout_secs: Option<i64>,
+    /// How to handle a duplicate `(workflow_name, workflow_id)` collision.
+    /// Omitted or `null` → `AllowDuplicate` (preserves existing wire behaviour).
+    /// An unknown string value returns `400 Bad Request`.
+    reuse_policy: Option<WorkflowIdReusePolicy>,
+}
+
+/// Response body for a 409 Conflict returned by `RejectDuplicate` policy.
+#[derive(Debug, Serialize)]
+struct AlreadyExistsResponse {
+    existing_execution_id: String,
+    existing_state: String,
 }
 
 #[derive(Debug, Deserialize)]
@@ -421,14 +432,20 @@ async fn start_workflow(
     Extension(api_state): Extension<HarvestApiState>,
     Path(workflow_name): Path<String>,
     Json(request): Json<StartWorkflowRequest>,
-) -> Result<(axum::http::StatusCode, Json<StartWorkflowResponse>), AutumnError> {
-    let runtime = api_state.runtime().map_err(map_error)?;
+) -> axum::response::Response {
+    use axum::response::IntoResponse as _;
+
+    let runtime = match api_state.runtime() {
+        Ok(r) => r,
+        Err(e) => return map_error(e).into_response(),
+    };
     if !runtime.registry.workflows.contains_key(&workflow_name) {
-        return Err(AutumnError::not_found_msg(format!(
-            "workflow '{workflow_name}'"
-        )));
+        return AutumnError::not_found_msg(format!("workflow '{workflow_name}'")).into_response();
     }
 
+    let reuse_policy = request
+        .reuse_policy
+        .unwrap_or(WorkflowIdReusePolicy::AllowDuplicate);
     let workflow_id = request
         .workflow_id
         .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
@@ -442,9 +459,12 @@ async fn start_workflow(
         .router
         .pick_for_new_workflow(&workflow_name, &workflow_id);
     let exec_id = ExecutionId::new_for_shard(shard);
-    let mut conn = db_conn_for_shard(&api_state, shard).await?;
+    let mut conn = match db_conn_for_shard(&api_state, shard).await {
+        Ok(c) => c,
+        Err(e) => return e.into_response(),
+    };
 
-    let start = start_or_load_workflow_execution(
+    let result = start_or_load_workflow_execution(
         &mut conn,
         StartWorkflowParams {
             workflow_name: &workflow_name,
@@ -458,24 +478,39 @@ async fn start_workflow(
                 .map(chrono::Duration::seconds),
             memo: request.memo.clone(),
             search_attrs: request.search_attrs.clone(),
+            reuse_policy,
         },
     )
-    .await
-    .map_err(map_error)?;
+    .await;
 
-    Ok((
-        if start.created {
-            axum::http::StatusCode::CREATED
-        } else {
-            axum::http::StatusCode::OK
-        },
-        Json(StartWorkflowResponse {
-            execution_id: start.exec_id.to_string(),
-            workflow_name: start.workflow_name,
-            workflow_id: start.workflow_id,
-            state: start.state,
-        }),
-    ))
+    match result {
+        Err(HarvestError::AlreadyExists {
+            existing_exec_id,
+            existing_state,
+        }) => (
+            axum::http::StatusCode::CONFLICT,
+            Json(AlreadyExistsResponse {
+                existing_execution_id: existing_exec_id.to_string(),
+                existing_state,
+            }),
+        )
+            .into_response(),
+        Err(e) => map_error(e).into_response(),
+        Ok(start) => (
+            if start.created {
+                axum::http::StatusCode::CREATED
+            } else {
+                axum::http::StatusCode::OK
+            },
+            Json(StartWorkflowResponse {
+                execution_id: start.exec_id.to_string(),
+                workflow_name: start.workflow_name,
+                workflow_id: start.workflow_id,
+                state: start.state,
+            }),
+        )
+            .into_response(),
+    }
 }
 
 async fn cancel_workflow(
@@ -934,6 +969,12 @@ pub(crate) fn map_error(error: HarvestError) -> AutumnError {
             name: _,
             reason: message,
         } => AutumnError::bad_request_msg(message),
+        HarvestError::AlreadyExists {
+            existing_exec_id,
+            existing_state,
+        } => AutumnError::bad_request_msg(format!(
+            "workflow execution already exists: {existing_exec_id} (state: {existing_state})"
+        )),
         HarvestError::Database(message) => AutumnError::service_unavailable_msg(message),
         other => AutumnError::service_unavailable_msg(other.to_string()),
     }

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -246,8 +246,9 @@ struct StartWorkflowRequest {
     execution_timeout_secs: Option<i64>,
     /// How to handle a duplicate `(workflow_name, workflow_id)` collision.
     /// Omitted or `null` → `AllowDuplicate` (preserves existing wire behaviour).
-    /// An unknown string value returns `400 Bad Request`.
-    reuse_policy: Option<WorkflowIdReusePolicy>,
+    /// An unknown string value returns `400 Bad Request` with the offending value
+    /// echoed in the response body.
+    reuse_policy: Option<String>,
 }
 
 /// Response body for a 409 Conflict returned by `RejectDuplicate` policy.
@@ -443,9 +444,10 @@ async fn start_workflow(
         return AutumnError::not_found_msg(format!("workflow '{workflow_name}'")).into_response();
     }
 
-    let reuse_policy = request
-        .reuse_policy
-        .unwrap_or(WorkflowIdReusePolicy::AllowDuplicate);
+    let reuse_policy = match parse_reuse_policy(request.reuse_policy.as_deref()) {
+        Ok(p) => p,
+        Err(e) => return e.into_response(),
+    };
     let workflow_id = request
         .workflow_id
         .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
@@ -949,6 +951,19 @@ async fn replay_dead_letter_from_shards(
     )))
 }
 
+fn parse_reuse_policy(raw: Option<&str>) -> Result<WorkflowIdReusePolicy, AutumnError> {
+    match raw {
+        None | Some("" | "allow_duplicate") => Ok(WorkflowIdReusePolicy::AllowDuplicate),
+        Some("reject_duplicate") => Ok(WorkflowIdReusePolicy::RejectDuplicate),
+        Some("allow_duplicate_failed_only") => Ok(WorkflowIdReusePolicy::AllowDuplicateFailedOnly),
+        Some("terminate_if_running") => Ok(WorkflowIdReusePolicy::TerminateIfRunning),
+        Some(other) => Err(AutumnError::bad_request_msg(format!(
+            "unknown reuse_policy '{other}'; expected one of: allow_duplicate, reject_duplicate, \
+             allow_duplicate_failed_only, terminate_if_running"
+        ))),
+    }
+}
+
 pub(crate) fn parse_execution_id(raw: &str) -> Result<ExecutionId, AutumnError> {
     raw.parse::<ExecutionId>()
         .map_err(|_| AutumnError::bad_request_msg(format!("invalid execution id '{raw}'")))
@@ -1074,5 +1089,62 @@ mod tests {
             .expect("unknown keys should be skipped");
         assert!(filters.states.is_empty());
         assert!(filters.workflow_name.is_none());
+    }
+
+    #[test]
+    fn parse_reuse_policy_none_defaults_to_allow_duplicate() {
+        assert_eq!(
+            parse_reuse_policy(None).unwrap(),
+            WorkflowIdReusePolicy::AllowDuplicate
+        );
+    }
+
+    #[test]
+    fn parse_reuse_policy_empty_string_defaults_to_allow_duplicate() {
+        assert_eq!(
+            parse_reuse_policy(Some("")).unwrap(),
+            WorkflowIdReusePolicy::AllowDuplicate
+        );
+    }
+
+    #[test]
+    fn parse_reuse_policy_accepts_all_known_values() {
+        use WorkflowIdReusePolicy::*;
+        let cases = [
+            ("allow_duplicate", AllowDuplicate),
+            ("reject_duplicate", RejectDuplicate),
+            ("allow_duplicate_failed_only", AllowDuplicateFailedOnly),
+            ("terminate_if_running", TerminateIfRunning),
+        ];
+        for (input, expected) in cases {
+            assert_eq!(
+                parse_reuse_policy(Some(input)).unwrap(),
+                expected,
+                "failed for '{input}'"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_reuse_policy_unknown_value_returns_400_error() {
+        let err = parse_reuse_policy(Some("bogus_policy")).expect_err("unknown value must error");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("bogus_policy"),
+            "offending value must be echoed in error: {msg}"
+        );
+        assert!(
+            msg.contains("unknown reuse_policy"),
+            "error must mention unknown reuse_policy: {msg}"
+        );
+    }
+
+    #[test]
+    fn parse_reuse_policy_unknown_value_is_not_silent_fallback() {
+        // Ensure "allow_DUPLICATE" (wrong case) is rejected, not silently coerced.
+        assert!(
+            parse_reuse_policy(Some("allow_DUPLICATE")).is_err(),
+            "wrong case must not silently fall back"
+        );
     }
 }

--- a/autumn-harvest-plugin/src/outbox.rs
+++ b/autumn-harvest-plugin/src/outbox.rs
@@ -293,6 +293,7 @@ pub(crate) async fn dispatch_workflow_start_request(
             execution_timeout: None,
             memo: request.memo.clone(),
             search_attrs: request.search_attrs.clone(),
+            reuse_policy: autumn_harvest::WorkflowIdReusePolicy::default(),
         },
     )
     .await?;

--- a/autumn-harvest-plugin/tests/api_scheduler_integration.rs
+++ b/autumn-harvest-plugin/tests/api_scheduler_integration.rs
@@ -341,6 +341,7 @@ async fn insert_workflow_on_url(
             execution_timeout: None,
             memo: None,
             search_attrs: None,
+            reuse_policy: autumn_harvest::WorkflowIdReusePolicy::default(),
         },
     )
     .await

--- a/autumn-harvest-plugin/tests/ui_integration.rs
+++ b/autumn-harvest-plugin/tests/ui_integration.rs
@@ -188,6 +188,7 @@ async fn insert_workflow_on_url(
             execution_timeout: None,
             memo: None,
             search_attrs: None,
+            reuse_policy: autumn_harvest::WorkflowIdReusePolicy::default(),
         },
     )
     .await

--- a/autumn-harvest-plugin/tests/workflow_filter_integration.rs
+++ b/autumn-harvest-plugin/tests/workflow_filter_integration.rs
@@ -149,6 +149,7 @@ async fn seed_workflow(
             execution_timeout: None,
             memo: None,
             search_attrs,
+            reuse_policy: autumn_harvest::WorkflowIdReusePolicy::default(),
         },
     )
     .await

--- a/autumn-harvest/src/error.rs
+++ b/autumn-harvest/src/error.rs
@@ -8,6 +8,8 @@
 //! — it's an HTTP response wrapper. `HarvestError` converts to `AutumnError` via
 //! the blanket `From<E: Error> for AutumnError` impl automatically.
 
+use crate::types::ExecutionId;
+
 /// The kind of timeout that fired.
 ///
 /// ## Examples
@@ -126,6 +128,21 @@ pub enum HarvestError {
     /// Invalid configuration provided to the engine.
     #[error("invalid configuration: {0}")]
     Config(String),
+
+    /// A workflow execution with the same `(workflow_name, workflow_id)` already
+    /// exists and the caller's reuse policy does not permit reuse.
+    ///
+    /// Returned by `start_or_load_workflow_execution` when the policy is
+    /// `WorkflowIdReusePolicy::RejectDuplicate`.
+    #[error(
+        "workflow execution already exists: {existing_exec_id} (state: {existing_state})"
+    )]
+    AlreadyExists {
+        /// The execution ID of the conflicting prior run.
+        existing_exec_id: ExecutionId,
+        /// The state of the conflicting prior run (e.g. `"RUNNING"`, `"COMPLETED"`).
+        existing_state: String,
+    },
 }
 
 /// Standard result type for internal harvest engine operations.

--- a/autumn-harvest/src/error.rs
+++ b/autumn-harvest/src/error.rs
@@ -134,9 +134,7 @@ pub enum HarvestError {
     ///
     /// Returned by `start_or_load_workflow_execution` when the policy is
     /// `WorkflowIdReusePolicy::RejectDuplicate`.
-    #[error(
-        "workflow execution already exists: {existing_exec_id} (state: {existing_state})"
-    )]
+    #[error("workflow execution already exists: {existing_exec_id} (state: {existing_state})")]
     AlreadyExists {
         /// The execution ID of the conflicting prior run.
         existing_exec_id: ExecutionId,

--- a/autumn-harvest/src/execution.rs
+++ b/autumn-harvest/src/execution.rs
@@ -20,7 +20,7 @@ use crate::models::{NewWorkflowExecution, WorkflowExecution};
 use crate::queue::{self, EnqueueParams, TaskType};
 use crate::schema::harvest_workflow_executions;
 use crate::store;
-use crate::types::ExecutionId;
+use crate::types::{ExecutionId, WorkflowIdReusePolicy};
 
 /// Parameters for starting a workflow execution.
 ///
@@ -42,6 +42,9 @@ pub struct StartWorkflowParams<'a> {
     pub execution_timeout: Option<chrono::Duration>,
     pub memo: Option<serde_json::Value>,
     pub search_attrs: Option<serde_json::Value>,
+    /// How to handle a duplicate `(workflow_name, workflow_id)` collision.
+    /// Defaults to [`WorkflowIdReusePolicy::AllowDuplicate`].
+    pub reuse_policy: WorkflowIdReusePolicy,
 }
 
 impl StartWorkflowParams<'_> {
@@ -120,23 +123,52 @@ impl CancelledWorkflowExecution {
     }
 }
 
-/// Start a workflow execution or load the existing one if the same
-/// `(workflow_name, workflow_id)` has already been published.
+/// Start a workflow execution or load the existing one, applying the caller's
+/// [`WorkflowIdReusePolicy`] when a duplicate `(workflow_name, workflow_id)`
+/// collision occurs.
 ///
-/// New starts insert the execution row, append `WorkflowStarted`, and enqueue
-/// the initial workflow task in one transaction. Duplicate starts return the
-/// previously-created execution without appending extra events or queue work.
+/// ## Policy behaviour
+///
+/// | Prior state | `AllowDuplicate` | `RejectDuplicate` | `AllowDuplicateFailedOnly` | `TerminateIfRunning` |
+/// |-------------|------------------|-------------------|---------------------------|----------------------|
+/// | none | create | create | create | create |
+/// | RUNNING | return existing | `Err(AlreadyExists)` | return existing | cancel + start fresh |
+/// | COMPLETED | return existing | `Err(AlreadyExists)` | return existing | start fresh |
+/// | FAILED | return existing | `Err(AlreadyExists)` | start fresh | start fresh |
+/// | CANCELLED | return existing | `Err(AlreadyExists)` | start fresh | start fresh |
+///
+/// For `TerminateIfRunning` + RUNNING the cancel is performed in a separate
+/// transaction (Transaction 1) before the start transaction (Transaction 2). A
+/// failure between the two leaves the prior workflow CANCELLED with no new run
+/// started; the caller can retry with the same policy to get a fresh run.
 ///
 /// # Errors
 ///
-/// Returns [`HarvestError::Database`] for insert/query failures and propagates
-/// queue/event-store failures from the new-start transaction.
+/// - [`HarvestError::AlreadyExists`] when `RejectDuplicate` rejects.
+/// - [`HarvestError::Database`] for insert/query failures.
+/// - Propagates queue/event-store failures from the start transaction.
 pub async fn start_or_load_workflow_execution(
     conn: &mut AsyncPgConnection,
     request: StartWorkflowParams<'_>,
 ) -> HarvestResult<StartedWorkflowExecution> {
     let exec_id = request.exec_id;
     let shard_id_value = request.shard_id();
+
+    // For TerminateIfRunning: if there is an existing RUNNING execution, cancel
+    // it (Transaction 1) before the start transaction below (Transaction 2). A
+    // crash between the two leaves the prior workflow CANCELLED with no new run;
+    // retrying with the same policy starts fresh on the next attempt because the
+    // CANCELLED row is treated as "start fresh" by TerminateIfRunning.
+    if request.reuse_policy == WorkflowIdReusePolicy::TerminateIfRunning
+        && let Some(existing) =
+            try_load_by_key(conn, request.workflow_name, request.workflow_id).await?
+        && existing.state == "RUNNING"
+    {
+        let existing_exec_id = ExecutionId::from_uuid(existing.id);
+        cancel_workflow_execution(conn, existing_exec_id, "terminated to start new execution")
+            .await?;
+    }
+
     let row = NewWorkflowExecution {
         id: exec_id.as_uuid(),
         workflow_name: request.workflow_name,
@@ -187,14 +219,135 @@ pub async fn start_or_load_workflow_execution(
                 return Ok(StartedWorkflowExecution::from_row(execution, true));
             }
 
-            let execution =
-                load_workflow_execution_by_key(conn, request.workflow_name, request.workflow_id)
-                    .await?;
-            Ok(StartedWorkflowExecution::from_row(execution, false))
+            // INSERT was a no-op: a prior execution exists. Lock the row to
+            // prevent concurrent state changes while we decide what to do.
+            let existing = load_workflow_execution_by_key_for_update(
+                conn,
+                request.workflow_name,
+                request.workflow_id,
+            )
+            .await?;
+
+            match request.reuse_policy {
+                WorkflowIdReusePolicy::AllowDuplicate => {
+                    Ok(StartedWorkflowExecution::from_row(existing, false))
+                }
+
+                WorkflowIdReusePolicy::RejectDuplicate => {
+                    Err(HarvestError::AlreadyExists {
+                        existing_exec_id: ExecutionId::from_uuid(existing.id),
+                        existing_state: existing.state,
+                    })
+                }
+
+                WorkflowIdReusePolicy::AllowDuplicateFailedOnly => {
+                    match existing.state.as_str() {
+                        "RUNNING" | "COMPLETED" => {
+                            Ok(StartedWorkflowExecution::from_row(existing, false))
+                        }
+                        _ => {
+                            // FAILED or CANCELLED: replace with a fresh execution.
+                            replace_execution(conn, existing, &row, &enqueue, exec_id, &request)
+                                .await
+                        }
+                    }
+                }
+
+                WorkflowIdReusePolicy::TerminateIfRunning => {
+                    // The pre-check above cancelled any RUNNING prior execution
+                    // (Transaction 1). By the time we reach this point the prior
+                    // execution's state is CANCELLED, FAILED, COMPLETED, or —
+                    // under extreme concurrency — still RUNNING. All cases start
+                    // fresh; for the still-RUNNING race we inline the cancel here
+                    // so the new start is not silently blocked.
+                    if existing.state == "RUNNING" {
+                        inline_cancel(conn, ExecutionId::from_uuid(existing.id)).await?;
+                    }
+                    replace_execution(conn, existing, &row, &enqueue, exec_id, &request).await
+                }
+            }
         }
         .scope_boxed()
     })
     .await
+}
+
+/// Transition `existing` to `CONTINUED_AS_NEW` (releasing the partial unique
+/// index slot) then insert `new_row` as a fresh execution with its own
+/// `WorkflowStarted` event and task queue entry.
+async fn replace_execution(
+    conn: &mut AsyncPgConnection,
+    existing: WorkflowExecution,
+    new_row: &NewWorkflowExecution<'_>,
+    enqueue: &EnqueueParams,
+    new_exec_id: ExecutionId,
+    request: &StartWorkflowParams<'_>,
+) -> HarvestResult<StartedWorkflowExecution> {
+    // Seal the prior execution row as CONTINUED_AS_NEW. This removes it from
+    // the partial unique index scope (WHERE state != 'CONTINUED_AS_NEW'),
+    // allowing the new row to be inserted without violating the constraint.
+    diesel::update(harvest_workflow_executions::table.find(existing.id))
+        .set((
+            harvest_workflow_executions::state.eq("CONTINUED_AS_NEW"),
+            harvest_workflow_executions::completed_at.eq(Some(Utc::now())),
+        ))
+        .execute(conn)
+        .await
+        .map_err(database_error)?;
+
+    let new_execution = diesel::insert_into(harvest_workflow_executions::table)
+        .values(new_row)
+        .returning(WorkflowExecution::as_returning())
+        .get_result(conn)
+        .await
+        .map_err(database_error)?;
+
+    let started_event = WorkflowEvent::WorkflowStarted {
+        input: request.input.clone(),
+        timestamp: Utc::now(),
+    };
+    store::append_events(conn, new_exec_id, &[started_event], 0).await?;
+    queue::enqueue(conn, enqueue).await?;
+
+    Ok(StartedWorkflowExecution::from_row(new_execution, true))
+}
+
+/// Inline cancellation for the `TerminateIfRunning` race condition where a
+/// RUNNING row appears inside the start transaction despite the pre-check.
+/// Appends a `WorkflowCancelled` event, transitions to CANCELLED, and fails
+/// open tasks — all within the caller's transaction.
+async fn inline_cancel(
+    conn: &mut AsyncPgConnection,
+    exec_id: ExecutionId,
+) -> HarvestResult<()> {
+    let reason = "terminated to start new execution";
+    let history = store::load_history(conn, exec_id).await?;
+    store::append_events(
+        conn,
+        exec_id,
+        &[WorkflowEvent::WorkflowCancelled {
+            reason: reason.to_string(),
+        }],
+        history.next_event_id,
+    )
+    .await?;
+    diesel::update(harvest_workflow_executions::table.find(exec_id.as_uuid()))
+        .filter(harvest_workflow_executions::state.eq("RUNNING"))
+        .set((
+            harvest_workflow_executions::state.eq("CANCELLED"),
+            harvest_workflow_executions::error.eq(Some(reason)),
+            harvest_workflow_executions::completed_at.eq(Some(Utc::now())),
+        ))
+        .execute(conn)
+        .await
+        .map_err(database_error)?;
+    queue::fail_open_tasks_for_execution(
+        conn,
+        exec_id,
+        &format!("workflow cancelled: {reason}"),
+    )
+    .await?;
+    Ok(())
 }
 
 /// Cancel a running workflow execution.
@@ -294,21 +447,37 @@ pub async fn cancel_workflow_execution(
     .await
 }
 
-async fn load_workflow_execution_by_key(
+/// Non-locking lookup used for the `TerminateIfRunning` pre-check outside any
+/// transaction. Returns `None` if no active execution exists.
+async fn try_load_by_key(
     conn: &mut AsyncPgConnection,
     workflow_name: &str,
     workflow_id: &str,
-) -> HarvestResult<WorkflowExecution> {
-    // After continue-as-new, several rows may share the same
-    // (workflow_name, workflow_id): every sealed run carries
-    // state='CONTINUED_AS_NEW' and only one row remains active. Filtering on
-    // state mirrors the partial unique index and returns the row that callers
-    // expect to keep operating against.
+) -> HarvestResult<Option<WorkflowExecution>> {
     harvest_workflow_executions::table
         .filter(harvest_workflow_executions::workflow_name.eq(workflow_name))
         .filter(harvest_workflow_executions::workflow_id.eq(workflow_id))
         .filter(harvest_workflow_executions::state.ne("CONTINUED_AS_NEW"))
         .select(WorkflowExecution::as_select())
+        .first(conn)
+        .await
+        .optional()
+        .map_err(database_error)
+}
+
+/// Locking lookup used inside the start transaction when a policy decision may
+/// modify or replace the existing row.
+async fn load_workflow_execution_by_key_for_update(
+    conn: &mut AsyncPgConnection,
+    workflow_name: &str,
+    workflow_id: &str,
+) -> HarvestResult<WorkflowExecution> {
+    harvest_workflow_executions::table
+        .filter(harvest_workflow_executions::workflow_name.eq(workflow_name))
+        .filter(harvest_workflow_executions::workflow_id.eq(workflow_id))
+        .filter(harvest_workflow_executions::state.ne("CONTINUED_AS_NEW"))
+        .select(WorkflowExecution::as_select())
+        .for_update()
         .first(conn)
         .await
         .optional()

--- a/autumn-harvest/src/execution.rs
+++ b/autumn-harvest/src/execution.rs
@@ -165,8 +165,15 @@ pub async fn start_or_load_workflow_execution(
         && existing.state == "RUNNING"
     {
         let existing_exec_id = ExecutionId::from_uuid(existing.id);
-        cancel_workflow_execution(conn, existing_exec_id, "terminated to start new execution")
-            .await?;
+        // Ignore Config errors: the execution may have transitioned to a terminal
+        // state between the pre-check and the cancel lock. In that race the prior
+        // run is already done, so we just continue to the start transaction below.
+        match cancel_workflow_execution(conn, existing_exec_id, "terminated to start new execution")
+            .await
+        {
+            Ok(_) | Err(HarvestError::Config(_)) => {}
+            Err(e) => return Err(e),
+        }
     }
 
     let row = NewWorkflowExecution {
@@ -233,22 +240,22 @@ pub async fn start_or_load_workflow_execution(
                     Ok(StartedWorkflowExecution::from_row(existing, false))
                 }
 
-                WorkflowIdReusePolicy::RejectDuplicate => {
-                    Err(HarvestError::AlreadyExists {
-                        existing_exec_id: ExecutionId::from_uuid(existing.id),
-                        existing_state: existing.state,
-                    })
-                }
+                WorkflowIdReusePolicy::RejectDuplicate => Err(HarvestError::AlreadyExists {
+                    existing_exec_id: ExecutionId::from_uuid(existing.id),
+                    existing_state: existing.state,
+                }),
 
                 WorkflowIdReusePolicy::AllowDuplicateFailedOnly => {
                     match existing.state.as_str() {
-                        "RUNNING" | "COMPLETED" => {
-                            Ok(StartedWorkflowExecution::from_row(existing, false))
-                        }
-                        _ => {
-                            // FAILED or CANCELLED: replace with a fresh execution.
+                        "FAILED" | "CANCELLED" => {
+                            // Only these two explicitly abnormal states start fresh.
                             replace_execution(conn, existing, &row, &enqueue, exec_id, &request)
                                 .await
+                        }
+                        _ => {
+                            // RUNNING, COMPLETED, TIMED_OUT, or any other state:
+                            // return the existing execution unchanged.
+                            Ok(StartedWorkflowExecution::from_row(existing, false))
                         }
                     }
                 }
@@ -316,10 +323,7 @@ async fn replace_execution(
 /// RUNNING row appears inside the start transaction despite the pre-check.
 /// Appends a `WorkflowCancelled` event, transitions to CANCELLED, and fails
 /// open tasks — all within the caller's transaction.
-async fn inline_cancel(
-    conn: &mut AsyncPgConnection,
-    exec_id: ExecutionId,
-) -> HarvestResult<()> {
+async fn inline_cancel(conn: &mut AsyncPgConnection, exec_id: ExecutionId) -> HarvestResult<()> {
     let reason = "terminated to start new execution";
     let history = store::load_history(conn, exec_id).await?;
     store::append_events(
@@ -341,12 +345,8 @@ async fn inline_cancel(
         .execute(conn)
         .await
         .map_err(database_error)?;
-    queue::fail_open_tasks_for_execution(
-        conn,
-        exec_id,
-        &format!("workflow cancelled: {reason}"),
-    )
-    .await?;
+    queue::fail_open_tasks_for_execution(conn, exec_id, &format!("workflow cancelled: {reason}"))
+        .await?;
     Ok(())
 }
 

--- a/autumn-harvest/src/lib.rs
+++ b/autumn-harvest/src/lib.rs
@@ -131,7 +131,9 @@ pub use telemetry::{
 };
 #[cfg(any(test, feature = "testing"))]
 pub use test_generator::TestHarnessGenerator;
-pub use types::{ActivityExecId, ExecutionId, ShardId, TimerId, WorkerId, WorkflowId};
+pub use types::{
+    ActivityExecId, ExecutionId, ShardId, TimerId, WorkerId, WorkflowId, WorkflowIdReusePolicy,
+};
 
 #[cfg(feature = "db")]
 pub use store::EventHistory;

--- a/autumn-harvest/src/types.rs
+++ b/autumn-harvest/src/types.rs
@@ -436,6 +436,55 @@ impl fmt::Display for WorkerId {
     }
 }
 
+/// Controls how a duplicate `(workflow_name, workflow_id)` start is handled.
+///
+/// The policy is a *caller* concern chosen at request time. It has no effect
+/// on the first start of a given `workflow_id`; it only changes behaviour when
+/// a prior execution already exists for the same `(workflow_name, workflow_id)`
+/// pair.
+///
+/// ## Examples
+///
+/// ```rust
+/// use autumn_harvest::types::WorkflowIdReusePolicy;
+///
+/// // AllowDuplicate is the default
+/// let policy = WorkflowIdReusePolicy::default();
+/// assert_eq!(policy, WorkflowIdReusePolicy::AllowDuplicate);
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WorkflowIdReusePolicy {
+    /// Return the existing execution unconditionally. This is the default.
+    ///
+    /// Correct for upstream retries when the caller does not know whether the
+    /// previous start succeeded — they get the same `exec_id` back and move on.
+    #[default]
+    AllowDuplicate,
+
+    /// Return [`crate::error::HarvestError::AlreadyExists`] for any prior
+    /// execution, including terminal ones.
+    ///
+    /// Use for at-most-one semantics: the second request is explicitly rejected
+    /// so the caller can decide what to do.
+    RejectDuplicate,
+
+    /// Start a fresh run if the prior execution is FAILED or CANCELLED; return
+    /// the existing execution unchanged if it is RUNNING or COMPLETED.
+    ///
+    /// Use for retry-after-failure semantics: a successful or in-progress run
+    /// is not superseded, but a failed one is automatically replaced.
+    AllowDuplicateFailedOnly,
+
+    /// Cancel a RUNNING prior execution and start a fresh run; start a fresh
+    /// run unconditionally if the prior execution is already terminal.
+    ///
+    /// The cancel and the new start are two separate transactions. A failure
+    /// between them leaves the prior workflow CANCELLED with no new run started;
+    /// retrying with the same policy starts a fresh run on the next attempt.
+    TerminateIfRunning,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/autumn-harvest/tests/cancellation_tests.rs
+++ b/autumn-harvest/tests/cancellation_tests.rs
@@ -103,6 +103,7 @@ async fn start_test_workflow(conn: &mut AsyncPgConnection) -> autumn_harvest::Ex
             execution_timeout: None,
             memo: None,
             search_attrs: None,
+            reuse_policy: autumn_harvest::WorkflowIdReusePolicy::default(),
         },
     )
     .await
@@ -425,6 +426,7 @@ async fn running_activity_heartbeat_observes_workflow_cancellation() {
             execution_timeout: None,
             memo: None,
             search_attrs: None,
+            reuse_policy: autumn_harvest::WorkflowIdReusePolicy::default(),
         },
     )
     .await
@@ -573,6 +575,7 @@ async fn uncooperative_activity_is_hard_aborted_after_grace_period() {
             execution_timeout: None,
             memo: None,
             search_attrs: None,
+            reuse_policy: autumn_harvest::WorkflowIdReusePolicy::default(),
         },
     )
     .await

--- a/autumn-harvest/tests/integration_e2e.rs
+++ b/autumn-harvest/tests/integration_e2e.rs
@@ -3291,8 +3291,8 @@ async fn reuse_policy_terminate_if_running_cancelled_starts_fresh() {
     assert_ne!(second.exec_id, first.exec_id);
 }
 
-/// TerminateIfRunning is idempotent: if the prior run is CANCELLED (e.g. from
-/// a previous TerminateIfRunning that crashed between the two transactions),
+/// `TerminateIfRunning` is idempotent: if the prior run is CANCELLED (e.g. from
+/// a previous `TerminateIfRunning` that crashed between the two transactions),
 /// the retry starts fresh without requiring manual intervention.
 #[tokio::test]
 async fn reuse_policy_terminate_if_running_retry_after_partial_failure_is_idempotent() {

--- a/autumn-harvest/tests/integration_e2e.rs
+++ b/autumn-harvest/tests/integration_e2e.rs
@@ -2925,7 +2925,10 @@ async fn reuse_policy_allow_duplicate_running_returns_existing() {
         .await
         .expect("AllowDuplicate on RUNNING should return existing");
     assert!(!second.created);
-    assert_eq!(second.exec_id, first.exec_id, "must return the first exec_id");
+    assert_eq!(
+        second.exec_id, first.exec_id,
+        "must return the first exec_id"
+    );
     assert_eq!(second.state, "RUNNING");
 }
 

--- a/autumn-harvest/tests/integration_e2e.rs
+++ b/autumn-harvest/tests/integration_e2e.rs
@@ -19,7 +19,8 @@ use autumn_harvest::types::{ActivityExecId, ExecutionId};
 use autumn_harvest::worker::{DbPool, HandlerRegistry, Worker, WorkerRuntimeConfig};
 use autumn_harvest::{
     ActivityContext, HarvestBuilder, HarvestError, StartWorkflowParams, TimeoutType, WorkerConfig,
-    WorkflowContext, queue, start_or_load_workflow_execution, timeout,
+    WorkflowContext, WorkflowIdReusePolicy, cancel_workflow_execution, queue,
+    start_or_load_workflow_execution, timeout,
 };
 
 use chrono::Utc;
@@ -280,6 +281,7 @@ async fn legacy_workflow_uniqueness_schema_can_be_upgraded_for_idempotent_starts
         execution_timeout: None,
         memo: None,
         search_attrs: None,
+        reuse_policy: autumn_harvest::WorkflowIdReusePolicy::default(),
     };
 
     // On the legacy schema there is no `(workflow_name, workflow_id)`
@@ -2853,4 +2855,466 @@ async fn continue_as_new_down_migration_rewrites_historical_runs_for_rollback() 
         rows_on_original_key, 1,
         "rollback should leave exactly one row on the original logical key before restoring uniqueness",
     );
+}
+
+// ── WorkflowIdReusePolicy integration matrix ─────────────────────────────────
+//
+// 4 policies × 5 prior states (none, RUNNING, COMPLETED, FAILED, CANCELLED)
+// = 20 cells, each asserting: (a) which exec_id the second start observes,
+// (b) whether a new exec_id was minted, (c) the error variant when applicable.
+
+/// Helpers for the reuse-policy matrix tests.
+mod reuse_policy_helpers {
+    use super::*;
+
+    pub fn base_params(
+        workflow_id: &'static str,
+        exec_id: ExecutionId,
+    ) -> StartWorkflowParams<'static> {
+        StartWorkflowParams {
+            workflow_name: "reuse_policy_wf",
+            workflow_id,
+            exec_id,
+            input: serde_json::json!({}),
+            parent_id: None,
+            queue_name: "default",
+            execution_timeout: None,
+            memo: None,
+            search_attrs: None,
+            reuse_policy: WorkflowIdReusePolicy::AllowDuplicate,
+        }
+    }
+
+    /// Force a workflow row into a terminal state by direct UPDATE.
+    pub async fn force_state(conn: &mut AsyncPgConnection, exec_id: ExecutionId, state: &str) {
+        diesel::update(harvest_workflow_executions::table.find(exec_id.as_uuid()))
+            .set(harvest_workflow_executions::state.eq(state))
+            .execute(conn)
+            .await
+            .expect("force_state UPDATE failed");
+    }
+}
+
+#[tokio::test]
+async fn reuse_policy_allow_duplicate_no_prior_creates() {
+    let (mut conn, _container) = setup_test_db().await;
+    let exec_id = ExecutionId::new_for_shard(autumn_harvest::ShardId::new(0));
+    let mut params = reuse_policy_helpers::base_params("rp-allow-none", exec_id);
+    params.reuse_policy = WorkflowIdReusePolicy::AllowDuplicate;
+    let result = start_or_load_workflow_execution(&mut conn, params)
+        .await
+        .expect("AllowDuplicate with no prior should succeed");
+    assert!(result.created, "should create when no prior exists");
+    assert_eq!(result.exec_id, exec_id);
+}
+
+#[tokio::test]
+async fn reuse_policy_allow_duplicate_running_returns_existing() {
+    let (mut conn, _container) = setup_test_db().await;
+    let first_id = ExecutionId::new_for_shard(autumn_harvest::ShardId::new(0));
+    let mut params = reuse_policy_helpers::base_params("rp-allow-run", first_id);
+    params.reuse_policy = WorkflowIdReusePolicy::AllowDuplicate;
+    let first = start_or_load_workflow_execution(&mut conn, params.clone())
+        .await
+        .expect("first start should succeed");
+    assert!(first.created);
+
+    let second_id = ExecutionId::new_for_shard(autumn_harvest::ShardId::new(0));
+    params.exec_id = second_id;
+    let second = start_or_load_workflow_execution(&mut conn, params)
+        .await
+        .expect("AllowDuplicate on RUNNING should return existing");
+    assert!(!second.created);
+    assert_eq!(second.exec_id, first.exec_id, "must return the first exec_id");
+    assert_eq!(second.state, "RUNNING");
+}
+
+#[tokio::test]
+async fn reuse_policy_allow_duplicate_completed_returns_existing() {
+    let (mut conn, _container) = setup_test_db().await;
+    let first_id = ExecutionId::new_for_shard(autumn_harvest::ShardId::new(0));
+    let mut params = reuse_policy_helpers::base_params("rp-allow-cmp", first_id);
+    params.reuse_policy = WorkflowIdReusePolicy::AllowDuplicate;
+    let first = start_or_load_workflow_execution(&mut conn, params.clone())
+        .await
+        .expect("first start should succeed");
+    reuse_policy_helpers::force_state(&mut conn, first.exec_id, "COMPLETED").await;
+
+    params.exec_id = ExecutionId::new_for_shard(autumn_harvest::ShardId::new(0));
+    let second = start_or_load_workflow_execution(&mut conn, params)
+        .await
+        .expect("AllowDuplicate on COMPLETED should return existing");
+    assert!(!second.created);
+    assert_eq!(second.exec_id, first.exec_id);
+}
+
+#[tokio::test]
+async fn reuse_policy_allow_duplicate_failed_returns_existing() {
+    let (mut conn, _container) = setup_test_db().await;
+    let first_id = ExecutionId::new_for_shard(autumn_harvest::ShardId::new(0));
+    let mut params = reuse_policy_helpers::base_params("rp-allow-fail", first_id);
+    params.reuse_policy = WorkflowIdReusePolicy::AllowDuplicate;
+    let first = start_or_load_workflow_execution(&mut conn, params.clone())
+        .await
+        .expect("first start should succeed");
+    reuse_policy_helpers::force_state(&mut conn, first.exec_id, "FAILED").await;
+
+    params.exec_id = ExecutionId::new_for_shard(autumn_harvest::ShardId::new(0));
+    let second = start_or_load_workflow_execution(&mut conn, params)
+        .await
+        .expect("AllowDuplicate on FAILED should return existing");
+    assert!(!second.created);
+    assert_eq!(second.exec_id, first.exec_id);
+}
+
+#[tokio::test]
+async fn reuse_policy_allow_duplicate_cancelled_returns_existing() {
+    let (mut conn, _container) = setup_test_db().await;
+    let first_id = ExecutionId::new_for_shard(autumn_harvest::ShardId::new(0));
+    let mut params = reuse_policy_helpers::base_params("rp-allow-can", first_id);
+    params.reuse_policy = WorkflowIdReusePolicy::AllowDuplicate;
+    let first = start_or_load_workflow_execution(&mut conn, params.clone())
+        .await
+        .expect("first start should succeed");
+    cancel_workflow_execution(&mut conn, first.exec_id, "test cancel")
+        .await
+        .expect("cancel should succeed");
+
+    params.exec_id = ExecutionId::new_for_shard(autumn_harvest::ShardId::new(0));
+    let second = start_or_load_workflow_execution(&mut conn, params)
+        .await
+        .expect("AllowDuplicate on CANCELLED should return existing");
+    assert!(!second.created);
+    assert_eq!(second.exec_id, first.exec_id);
+    assert_eq!(second.state, "CANCELLED");
+}
+
+#[tokio::test]
+async fn reuse_policy_reject_duplicate_no_prior_creates() {
+    let (mut conn, _container) = setup_test_db().await;
+    let exec_id = ExecutionId::new_for_shard(autumn_harvest::ShardId::new(0));
+    let mut params = reuse_policy_helpers::base_params("rp-reject-none", exec_id);
+    params.reuse_policy = WorkflowIdReusePolicy::RejectDuplicate;
+    let result = start_or_load_workflow_execution(&mut conn, params)
+        .await
+        .expect("RejectDuplicate with no prior should succeed");
+    assert!(result.created);
+}
+
+#[tokio::test]
+async fn reuse_policy_reject_duplicate_running_errors() {
+    let (mut conn, _container) = setup_test_db().await;
+    let first_id = ExecutionId::new_for_shard(autumn_harvest::ShardId::new(0));
+    let mut params = reuse_policy_helpers::base_params("rp-reject-run", first_id);
+    params.reuse_policy = WorkflowIdReusePolicy::RejectDuplicate;
+    let first = start_or_load_workflow_execution(&mut conn, params.clone())
+        .await
+        .expect("first start should succeed");
+
+    params.exec_id = ExecutionId::new_for_shard(autumn_harvest::ShardId::new(0));
+    let err = start_or_load_workflow_execution(&mut conn, params)
+        .await
+        .expect_err("RejectDuplicate on RUNNING must error");
+    match err {
+        HarvestError::AlreadyExists {
+            existing_exec_id,
+            existing_state,
+        } => {
+            assert_eq!(existing_exec_id, first.exec_id);
+            assert_eq!(existing_state, "RUNNING");
+        }
+        other => panic!("expected AlreadyExists, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn reuse_policy_reject_duplicate_completed_errors() {
+    let (mut conn, _container) = setup_test_db().await;
+    let first_id = ExecutionId::new_for_shard(autumn_harvest::ShardId::new(0));
+    let mut params = reuse_policy_helpers::base_params("rp-reject-cmp", first_id);
+    params.reuse_policy = WorkflowIdReusePolicy::RejectDuplicate;
+    let first = start_or_load_workflow_execution(&mut conn, params.clone())
+        .await
+        .expect("first start should succeed");
+    reuse_policy_helpers::force_state(&mut conn, first.exec_id, "COMPLETED").await;
+
+    params.exec_id = ExecutionId::new_for_shard(autumn_harvest::ShardId::new(0));
+    let err = start_or_load_workflow_execution(&mut conn, params)
+        .await
+        .expect_err("RejectDuplicate on COMPLETED must error");
+    assert!(matches!(err, HarvestError::AlreadyExists { .. }));
+}
+
+#[tokio::test]
+async fn reuse_policy_reject_duplicate_failed_errors() {
+    let (mut conn, _container) = setup_test_db().await;
+    let first_id = ExecutionId::new_for_shard(autumn_harvest::ShardId::new(0));
+    let mut params = reuse_policy_helpers::base_params("rp-reject-fail", first_id);
+    params.reuse_policy = WorkflowIdReusePolicy::RejectDuplicate;
+    let first = start_or_load_workflow_execution(&mut conn, params.clone())
+        .await
+        .expect("first start should succeed");
+    reuse_policy_helpers::force_state(&mut conn, first.exec_id, "FAILED").await;
+
+    params.exec_id = ExecutionId::new_for_shard(autumn_harvest::ShardId::new(0));
+    let err = start_or_load_workflow_execution(&mut conn, params)
+        .await
+        .expect_err("RejectDuplicate on FAILED must error");
+    assert!(matches!(err, HarvestError::AlreadyExists { .. }));
+}
+
+#[tokio::test]
+async fn reuse_policy_reject_duplicate_cancelled_errors() {
+    let (mut conn, _container) = setup_test_db().await;
+    let first_id = ExecutionId::new_for_shard(autumn_harvest::ShardId::new(0));
+    let mut params = reuse_policy_helpers::base_params("rp-reject-can", first_id);
+    params.reuse_policy = WorkflowIdReusePolicy::RejectDuplicate;
+    let first = start_or_load_workflow_execution(&mut conn, params.clone())
+        .await
+        .expect("first start should succeed");
+    cancel_workflow_execution(&mut conn, first.exec_id, "test cancel")
+        .await
+        .expect("cancel should succeed");
+
+    params.exec_id = ExecutionId::new_for_shard(autumn_harvest::ShardId::new(0));
+    let err = start_or_load_workflow_execution(&mut conn, params)
+        .await
+        .expect_err("RejectDuplicate on CANCELLED must error");
+    assert!(matches!(err, HarvestError::AlreadyExists { .. }));
+}
+
+#[tokio::test]
+async fn reuse_policy_allow_failed_only_no_prior_creates() {
+    let (mut conn, _container) = setup_test_db().await;
+    let exec_id = ExecutionId::new_for_shard(autumn_harvest::ShardId::new(0));
+    let mut params = reuse_policy_helpers::base_params("rp-afo-none", exec_id);
+    params.reuse_policy = WorkflowIdReusePolicy::AllowDuplicateFailedOnly;
+    let result = start_or_load_workflow_execution(&mut conn, params)
+        .await
+        .expect("AllowDuplicateFailedOnly with no prior should create");
+    assert!(result.created);
+}
+
+#[tokio::test]
+async fn reuse_policy_allow_failed_only_running_returns_existing() {
+    let (mut conn, _container) = setup_test_db().await;
+    let first_id = ExecutionId::new_for_shard(autumn_harvest::ShardId::new(0));
+    let mut params = reuse_policy_helpers::base_params("rp-afo-run", first_id);
+    params.reuse_policy = WorkflowIdReusePolicy::AllowDuplicateFailedOnly;
+    let first = start_or_load_workflow_execution(&mut conn, params.clone())
+        .await
+        .expect("first start should succeed");
+
+    params.exec_id = ExecutionId::new_for_shard(autumn_harvest::ShardId::new(0));
+    let second = start_or_load_workflow_execution(&mut conn, params)
+        .await
+        .expect("AllowDuplicateFailedOnly on RUNNING should return existing");
+    assert!(!second.created);
+    assert_eq!(second.exec_id, first.exec_id);
+}
+
+#[tokio::test]
+async fn reuse_policy_allow_failed_only_completed_returns_existing() {
+    let (mut conn, _container) = setup_test_db().await;
+    let first_id = ExecutionId::new_for_shard(autumn_harvest::ShardId::new(0));
+    let mut params = reuse_policy_helpers::base_params("rp-afo-cmp", first_id);
+    params.reuse_policy = WorkflowIdReusePolicy::AllowDuplicateFailedOnly;
+    let first = start_or_load_workflow_execution(&mut conn, params.clone())
+        .await
+        .expect("first start should succeed");
+    reuse_policy_helpers::force_state(&mut conn, first.exec_id, "COMPLETED").await;
+
+    params.exec_id = ExecutionId::new_for_shard(autumn_harvest::ShardId::new(0));
+    let second = start_or_load_workflow_execution(&mut conn, params)
+        .await
+        .expect("AllowDuplicateFailedOnly on COMPLETED should return existing");
+    assert!(!second.created);
+    assert_eq!(second.exec_id, first.exec_id);
+}
+
+#[tokio::test]
+async fn reuse_policy_allow_failed_only_failed_starts_fresh() {
+    let (mut conn, _container) = setup_test_db().await;
+    let first_id = ExecutionId::new_for_shard(autumn_harvest::ShardId::new(0));
+    let mut params = reuse_policy_helpers::base_params("rp-afo-fail", first_id);
+    params.reuse_policy = WorkflowIdReusePolicy::AllowDuplicateFailedOnly;
+    let first = start_or_load_workflow_execution(&mut conn, params.clone())
+        .await
+        .expect("first start should succeed");
+    reuse_policy_helpers::force_state(&mut conn, first.exec_id, "FAILED").await;
+
+    let second_id = ExecutionId::new_for_shard(autumn_harvest::ShardId::new(0));
+    params.exec_id = second_id;
+    let second = start_or_load_workflow_execution(&mut conn, params)
+        .await
+        .expect("AllowDuplicateFailedOnly on FAILED should start fresh");
+    assert!(second.created, "must mint a new execution");
+    assert_eq!(second.exec_id, second_id, "must use the new exec_id");
+    assert_ne!(second.exec_id, first.exec_id);
+}
+
+#[tokio::test]
+async fn reuse_policy_allow_failed_only_cancelled_starts_fresh() {
+    let (mut conn, _container) = setup_test_db().await;
+    let first_id = ExecutionId::new_for_shard(autumn_harvest::ShardId::new(0));
+    let mut params = reuse_policy_helpers::base_params("rp-afo-can", first_id);
+    params.reuse_policy = WorkflowIdReusePolicy::AllowDuplicateFailedOnly;
+    let first = start_or_load_workflow_execution(&mut conn, params.clone())
+        .await
+        .expect("first start should succeed");
+    cancel_workflow_execution(&mut conn, first.exec_id, "test cancel")
+        .await
+        .expect("cancel should succeed");
+
+    let second_id = ExecutionId::new_for_shard(autumn_harvest::ShardId::new(0));
+    params.exec_id = second_id;
+    let second = start_or_load_workflow_execution(&mut conn, params)
+        .await
+        .expect("AllowDuplicateFailedOnly on CANCELLED should start fresh");
+    assert!(second.created, "must mint a new execution");
+    assert_eq!(second.exec_id, second_id);
+    assert_ne!(second.exec_id, first.exec_id);
+}
+
+#[tokio::test]
+async fn reuse_policy_terminate_if_running_no_prior_creates() {
+    let (mut conn, _container) = setup_test_db().await;
+    let exec_id = ExecutionId::new_for_shard(autumn_harvest::ShardId::new(0));
+    let mut params = reuse_policy_helpers::base_params("rp-tir-none", exec_id);
+    params.reuse_policy = WorkflowIdReusePolicy::TerminateIfRunning;
+    let result = start_or_load_workflow_execution(&mut conn, params)
+        .await
+        .expect("TerminateIfRunning with no prior should create");
+    assert!(result.created);
+    assert_eq!(result.exec_id, exec_id);
+}
+
+#[tokio::test]
+async fn reuse_policy_terminate_if_running_running_cancels_and_starts_fresh() {
+    let (mut conn, _container) = setup_test_db().await;
+    let first_id = ExecutionId::new_for_shard(autumn_harvest::ShardId::new(0));
+    let mut params = reuse_policy_helpers::base_params("rp-tir-run", first_id);
+    params.reuse_policy = WorkflowIdReusePolicy::TerminateIfRunning;
+    let first = start_or_load_workflow_execution(&mut conn, params.clone())
+        .await
+        .expect("first start should succeed");
+    assert_eq!(first.state, "RUNNING");
+
+    let second_id = ExecutionId::new_for_shard(autumn_harvest::ShardId::new(0));
+    params.exec_id = second_id;
+    let second = start_or_load_workflow_execution(&mut conn, params)
+        .await
+        .expect("TerminateIfRunning on RUNNING should cancel and start fresh");
+    assert!(second.created, "must mint a new execution");
+    assert_eq!(second.exec_id, second_id);
+    assert_ne!(second.exec_id, first.exec_id);
+    assert_eq!(second.state, "RUNNING");
+
+    // Verify prior run was cancelled
+    let prior = harvest_workflow_executions::table
+        .find(first.exec_id.as_uuid())
+        .select(WorkflowExecution::as_select())
+        .first(&mut conn)
+        .await
+        .expect("prior execution row must still exist");
+    assert_eq!(
+        prior.state, "CONTINUED_AS_NEW",
+        "prior run should be sealed as CONTINUED_AS_NEW"
+    );
+}
+
+#[tokio::test]
+async fn reuse_policy_terminate_if_running_completed_starts_fresh() {
+    let (mut conn, _container) = setup_test_db().await;
+    let first_id = ExecutionId::new_for_shard(autumn_harvest::ShardId::new(0));
+    let mut params = reuse_policy_helpers::base_params("rp-tir-cmp", first_id);
+    params.reuse_policy = WorkflowIdReusePolicy::TerminateIfRunning;
+    let first = start_or_load_workflow_execution(&mut conn, params.clone())
+        .await
+        .expect("first start should succeed");
+    reuse_policy_helpers::force_state(&mut conn, first.exec_id, "COMPLETED").await;
+
+    let second_id = ExecutionId::new_for_shard(autumn_harvest::ShardId::new(0));
+    params.exec_id = second_id;
+    let second = start_or_load_workflow_execution(&mut conn, params)
+        .await
+        .expect("TerminateIfRunning on COMPLETED should start fresh");
+    assert!(second.created, "must mint a new execution");
+    assert_eq!(second.exec_id, second_id);
+    assert_ne!(second.exec_id, first.exec_id);
+}
+
+#[tokio::test]
+async fn reuse_policy_terminate_if_running_failed_starts_fresh() {
+    let (mut conn, _container) = setup_test_db().await;
+    let first_id = ExecutionId::new_for_shard(autumn_harvest::ShardId::new(0));
+    let mut params = reuse_policy_helpers::base_params("rp-tir-fail", first_id);
+    params.reuse_policy = WorkflowIdReusePolicy::TerminateIfRunning;
+    let first = start_or_load_workflow_execution(&mut conn, params.clone())
+        .await
+        .expect("first start should succeed");
+    reuse_policy_helpers::force_state(&mut conn, first.exec_id, "FAILED").await;
+
+    let second_id = ExecutionId::new_for_shard(autumn_harvest::ShardId::new(0));
+    params.exec_id = second_id;
+    let second = start_or_load_workflow_execution(&mut conn, params)
+        .await
+        .expect("TerminateIfRunning on FAILED should start fresh");
+    assert!(second.created, "must mint a new execution");
+    assert_eq!(second.exec_id, second_id);
+    assert_ne!(second.exec_id, first.exec_id);
+}
+
+#[tokio::test]
+async fn reuse_policy_terminate_if_running_cancelled_starts_fresh() {
+    let (mut conn, _container) = setup_test_db().await;
+    let first_id = ExecutionId::new_for_shard(autumn_harvest::ShardId::new(0));
+    let mut params = reuse_policy_helpers::base_params("rp-tir-can", first_id);
+    params.reuse_policy = WorkflowIdReusePolicy::TerminateIfRunning;
+    let first = start_or_load_workflow_execution(&mut conn, params.clone())
+        .await
+        .expect("first start should succeed");
+    cancel_workflow_execution(&mut conn, first.exec_id, "test cancel")
+        .await
+        .expect("cancel should succeed");
+
+    let second_id = ExecutionId::new_for_shard(autumn_harvest::ShardId::new(0));
+    params.exec_id = second_id;
+    let second = start_or_load_workflow_execution(&mut conn, params)
+        .await
+        .expect("TerminateIfRunning on CANCELLED should start fresh");
+    assert!(second.created, "must mint a new execution");
+    assert_eq!(second.exec_id, second_id);
+    assert_ne!(second.exec_id, first.exec_id);
+}
+
+/// TerminateIfRunning is idempotent: if the prior run is CANCELLED (e.g. from
+/// a previous TerminateIfRunning that crashed between the two transactions),
+/// the retry starts fresh without requiring manual intervention.
+#[tokio::test]
+async fn reuse_policy_terminate_if_running_retry_after_partial_failure_is_idempotent() {
+    let (mut conn, _container) = setup_test_db().await;
+    let first_id = ExecutionId::new_for_shard(autumn_harvest::ShardId::new(0));
+    let mut params = reuse_policy_helpers::base_params("rp-tir-retry", first_id);
+
+    // Simulate transaction 1 completing (cancel) but transaction 2 failing
+    // by manually cancelling the first run and then not starting a new one.
+    params.reuse_policy = WorkflowIdReusePolicy::AllowDuplicate;
+    let first = start_or_load_workflow_execution(&mut conn, params.clone())
+        .await
+        .expect("initial start should succeed");
+    cancel_workflow_execution(&mut conn, first.exec_id, "simulated T1 complete")
+        .await
+        .expect("cancel should succeed");
+
+    // Now retry with TerminateIfRunning. Prior run is CANCELLED → start fresh.
+    let second_id = ExecutionId::new_for_shard(autumn_harvest::ShardId::new(0));
+    params.exec_id = second_id;
+    params.reuse_policy = WorkflowIdReusePolicy::TerminateIfRunning;
+    let second = start_or_load_workflow_execution(&mut conn, params)
+        .await
+        .expect("retry with TerminateIfRunning on CANCELLED should start fresh");
+    assert!(second.created, "retry must mint a fresh execution");
+    assert_eq!(second.exec_id, second_id);
+    assert_ne!(second.exec_id, first.exec_id);
 }


### PR DESCRIPTION
## Summary

Introduces `WorkflowIdReusePolicy` to give callers fine-grained control over how duplicate `(workflow_name, workflow_id)` starts are handled. Previously, all duplicate starts would return the existing execution. Now callers can choose from four policies: allow duplicates (default), reject duplicates, allow duplicates only for failed/cancelled runs, or terminate a running execution and start fresh.

## Key Changes

- **New `WorkflowIdReusePolicy` enum** (`types.rs`):
  - `AllowDuplicate` (default): Return existing execution unconditionally
  - `RejectDuplicate`: Return 409 Conflict error for any prior execution
  - `AllowDuplicateFailedOnly`: Start fresh only if prior is FAILED/CANCELLED; return existing if RUNNING/COMPLETED
  - `TerminateIfRunning`: Cancel RUNNING prior execution and start fresh; start fresh for any terminal state

- **Updated `StartWorkflowParams`** to include `reuse_policy` field

- **Enhanced `start_or_load_workflow_execution`** logic:
  - Pre-check for `TerminateIfRunning` to cancel RUNNING executions in a separate transaction (Transaction 1) before the start transaction (Transaction 2)
  - Lock existing rows with `FOR UPDATE` to prevent concurrent state changes
  - Implement policy-specific branching: return existing, reject with error, or replace with fresh execution
  - New `replace_execution()` helper transitions prior execution to `CONTINUED_AS_NEW` (releasing unique index slot) before inserting fresh execution
  - New `inline_cancel()` helper for race condition handling within the start transaction

- **New `HarvestError::AlreadyExists`** variant for `RejectDuplicate` policy violations, includes `existing_exec_id` and `existing_state`

- **HTTP API changes** (`autumn-harvest-plugin/src/api.rs`):
  - Accept optional `reuse_policy` field in `StartWorkflowRequest`
  - Parse policy string values with validation; unknown values return 400 Bad Request
  - Return 409 Conflict with `AlreadyExistsResponse` body when `RejectDuplicate` rejects
  - Refactored error handling to use `IntoResponse` for cleaner response composition

- **CLI support** (`autumn-harvest-cli/src/lib.rs`):
  - Add `--reuse-policy` flag to `workflow start` command
  - Support all four policy values with snake_case naming
  - Comprehensive tests for CLI parsing and request body generation

- **Comprehensive integration tests** (`integration_e2e.rs`):
  - 20-cell integration matrix: 4 policies × 5 prior states (none, RUNNING, COMPLETED, FAILED, CANCELLED)
  - Tests for each policy's behavior across all state transitions
  - Verification of error variants, execution ID reuse, and state transitions
  - Special test for `TerminateIfRunning` idempotency after partial failure

- **Documentation** (`README.md`):
  - New section explaining duplicate workflow start control
  - Policy behavior table and usage examples
  - CLI and HTTP API examples for each use case

## Notable Implementation Details

- **Transaction safety for `TerminateIfRunning`**: The cancel operation (Transaction 1) is separate from the start operation (Transaction 2). A crash between them leaves the prior workflow CANCELLED with no new run; retrying with the same policy starts fresh on the next attempt because CANCELLED is treated as "start fresh".

- **Unique index slot management**: The partial unique index `(workflow_name, workflow_id) WHERE state != 'CONTINUED_AS_NEW'` allows fresh executions to be inserted after sealing prior ones as `CONTINUED_AS_NEW`.

- **Race condition handling**: For `TerminateIfRunning`, an inline cancel is performed within the start transaction if a RUNNING row appears despite the pre-check, ensuring atomicity.

- **Backward compatibility**: Omitting `reuse_policy` defaults to `AllowDuplicate`, preserving existing behavior.

https://claude.ai/code/session_01Xx9bcvUWM84jJgbayS2Go5