### PR TITLE
🔒 Warden: Fix Tokio Semaphore Truncation Panic

### DIFF
--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -2236,17 +2236,22 @@ impl Worker {
 
         let drain = async {
             // Try to acquire ALL permits — when we can, all in-flight tasks are done.
-            let max_permits = (1 << 31) - 1;
-            let wf_permits = u32::try_from(self.config.max_concurrent_workflows)
-                .unwrap_or(u32::MAX)
-                .min(max_permits);
-
-            let act_permits = u32::try_from(self.config.max_concurrent_activities)
-                .unwrap_or(u32::MAX)
-                .min(max_permits);
-
-            let _wf = self.workflow_semaphore.acquire_many(wf_permits).await;
-            let _act = self.activity_semaphore.acquire_many(act_permits).await;
+            let _wf = self
+                .workflow_semaphore
+                .acquire_many(
+                    u32::try_from(self.config.max_concurrent_workflows)
+                        .unwrap_or(u32::MAX)
+                        .min((1 << 31) - 1),
+                )
+                .await;
+            let _act = self
+                .activity_semaphore
+                .acquire_many(
+                    u32::try_from(self.config.max_concurrent_activities)
+                        .unwrap_or(u32::MAX)
+                        .min((1 << 31) - 1),
+                )
+                .await;
         };
 
         if tokio::time::timeout(self.config.shutdown_timeout, drain)

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -2236,20 +2236,17 @@ impl Worker {
 
         let drain = async {
             // Try to acquire ALL permits — when we can, all in-flight tasks are done.
-            let _wf = self
-                .workflow_semaphore
-                .acquire_many(
-                    u32::try_from(self.config.max_concurrent_workflows)
-                        .expect("Concurrency limit overflow"),
-                )
-                .await;
-            let _act = self
-                .activity_semaphore
-                .acquire_many(
-                    u32::try_from(self.config.max_concurrent_activities)
-                        .expect("Concurrency limit overflow"),
-                )
-                .await;
+            let max_permits = (1 << 31) - 1;
+            let wf_permits = u32::try_from(self.config.max_concurrent_workflows)
+                .unwrap_or(u32::MAX)
+                .min(max_permits);
+
+            let act_permits = u32::try_from(self.config.max_concurrent_activities)
+                .unwrap_or(u32::MAX)
+                .min(max_permits);
+
+            let _wf = self.workflow_semaphore.acquire_many(wf_permits).await;
+            let _act = self.activity_semaphore.acquire_many(act_permits).await;
         };
 
         if tokio::time::timeout(self.config.shutdown_timeout, drain)


### PR DESCRIPTION
* 🦠 **Threat:** In `worker.rs`, semaphore limits derived from user-controlled config options (`max_concurrent_workflows`, `max_concurrent_activities`) could be cast down to `u32`. If those numbers were pathologically large, trying to acquire permits beyond `tokio::sync::Semaphore::MAX_PERMITS` (which is hardcoded inside Tokio to `(1<<31) - 1`) would unconditionally panic the Tokio runtime and crash the worker.
* 🛡️ **Defense:** Replaced the `expect()` calls with a safe clamp that uses `try_from().unwrap_or(u32::MAX).min((1 << 31) - 1)`. This ensures that even if users configure an absurd concurrency limit, the semaphore acquisition will cap out at Tokio's internal maximum safely instead of crashing the thread.
* 💥 **Severity:** High (Denial of Service). If an attacker or misconfigured deployment supplied a massive concurrency limit, the worker node would repeatedly crash-loop on startup or during shutdown procedures when attempting to drain tasks.
* 🧪 **Verification:** Wrote POCs to verify Tokio's internal limits (`acquire_many` panics above `(1<<31)-1`), ran `cargo clippy --all-targets --all-features -- -D warnings`, and verified all components pass via `cargo test --lib`.

---
*PR created automatically by Jules for task [10623645506836950548](https://jules.google.com/task/10623645506836950548) started by @madmax983*