### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/autumn-harvest/src/history_export.rs
+++ b/autumn-harvest/src/history_export.rs
@@ -292,4 +292,62 @@ mod tests {
         assert!(diagram.contains("WF->>+Activity_download_file: Schedule (ID: "));
         assert!(diagram.contains("Note over WF: Workflow Completed"));
     }
+
+    #[test]
+    #[should_panic(expected = "internal error: entered unreachable code")]
+    fn test_handle_workflow_event_unreachable_panics() {
+        let mut exporter = MermaidExporter::new();
+        // WorkflowCompleted is not an unreachable arm, but ActivityScheduled is (for workflow event handler)
+        let event = WorkflowEvent::ActivityScheduled {
+            activity_id: ActivityExecId::new(),
+            name: "test".to_string(),
+            input: serde_json::json!({}),
+            queue: "default".to_string(),
+        };
+        let _ = exporter.handle_workflow_event(&event);
+    }
+
+    #[test]
+    #[should_panic(expected = "internal error: entered unreachable code")]
+    fn test_handle_activity_event_unreachable_panics() {
+        let mut exporter = MermaidExporter::new();
+        let event = WorkflowEvent::WorkflowStarted {
+            input: serde_json::json!({}),
+            timestamp: Utc::now(),
+        };
+        let _ = exporter.handle_activity_event(&event);
+    }
+
+    #[test]
+    #[should_panic(expected = "internal error: entered unreachable code")]
+    fn test_handle_timer_event_unreachable_panics() {
+        let mut exporter = MermaidExporter::new();
+        let event = WorkflowEvent::WorkflowStarted {
+            input: serde_json::json!({}),
+            timestamp: Utc::now(),
+        };
+        let _ = exporter.handle_timer_event(&event);
+    }
+
+    #[test]
+    #[should_panic(expected = "internal error: entered unreachable code")]
+    fn test_handle_child_workflow_event_unreachable_panics() {
+        let mut exporter = MermaidExporter::new();
+        let event = WorkflowEvent::WorkflowStarted {
+            input: serde_json::json!({}),
+            timestamp: Utc::now(),
+        };
+        let _ = exporter.handle_child_workflow_event(&event);
+    }
+
+    #[test]
+    #[should_panic(expected = "internal error: entered unreachable code")]
+    fn test_handle_misc_event_unreachable_panics() {
+        let mut exporter = MermaidExporter::new();
+        let event = WorkflowEvent::WorkflowStarted {
+            input: serde_json::json!({}),
+            timestamp: Utc::now(),
+        };
+        let _ = exporter.handle_misc_event(&event);
+    }
 }


### PR DESCRIPTION
🎯 Target: `autumn-harvest/src/history_export.rs`
💣 Risk: The Mermaid exporter functions (`handle_workflow_event`, `handle_activity_event`, `handle_timer_event`, `handle_child_workflow_event`, `handle_misc_event`) contain `unreachable!()` guards for unhandled `WorkflowEvent` variants. If future code passes inappropriate events to these functions, the panics must trigger correctly, but they were previously completely untested.
🧪 Strategy: Added 5 isolated unit tests at the end of the `tests` module using `#[should_panic(expected = "internal error: entered unreachable code")]` to verify that these functions accurately panic when an unhandled `WorkflowEvent` is passed into them.
🔬 Verification: Run `cargo test --lib history_export`.

---
*PR created automatically by Jules for task [2517830951175240075](https://jules.google.com/task/2517830951175240075) started by @madmax983*