### PR TITLE
⚒️ Forge: Refactor context history matching and guard clauses

### DIFF
--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -249,6 +249,16 @@ pub struct WorkflowContext {
 }
 
 impl WorkflowContext {
+    // ── Internal Helpers ──────────────────────────────────────────────────
+
+    fn match_history<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce(&mut HistoryMatcher) -> R,
+    {
+        let mut matcher = self.matcher.lock().expect("matcher lock poisoned");
+        f(&mut matcher)
+    }
+
     // ── Constructors ──────────────────────────────────────────────────
 
     /// Create a context for replaying a workflow from its event history.
@@ -528,11 +538,7 @@ impl WorkflowContext {
         F: FnOnce() -> T,
         T: serde::Serialize + serde::de::DeserializeOwned,
     {
-        let history_match = self
-            .matcher
-            .lock()
-            .expect("matcher lock poisoned")
-            .match_side_effect(id);
+        let history_match = self.match_history(|m| m.match_side_effect(id));
 
         match history_match {
             HistoryMatch::Matched { output } => {
@@ -604,11 +610,7 @@ impl WorkflowContext {
     ///
     /// Panics if the internal matcher or commands mutex is poisoned.
     pub fn version(&self, change_id: &str, min: u32, max: u32) -> u32 {
-        let version = self
-            .matcher
-            .lock()
-            .expect("matcher lock poisoned")
-            .match_version(change_id, min, max);
+        let version = self.match_history(|m| m.match_version(change_id, min, max));
 
         // During live execution (matcher returned max_version and is past
         // history), emit a marker so future replays see this version.
@@ -647,11 +649,7 @@ impl WorkflowContext {
         queue: &str,
     ) -> HarvestResult<Value> {
         // Step 1: Match against history (lock is dropped before any .await).
-        let history_match = self
-            .matcher
-            .lock()
-            .expect("matcher lock poisoned")
-            .match_activity(name);
+        let history_match = self.match_history(|m| m.match_activity(name));
 
         match history_match {
             HistoryMatch::Matched { output } => Ok(output),
@@ -718,11 +716,7 @@ impl WorkflowContext {
     ///
     /// Panics if the internal matcher or commands mutex is poisoned.
     pub async fn timer(&self, timer_id: &str, duration_secs: u64) -> HarvestResult<()> {
-        let history_match = self
-            .matcher
-            .lock()
-            .expect("matcher lock poisoned")
-            .match_timer(timer_id);
+        let history_match = self.match_history(|m| m.match_timer(timer_id));
 
         match history_match {
             HistoryMatch::Matched { .. } => Ok(()),
@@ -773,11 +767,7 @@ impl WorkflowContext {
         workflow_name: &str,
         input: Value,
     ) -> HarvestResult<Value> {
-        let history_match = self
-            .matcher
-            .lock()
-            .expect("matcher lock poisoned")
-            .match_child_workflow(workflow_name, &input);
+        let history_match = self.match_history(|m| m.match_child_workflow(workflow_name, &input));
 
         match history_match {
             HistoryMatch::Matched { output } => Ok(output),
@@ -828,11 +818,7 @@ impl WorkflowContext {
     ///
     /// Panics if the internal replay matcher mutex is poisoned.
     pub async fn wait_for_signal(&self, signal_name: &str) -> HarvestResult<Value> {
-        let history_match = self
-            .matcher
-            .lock()
-            .expect("matcher lock poisoned")
-            .match_signal(signal_name);
+        let history_match = self.match_history(|m| m.match_signal(signal_name));
 
         match history_match {
             HistoryMatch::Matched { output } => Ok(output),
@@ -886,11 +872,7 @@ impl WorkflowContext {
     ///
     /// Panics if the internal matcher or commands mutex is poisoned.
     pub async fn continue_as_new(&self, input: Value) -> HarvestResult<()> {
-        let history_match = self
-            .matcher
-            .lock()
-            .expect("matcher lock poisoned")
-            .match_continue_as_new(&input);
+        let history_match = self.match_history(|m| m.match_continue_as_new(&input));
 
         match history_match {
             HistoryMatch::Matched { output } => {

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -1063,18 +1063,8 @@ async fn fail_task_and_execution(
     };
 
     let exec_id = execution_id_from_uuid(exec_uuid);
-    match store::load_history(conn, exec_id).await {
-        Ok(history) => {
-            persist_workflow_failure(
-                conn,
-                task.id,
-                exec_id,
-                history.next_event_id,
-                worker_id,
-                error,
-            )
-            .await
-        }
+    let history = match store::load_history(conn, exec_id).await {
+        Ok(h) => h,
         Err(history_error) => {
             tracing::warn!(
                 task_id = %task.id,
@@ -1083,9 +1073,19 @@ async fn fail_task_and_execution(
                 "failed to load workflow history while persisting task failure; updating rows without event append"
             );
             update_workflow_execution_failed(conn, exec_id, worker_id, error).await?;
-            queue::fail_task(conn, task.id, error).await
+            return queue::fail_task(conn, task.id, error).await;
         }
-    }
+    };
+
+    persist_workflow_failure(
+        conn,
+        task.id,
+        exec_id,
+        history.next_event_id,
+        worker_id,
+        error,
+    )
+    .await
 }
 
 async fn finalize_activity_completion(
@@ -1543,13 +1543,12 @@ async fn fail_execution_on_error<T>(
     worker_id: &str,
     result: HarvestResult<T>,
 ) -> HarvestResult<T> {
-    match result {
-        Ok(value) => Ok(value),
-        Err(error) => {
-            fail_task_and_execution(conn, task, worker_id, &error.to_string()).await?;
-            Err(error)
-        }
-    }
+    let error = match result {
+        Ok(val) => return Ok(val),
+        Err(e) => e,
+    };
+    fail_task_and_execution(conn, task, worker_id, &error.to_string()).await?;
+    Err(error)
 }
 
 async fn load_task_execution(
@@ -1557,13 +1556,12 @@ async fn load_task_execution(
     task: &TaskQueueItem,
     exec_id: ExecutionId,
 ) -> HarvestResult<WorkflowExecution> {
-    match load_workflow_execution(conn, exec_id).await {
-        Ok(execution) => Ok(execution),
-        Err(error) => {
-            fail_task_only(conn, task.id, &error.to_string()).await?;
-            Err(error)
-        }
-    }
+    let error = match load_workflow_execution(conn, exec_id).await {
+        Ok(val) => return Ok(val),
+        Err(e) => e,
+    };
+    fail_task_only(conn, task.id, &error.to_string()).await?;
+    Err(error)
 }
 
 async fn load_workflow_replay_state(


### PR DESCRIPTION
🚮 Smell: 
- `WorkflowContext` methods (`side_effect`, `activity`, `timer`, etc.) repeatedly acquired a lock on the `HistoryMatcher` using repetitive `.lock().expect(...)` boilerplate.
- Deeply nested `match` statements in `worker.rs` (`fail_execution_on_error`, `load_task_execution`, `fail_task_and_execution`) created a "Pyramid of Doom" that hindered readability.

✨ Solution:
- Created a `match_history` helper in `context.rs` to abstract lock acquisition and encapsulate the closure application, applying it uniformly across context methods.
- Flattened the `worker.rs` functions using idiomatic early-returns (returning the `Ok` branch early via `match` block) to reduce indentation without moving non-`Copy` results improperly.

🧼 Benefit: 
- Removes boilerplate duplication in the context logic, centralizing synchronization handling.
- Reduces nesting and cognitive load in the worker's critical error handling paths.

🛡️ Verification: Tests passed. No runtime logic was altered.

---
*PR created automatically by Jules for task [15807587605570258382](https://jules.google.com/task/15807587605570258382) started by @madmax983*