### PR TITLE
Add external activity completion via task tokens (issue #92)

### DIFF
--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -1448,15 +1448,10 @@ async fn heartbeat_external_activity(
             .await
             .map_err(map_error)?
         {
-            // Default to the original configured duration (schedule_to_close_at
-            // - created_at) so that omitting extend_by_secs resets the deadline
-            // to the same window as the initial schedule rather than a fixed 300s.
-            let original_secs = u64::try_from(
-                (task.schedule_to_close_at - task.created_at)
-                    .num_seconds()
-                    .max(1),
-            )
-            .unwrap_or(1);
+            // Default to the original configured duration so that omitting
+            // extend_by_secs resets the deadline by the same fixed window every
+            // time, regardless of how many heartbeats have already fired.
+            let original_secs = u64::try_from(task.schedule_to_close_secs).unwrap_or(1);
             let extend_by = request.extend_by_secs.unwrap_or(original_secs);
             external_task::extend_deadline(&mut conn, token, extend_by)
                 .await

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -1402,14 +1402,10 @@ async fn complete_external_activity(
     let token = parse_external_token(&token_str)?;
     let output = request.output.unwrap_or(Value::Null);
 
-    let newly_resolved = resolve_external_on_shards(
-        &api_state,
-        token,
-        |conn, tok| {
-            let out = output.clone();
-            Box::pin(async move { external_task::complete_externally(conn, tok, out).await })
-        },
-    )
+    let newly_resolved = resolve_external_on_shards(&api_state, token, |conn, tok| {
+        let out = output.clone();
+        Box::pin(async move { external_task::complete_externally(conn, tok, out).await })
+    })
     .await?;
 
     Ok(Json(ExternalActivityAck {
@@ -1425,17 +1421,11 @@ async fn fail_external_activity(
 ) -> Result<Json<ExternalActivityAck>, AutumnError> {
     let token = parse_external_token(&token_str)?;
 
-    let newly_resolved = resolve_external_on_shards(
-        &api_state,
-        token,
-        |conn, tok| {
-            let err = request.error.clone();
-            let retryable = request.retryable;
-            Box::pin(async move {
-                external_task::fail_externally(conn, tok, err, retryable).await
-            })
-        },
-    )
+    let newly_resolved = resolve_external_on_shards(&api_state, token, |conn, tok| {
+        let err = request.error.clone();
+        let retryable = request.retryable;
+        Box::pin(async move { external_task::fail_externally(conn, tok, err, retryable).await })
+    })
     .await?;
 
     Ok(Json(ExternalActivityAck {

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -1441,15 +1441,20 @@ async fn heartbeat_external_activity(
 ) -> Result<Json<BasicAck>, AutumnError> {
     let token = parse_external_token(&token_str)?;
     let pool = api_state.storage_pool().map_err(map_error)?;
-    let extend_by = request.extend_by_secs.unwrap_or(300);
 
     for (_shard, shard_pool) in pool.iter_shards() {
         let mut conn = acquire_conn(shard_pool).await?;
-        if external_task::find_by_token(&mut conn, token)
+        if let Some(task) = external_task::find_by_token(&mut conn, token)
             .await
             .map_err(map_error)?
-            .is_some()
         {
+            // Default to the original configured duration (schedule_to_close_at
+            // - created_at) so that omitting extend_by_secs resets the deadline
+            // to the same window as the initial schedule rather than a fixed 300s.
+            let original_secs = (task.schedule_to_close_at - task.created_at)
+                .num_seconds()
+                .max(1) as u64;
+            let extend_by = request.extend_by_secs.unwrap_or(original_secs);
             external_task::extend_deadline(&mut conn, token, extend_by)
                 .await
                 .map_err(map_error)?;

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -23,6 +23,7 @@ use serde_json::Value;
 use autumn_harvest::context::WorkflowContext;
 use autumn_harvest::dlq;
 use autumn_harvest::error::{HarvestError, HarvestResult, database_error};
+use autumn_harvest::external_task;
 use autumn_harvest::models::{DagRun, DeadLetter, HarvestSchedule, WorkflowExecution};
 use autumn_harvest::policy::WorkflowSchedule;
 use autumn_harvest::queue::{self, ConcurrencyKeyStats};
@@ -34,7 +35,7 @@ use autumn_harvest::schema::{harvest_dag_runs, harvest_schedules, harvest_workfl
 use autumn_harvest::shard::ShardRouter;
 use autumn_harvest::signal;
 use autumn_harvest::store;
-use autumn_harvest::types::{ExecutionId, ShardId, WorkflowIdReusePolicy};
+use autumn_harvest::types::{ExecutionId, ExternalActivityToken, ShardId, WorkflowIdReusePolicy};
 use autumn_harvest::worker::{DbPool, HandlerRegistry};
 use autumn_harvest::{
     StartWorkflowParams, cancel_workflow_execution, start_or_load_workflow_execution,
@@ -392,6 +393,19 @@ pub fn harvest_api_router(api_state: HarvestApiState) -> Router<AppState> {
         .route("/admin/schedules/{id}/pause", post(pause_schedule))
         .route("/admin/schedules/{id}/resume", post(resume_schedule))
         .route("/admin/schedules/{id}", delete(delete_schedule))
+        // External activity completion (issue #92): async task-token API.
+        .route(
+            "/activities/external/{token}/complete",
+            post(complete_external_activity),
+        )
+        .route(
+            "/activities/external/{token}/fail",
+            post(fail_external_activity),
+        )
+        .route(
+            "/activities/external/{token}/heartbeat",
+            post(heartbeat_external_activity),
+        )
         .layer(Extension(api_state))
 }
 
@@ -1351,6 +1365,151 @@ pub(crate) fn map_error(error: HarvestError) -> AutumnError {
         HarvestError::Database(message) => AutumnError::service_unavailable_msg(message),
         other => AutumnError::service_unavailable_msg(other.to_string()),
     }
+}
+
+// ── External activity completion (issue #92) ──────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+struct CompleteExternalActivityRequest {
+    output: Option<Value>,
+}
+
+#[derive(Debug, Deserialize)]
+struct FailExternalActivityRequest {
+    error: String,
+    #[serde(default)]
+    retryable: bool,
+}
+
+#[derive(Debug, Deserialize)]
+struct HeartbeatExternalActivityRequest {
+    /// How many seconds to extend the schedule-to-close deadline from now.
+    /// Defaults to the original `schedule_to_close_secs` if omitted.
+    extend_by_secs: Option<u64>,
+}
+
+#[derive(Debug, Serialize)]
+struct ExternalActivityAck {
+    ok: bool,
+    newly_resolved: bool,
+}
+
+async fn complete_external_activity(
+    Extension(api_state): Extension<HarvestApiState>,
+    Path(token_str): Path<String>,
+    Json(request): Json<CompleteExternalActivityRequest>,
+) -> Result<Json<ExternalActivityAck>, AutumnError> {
+    let token = parse_external_token(&token_str)?;
+    let output = request.output.unwrap_or(Value::Null);
+
+    let newly_resolved = resolve_external_on_shards(
+        &api_state,
+        token,
+        |conn, tok| {
+            let out = output.clone();
+            Box::pin(async move { external_task::complete_externally(conn, tok, out).await })
+        },
+    )
+    .await?;
+
+    Ok(Json(ExternalActivityAck {
+        ok: true,
+        newly_resolved,
+    }))
+}
+
+async fn fail_external_activity(
+    Extension(api_state): Extension<HarvestApiState>,
+    Path(token_str): Path<String>,
+    Json(request): Json<FailExternalActivityRequest>,
+) -> Result<Json<ExternalActivityAck>, AutumnError> {
+    let token = parse_external_token(&token_str)?;
+
+    let newly_resolved = resolve_external_on_shards(
+        &api_state,
+        token,
+        |conn, tok| {
+            let err = request.error.clone();
+            let retryable = request.retryable;
+            Box::pin(async move {
+                external_task::fail_externally(conn, tok, err, retryable).await
+            })
+        },
+    )
+    .await?;
+
+    Ok(Json(ExternalActivityAck {
+        ok: true,
+        newly_resolved,
+    }))
+}
+
+async fn heartbeat_external_activity(
+    Extension(api_state): Extension<HarvestApiState>,
+    Path(token_str): Path<String>,
+    Json(request): Json<HeartbeatExternalActivityRequest>,
+) -> Result<Json<BasicAck>, AutumnError> {
+    let token = parse_external_token(&token_str)?;
+    let pool = api_state.storage_pool().map_err(map_error)?;
+    let extend_by = request.extend_by_secs.unwrap_or(300);
+
+    for (_shard, shard_pool) in pool.iter_shards() {
+        let mut conn = acquire_conn(shard_pool).await?;
+        if external_task::find_by_token(&mut conn, token)
+            .await
+            .map_err(map_error)?
+            .is_some()
+        {
+            external_task::extend_deadline(&mut conn, token, extend_by)
+                .await
+                .map_err(map_error)?;
+            return Ok(Json(BasicAck { ok: true }));
+        }
+    }
+
+    Err(AutumnError::not_found_msg(format!(
+        "external task token {token_str}"
+    )))
+}
+
+fn parse_external_token(raw: &str) -> Result<ExternalActivityToken, AutumnError> {
+    raw.parse::<ExternalActivityToken>()
+        .map_err(|_| AutumnError::bad_request_msg(format!("invalid external task token '{raw}'")))
+}
+
+/// Scan all shards for the external task identified by `token`, then invoke
+/// `action` on the shard that owns it.  Returns `true` if the state transition
+/// happened, `false` if the token was already in a terminal state (idempotent).
+async fn resolve_external_on_shards<F>(
+    api_state: &HarvestApiState,
+    token: ExternalActivityToken,
+    action: F,
+) -> Result<bool, AutumnError>
+where
+    F: for<'c> Fn(
+        &'c mut diesel_async::AsyncPgConnection,
+        ExternalActivityToken,
+    ) -> std::pin::Pin<
+        Box<dyn std::future::Future<Output = HarvestResult<bool>> + Send + 'c>,
+    >,
+{
+    let pool = api_state.storage_pool().map_err(map_error)?;
+
+    for (_shard, shard_pool) in pool.iter_shards() {
+        let mut conn = acquire_conn(shard_pool).await?;
+        if external_task::find_by_token(&mut conn, token)
+            .await
+            .map_err(map_error)?
+            .is_some()
+        {
+            let result = action(&mut conn, token).await.map_err(map_error)?;
+            return Ok(result);
+        }
+    }
+
+    Err(AutumnError::not_found_msg(format!(
+        "external task token {token}"
+    )))
 }
 
 #[cfg(test)]

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -1451,9 +1451,12 @@ async fn heartbeat_external_activity(
             // Default to the original configured duration (schedule_to_close_at
             // - created_at) so that omitting extend_by_secs resets the deadline
             // to the same window as the initial schedule rather than a fixed 300s.
-            let original_secs = (task.schedule_to_close_at - task.created_at)
-                .num_seconds()
-                .max(1) as u64;
+            let original_secs = u64::try_from(
+                (task.schedule_to_close_at - task.created_at)
+                    .num_seconds()
+                    .max(1),
+            )
+            .unwrap_or(1);
             let extend_by = request.extend_by_secs.unwrap_or(original_secs);
             external_task::extend_deadline(&mut conn, token, extend_by)
                 .await

--- a/autumn-harvest-plugin/tests/api_scheduler_integration.rs
+++ b/autumn-harvest-plugin/tests/api_scheduler_integration.rs
@@ -62,6 +62,8 @@ const INIT_SQL: &str = concat!(
     include_str!(
         "../../autumn-harvest/migrations/20260430000000_harvest_workflow_schedules/up.sql"
     ),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260430000001_harvest_external_tasks/up.sql"),
 );
 type HarvestApiApp = axum::Router;
 

--- a/autumn-harvest/Cargo.toml
+++ b/autumn-harvest/Cargo.toml
@@ -44,6 +44,10 @@ diesel_migrations = { workspace = true, optional = true }
 scoped-futures = { version = "0.1", optional = true }
 tokio-postgres = { version = "0.7", optional = true }
 
+[[test]]
+name = "external_completion_tests"
+required-features = ["testing"]
+
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
 testcontainers = { workspace = true }

--- a/autumn-harvest/examples/approval_workflow.rs
+++ b/autumn-harvest/examples/approval_workflow.rs
@@ -108,7 +108,9 @@ pub async fn notify_approver(
     println!("[notify_approver]   GET /harvest/workflows/<EXEC_ID>");
     println!("[notify_approver] Then call:");
     println!("[notify_approver]   POST /harvest/activities/external/<TOKEN>/complete");
-    println!("[notify_approver]        {{\"output\": {{\"approved\": true, \"approver\": \"alice\", \"comment\": null}}}}");
+    println!(
+        "[notify_approver]        {{\"output\": {{\"approved\": true, \"approver\": \"alice\", \"comment\": null}}}}"
+    );
     Ok("notification_sent".to_string())
 }
 
@@ -118,9 +120,7 @@ fn main() {
     println!("Key curl commands after starting the server:");
     println!();
     println!("# Start a workflow");
-    println!(
-        r#"curl -X POST http://localhost:8080/harvest/workflows/expense_approval/start \"#
-    );
+    println!(r#"curl -X POST http://localhost:8080/harvest/workflows/expense_approval/start \"#);
     println!(r#"     -H 'Content-Type: application/json' \"#);
     println!(r#"     -d '{{"input": ["exp-001", 49900]}}'"#);
     println!();
@@ -140,9 +140,7 @@ fn main() {
     println!(r#"     -d '{{"error": "expense exceeds budget", "retryable": false}}'"#);
     println!();
     println!("# Extend the deadline by 3 more days");
-    println!(
-        "curl -X POST http://localhost:8080/harvest/activities/external/<TOKEN>/heartbeat \\"
-    );
+    println!("curl -X POST http://localhost:8080/harvest/activities/external/<TOKEN>/heartbeat \\");
     println!("     -H 'Content-Type: application/json' \\");
     println!(r#"     -d '{{"extend_by_secs": 259200}}'"#);
 }

--- a/autumn-harvest/examples/approval_workflow.rs
+++ b/autumn-harvest/examples/approval_workflow.rs
@@ -1,0 +1,148 @@
+//! Example: manager-approval workflow using external activity completion.
+//!
+//! This example shows how to model a human-in-the-loop approval step with
+//! `execute_activity_external`.  The workflow suspends without blocking a worker
+//! slot; an external system (a manager clicking "Approve" in a UI, or a webhook
+//! from an approval service) calls the management API to deliver the decision.
+//!
+//! # Flow
+//!
+//! 1. Workflow calls `ctx.execute_activity_external(...)` and suspends.
+//! 2. Harvest records an `ActivityAwaitingExternal` event and inserts a row in
+//!    `harvest_external_tasks`, embedding the opaque `token`.
+//! 3. The token is delivered to the approval system (e-mail, Slack, etc.) —
+//!    this example just prints it.
+//! 4. The approver POSTs to the management API:
+//!    ```bash
+//!    curl -X POST http://localhost:8080/harvest/activities/external/<TOKEN>/complete \
+//!         -H 'Content-Type: application/json' \
+//!         -d '{"output": {"approved": true}}'
+//!    ```
+//! 5. Harvest appends `ActivityCompletedExternally`, wakes the workflow, and
+//!    the workflow resumes with the approval decision.
+//!
+//! # Running
+//!
+//! ```bash
+//! cargo run --example approval_workflow
+//! ```
+//!
+//! This requires a running Postgres instance and the `db` feature (the default).
+//! Set `DATABASE_URL` before running.
+
+use autumn_harvest::context::{ActivityContext, WorkflowContext};
+use autumn_harvest::prelude::*;
+
+/// Payload delivered by the approval activity.
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct ApprovalDecision {
+    pub approved: bool,
+    pub approver: String,
+    pub comment: Option<String>,
+}
+
+/// An approval workflow for an expense report.
+///
+/// Suspends until a manager approves or rejects the expense via the
+/// management API.  Automatically times out after 7 days.
+#[workflow]
+pub async fn expense_approval(
+    ctx: &WorkflowContext,
+    expense_id: String,
+    amount_cents: u64,
+) -> Result<ApprovalDecision, String> {
+    // Send a notification to the approver so they know action is needed.
+    ctx.execute_activity_raw(
+        "notify_approver",
+        serde_json::json!({
+            "expense_id": expense_id,
+            "amount_cents": amount_cents,
+        }),
+        "default",
+    )
+    .await
+    .map_err(|e: autumn_harvest::error::HarvestError| e.to_string())?;
+
+    // Suspend until the manager completes or fails the activity via the token.
+    // The `schedule_to_close_secs` sets the hard deadline; after 7 days the
+    // workflow automatically receives a Timeout error and can follow retry /
+    // escalation logic.
+    let schedule_to_close_secs: u64 = 7 * 24 * 60 * 60; // 7 days
+    let result = ctx
+        .execute_activity_external(
+            "manager_approval",
+            serde_json::json!({
+                "expense_id": expense_id,
+                "amount_cents": amount_cents,
+            }),
+            "approvals",
+            schedule_to_close_secs,
+        )
+        .await
+        .map_err(|e: autumn_harvest::error::HarvestError| e.to_string())?;
+
+    let decision: ApprovalDecision =
+        serde_json::from_value(result).map_err(|e| format!("bad approval payload: {e}"))?;
+
+    Ok(decision)
+}
+
+/// A stub activity that pretends to notify an approver.
+///
+/// In a real app, this would send an e-mail, Slack message, or push
+/// notification that includes the task token so the approver UI can call the
+/// management API to complete the activity.
+#[activity(start_to_close = "30s", queue = "default")]
+pub async fn notify_approver(
+    _ctx: &ActivityContext,
+    expense_id: String,
+    amount_cents: u64,
+) -> Result<String, String> {
+    // In production: send email / push notification with the token.
+    // The token is retrieved from the workflow's event history via your
+    // application layer; the worker embeds it in the notification payload.
+    println!(
+        "[notify_approver] Expense {expense_id} for {amount_cents} cents is awaiting approval."
+    );
+    println!("[notify_approver] Retrieve the task token from the management API:");
+    println!("[notify_approver]   GET /harvest/workflows/<EXEC_ID>");
+    println!("[notify_approver] Then call:");
+    println!("[notify_approver]   POST /harvest/activities/external/<TOKEN>/complete");
+    println!("[notify_approver]        {{\"output\": {{\"approved\": true, \"approver\": \"alice\", \"comment\": null}}}}");
+    Ok("notification_sent".to_string())
+}
+
+fn main() {
+    println!("approval_workflow example — see module-level doc comment for usage.");
+    println!();
+    println!("Key curl commands after starting the server:");
+    println!();
+    println!("# Start a workflow");
+    println!(
+        r#"curl -X POST http://localhost:8080/harvest/workflows/expense_approval/start \"#
+    );
+    println!(r#"     -H 'Content-Type: application/json' \"#);
+    println!(r#"     -d '{{"input": ["exp-001", 49900]}}'"#);
+    println!();
+    println!("# (Retrieve EXEC_ID and TOKEN from the event history)");
+    println!("# GET /harvest/workflows/<EXEC_ID>");
+    println!();
+    println!("# Approve the expense");
+    println!("curl -X POST http://localhost:8080/harvest/activities/external/<TOKEN>/complete \\");
+    println!("     -H 'Content-Type: application/json' \\");
+    println!(
+        r#"     -d '{{"output": {{"approved": true, "approver": "alice", "comment": null}}}}'"#
+    );
+    println!();
+    println!("# Reject the expense");
+    println!("curl -X POST http://localhost:8080/harvest/activities/external/<TOKEN>/fail \\");
+    println!("     -H 'Content-Type: application/json' \\");
+    println!(r#"     -d '{{"error": "expense exceeds budget", "retryable": false}}'"#);
+    println!();
+    println!("# Extend the deadline by 3 more days");
+    println!(
+        "curl -X POST http://localhost:8080/harvest/activities/external/<TOKEN>/heartbeat \\"
+    );
+    println!("     -H 'Content-Type: application/json' \\");
+    println!(r#"     -d '{{"extend_by_secs": 259200}}'"#);
+}

--- a/autumn-harvest/migrations/20260430000001_harvest_external_tasks/down.sql
+++ b/autumn-harvest/migrations/20260430000001_harvest_external_tasks/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS harvest_external_tasks;

--- a/autumn-harvest/migrations/20260430000001_harvest_external_tasks/up.sql
+++ b/autumn-harvest/migrations/20260430000001_harvest_external_tasks/up.sql
@@ -1,0 +1,28 @@
+-- harvest_external_tasks: lookup table for async/external activity completion.
+--
+-- The `token` column is the externally-visible, single-use completion handle
+-- embedded in the ActivityAwaitingExternal event. The management API resolves
+-- (exec_id, activity_id) from a token in O(log n) via the unique index below,
+-- without scanning the full event history.
+--
+-- State machine: PENDING → COMPLETED | FAILED | TIMED_OUT
+
+CREATE TABLE harvest_external_tasks (
+    id                   UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    token                UUID NOT NULL,
+    workflow_exec_id     UUID NOT NULL REFERENCES harvest_workflow_executions(id) ON DELETE CASCADE,
+    activity_id          UUID NOT NULL,
+    name                 TEXT NOT NULL,
+    queue                TEXT NOT NULL,
+    state                TEXT NOT NULL DEFAULT 'PENDING'
+                             CHECK (state IN ('PENDING', 'COMPLETED', 'FAILED', 'TIMED_OUT')),
+    schedule_to_close_at TIMESTAMPTZ NOT NULL,
+    created_at           TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Primary access pattern: management API resolves token → exec_id in O(log n)
+CREATE UNIQUE INDEX idx_harvest_ext_token ON harvest_external_tasks (token);
+
+-- Secondary: timeout scanner finds expired pending tasks
+CREATE INDEX idx_harvest_ext_timeout ON harvest_external_tasks (schedule_to_close_at)
+    WHERE state = 'PENDING';

--- a/autumn-harvest/migrations/20260430000001_harvest_external_tasks/up.sql
+++ b/autumn-harvest/migrations/20260430000001_harvest_external_tasks/up.sql
@@ -8,16 +8,17 @@
 -- State machine: PENDING → COMPLETED | FAILED | TIMED_OUT
 
 CREATE TABLE harvest_external_tasks (
-    id                   UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    token                UUID NOT NULL,
-    workflow_exec_id     UUID NOT NULL REFERENCES harvest_workflow_executions(id) ON DELETE CASCADE,
-    activity_id          UUID NOT NULL,
-    name                 TEXT NOT NULL,
-    queue                TEXT NOT NULL,
-    state                TEXT NOT NULL DEFAULT 'PENDING'
-                             CHECK (state IN ('PENDING', 'COMPLETED', 'FAILED', 'TIMED_OUT')),
-    schedule_to_close_at TIMESTAMPTZ NOT NULL,
-    created_at           TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    id                    UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    token                 UUID NOT NULL,
+    workflow_exec_id      UUID NOT NULL REFERENCES harvest_workflow_executions(id) ON DELETE CASCADE,
+    activity_id           UUID NOT NULL,
+    name                  TEXT NOT NULL,
+    queue                 TEXT NOT NULL,
+    state                 TEXT NOT NULL DEFAULT 'PENDING'
+                              CHECK (state IN ('PENDING', 'COMPLETED', 'FAILED', 'TIMED_OUT')),
+    schedule_to_close_at  TIMESTAMPTZ NOT NULL,
+    schedule_to_close_secs BIGINT NOT NULL,
+    created_at            TIMESTAMPTZ NOT NULL DEFAULT NOW()
 );
 
 -- Primary access pattern: management API resolves token → exec_id in O(log n)

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -20,7 +20,7 @@ use crate::error::{HarvestError, HarvestResult};
 use crate::event::WorkflowEvent;
 use crate::query::QueryRegistry;
 use crate::replay::{HistoryMatch, HistoryMatcher};
-use crate::types::{ActivityExecId, ExecutionId, TimerId};
+use crate::types::{ActivityExecId, ExecutionId, ExternalActivityToken, TimerId};
 
 /// Runtime map of typed shared state registered on the harvest builder.
 pub type SharedStateMap = HashMap<TypeId, Box<dyn Any + Send + Sync>>;
@@ -117,6 +117,25 @@ pub enum WorkflowCommand {
         /// Optional details or payload associated with the marker.
         details: Value,
     },
+    /// Schedule an activity that completes externally via a task token.
+    ScheduleExternalActivity {
+        /// The unique execution ID of the activity.
+        activity_id: ActivityExecId,
+        /// The opaque task token the external system uses to deliver a result.
+        token: ExternalActivityToken,
+        /// The name of the activity to execute.
+        name: String,
+        /// The input payload for the activity.
+        input: Value,
+        /// The queue to schedule the activity on.
+        queue: String,
+        /// Maximum seconds before the activity times out.
+        schedule_to_close_secs: u64,
+        /// The worker sends the result back through this channel if a result
+        /// arrives in the same execution cycle (rare; normally the channel is
+        /// dropped and the workflow is re-run when external completion arrives).
+        result_tx: oneshot::Sender<Result<Value, String>>,
+    },
     /// Suspend until a named signal is delivered.
     WaitForSignal {
         /// The name of the signal to wait for.
@@ -186,6 +205,21 @@ impl std::fmt::Debug for WorkflowCommand {
                 .field("name", name)
                 .field("details", details)
                 .finish(),
+            Self::ScheduleExternalActivity {
+                activity_id,
+                token,
+                name,
+                queue,
+                schedule_to_close_secs,
+                ..
+            } => f
+                .debug_struct("ScheduleExternalActivity")
+                .field("activity_id", activity_id)
+                .field("token", token)
+                .field("name", name)
+                .field("queue", queue)
+                .field("schedule_to_close_secs", schedule_to_close_secs)
+                .finish_non_exhaustive(),
             Self::WaitForSignal { signal_name, .. } => f
                 .debug_struct("WaitForSignal")
                 .field("signal_name", signal_name)
@@ -549,7 +583,9 @@ impl WorkflowContext {
                 format!("side effect mismatch: expected {expected}, got {actual}"),
             )),
 
-            HistoryMatch::Failed { .. } | HistoryMatch::TimedOut { .. } => {
+            HistoryMatch::Failed { .. }
+            | HistoryMatch::TimedOut { .. }
+            | HistoryMatch::AwaitingExternalCompletion { .. } => {
                 unreachable!("match_side_effect only returns Matched, Diverged or NoMatch")
             }
 
@@ -669,6 +705,10 @@ impl WorkflowContext {
                 format!("activity mismatch: expected {expected}, got {actual}"),
             )),
 
+            HistoryMatch::AwaitingExternalCompletion { .. } => {
+                unreachable!("match_activity never returns AwaitingExternalCompletion")
+            }
+
             HistoryMatch::NoMatch => {
                 // Live execution: emit a ScheduleActivity command and suspend
                 // until the worker sends the result through the oneshot channel.
@@ -725,7 +765,9 @@ impl WorkflowContext {
                 format!("timer mismatch: expected {expected}, got {actual}"),
             )),
 
-            HistoryMatch::Failed { .. } | HistoryMatch::TimedOut { .. } => {
+            HistoryMatch::Failed { .. }
+            | HistoryMatch::TimedOut { .. }
+            | HistoryMatch::AwaitingExternalCompletion { .. } => {
                 unreachable!("timers do not fail or time out in history matching")
             }
 
@@ -776,7 +818,7 @@ impl WorkflowContext {
                 attempt,
                 source: error.into(),
             }),
-            HistoryMatch::TimedOut { .. } => {
+            HistoryMatch::TimedOut { .. } | HistoryMatch::AwaitingExternalCompletion { .. } => {
                 unreachable!("child workflows do not time out in match_child_workflow")
             }
             HistoryMatch::Diverged { expected, actual } => Err(HarvestError::NonDeterministic(
@@ -825,7 +867,9 @@ impl WorkflowContext {
             HistoryMatch::Diverged { expected, actual } => Err(HarvestError::NonDeterministic(
                 format!("signal mismatch: expected {expected}, got {actual}"),
             )),
-            HistoryMatch::Failed { .. } | HistoryMatch::TimedOut { .. } => Err(
+            HistoryMatch::Failed { .. }
+            | HistoryMatch::TimedOut { .. }
+            | HistoryMatch::AwaitingExternalCompletion { .. } => Err(
                 HarvestError::NonDeterministic("signal history contains unexpected failure".into()),
             ),
             HistoryMatch::NoMatch => {
@@ -839,6 +883,116 @@ impl WorkflowContext {
                         "signal '{signal_name}' cancelled: result channel dropped"
                     ))
                 })
+            }
+        }
+    }
+
+    // ── External activity completion ───────────────────────────────────
+
+    /// Schedule an activity that completes when an *external* system delivers
+    /// a result via the management API task-token endpoint.
+    ///
+    /// Unlike [`execute_activity_raw`](Self::execute_activity_raw), external
+    /// activities do **not** occupy a worker slot — the workflow suspends until
+    /// an operator or third-party service posts to
+    /// `POST /activities/external/{token}/complete` or `/fail`.
+    ///
+    /// The scheduling step generates a durable, opaque **task token** (UUID)
+    /// embedded in event history. On replay the recorded outcome is returned
+    /// without contacting anything external.
+    ///
+    /// # Errors
+    ///
+    /// - [`HarvestError::NonDeterministic`] if the activity name recorded in
+    ///   history does not match `name`.
+    /// - [`HarvestError::ActivityFailed`] if the recorded history shows a failure.
+    /// - [`HarvestError::Timeout`] if the schedule-to-close deadline expired.
+    /// - [`HarvestError::Cancelled`] if the result channel is dropped.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal matcher or commands mutex is poisoned.
+    pub async fn execute_activity_external(
+        &self,
+        name: &str,
+        input: Value,
+        queue: &str,
+        schedule_to_close_secs: u64,
+    ) -> HarvestResult<Value> {
+        use crate::replay::HistoryMatch;
+
+        let history_match = self.match_history(|m| m.match_external_activity(name));
+
+        match history_match {
+            HistoryMatch::Matched { output } => Ok(output),
+
+            HistoryMatch::Failed { error, attempt } => Err(HarvestError::ActivityFailed {
+                name: name.to_string(),
+                attempt,
+                source: error.into(),
+            }),
+
+            HistoryMatch::TimedOut { timeout_type } => Err(HarvestError::Timeout {
+                timeout_type,
+                task_name: name.to_string(),
+            }),
+
+            HistoryMatch::Diverged { expected, actual } => Err(HarvestError::NonDeterministic(
+                format!("external activity mismatch: expected {expected}, got {actual}"),
+            )),
+
+            HistoryMatch::AwaitingExternalCompletion { activity_id, token } => {
+                // Already recorded — re-emit idempotently so the worker confirms
+                // the lookup-table entry is present, then suspend until the
+                // external completion triggers a re-run.
+                let (tx, rx) = oneshot::channel();
+                self.push_command(WorkflowCommand::ScheduleExternalActivity {
+                    activity_id,
+                    token,
+                    name: name.to_string(),
+                    input,
+                    queue: queue.to_string(),
+                    schedule_to_close_secs,
+                    result_tx: tx,
+                });
+                match rx.await {
+                    Ok(Ok(output)) => Ok(output),
+                    Ok(Err(error)) => Err(HarvestError::ActivityFailed {
+                        name: name.to_string(),
+                        attempt: 1,
+                        source: error.into(),
+                    }),
+                    Err(_) => Err(HarvestError::Cancelled(format!(
+                        "external activity '{name}' cancelled: result channel dropped"
+                    ))),
+                }
+            }
+
+            HistoryMatch::NoMatch => {
+                // First time — generate a fresh token and schedule.
+                let activity_id = self.next_activity_id();
+                let token = ExternalActivityToken::new();
+                let (tx, rx) = oneshot::channel();
+                self.push_command(WorkflowCommand::ScheduleExternalActivity {
+                    activity_id,
+                    token,
+                    name: name.to_string(),
+                    input,
+                    queue: queue.to_string(),
+                    schedule_to_close_secs,
+                    result_tx: tx,
+                });
+                match rx.await {
+                    Ok(Ok(output)) => Ok(output),
+                    Ok(Err(error)) => Err(HarvestError::ActivityFailed {
+                        name: name.to_string(),
+                        attempt: 1,
+                        source: error.into(),
+                    }),
+                    Err(_) => Err(HarvestError::Cancelled(format!(
+                        "external activity '{name}' cancelled: result channel dropped"
+                    ))),
+                }
             }
         }
     }
@@ -884,7 +1038,9 @@ impl WorkflowContext {
             HistoryMatch::Diverged { expected, actual } => Err(HarvestError::NonDeterministic(
                 format!("continue_as_new mismatch: expected {expected}, got {actual}"),
             )),
-            HistoryMatch::Failed { .. } | HistoryMatch::TimedOut { .. } => {
+            HistoryMatch::Failed { .. }
+            | HistoryMatch::TimedOut { .. }
+            | HistoryMatch::AwaitingExternalCompletion { .. } => {
                 Err(HarvestError::NonDeterministic(
                     "continue_as_new history contains unexpected terminal state".into(),
                 ))

--- a/autumn-harvest/src/event.rs
+++ b/autumn-harvest/src/event.rs
@@ -12,7 +12,7 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::error::TimeoutType;
-use crate::types::{ActivityExecId, ExecutionId, TimerId, WorkerId};
+use crate::types::{ActivityExecId, ExecutionId, ExternalActivityToken, TimerId, WorkerId};
 
 /// All possible events in a workflow's history.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -159,6 +159,53 @@ pub enum WorkflowEvent {
         /// The JSON payload passed to the next iteration of the workflow.
         input: serde_json::Value,
     },
+
+    // ── External activity completion (issue #92) ──────────────────────
+    /// An external activity was scheduled and is awaiting completion via the
+    /// management API task-token endpoint. The `token` is a single-use handle
+    /// that external systems round-trip through `/activities/external/{token}/complete`.
+    ActivityAwaitingExternal {
+        /// Unique ID for this specific activity attempt.
+        activity_id: ActivityExecId,
+        /// Opaque token that external systems use to complete or fail the activity.
+        token: ExternalActivityToken,
+        /// The name of the registered activity handler.
+        name: String,
+        /// JSON input for the activity.
+        input: serde_json::Value,
+        /// Target worker queue (informational; external activities don't occupy a slot).
+        queue: String,
+        /// Maximum seconds the external system has to deliver a result.
+        schedule_to_close_secs: u64,
+    },
+    /// An external system delivered a successful result via the management API.
+    ActivityCompletedExternally {
+        /// Unique ID for this specific activity attempt.
+        activity_id: ActivityExecId,
+        /// Token that was used to complete the activity.
+        token: ExternalActivityToken,
+        /// The JSON result returned by the external system.
+        output: serde_json::Value,
+    },
+    /// An external system reported a failure via the management API.
+    ActivityFailedExternally {
+        /// Unique ID for this specific activity attempt.
+        activity_id: ActivityExecId,
+        /// Token that was used to fail the activity.
+        token: ExternalActivityToken,
+        /// String representation of the failure.
+        error: String,
+        /// Whether the failure is retryable per the activity's `RetryPolicy`.
+        retryable: bool,
+    },
+    /// The schedule-to-close deadline for an external activity was extended via
+    /// the management API heartbeat endpoint.
+    ActivityExternalDeadlineExtended {
+        /// Unique ID for this specific activity attempt.
+        activity_id: ActivityExecId,
+        /// Token of the activity whose deadline was extended.
+        token: ExternalActivityToken,
+    },
 }
 
 impl WorkflowEvent {
@@ -185,6 +232,10 @@ impl WorkflowEvent {
             Self::ChildWorkflowFailed { .. } => "ChildWorkflowFailed",
             Self::MarkerRecorded { .. } => "MarkerRecorded",
             Self::WorkflowContinuedAsNew { .. } => "WorkflowContinuedAsNew",
+            Self::ActivityAwaitingExternal { .. } => "ActivityAwaitingExternal",
+            Self::ActivityCompletedExternally { .. } => "ActivityCompletedExternally",
+            Self::ActivityFailedExternally { .. } => "ActivityFailedExternally",
+            Self::ActivityExternalDeadlineExtended { .. } => "ActivityExternalDeadlineExtended",
         }
     }
 }
@@ -231,7 +282,7 @@ mod tests {
 
     #[test]
     fn all_type_names_are_unique() {
-        use crate::types::{ActivityExecId, ExecutionId, TimerId, WorkerId};
+        use crate::types::{ActivityExecId, ExecutionId, ExternalActivityToken, TimerId, WorkerId};
         use std::collections::HashSet;
 
         let events = vec![
@@ -303,10 +354,33 @@ mod tests {
                 new_exec_id: ExecutionId::new(),
                 input: serde_json::Value::Null,
             },
+            WorkflowEvent::ActivityAwaitingExternal {
+                activity_id: ActivityExecId::new(),
+                token: crate::types::ExternalActivityToken::new(),
+                name: "x".into(),
+                input: serde_json::Value::Null,
+                queue: "default".into(),
+                schedule_to_close_secs: 0,
+            },
+            WorkflowEvent::ActivityCompletedExternally {
+                activity_id: ActivityExecId::new(),
+                token: crate::types::ExternalActivityToken::new(),
+                output: serde_json::Value::Null,
+            },
+            WorkflowEvent::ActivityFailedExternally {
+                activity_id: ActivityExecId::new(),
+                token: crate::types::ExternalActivityToken::new(),
+                error: "x".into(),
+                retryable: false,
+            },
+            WorkflowEvent::ActivityExternalDeadlineExtended {
+                activity_id: ActivityExecId::new(),
+                token: crate::types::ExternalActivityToken::new(),
+            },
         ];
 
-        assert_eq!(events.len(), 18);
+        assert_eq!(events.len(), 22);
         let names: HashSet<_> = events.iter().map(WorkflowEvent::type_name).collect();
-        assert_eq!(names.len(), 18, "duplicate type names detected");
+        assert_eq!(names.len(), 22, "duplicate type names detected");
     }
 }

--- a/autumn-harvest/src/event.rs
+++ b/autumn-harvest/src/event.rs
@@ -282,7 +282,7 @@ mod tests {
 
     #[test]
     fn all_type_names_are_unique() {
-        use crate::types::{ActivityExecId, ExecutionId, ExternalActivityToken, TimerId, WorkerId};
+        use crate::types::{ActivityExecId, ExecutionId, TimerId, WorkerId};
         use std::collections::HashSet;
 
         let events = vec![

--- a/autumn-harvest/src/external_task.rs
+++ b/autumn-harvest/src/external_task.rs
@@ -1,0 +1,240 @@
+//! External activity task management — token-based async completion.
+//!
+//! When a workflow calls `execute_activity_external`, the worker records a row
+//! here that maps the opaque `ExternalActivityToken` to the pending
+//! `(workflow_exec_id, activity_id)`.  The management API resolves that mapping
+//! in O(log n) via the `idx_harvest_ext_token` index and then appends the
+//! appropriate terminal event and wakes the workflow.
+
+use chrono::Utc;
+use diesel::{ExpressionMethods, OptionalExtension, QueryDsl, SelectableHelper};
+use diesel_async::{AsyncConnection, AsyncPgConnection, RunQueryDsl};
+use scoped_futures::ScopedFutureExt;
+
+use crate::error::{HarvestError, HarvestResult, database_error};
+use crate::event::WorkflowEvent;
+use crate::models::{ExternalTask, NewExternalTask};
+use crate::schema::harvest_external_tasks;
+use crate::store;
+use crate::types::{ActivityExecId, ExecutionId, ExternalActivityToken};
+
+/// Insert a new external-task row, linking `token` → `(exec_id, activity_id)`.
+///
+/// Uses `ON CONFLICT DO NOTHING` so replaying a workflow that already recorded
+/// the awaiting event is safely idempotent.
+///
+/// # Errors
+///
+/// Returns [`HarvestError::Database`] if the INSERT fails.
+pub async fn record_external_task(
+    conn: &mut AsyncPgConnection,
+    exec_id: ExecutionId,
+    token: ExternalActivityToken,
+    activity_id: ActivityExecId,
+    name: &str,
+    queue: &str,
+    schedule_to_close_secs: u64,
+) -> HarvestResult<()> {
+    let schedule_to_close_at = Utc::now()
+        + chrono::Duration::seconds(i64::try_from(schedule_to_close_secs).unwrap_or(i64::MAX));
+
+    let row = NewExternalTask {
+        token: token.as_uuid(),
+        workflow_exec_id: exec_id.as_uuid(),
+        activity_id: activity_id.as_uuid(),
+        name,
+        queue,
+        schedule_to_close_at,
+    };
+
+    diesel::insert_into(harvest_external_tasks::table)
+        .values(&row)
+        .on_conflict(harvest_external_tasks::token)
+        .do_nothing()
+        .execute(conn)
+        .await
+        .map_err(database_error)?;
+
+    Ok(())
+}
+
+/// Look up an external task by its opaque token.
+///
+/// Returns `None` when the token is unknown (wrong shard, already deleted, etc.).
+///
+/// # Errors
+///
+/// Returns [`HarvestError::Database`] if the query fails.
+pub async fn find_by_token(
+    conn: &mut AsyncPgConnection,
+    token: ExternalActivityToken,
+) -> HarvestResult<Option<ExternalTask>> {
+    harvest_external_tasks::table
+        .filter(harvest_external_tasks::token.eq(token.as_uuid()))
+        .select(ExternalTask::as_select())
+        .first(conn)
+        .await
+        .optional()
+        .map_err(database_error)
+}
+
+/// Mark an external activity as successfully completed.
+///
+/// Appends `ActivityCompletedExternally` to the event history and wakes the
+/// parked workflow task.  Returns `true` if the state transition happened,
+/// `false` if the token was already in a terminal state (idempotent).
+///
+/// # Errors
+///
+/// Returns [`HarvestError::NotFound`] when `token` is unknown on this shard.
+pub async fn complete_externally(
+    conn: &mut AsyncPgConnection,
+    token: ExternalActivityToken,
+    output: serde_json::Value,
+) -> HarvestResult<bool> {
+    conn.transaction::<bool, HarvestError, _>(|conn| {
+        async move {
+            let task = lock_task(conn, token).await?;
+
+            if task.state != "PENDING" {
+                return Ok(false);
+            }
+
+            let exec_id = ExecutionId::from_uuid(task.workflow_exec_id);
+            let activity_id = ActivityExecId::from_uuid(task.activity_id);
+
+            diesel::update(harvest_external_tasks::table.find(task.id))
+                .set(harvest_external_tasks::state.eq("COMPLETED"))
+                .execute(conn)
+                .await
+                .map_err(database_error)?;
+
+            let event = WorkflowEvent::ActivityCompletedExternally {
+                activity_id,
+                token,
+                output,
+            };
+            store::append_single_event(conn, exec_id, event).await?;
+            crate::queue::wake_workflow_task(conn, exec_id).await?;
+
+            Ok(true)
+        }
+        .scope_boxed()
+    })
+    .await
+}
+
+/// Mark an external activity as failed.
+///
+/// Appends `ActivityFailedExternally` to the event history and wakes the
+/// parked workflow task.  Returns `true` if the state transition happened,
+/// `false` if the token was already in a terminal state (idempotent).
+///
+/// # Errors
+///
+/// Returns [`HarvestError::NotFound`] when `token` is unknown on this shard.
+pub async fn fail_externally(
+    conn: &mut AsyncPgConnection,
+    token: ExternalActivityToken,
+    error: String,
+    retryable: bool,
+) -> HarvestResult<bool> {
+    conn.transaction::<bool, HarvestError, _>(|conn| {
+        async move {
+            let task = lock_task(conn, token).await?;
+
+            if task.state != "PENDING" {
+                return Ok(false);
+            }
+
+            let exec_id = ExecutionId::from_uuid(task.workflow_exec_id);
+            let activity_id = ActivityExecId::from_uuid(task.activity_id);
+
+            diesel::update(harvest_external_tasks::table.find(task.id))
+                .set(harvest_external_tasks::state.eq("FAILED"))
+                .execute(conn)
+                .await
+                .map_err(database_error)?;
+
+            let event = WorkflowEvent::ActivityFailedExternally {
+                activity_id,
+                token,
+                error,
+                retryable,
+            };
+            store::append_single_event(conn, exec_id, event).await?;
+            crate::queue::wake_workflow_task(conn, exec_id).await?;
+
+            Ok(true)
+        }
+        .scope_boxed()
+    })
+    .await
+}
+
+/// Extend the deadline for a pending external activity.
+///
+/// Appends `ActivityExternalDeadlineExtended` to the event history and updates
+/// `schedule_to_close_at` by `extend_by_secs` seconds from now.
+///
+/// # Errors
+///
+/// Returns [`HarvestError::NotFound`] when `token` is unknown on this shard.
+/// Returns [`HarvestError::Config`] if the task is already in a terminal state.
+pub async fn extend_deadline(
+    conn: &mut AsyncPgConnection,
+    token: ExternalActivityToken,
+    extend_by_secs: u64,
+) -> HarvestResult<()> {
+    conn.transaction::<(), HarvestError, _>(|conn| {
+        async move {
+            let task = lock_task(conn, token).await?;
+
+            if task.state != "PENDING" {
+                return Err(HarvestError::Config(format!(
+                    "external task {token} is already terminal ({}); cannot extend deadline",
+                    task.state
+                )));
+            }
+
+            let exec_id = ExecutionId::from_uuid(task.workflow_exec_id);
+            let activity_id = ActivityExecId::from_uuid(task.activity_id);
+
+            let new_deadline = Utc::now()
+                + chrono::Duration::seconds(
+                    i64::try_from(extend_by_secs).unwrap_or(i64::MAX),
+                );
+
+            diesel::update(harvest_external_tasks::table.find(task.id))
+                .set(harvest_external_tasks::schedule_to_close_at.eq(new_deadline))
+                .execute(conn)
+                .await
+                .map_err(database_error)?;
+
+            let event = WorkflowEvent::ActivityExternalDeadlineExtended {
+                activity_id,
+                token,
+            };
+            store::append_single_event(conn, exec_id, event).await?;
+
+            Ok(())
+        }
+        .scope_boxed()
+    })
+    .await
+}
+
+async fn lock_task(
+    conn: &mut AsyncPgConnection,
+    token: ExternalActivityToken,
+) -> HarvestResult<ExternalTask> {
+    harvest_external_tasks::table
+        .filter(harvest_external_tasks::token.eq(token.as_uuid()))
+        .for_update()
+        .select(ExternalTask::as_select())
+        .first(conn)
+        .await
+        .optional()
+        .map_err(database_error)?
+        .ok_or_else(|| HarvestError::NotFound(format!("external task token {token}")))
+}

--- a/autumn-harvest/src/external_task.rs
+++ b/autumn-harvest/src/external_task.rs
@@ -201,9 +201,7 @@ pub async fn extend_deadline(
             let activity_id = ActivityExecId::from_uuid(task.activity_id);
 
             let new_deadline = Utc::now()
-                + chrono::Duration::seconds(
-                    i64::try_from(extend_by_secs).unwrap_or(i64::MAX),
-                );
+                + chrono::Duration::seconds(i64::try_from(extend_by_secs).unwrap_or(i64::MAX));
 
             diesel::update(harvest_external_tasks::table.find(task.id))
                 .set(harvest_external_tasks::schedule_to_close_at.eq(new_deadline))
@@ -211,10 +209,7 @@ pub async fn extend_deadline(
                 .await
                 .map_err(database_error)?;
 
-            let event = WorkflowEvent::ActivityExternalDeadlineExtended {
-                activity_id,
-                token,
-            };
+            let event = WorkflowEvent::ActivityExternalDeadlineExtended { activity_id, token };
             store::append_single_event(conn, exec_id, event).await?;
 
             Ok(())

--- a/autumn-harvest/src/external_task.rs
+++ b/autumn-harvest/src/external_task.rs
@@ -45,6 +45,7 @@ pub async fn record_external_task(
         name,
         queue,
         schedule_to_close_at,
+        schedule_to_close_secs: i64::try_from(schedule_to_close_secs).unwrap_or(i64::MAX),
     };
 
     diesel::insert_into(harvest_external_tasks::table)

--- a/autumn-harvest/src/external_task.rs
+++ b/autumn-harvest/src/external_task.rs
@@ -79,6 +79,31 @@ pub async fn find_by_token(
         .map_err(database_error)
 }
 
+/// Look up an external task by its opaque token, acquiring a row-level lock.
+///
+/// Like [`find_by_token`] but uses `FOR UPDATE`, serializing the caller
+/// against concurrent writers (complete/fail) that also lock this row.
+/// Must be called inside a transaction.
+///
+/// Returns `None` when the token is unknown (wrong shard, already deleted, etc.).
+///
+/// # Errors
+///
+/// Returns [`HarvestError::Database`] if the query fails.
+pub async fn find_by_token_locked(
+    conn: &mut AsyncPgConnection,
+    token: ExternalActivityToken,
+) -> HarvestResult<Option<ExternalTask>> {
+    harvest_external_tasks::table
+        .filter(harvest_external_tasks::token.eq(token.as_uuid()))
+        .for_update()
+        .select(ExternalTask::as_select())
+        .first(conn)
+        .await
+        .optional()
+        .map_err(database_error)
+}
+
 /// Mark an external activity as successfully completed.
 ///
 /// Appends `ActivityCompletedExternally` to the event history and wakes the

--- a/autumn-harvest/src/history_export.rs
+++ b/autumn-harvest/src/history_export.rs
@@ -66,6 +66,12 @@ impl MermaidExporter {
                 WorkflowEvent::SignalReceived { .. } | WorkflowEvent::MarkerRecorded { .. } => {
                     self.handle_misc_event(event)?;
                 }
+                WorkflowEvent::ActivityAwaitingExternal { .. }
+                | WorkflowEvent::ActivityCompletedExternally { .. }
+                | WorkflowEvent::ActivityFailedExternally { .. }
+                | WorkflowEvent::ActivityExternalDeadlineExtended { .. } => {
+                    self.handle_external_activity_event(event)?;
+                }
             }
         }
         Ok(())
@@ -247,6 +253,45 @@ impl MermaidExporter {
             }
             WorkflowEvent::MarkerRecorded { name, .. } => {
                 writeln!(self.out, "    Note over WF: Marker: {name}")?;
+            }
+            _ => unreachable!(),
+        }
+        Ok(())
+    }
+
+    fn handle_external_activity_event(
+        &mut self,
+        event: &WorkflowEvent,
+    ) -> Result<(), std::fmt::Error> {
+        let participant = "ExternalSystem";
+        if self.participants.insert(participant.to_string()) {
+            writeln!(self.out, "    participant {participant} as External System")?;
+        }
+        match event {
+            WorkflowEvent::ActivityAwaitingExternal { name, token, .. } => {
+                writeln!(
+                    self.out,
+                    "    WF->>{participant}: Awaiting External: {name} (token: {token})"
+                )?;
+            }
+            WorkflowEvent::ActivityCompletedExternally { token, .. } => {
+                writeln!(
+                    self.out,
+                    "    {participant}->>WF: Completed Externally (token: {token})"
+                )?;
+            }
+            WorkflowEvent::ActivityFailedExternally { token, error, .. } => {
+                let safe_error = error.replace('\n', " ").replace('"', "'");
+                writeln!(
+                    self.out,
+                    "    {participant}->>WF: Failed Externally (token: {token}): {safe_error}"
+                )?;
+            }
+            WorkflowEvent::ActivityExternalDeadlineExtended { token, .. } => {
+                writeln!(
+                    self.out,
+                    "    Note right of WF: Deadline Extended (token: {token})"
+                )?;
             }
             _ => unreachable!(),
         }

--- a/autumn-harvest/src/lib.rs
+++ b/autumn-harvest/src/lib.rs
@@ -135,7 +135,8 @@ pub use telemetry::{
 #[cfg(any(test, feature = "testing"))]
 pub use test_generator::TestHarnessGenerator;
 pub use types::{
-    ActivityExecId, ExecutionId, ShardId, TimerId, WorkerId, WorkflowId, WorkflowIdReusePolicy,
+    ActivityExecId, ExecutionId, ExternalActivityToken, ShardId, TimerId, WorkerId, WorkflowId,
+    WorkflowIdReusePolicy,
 };
 
 #[cfg(feature = "db")]

--- a/autumn-harvest/src/lib.rs
+++ b/autumn-harvest/src/lib.rs
@@ -32,6 +32,8 @@ pub mod event;
 #[doc(hidden)]
 pub mod execution;
 pub mod executor;
+#[cfg(feature = "db")]
+pub mod external_task;
 pub mod history_export;
 pub mod info;
 pub mod policy;

--- a/autumn-harvest/src/models.rs
+++ b/autumn-harvest/src/models.rs
@@ -346,6 +346,7 @@ pub struct ExternalTask {
     pub queue: String,
     pub state: String,
     pub schedule_to_close_at: DateTime<Utc>,
+    pub schedule_to_close_secs: i64,
     pub created_at: DateTime<Utc>,
 }
 
@@ -359,4 +360,5 @@ pub struct NewExternalTask<'a> {
     pub name: &'a str,
     pub queue: &'a str,
     pub schedule_to_close_at: DateTime<Utc>,
+    pub schedule_to_close_secs: i64,
 }

--- a/autumn-harvest/src/models.rs
+++ b/autumn-harvest/src/models.rs
@@ -10,8 +10,9 @@ use diesel::prelude::*;
 use uuid::Uuid;
 
 use crate::schema::{
-    harvest_dag_runs, harvest_dead_letters, harvest_events, harvest_schedules, harvest_signals,
-    harvest_task_queue, harvest_timers, harvest_workflow_executions,
+    harvest_dag_runs, harvest_dead_letters, harvest_events, harvest_external_tasks,
+    harvest_schedules, harvest_signals, harvest_task_queue, harvest_timers,
+    harvest_workflow_executions,
 };
 
 // ── WorkflowExecution ─────────────────────────────────────────────────────────
@@ -326,4 +327,36 @@ pub struct NewDeadLetter<'a> {
     pub input: serde_json::Value,
     pub error: &'a str,
     pub attempts: i32,
+}
+
+// ── ExternalTask ──────────────────────────────────────────────────────────────
+
+/// A pending or resolved external activity task, keyed by its opaque token.
+#[derive(
+    Debug, Clone, Queryable, Selectable, Identifiable, serde::Serialize, serde::Deserialize,
+)]
+#[diesel(table_name = harvest_external_tasks)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct ExternalTask {
+    pub id: Uuid,
+    pub token: Uuid,
+    pub workflow_exec_id: Uuid,
+    pub activity_id: Uuid,
+    pub name: String,
+    pub queue: String,
+    pub state: String,
+    pub schedule_to_close_at: DateTime<Utc>,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Insert struct for registering a new external activity task.
+#[derive(Debug, Insertable)]
+#[diesel(table_name = harvest_external_tasks)]
+pub struct NewExternalTask<'a> {
+    pub token: Uuid,
+    pub workflow_exec_id: Uuid,
+    pub activity_id: Uuid,
+    pub name: &'a str,
+    pub queue: &'a str,
+    pub schedule_to_close_at: DateTime<Utc>,
 }

--- a/autumn-harvest/src/replay.rs
+++ b/autumn-harvest/src/replay.rs
@@ -14,6 +14,7 @@ use std::collections::{HashSet, VecDeque};
 
 use crate::error::TimeoutType;
 use crate::event::WorkflowEvent;
+use crate::types::{ActivityExecId, ExternalActivityToken};
 
 /// Result of matching a workflow command against the event history.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -44,6 +45,16 @@ pub enum HistoryMatch {
         expected: String,
         /// What the workflow actually requested.
         actual: String,
+    },
+    /// History shows an external activity was scheduled but no terminal event
+    /// (completed/failed/timed-out) exists yet. The workflow should re-emit the
+    /// schedule command with the same token and activity ID (idempotent at the
+    /// worker level) and then suspend until the external completion arrives.
+    AwaitingExternalCompletion {
+        /// The activity execution ID already recorded in history.
+        activity_id: ActivityExecId,
+        /// The token already recorded in history. Must be reused to stay idempotent.
+        token: ExternalActivityToken,
     },
 }
 
@@ -306,6 +317,119 @@ impl HistoryMatcher {
         // We found the Scheduled event but no terminal event — treat as
         // incomplete history (the activity was scheduled but never finished).
         HistoryMatch::NoMatch
+    }
+
+    /// Match an `execute_activity_external` command against history.
+    ///
+    /// Expects `ActivityAwaitingExternal { name }` at the current cursor, then
+    /// scans forward for a terminal event (`ActivityCompletedExternally`,
+    /// `ActivityFailedExternally`, or `ActivityTimedOut`) with the same
+    /// `activity_id`. `ActivityExternalDeadlineExtended` events are skipped.
+    ///
+    /// Returns:
+    /// - [`HistoryMatch::Matched`] when the external system completed the activity
+    /// - [`HistoryMatch::Failed`] when the external system failed the activity
+    /// - [`HistoryMatch::TimedOut`] when the schedule-to-close clock expired
+    /// - [`HistoryMatch::AwaitingExternalCompletion`] when scheduled but no terminal yet
+    /// - [`HistoryMatch::NoMatch`] when past end of history (first-time scheduling)
+    /// - [`HistoryMatch::Diverged`] when history has a different event at this position
+    pub fn match_external_activity(&mut self, activity_name: &str) -> HistoryMatch {
+        if !self.prepare_match() {
+            return HistoryMatch::NoMatch;
+        }
+
+        let WorkflowEvent::ActivityAwaitingExternal {
+            activity_id,
+            token,
+            name: recorded_name,
+            ..
+        } = &self.events[self.cursor]
+        else {
+            return HistoryMatch::Diverged {
+                expected: format!("ActivityAwaitingExternal({activity_name})"),
+                actual: self.events[self.cursor].type_name().to_string(),
+            };
+        };
+
+        if recorded_name != activity_name {
+            return HistoryMatch::Diverged {
+                expected: format!("ActivityAwaitingExternal({activity_name})"),
+                actual: format!("ActivityAwaitingExternal({recorded_name})"),
+            };
+        }
+
+        let activity_id = *activity_id;
+        let token = *token;
+
+        // Advance past the ActivityAwaitingExternal event.
+        self.cursor += 1;
+        let mut scan_cursor = self.cursor;
+
+        while scan_cursor < self.events.len() {
+            if self.is_consumed(scan_cursor) {
+                scan_cursor += 1;
+                continue;
+            }
+
+            match &self.events[scan_cursor] {
+                WorkflowEvent::ActivityCompletedExternally {
+                    activity_id: id,
+                    output,
+                    ..
+                } if *id == activity_id => {
+                    let result = HistoryMatch::Matched {
+                        output: output.clone(),
+                    };
+                    self.cursor = scan_cursor + 1;
+                    self.advance_to_next_unconsumed_event();
+                    return result;
+                }
+                WorkflowEvent::ActivityFailedExternally {
+                    activity_id: id,
+                    error,
+                    ..
+                } if *id == activity_id => {
+                    let result = HistoryMatch::Failed {
+                        error: error.clone(),
+                        attempt: 1,
+                    };
+                    self.cursor = scan_cursor + 1;
+                    self.advance_to_next_unconsumed_event();
+                    return result;
+                }
+                WorkflowEvent::ActivityTimedOut {
+                    activity_id: id,
+                    timeout_type,
+                } if *id == activity_id => {
+                    let result = HistoryMatch::TimedOut {
+                        timeout_type: timeout_type.clone(),
+                    };
+                    self.cursor = scan_cursor + 1;
+                    self.advance_to_next_unconsumed_event();
+                    return result;
+                }
+                // Deadline-extended events are informational; skip them.
+                WorkflowEvent::ActivityExternalDeadlineExtended {
+                    activity_id: id, ..
+                } if *id == activity_id => {
+                    scan_cursor += 1;
+                }
+                // Signals can arrive while an external activity is pending.
+                WorkflowEvent::SignalReceived {
+                    signal_name,
+                    payload,
+                } => {
+                    let signal_name = signal_name.clone();
+                    let payload = payload.clone();
+                    self.stash_signal(scan_cursor, signal_name, payload);
+                    scan_cursor += 1;
+                }
+                _ => break,
+            }
+        }
+
+        // Awaiting event exists in history but no terminal found yet.
+        HistoryMatch::AwaitingExternalCompletion { activity_id, token }
     }
 
     /// Match a timer command against history.

--- a/autumn-harvest/src/replay.rs
+++ b/autumn-harvest/src/replay.rs
@@ -424,6 +424,16 @@ impl HistoryMatcher {
                     self.stash_signal(scan_cursor, signal_name, payload);
                     scan_cursor += 1;
                 }
+                // A second ActivityAwaitingExternal for the same activity can
+                // appear when a workflow is woken by a signal while still
+                // awaiting external completion: the worker re-runs
+                // persist_scheduled_external_activity, but record_external_task
+                // is idempotent (ON CONFLICT DO NOTHING).  Skip the duplicate.
+                WorkflowEvent::ActivityAwaitingExternal {
+                    activity_id: id, ..
+                } if *id == activity_id => {
+                    scan_cursor += 1;
+                }
                 _ => break,
             }
         }

--- a/autumn-harvest/src/schema.rs
+++ b/autumn-harvest/src/schema.rs
@@ -172,6 +172,7 @@ diesel::table! {
         queue -> Text,
         state -> Text,
         schedule_to_close_at -> Timestamptz,
+        schedule_to_close_secs -> Int8,
         created_at -> Timestamptz,
     }
 }

--- a/autumn-harvest/src/schema.rs
+++ b/autumn-harvest/src/schema.rs
@@ -160,11 +160,28 @@ diesel::table! {
     }
 }
 
+diesel::table! {
+    use diesel::sql_types::*;
+
+    harvest_external_tasks (id) {
+        id -> Uuid,
+        token -> Uuid,
+        workflow_exec_id -> Uuid,
+        activity_id -> Uuid,
+        name -> Text,
+        queue -> Text,
+        state -> Text,
+        schedule_to_close_at -> Timestamptz,
+        created_at -> Timestamptz,
+    }
+}
+
 diesel::joinable!(harvest_events -> harvest_workflow_executions (workflow_exec_id));
 diesel::joinable!(harvest_task_queue -> harvest_workflow_executions (workflow_exec_id));
 diesel::joinable!(harvest_dag_runs -> harvest_workflow_executions (workflow_exec_id));
 diesel::joinable!(harvest_signals -> harvest_workflow_executions (workflow_exec_id));
 diesel::joinable!(harvest_timers -> harvest_workflow_executions (workflow_exec_id));
+diesel::joinable!(harvest_external_tasks -> harvest_workflow_executions (workflow_exec_id));
 
 diesel::allow_tables_to_appear_in_same_query!(
     harvest_workflow_executions,
@@ -175,4 +192,5 @@ diesel::allow_tables_to_appear_in_same_query!(
     harvest_signals,
     harvest_timers,
     harvest_dead_letters,
+    harvest_external_tasks,
 );

--- a/autumn-harvest/src/store.rs
+++ b/autumn-harvest/src/store.rs
@@ -102,6 +102,34 @@ pub async fn append_events(
         .map_err(crate::error::database_error)
 }
 
+/// Append a single event to a workflow's history without loading the full log.
+///
+/// Queries the current maximum `event_id` and inserts one position past it.
+/// Use this from management-API paths (external completion, heartbeat) where
+/// loading the full history would be wasteful.
+///
+/// # Errors
+///
+/// Returns [`crate::error::HarvestError::Database`] if the query or insert fails.
+pub async fn append_single_event(
+    conn: &mut AsyncPgConnection,
+    exec_id: ExecutionId,
+    event: WorkflowEvent,
+) -> HarvestResult<()> {
+    use diesel::dsl::max;
+
+    let max_id: Option<i32> = harvest_events::table
+        .filter(harvest_events::workflow_exec_id.eq(exec_id.as_uuid()))
+        .select(max(harvest_events::event_id))
+        .first(conn)
+        .await
+        .map_err(crate::error::database_error)?;
+
+    let next_id = max_id.map_or(0, |id| id.saturating_add(1));
+    append_events(conn, exec_id, &[event], next_id).await?;
+    Ok(())
+}
+
 /// Load the full event history for a workflow execution, ordered by `event_id`.
 ///
 /// Deserializes each row's `event_data` JSON back into [`WorkflowEvent`].

--- a/autumn-harvest/src/store.rs
+++ b/autumn-harvest/src/store.rs
@@ -5,7 +5,9 @@
 //! that two workers can't append conflicting events to the same workflow.
 
 use diesel::ExpressionMethods;
+use diesel::OptionalExtension;
 use diesel::QueryDsl;
+use diesel::SelectableHelper;
 use diesel_async::AsyncPgConnection;
 use diesel_async::RunQueryDsl;
 
@@ -104,19 +106,39 @@ pub async fn append_events(
 
 /// Append a single event to a workflow's history without loading the full log.
 ///
-/// Queries the current maximum `event_id` and inserts one position past it.
-/// Use this from management-API paths (external completion, heartbeat) where
-/// loading the full history would be wasteful.
+/// Acquires a row-level lock on the workflow execution before reading
+/// `MAX(event_id)`, serializing concurrent appenders (management API paths,
+/// timeout enforcement) so they never race to allocate the same event ID.
+/// Must be called inside a transaction; the lock is held until the transaction
+/// commits or rolls back.
 ///
 /// # Errors
 ///
-/// Returns [`crate::error::HarvestError::Database`] if the query or insert fails.
+/// Returns [`crate::error::HarvestError::Database`] if the query or insert fails,
+/// or [`crate::error::HarvestError::NotFound`] if the execution does not exist.
 pub async fn append_single_event(
     conn: &mut AsyncPgConnection,
     exec_id: ExecutionId,
     event: WorkflowEvent,
 ) -> HarvestResult<()> {
+    use crate::models::WorkflowExecution;
+    use crate::schema::harvest_workflow_executions;
     use diesel::dsl::max;
+
+    // Lock the parent execution row so that concurrent callers serialise their
+    // MAX(event_id) + INSERT pairs — preventing a duplicate-event-id collision
+    // on the UNIQUE(workflow_exec_id, event_id) constraint.
+    harvest_workflow_executions::table
+        .find(exec_id.as_uuid())
+        .for_update()
+        .select(WorkflowExecution::as_select())
+        .first(conn)
+        .await
+        .optional()
+        .map_err(crate::error::database_error)?
+        .ok_or_else(|| {
+            crate::error::HarvestError::NotFound(format!("workflow execution {exec_id}"))
+        })?;
 
     let max_id: Option<i32> = harvest_events::table
         .filter(harvest_events::workflow_exec_id.eq(exec_id.as_uuid()))

--- a/autumn-harvest/src/timeout.rs
+++ b/autumn-harvest/src/timeout.rs
@@ -378,11 +378,22 @@ pub async fn enforce_external_task_timeouts(conn: &mut AsyncPgConnection) -> Har
         let result = conn
             .transaction::<(), HarvestError, _>(|conn| {
                 async move {
-                    diesel::update(harvest_external_tasks::table.find(task_id))
-                        .set(harvest_external_tasks::state.eq("TIMED_OUT"))
-                        .execute(conn)
-                        .await
-                        .map_err(crate::error::database_error)?;
+                    // Guard against races: only transition if still PENDING.
+                    // If complete/fail landed between our scan and this update,
+                    // their state wins and we skip the timeout event entirely.
+                    let rows = diesel::update(
+                        harvest_external_tasks::table
+                            .find(task_id)
+                            .filter(harvest_external_tasks::state.eq("PENDING")),
+                    )
+                    .set(harvest_external_tasks::state.eq("TIMED_OUT"))
+                    .execute(conn)
+                    .await
+                    .map_err(crate::error::database_error)?;
+
+                    if rows == 0 {
+                        return Ok(());
+                    }
 
                     store::append_single_event(conn, exec_id, timeout_event).await?;
                     queue::wake_workflow_task(conn, exec_id).await

--- a/autumn-harvest/src/timeout.rs
+++ b/autumn-harvest/src/timeout.rs
@@ -23,7 +23,9 @@ use tokio_util::sync::CancellationToken;
 
 use crate::error::{HarvestError, HarvestResult, TimeoutType};
 use crate::event::WorkflowEvent;
-use crate::models::{TaskQueueItem, WorkflowExecution};
+use crate::models::{ExternalTask, TaskQueueItem, WorkflowExecution};
+use crate::schema::harvest_external_tasks;
+use crate::types::ActivityExecId;
 use crate::{queue, store};
 
 /// The reason a task was identified as timed out.
@@ -337,6 +339,74 @@ async fn enforce_workflow_timeout(
     .await
 }
 
+/// Enforce schedule-to-close timeouts for pending external activity tasks.
+///
+/// Scans `harvest_external_tasks` for rows that are still `PENDING` but whose
+/// `schedule_to_close_at` has elapsed.  For each expired row the function:
+///
+/// 1. Marks the row `TIMED_OUT`.
+/// 2. Appends `ActivityTimedOut { timeout_type: ScheduleToClose }` to the
+///    owning workflow's event history.
+/// 3. Wakes the parked workflow task so it can process the timeout.
+///
+/// Returns the number of external tasks that were timed out.
+///
+/// # Errors
+///
+/// Returns the first database or persistence error encountered.
+pub async fn enforce_external_task_timeouts(
+    conn: &mut AsyncPgConnection,
+) -> HarvestResult<usize> {
+    let expired: Vec<ExternalTask> = harvest_external_tasks::table
+        .filter(harvest_external_tasks::state.eq("PENDING"))
+        .filter(harvest_external_tasks::schedule_to_close_at.lt(Utc::now()))
+        .select(ExternalTask::as_select())
+        .load(conn)
+        .await
+        .map_err(crate::error::database_error)?;
+
+    let count = expired.len();
+
+    for task in &expired {
+        let exec_id = execution_id_from_uuid(task.workflow_exec_id);
+        let activity_id = ActivityExecId::from_uuid(task.activity_id);
+        let task_id = task.id;
+
+        let timeout_event = WorkflowEvent::ActivityTimedOut {
+            activity_id,
+            timeout_type: TimeoutType::ScheduleToClose,
+        };
+
+        let result = conn
+            .transaction::<(), HarvestError, _>(|conn| {
+                async move {
+                    diesel::update(harvest_external_tasks::table.find(task_id))
+                        .set(harvest_external_tasks::state.eq("TIMED_OUT"))
+                        .execute(conn)
+                        .await
+                        .map_err(crate::error::database_error)?;
+
+                    store::append_single_event(conn, exec_id, timeout_event).await?;
+                    queue::wake_workflow_task(conn, exec_id).await
+                }
+                .scope_boxed()
+            })
+            .await;
+
+        if let Err(error) = result {
+            tracing::error!(
+                task_id = %task.id,
+                exec_id = %exec_id,
+                error = %error,
+                "failed to enforce external task schedule-to-close timeout"
+            );
+            return Err(error);
+        }
+    }
+
+    Ok(count)
+}
+
 /// Enforce all currently expired task timeouts against the database state.
 ///
 /// This mutates queue rows and workflow history so timed-out tasks are not
@@ -348,7 +418,7 @@ async fn enforce_workflow_timeout(
 /// Returns the first database or persistence error encountered.
 pub async fn enforce_timeouts_once(conn: &mut AsyncPgConnection) -> HarvestResult<usize> {
     let timed_out = find_timed_out_tasks(conn).await?;
-    let count = timed_out.len();
+    let mut count = timed_out.len();
 
     for (task, reason) in timed_out {
         let result = match (task.task_type.as_str(), task.workflow_exec_id) {
@@ -375,6 +445,7 @@ pub async fn enforce_timeouts_once(conn: &mut AsyncPgConnection) -> HarvestResul
         }
     }
 
+    count += enforce_external_task_timeouts(conn).await?;
     Ok(count)
 }
 

--- a/autumn-harvest/src/timeout.rs
+++ b/autumn-harvest/src/timeout.rs
@@ -354,9 +354,7 @@ async fn enforce_workflow_timeout(
 /// # Errors
 ///
 /// Returns the first database or persistence error encountered.
-pub async fn enforce_external_task_timeouts(
-    conn: &mut AsyncPgConnection,
-) -> HarvestResult<usize> {
+pub async fn enforce_external_task_timeouts(conn: &mut AsyncPgConnection) -> HarvestResult<usize> {
     let expired: Vec<ExternalTask> = harvest_external_tasks::table
         .filter(harvest_external_tasks::state.eq("PENDING"))
         .filter(harvest_external_tasks::schedule_to_close_at.lt(Utc::now()))

--- a/autumn-harvest/src/timeout.rs
+++ b/autumn-harvest/src/timeout.rs
@@ -378,13 +378,16 @@ pub async fn enforce_external_task_timeouts(conn: &mut AsyncPgConnection) -> Har
         let result = conn
             .transaction::<(), HarvestError, _>(|conn| {
                 async move {
-                    // Guard against races: only transition if still PENDING.
-                    // If complete/fail landed between our scan and this update,
-                    // their state wins and we skip the timeout event entirely.
+                    // Guard against two races:
+                    // 1. complete/fail landed after our scan → state != PENDING
+                    // 2. heartbeat extended the deadline after our scan →
+                    //    schedule_to_close_at is now in the future
+                    // Either way, 0 rows updated means we skip the timeout event.
                     let rows = diesel::update(
                         harvest_external_tasks::table
                             .find(task_id)
-                            .filter(harvest_external_tasks::state.eq("PENDING")),
+                            .filter(harvest_external_tasks::state.eq("PENDING"))
+                            .filter(harvest_external_tasks::schedule_to_close_at.lt(Utc::now())),
                     )
                     .set(harvest_external_tasks::state.eq("TIMED_OUT"))
                     .execute(conn)

--- a/autumn-harvest/src/types.rs
+++ b/autumn-harvest/src/types.rs
@@ -336,6 +336,63 @@ impl FromStr for ActivityExecId {
     }
 }
 
+/// Opaque single-use token that uniquely identifies a pending external activity.
+///
+/// The token is embedded in the `ActivityAwaitingExternal` event when a workflow
+/// calls `execute_activity_external`, and is round-tripped by external systems
+/// through the management API to deliver a result (`/complete`, `/fail`) or extend
+/// the deadline (`/heartbeat`).
+///
+/// ## Examples
+///
+/// ```rust
+/// use autumn_harvest::types::ExternalActivityToken;
+///
+/// let token = ExternalActivityToken::new();
+/// assert!(!token.as_uuid().is_nil());
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct ExternalActivityToken(Uuid);
+
+impl ExternalActivityToken {
+    /// Create a fresh, random token.
+    #[must_use]
+    pub fn new() -> Self {
+        Self(Uuid::new_v4())
+    }
+
+    /// The nil token (all-zero UUID), useful as a sentinel in tests.
+    #[must_use]
+    pub const fn nil() -> Self {
+        Self(Uuid::nil())
+    }
+
+    /// The underlying UUID.
+    #[must_use]
+    pub const fn as_uuid(&self) -> Uuid {
+        self.0
+    }
+}
+
+impl Default for ExternalActivityToken {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Display for ExternalActivityToken {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl FromStr for ExternalActivityToken {
+    type Err = uuid::Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Uuid::parse_str(s).map(Self)
+    }
+}
+
 /// Durable timer handle within a workflow.
 ///
 /// ## Examples

--- a/autumn-harvest/src/types.rs
+++ b/autumn-harvest/src/types.rs
@@ -315,6 +315,12 @@ impl ActivityExecId {
     pub const fn as_uuid(&self) -> Uuid {
         self.0
     }
+
+    /// Wraps an existing `Uuid` as an `ActivityExecId`.
+    #[must_use]
+    pub const fn from_uuid(id: Uuid) -> Self {
+        Self(id)
+    }
 }
 
 impl Default for ActivityExecId {
@@ -371,6 +377,12 @@ impl ExternalActivityToken {
     #[must_use]
     pub const fn as_uuid(&self) -> Uuid {
         self.0
+    }
+
+    /// Wraps an existing `Uuid` as an `ExternalActivityToken`.
+    #[must_use]
+    pub const fn from_uuid(id: Uuid) -> Self {
+        Self(id)
     }
 }
 

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -26,6 +26,7 @@ use crate::context::{ActivityContext, SharedState, WorkflowCommand, empty_shared
 use crate::error::{HarvestError, HarvestResult};
 use crate::event::WorkflowEvent;
 use crate::executor::{WorkflowOutcome, run_workflow_with_state};
+use crate::external_task;
 use crate::info::{ActivityInfo, WorkflowInfo};
 use crate::models::{
     HarvestTimer, NewHarvestTimer, NewWorkflowExecution, TaskQueueItem, WorkflowExecution,
@@ -33,7 +34,6 @@ use crate::models::{
 use crate::policy::RetryPolicy;
 use crate::queue::{self, TaskType};
 use crate::schema::{harvest_timers, harvest_workflow_executions};
-use crate::external_task;
 use crate::signal;
 use crate::store;
 use crate::telemetry::{ActivityStatus, TraceContextCarrier, WorkflowStatus};

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -33,10 +33,11 @@ use crate::models::{
 use crate::policy::RetryPolicy;
 use crate::queue::{self, TaskType};
 use crate::schema::{harvest_timers, harvest_workflow_executions};
+use crate::external_task;
 use crate::signal;
 use crate::store;
 use crate::telemetry::{ActivityStatus, TraceContextCarrier, WorkflowStatus};
-use crate::types::{ActivityExecId, ExecutionId, TimerId, WorkerId};
+use crate::types::{ActivityExecId, ExecutionId, ExternalActivityToken, TimerId, WorkerId};
 
 /// Type alias for the deadpool-managed async Diesel connection pool.
 pub type DbPool = deadpool::managed::Pool<
@@ -236,6 +237,7 @@ fn execution_id_from_uuid(id: uuid::Uuid) -> ExecutionId {
 const fn workflow_command_name(command: &WorkflowCommand) -> &'static str {
     match command {
         WorkflowCommand::ScheduleActivity { .. } => "ScheduleActivity",
+        WorkflowCommand::ScheduleExternalActivity { .. } => "ScheduleExternalActivity",
         WorkflowCommand::StartTimer { .. } => "StartTimer",
         WorkflowCommand::StartChildWorkflow { .. } => "StartChildWorkflow",
         WorkflowCommand::RecordMarker { .. } => "RecordMarker",
@@ -307,6 +309,16 @@ struct StartedChildWorkflowCommand {
     child_id: ExecutionId,
     workflow_name: String,
     input: serde_json::Value,
+}
+
+#[derive(Debug, Clone)]
+struct ScheduledExternalActivityCommand {
+    activity_id: ActivityExecId,
+    token: ExternalActivityToken,
+    name: String,
+    input: serde_json::Value,
+    queue: String,
+    schedule_to_close_secs: u64,
 }
 
 #[derive(Debug)]
@@ -440,6 +452,34 @@ fn extract_single_started_child_workflow(
             child_id: *child_id,
             workflow_name: workflow_name.clone(),
             input: input.clone(),
+        })
+    })
+}
+
+fn extract_single_schedule_external_activity(
+    commands: &[WorkflowCommand],
+) -> Option<ScheduledExternalActivityCommand> {
+    extract_single_command(commands, |cmd| {
+        let WorkflowCommand::ScheduleExternalActivity {
+            activity_id,
+            token,
+            name,
+            input,
+            queue,
+            schedule_to_close_secs,
+            ..
+        } = cmd
+        else {
+            return None;
+        };
+
+        Some(ScheduledExternalActivityCommand {
+            activity_id: *activity_id,
+            token: *token,
+            name: name.clone(),
+            input: input.clone(),
+            queue: queue.clone(),
+            schedule_to_close_secs: *schedule_to_close_secs,
         })
     })
 }
@@ -1428,6 +1468,48 @@ async fn process_activity_task(
     }
 }
 
+async fn persist_scheduled_external_activity(
+    conn: &mut AsyncPgConnection,
+    exec_id: ExecutionId,
+    next_event_id: i32,
+    task_id: uuid::Uuid,
+    commands: &[WorkflowCommand],
+    scheduled: &ScheduledExternalActivityCommand,
+    sticky: Option<queue::StickyHint<'_>>,
+) -> HarvestResult<()> {
+    let marker_events = marker_events_from_commands(commands);
+    let awaiting_event = WorkflowEvent::ActivityAwaitingExternal {
+        activity_id: scheduled.activity_id,
+        token: scheduled.token,
+        name: scheduled.name.clone(),
+        input: scheduled.input.clone(),
+        queue: scheduled.queue.clone(),
+        schedule_to_close_secs: scheduled.schedule_to_close_secs,
+    };
+    let mut events = marker_events;
+    events.push(awaiting_event);
+
+    conn.transaction::<(), HarvestError, _>(|conn| {
+        async move {
+            store::append_events(conn, exec_id, &events, next_event_id).await?;
+            external_task::record_external_task(
+                conn,
+                exec_id,
+                scheduled.token,
+                scheduled.activity_id,
+                &scheduled.name,
+                &scheduled.queue,
+                scheduled.schedule_to_close_secs,
+            )
+            .await?;
+            queue::park_workflow_task(conn, task_id, sticky).await?;
+            Ok(())
+        }
+        .scope_boxed()
+    })
+    .await
+}
+
 #[allow(clippy::too_many_lines)]
 async fn handle_suspended_workflow(
     conn: &mut AsyncPgConnection,
@@ -1515,6 +1597,26 @@ async fn handle_suspended_workflow(
             context.persistence.next_event_id,
             commands,
             &child,
+            sticky,
+        )
+        .await;
+        return fail_execution_on_error(
+            conn,
+            context.persistence.task,
+            context.persistence.worker_id,
+            result,
+        )
+        .await;
+    }
+
+    if let Some(scheduled) = extract_single_schedule_external_activity(commands) {
+        let result = persist_scheduled_external_activity(
+            conn,
+            context.persistence.exec_id,
+            context.persistence.next_event_id,
+            context.persistence.task.id,
+            commands,
+            &scheduled,
             sticky,
         )
         .await;

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -1480,11 +1480,16 @@ async fn persist_scheduled_external_activity(
     // If the token is already registered the awaiting event was already
     // appended by a prior run.  A workflow woken by a signal while still
     // waiting for external completion will re-emit ScheduleExternalActivity —
-    // just re-park without duplicating the event.
+    // persist any marker events from this run then re-park without duplicating
+    // the awaiting event.
     if external_task::find_by_token(conn, scheduled.token)
         .await?
         .is_some()
     {
+        let marker_events = marker_events_from_commands(commands);
+        if !marker_events.is_empty() {
+            store::append_events(conn, exec_id, &marker_events, next_event_id).await?;
+        }
         return queue::park_workflow_task(conn, task_id, sticky).await;
     }
 

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -1479,18 +1479,39 @@ async fn persist_scheduled_external_activity(
 ) -> HarvestResult<()> {
     // If the token is already registered the awaiting event was already
     // appended by a prior run.  A workflow woken by a signal while still
-    // waiting for external completion will re-emit ScheduleExternalActivity —
-    // persist any marker events from this run then re-park without duplicating
-    // the awaiting event.
+    // waiting for external completion will re-emit ScheduleExternalActivity.
+    // Use a fast non-locking check first; if the row exists, enter a
+    // transaction that locks it to close the race with complete/fail_externally:
+    // the management API holds FOR UPDATE on the external task row while it
+    // appends the terminal event and calls wake_workflow_task.  Because the
+    // workflow task is still RUNNING at that point, the wake is a no-op.  By
+    // waiting for the same lock here we read the post-commit state and re-wake
+    // the workflow ourselves if the task is already terminal, preventing an
+    // indefinite park despite terminal history being present.
     if external_task::find_by_token(conn, scheduled.token)
         .await?
         .is_some()
     {
-        let marker_events = marker_events_from_commands(commands);
-        if !marker_events.is_empty() {
-            store::append_events(conn, exec_id, &marker_events, next_event_id).await?;
-        }
-        return queue::park_workflow_task(conn, task_id, sticky).await;
+        let token = scheduled.token;
+        conn.transaction::<(), HarvestError, _>(|conn| {
+            async move {
+                let locked = external_task::find_by_token_locked(conn, token).await?;
+
+                let marker_events = marker_events_from_commands(commands);
+                if !marker_events.is_empty() {
+                    store::append_events(conn, exec_id, &marker_events, next_event_id).await?;
+                }
+
+                if locked.is_some_and(|t| t.state != "PENDING") {
+                    queue::wake_workflow_task(conn, exec_id).await
+                } else {
+                    queue::park_workflow_task(conn, task_id, sticky).await
+                }
+            }
+            .scope_boxed()
+        })
+        .await?;
+        return Ok(());
     }
 
     let marker_events = marker_events_from_commands(commands);

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -1477,6 +1477,17 @@ async fn persist_scheduled_external_activity(
     scheduled: &ScheduledExternalActivityCommand,
     sticky: Option<queue::StickyHint<'_>>,
 ) -> HarvestResult<()> {
+    // If the token is already registered the awaiting event was already
+    // appended by a prior run.  A workflow woken by a signal while still
+    // waiting for external completion will re-emit ScheduleExternalActivity —
+    // just re-park without duplicating the event.
+    if external_task::find_by_token(conn, scheduled.token)
+        .await?
+        .is_some()
+    {
+        return queue::park_workflow_task(conn, task_id, sticky).await;
+    }
+
     let marker_events = marker_events_from_commands(commands);
     let awaiting_event = WorkflowEvent::ActivityAwaitingExternal {
         activity_id: scheduled.activity_id,

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -1497,12 +1497,22 @@ async fn persist_scheduled_external_activity(
             async move {
                 let locked = external_task::find_by_token_locked(conn, token).await?;
 
+                // Recompute the event offset inside the transaction: external
+                // completion may have appended a terminal event between replay
+                // start (when next_event_id was sampled) and here.  Using
+                // append_single_event serialises each append against concurrent
+                // writers via the per-execution FOR UPDATE it acquires.
                 let marker_events = marker_events_from_commands(commands);
-                if !marker_events.is_empty() {
-                    store::append_events(conn, exec_id, &marker_events, next_event_id).await?;
+                for event in marker_events {
+                    store::append_single_event(conn, exec_id, event).await?;
                 }
 
                 if locked.is_some_and(|t| t.state != "PENDING") {
+                    // The task is still RUNNING (owned by this worker), so
+                    // wake_workflow_task (which only moves parked rows) is a
+                    // no-op.  Park first to clear worker ownership, then wake
+                    // so the next available worker picks up the terminal event.
+                    queue::park_workflow_task(conn, task_id, sticky).await?;
                     queue::wake_workflow_task(conn, exec_id).await
                 } else {
                     queue::park_workflow_task(conn, task_id, sticky).await

--- a/autumn-harvest/tests/external_completion_tests.rs
+++ b/autumn-harvest/tests/external_completion_tests.rs
@@ -611,3 +611,103 @@ async fn context_execute_activity_external_detects_non_determinism() {
     );
     assert!(ctx.drain_commands().is_empty());
 }
+
+#[tokio::test]
+async fn context_double_complete_is_idempotent_replay() {
+    // Simulates the "double-complete" scenario at the replay layer:
+    // if ActivityCompletedExternally is already in history, a second call to
+    // execute_activity_external returns the same recorded output without
+    // suspending or emitting new commands.
+    let activity_id = ActivityExecId::new();
+    let token = ExternalActivityToken::new();
+    let output = serde_json::json!({"approved": true});
+
+    let events = vec![
+        WorkflowEvent::WorkflowStarted {
+            input: Value::Null,
+            timestamp: Utc::now(),
+        },
+        WorkflowEvent::ActivityAwaitingExternal {
+            activity_id,
+            token,
+            name: "approve_expense".into(),
+            input: Value::Null,
+            queue: "approvals".into(),
+            schedule_to_close_secs: 86400,
+        },
+        WorkflowEvent::ActivityCompletedExternally {
+            activity_id,
+            token,
+            output: output.clone(),
+        },
+    ];
+
+    let ctx = WorkflowContext::for_replay(ExecutionId::new(), events);
+
+    // First call — replays from history.
+    let result1 = ctx
+        .execute_activity_external("approve_expense", Value::Null, "approvals", 86400)
+        .await;
+    assert!(result1.is_ok(), "first call must succeed: {result1:?}");
+    assert_eq!(result1.unwrap(), output);
+
+    // No live commands emitted during a pure replay.
+    assert!(ctx.drain_commands().is_empty());
+}
+
+#[tokio::test]
+async fn context_post_restart_while_awaiting_with_deadline_extensions() {
+    // After a process restart, the workflow is re-run from scratch.  History
+    // contains ActivityAwaitingExternal + two deadline extensions but no
+    // terminal event.  The context must:
+    //   (a) return AwaitingExternalCompletion (not a terminal result), and
+    //   (b) re-emit ScheduleExternalActivity with the SAME token and activity_id.
+    let activity_id = ActivityExecId::new();
+    let token = ExternalActivityToken::new();
+
+    let events = vec![
+        WorkflowEvent::WorkflowStarted {
+            input: Value::Null,
+            timestamp: Utc::now(),
+        },
+        WorkflowEvent::ActivityAwaitingExternal {
+            activity_id,
+            token,
+            name: "approve_expense".into(),
+            input: Value::Null,
+            queue: "approvals".into(),
+            schedule_to_close_secs: 86400,
+        },
+        WorkflowEvent::ActivityExternalDeadlineExtended { activity_id, token },
+        WorkflowEvent::ActivityExternalDeadlineExtended { activity_id, token },
+    ];
+
+    let ctx = Arc::new(WorkflowContext::for_replay(ExecutionId::new(), events));
+    let ctx2 = Arc::clone(&ctx);
+
+    let handle = tokio::spawn(async move {
+        ctx2.execute_activity_external("approve_expense", Value::Null, "approvals", 86400)
+            .await
+    });
+
+    tokio::task::yield_now().await;
+
+    let cmds = ctx.drain_commands();
+    assert_eq!(cmds.len(), 1, "must re-emit exactly one command");
+
+    let WorkflowCommand::ScheduleExternalActivity {
+        token: emitted_token,
+        activity_id: emitted_id,
+        name,
+        ..
+    } = &cmds[0]
+    else {
+        panic!("expected ScheduleExternalActivity, got {:?}", cmds[0]);
+    };
+
+    assert_eq!(*emitted_token, token, "token must be preserved across restart");
+    assert_eq!(*emitted_id, activity_id, "activity_id must be preserved");
+    assert_eq!(name, "approve_expense");
+
+    handle.abort();
+}

--- a/autumn-harvest/tests/external_completion_tests.rs
+++ b/autumn-harvest/tests/external_completion_tests.rs
@@ -1,0 +1,613 @@
+//! Tests for async/external activity completion via task tokens (issue #92).
+//!
+//! These tests cover the core engine behaviour (no DB required):
+//! - New event variants serialize and deserialize correctly
+//! - `execute_activity_external` suspends and emits a command on first call
+//! - Replay returns recorded output when `ActivityCompletedExternally` is in history
+//! - Replay returns recorded failure when `ActivityFailedExternally` is in history
+//! - Replay returns timeout when `ActivityTimedOut` is in history
+//! - Re-emission of the same token when awaiting but no terminal event exists yet
+//! - `all_type_names_are_unique` extended with the four new variants
+//!
+//! The integration/DB tests live in `tests/integration_e2e.rs` behind the `db`
+//! feature flag.
+
+use std::sync::Arc;
+
+use autumn_harvest::context::{WorkflowCommand, WorkflowContext};
+use autumn_harvest::error::{HarvestError, TimeoutType};
+use autumn_harvest::event::WorkflowEvent;
+use autumn_harvest::replay::HistoryMatcher;
+use autumn_harvest::types::{ActivityExecId, ExecutionId, ExternalActivityToken};
+use chrono::Utc;
+use serde_json::Value;
+
+// ---------------------------------------------------------------------------
+// Event serialization
+// ---------------------------------------------------------------------------
+
+#[test]
+fn activity_awaiting_external_round_trips_serde() {
+    let activity_id = ActivityExecId::new();
+    let token = ExternalActivityToken::new();
+    let event = WorkflowEvent::ActivityAwaitingExternal {
+        activity_id,
+        token,
+        name: "approve_expense".to_string(),
+        input: serde_json::json!({"amount": 500}),
+        queue: "approvals".to_string(),
+        schedule_to_close_secs: 86400,
+    };
+    let json = serde_json::to_string(&event).expect("serialize");
+    let back: WorkflowEvent = serde_json::from_str(&json).expect("deserialize");
+    assert!(matches!(back, WorkflowEvent::ActivityAwaitingExternal { .. }));
+}
+
+#[test]
+fn activity_completed_externally_round_trips_serde() {
+    let activity_id = ActivityExecId::new();
+    let token = ExternalActivityToken::new();
+    let event = WorkflowEvent::ActivityCompletedExternally {
+        activity_id,
+        token,
+        output: serde_json::json!({"approved": true}),
+    };
+    let json = serde_json::to_string(&event).expect("serialize");
+    let back: WorkflowEvent = serde_json::from_str(&json).expect("deserialize");
+    assert!(matches!(back, WorkflowEvent::ActivityCompletedExternally { .. }));
+}
+
+#[test]
+fn activity_failed_externally_round_trips_serde() {
+    let activity_id = ActivityExecId::new();
+    let token = ExternalActivityToken::new();
+    let event = WorkflowEvent::ActivityFailedExternally {
+        activity_id,
+        token,
+        error: "manager rejected".to_string(),
+        retryable: false,
+    };
+    let json = serde_json::to_string(&event).expect("serialize");
+    let back: WorkflowEvent = serde_json::from_str(&json).expect("deserialize");
+    assert!(matches!(back, WorkflowEvent::ActivityFailedExternally { .. }));
+}
+
+#[test]
+fn activity_external_deadline_extended_round_trips_serde() {
+    let activity_id = ActivityExecId::new();
+    let token = ExternalActivityToken::new();
+    let event = WorkflowEvent::ActivityExternalDeadlineExtended { activity_id, token };
+    let json = serde_json::to_string(&event).expect("serialize");
+    let back: WorkflowEvent = serde_json::from_str(&json).expect("deserialize");
+    assert!(matches!(
+        back,
+        WorkflowEvent::ActivityExternalDeadlineExtended { .. }
+    ));
+}
+
+#[test]
+fn external_event_type_names_are_stable() {
+    let activity_id = ActivityExecId::new();
+    let token = ExternalActivityToken::new();
+
+    assert_eq!(
+        WorkflowEvent::ActivityAwaitingExternal {
+            activity_id,
+            token,
+            name: "x".into(),
+            input: Value::Null,
+            queue: "default".into(),
+            schedule_to_close_secs: 0,
+        }
+        .type_name(),
+        "ActivityAwaitingExternal"
+    );
+    assert_eq!(
+        WorkflowEvent::ActivityCompletedExternally {
+            activity_id,
+            token,
+            output: Value::Null,
+        }
+        .type_name(),
+        "ActivityCompletedExternally"
+    );
+    assert_eq!(
+        WorkflowEvent::ActivityFailedExternally {
+            activity_id,
+            token,
+            error: "x".into(),
+            retryable: false,
+        }
+        .type_name(),
+        "ActivityFailedExternally"
+    );
+    assert_eq!(
+        WorkflowEvent::ActivityExternalDeadlineExtended { activity_id, token }.type_name(),
+        "ActivityExternalDeadlineExtended"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// HistoryMatcher — match_external_activity
+// ---------------------------------------------------------------------------
+
+#[test]
+fn matcher_replays_completed_external_activity() {
+    let activity_id = ActivityExecId::new();
+    let token = ExternalActivityToken::new();
+    let output = serde_json::json!({"approved": true});
+
+    let events = vec![
+        WorkflowEvent::ActivityAwaitingExternal {
+            activity_id,
+            token,
+            name: "approve_expense".into(),
+            input: Value::Null,
+            queue: "default".into(),
+            schedule_to_close_secs: 86400,
+        },
+        WorkflowEvent::ActivityCompletedExternally {
+            activity_id,
+            token,
+            output: output.clone(),
+        },
+    ];
+
+    let mut matcher = HistoryMatcher::new(events);
+    let result = matcher.match_external_activity("approve_expense");
+
+    assert!(
+        matches!(&result, autumn_harvest::replay::HistoryMatch::Matched { output: o } if o == &output),
+        "expected Matched, got {result:?}"
+    );
+    assert_eq!(matcher.position(), 2);
+    assert!(!matcher.is_replaying());
+}
+
+#[test]
+fn matcher_replays_failed_external_activity() {
+    let activity_id = ActivityExecId::new();
+    let token = ExternalActivityToken::new();
+
+    let events = vec![
+        WorkflowEvent::ActivityAwaitingExternal {
+            activity_id,
+            token,
+            name: "approve_expense".into(),
+            input: Value::Null,
+            queue: "default".into(),
+            schedule_to_close_secs: 86400,
+        },
+        WorkflowEvent::ActivityFailedExternally {
+            activity_id,
+            token,
+            error: "manager rejected".into(),
+            retryable: false,
+        },
+    ];
+
+    let mut matcher = HistoryMatcher::new(events);
+    let result = matcher.match_external_activity("approve_expense");
+
+    assert!(
+        matches!(&result, autumn_harvest::replay::HistoryMatch::Failed { error, .. } if error == "manager rejected"),
+        "expected Failed, got {result:?}"
+    );
+}
+
+#[test]
+fn matcher_replays_timed_out_external_activity() {
+    let activity_id = ActivityExecId::new();
+    let token = ExternalActivityToken::new();
+
+    let events = vec![
+        WorkflowEvent::ActivityAwaitingExternal {
+            activity_id,
+            token,
+            name: "approve_expense".into(),
+            input: Value::Null,
+            queue: "default".into(),
+            schedule_to_close_secs: 86400,
+        },
+        WorkflowEvent::ActivityTimedOut {
+            activity_id,
+            timeout_type: autumn_harvest::error::TimeoutType::ScheduleToClose,
+        },
+    ];
+
+    let mut matcher = HistoryMatcher::new(events);
+    let result = matcher.match_external_activity("approve_expense");
+
+    assert!(
+        matches!(
+            &result,
+            autumn_harvest::replay::HistoryMatch::TimedOut {
+                timeout_type: TimeoutType::ScheduleToClose,
+            }
+        ),
+        "expected TimedOut, got {result:?}"
+    );
+}
+
+#[test]
+fn matcher_returns_awaiting_when_no_terminal_event() {
+    let activity_id = ActivityExecId::new();
+    let token = ExternalActivityToken::new();
+
+    let events = vec![WorkflowEvent::ActivityAwaitingExternal {
+        activity_id,
+        token,
+        name: "approve_expense".into(),
+        input: Value::Null,
+        queue: "default".into(),
+        schedule_to_close_secs: 86400,
+    }];
+
+    let mut matcher = HistoryMatcher::new(events);
+    let result = matcher.match_external_activity("approve_expense");
+
+    match result {
+        autumn_harvest::replay::HistoryMatch::AwaitingExternalCompletion {
+            activity_id: aid,
+            token: tok,
+        } => {
+            assert_eq!(aid, activity_id);
+            assert_eq!(tok, token);
+        }
+        other => panic!("expected AwaitingExternalCompletion, got {other:?}"),
+    }
+}
+
+#[test]
+fn matcher_diverges_on_wrong_name_for_external_activity() {
+    let activity_id = ActivityExecId::new();
+    let token = ExternalActivityToken::new();
+
+    let events = vec![WorkflowEvent::ActivityAwaitingExternal {
+        activity_id,
+        token,
+        name: "approve_expense".into(),
+        input: Value::Null,
+        queue: "default".into(),
+        schedule_to_close_secs: 86400,
+    }];
+
+    let mut matcher = HistoryMatcher::new(events);
+    let result = matcher.match_external_activity("different_activity");
+
+    assert!(
+        matches!(result, autumn_harvest::replay::HistoryMatch::Diverged { .. }),
+        "expected Diverged, got {result:?}"
+    );
+}
+
+#[test]
+fn matcher_no_match_past_end_of_history_for_external_activity() {
+    let mut matcher = HistoryMatcher::new(vec![]);
+    let result = matcher.match_external_activity("approve_expense");
+    assert!(
+        matches!(result, autumn_harvest::replay::HistoryMatch::NoMatch),
+        "expected NoMatch, got {result:?}"
+    );
+}
+
+#[test]
+fn matcher_skips_deadline_extended_events_between_awaiting_and_terminal() {
+    let activity_id = ActivityExecId::new();
+    let token = ExternalActivityToken::new();
+    let output = serde_json::json!({"ok": true});
+
+    let events = vec![
+        WorkflowEvent::ActivityAwaitingExternal {
+            activity_id,
+            token,
+            name: "approve_expense".into(),
+            input: Value::Null,
+            queue: "default".into(),
+            schedule_to_close_secs: 86400,
+        },
+        WorkflowEvent::ActivityExternalDeadlineExtended { activity_id, token },
+        WorkflowEvent::ActivityExternalDeadlineExtended { activity_id, token },
+        WorkflowEvent::ActivityCompletedExternally {
+            activity_id,
+            token,
+            output: output.clone(),
+        },
+    ];
+
+    let mut matcher = HistoryMatcher::new(events);
+    let result = matcher.match_external_activity("approve_expense");
+
+    assert!(
+        matches!(&result, autumn_harvest::replay::HistoryMatch::Matched { output: o } if o == &output),
+        "expected Matched, got {result:?}"
+    );
+    assert_eq!(matcher.position(), 4);
+}
+
+// ---------------------------------------------------------------------------
+// WorkflowContext — execute_activity_external
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn context_execute_activity_external_suspends_on_first_call() {
+    let ctx = Arc::new(WorkflowContext::new_test());
+    let ctx2 = Arc::clone(&ctx);
+
+    let handle = tokio::spawn(async move {
+        ctx2.execute_activity_external("approve_expense", Value::Null, "approvals", 86400)
+            .await
+    });
+
+    // Give the coroutine time to emit the command and suspend.
+    tokio::task::yield_now().await;
+
+    let cmds = ctx.drain_commands();
+    assert_eq!(cmds.len(), 1, "expected exactly one command");
+
+    match &cmds[0] {
+        WorkflowCommand::ScheduleExternalActivity {
+            name,
+            queue,
+            schedule_to_close_secs,
+            ..
+        } => {
+            assert_eq!(name, "approve_expense");
+            assert_eq!(queue, "approvals");
+            assert_eq!(*schedule_to_close_secs, 86400);
+        }
+        other => panic!("expected ScheduleExternalActivity, got {other:?}"),
+    }
+
+    handle.abort();
+}
+
+#[tokio::test]
+async fn context_execute_activity_external_emits_unique_token() {
+    let ctx = Arc::new(WorkflowContext::new_test());
+    let ctx2 = Arc::clone(&ctx);
+
+    let handle = tokio::spawn(async move {
+        ctx2.execute_activity_external("approve_expense", Value::Null, "approvals", 86400)
+            .await
+    });
+
+    tokio::task::yield_now().await;
+
+    let cmds = ctx.drain_commands();
+    assert_eq!(cmds.len(), 1);
+
+    let WorkflowCommand::ScheduleExternalActivity { token, .. } = &cmds[0] else {
+        panic!("expected ScheduleExternalActivity");
+    };
+    // Token must be a valid UUID (non-nil).
+    assert_ne!(*token, ExternalActivityToken::nil());
+
+    handle.abort();
+}
+
+#[tokio::test]
+async fn context_execute_activity_external_resolves_via_oneshot() {
+    let ctx = Arc::new(WorkflowContext::new_test());
+    let ctx2 = Arc::clone(&ctx);
+    let expected = serde_json::json!({"approved": true});
+    let expected2 = expected.clone();
+
+    let handle = tokio::spawn(async move {
+        ctx2.execute_activity_external("approve_expense", Value::Null, "approvals", 86400)
+            .await
+    });
+
+    tokio::task::yield_now().await;
+
+    let mut cmds = ctx.drain_commands();
+    let WorkflowCommand::ScheduleExternalActivity { result_tx, .. } = cmds.remove(0) else {
+        panic!("expected ScheduleExternalActivity");
+    };
+    result_tx
+        .send(Ok(expected2))
+        .expect("send should succeed");
+
+    let result = handle.await.expect("no panic");
+    assert!(result.is_ok());
+    assert_eq!(result.unwrap(), expected);
+}
+
+#[tokio::test]
+async fn context_replays_completed_external_activity() {
+    let activity_id = ActivityExecId::new();
+    let token = ExternalActivityToken::new();
+    let output = serde_json::json!({"approved": true});
+
+    let events = vec![
+        WorkflowEvent::WorkflowStarted {
+            input: Value::Null,
+            timestamp: Utc::now(),
+        },
+        WorkflowEvent::ActivityAwaitingExternal {
+            activity_id,
+            token,
+            name: "approve_expense".into(),
+            input: Value::Null,
+            queue: "approvals".into(),
+            schedule_to_close_secs: 86400,
+        },
+        WorkflowEvent::ActivityCompletedExternally {
+            activity_id,
+            token,
+            output: output.clone(),
+        },
+    ];
+
+    let ctx = WorkflowContext::for_replay(ExecutionId::new(), events);
+    let result = ctx
+        .execute_activity_external("approve_expense", Value::Null, "approvals", 86400)
+        .await;
+
+    assert!(result.is_ok(), "expected Ok, got {result:?}");
+    assert_eq!(result.unwrap(), output);
+
+    // No live commands should be emitted during full replay.
+    assert!(ctx.drain_commands().is_empty());
+    assert!(!ctx.is_replaying());
+}
+
+#[tokio::test]
+async fn context_replays_failed_external_activity() {
+    let activity_id = ActivityExecId::new();
+    let token = ExternalActivityToken::new();
+
+    let events = vec![
+        WorkflowEvent::WorkflowStarted {
+            input: Value::Null,
+            timestamp: Utc::now(),
+        },
+        WorkflowEvent::ActivityAwaitingExternal {
+            activity_id,
+            token,
+            name: "approve_expense".into(),
+            input: Value::Null,
+            queue: "approvals".into(),
+            schedule_to_close_secs: 86400,
+        },
+        WorkflowEvent::ActivityFailedExternally {
+            activity_id,
+            token,
+            error: "manager rejected".into(),
+            retryable: false,
+        },
+    ];
+
+    let ctx = WorkflowContext::for_replay(ExecutionId::new(), events);
+    let result = ctx
+        .execute_activity_external("approve_expense", Value::Null, "approvals", 86400)
+        .await;
+
+    assert!(result.is_err());
+    assert!(matches!(result.unwrap_err(), HarvestError::ActivityFailed { .. }));
+}
+
+#[tokio::test]
+async fn context_replays_timed_out_external_activity() {
+    let activity_id = ActivityExecId::new();
+    let token = ExternalActivityToken::new();
+
+    let events = vec![
+        WorkflowEvent::WorkflowStarted {
+            input: Value::Null,
+            timestamp: Utc::now(),
+        },
+        WorkflowEvent::ActivityAwaitingExternal {
+            activity_id,
+            token,
+            name: "approve_expense".into(),
+            input: Value::Null,
+            queue: "approvals".into(),
+            schedule_to_close_secs: 86400,
+        },
+        WorkflowEvent::ActivityTimedOut {
+            activity_id,
+            timeout_type: TimeoutType::ScheduleToClose,
+        },
+    ];
+
+    let ctx = WorkflowContext::for_replay(ExecutionId::new(), events);
+    let result = ctx
+        .execute_activity_external("approve_expense", Value::Null, "approvals", 86400)
+        .await;
+
+    assert!(matches!(
+        result,
+        Err(HarvestError::Timeout {
+            timeout_type: TimeoutType::ScheduleToClose,
+            ..
+        })
+    ));
+}
+
+#[tokio::test]
+async fn context_awaiting_external_re_emits_same_token_idempotently() {
+    // When history has ActivityAwaitingExternal but no terminal, the context
+    // should re-emit ScheduleExternalActivity with the SAME token from history.
+    let activity_id = ActivityExecId::new();
+    let token = ExternalActivityToken::new();
+
+    let events = vec![
+        WorkflowEvent::WorkflowStarted {
+            input: Value::Null,
+            timestamp: Utc::now(),
+        },
+        WorkflowEvent::ActivityAwaitingExternal {
+            activity_id,
+            token,
+            name: "approve_expense".into(),
+            input: Value::Null,
+            queue: "approvals".into(),
+            schedule_to_close_secs: 86400,
+        },
+    ];
+
+    let ctx = Arc::new(WorkflowContext::for_replay(ExecutionId::new(), events));
+    let ctx2 = Arc::clone(&ctx);
+
+    let handle = tokio::spawn(async move {
+        ctx2.execute_activity_external("approve_expense", Value::Null, "approvals", 86400)
+            .await
+    });
+
+    tokio::task::yield_now().await;
+
+    let cmds = ctx.drain_commands();
+    assert_eq!(cmds.len(), 1, "should re-emit idempotent command");
+    let WorkflowCommand::ScheduleExternalActivity {
+        token: emitted_token,
+        activity_id: emitted_id,
+        ..
+    } = &cmds[0]
+    else {
+        panic!("expected ScheduleExternalActivity");
+    };
+    // Crucially, the token and activity_id must match what's already in history.
+    assert_eq!(*emitted_token, token, "token must be reused from history");
+    assert_eq!(*emitted_id, activity_id, "activity_id must be reused from history");
+
+    handle.abort();
+}
+
+#[tokio::test]
+async fn context_execute_activity_external_detects_non_determinism() {
+    let activity_id = ActivityExecId::new();
+    let token = ExternalActivityToken::new();
+
+    let events = vec![
+        WorkflowEvent::WorkflowStarted {
+            input: Value::Null,
+            timestamp: Utc::now(),
+        },
+        WorkflowEvent::ActivityAwaitingExternal {
+            activity_id,
+            token,
+            name: "approve_expense".into(),
+            input: Value::Null,
+            queue: "approvals".into(),
+            schedule_to_close_secs: 86400,
+        },
+        WorkflowEvent::ActivityCompletedExternally {
+            activity_id,
+            token,
+            output: Value::Null,
+        },
+    ];
+
+    let ctx = WorkflowContext::for_replay(ExecutionId::new(), events);
+    // Call with a DIFFERENT name → should be non-deterministic.
+    let result = ctx
+        .execute_activity_external("different_activity", Value::Null, "approvals", 86400)
+        .await;
+
+    assert!(
+        matches!(result, Err(HarvestError::NonDeterministic(_))),
+        "expected NonDeterministic, got {result:?}"
+    );
+    assert!(ctx.drain_commands().is_empty());
+}

--- a/autumn-harvest/tests/external_completion_tests.rs
+++ b/autumn-harvest/tests/external_completion_tests.rs
@@ -40,7 +40,10 @@ fn activity_awaiting_external_round_trips_serde() {
     };
     let json = serde_json::to_string(&event).expect("serialize");
     let back: WorkflowEvent = serde_json::from_str(&json).expect("deserialize");
-    assert!(matches!(back, WorkflowEvent::ActivityAwaitingExternal { .. }));
+    assert!(matches!(
+        back,
+        WorkflowEvent::ActivityAwaitingExternal { .. }
+    ));
 }
 
 #[test]
@@ -54,7 +57,10 @@ fn activity_completed_externally_round_trips_serde() {
     };
     let json = serde_json::to_string(&event).expect("serialize");
     let back: WorkflowEvent = serde_json::from_str(&json).expect("deserialize");
-    assert!(matches!(back, WorkflowEvent::ActivityCompletedExternally { .. }));
+    assert!(matches!(
+        back,
+        WorkflowEvent::ActivityCompletedExternally { .. }
+    ));
 }
 
 #[test]
@@ -69,7 +75,10 @@ fn activity_failed_externally_round_trips_serde() {
     };
     let json = serde_json::to_string(&event).expect("serialize");
     let back: WorkflowEvent = serde_json::from_str(&json).expect("deserialize");
-    assert!(matches!(back, WorkflowEvent::ActivityFailedExternally { .. }));
+    assert!(matches!(
+        back,
+        WorkflowEvent::ActivityFailedExternally { .. }
+    ));
 }
 
 #[test]
@@ -276,7 +285,10 @@ fn matcher_diverges_on_wrong_name_for_external_activity() {
     let result = matcher.match_external_activity("different_activity");
 
     assert!(
-        matches!(result, autumn_harvest::replay::HistoryMatch::Diverged { .. }),
+        matches!(
+            result,
+            autumn_harvest::replay::HistoryMatch::Diverged { .. }
+        ),
         "expected Diverged, got {result:?}"
     );
 }
@@ -404,9 +416,7 @@ async fn context_execute_activity_external_resolves_via_oneshot() {
     let WorkflowCommand::ScheduleExternalActivity { result_tx, .. } = cmds.remove(0) else {
         panic!("expected ScheduleExternalActivity");
     };
-    result_tx
-        .send(Ok(expected2))
-        .expect("send should succeed");
+    result_tx.send(Ok(expected2)).expect("send should succeed");
 
     let result = handle.await.expect("no panic");
     assert!(result.is_ok());
@@ -484,7 +494,10 @@ async fn context_replays_failed_external_activity() {
         .await;
 
     assert!(result.is_err());
-    assert!(matches!(result.unwrap_err(), HarvestError::ActivityFailed { .. }));
+    assert!(matches!(
+        result.unwrap_err(),
+        HarvestError::ActivityFailed { .. }
+    ));
 }
 
 #[tokio::test]
@@ -569,7 +582,10 @@ async fn context_awaiting_external_re_emits_same_token_idempotently() {
     };
     // Crucially, the token and activity_id must match what's already in history.
     assert_eq!(*emitted_token, token, "token must be reused from history");
-    assert_eq!(*emitted_id, activity_id, "activity_id must be reused from history");
+    assert_eq!(
+        *emitted_id, activity_id,
+        "activity_id must be reused from history"
+    );
 
     handle.abort();
 }
@@ -705,7 +721,10 @@ async fn context_post_restart_while_awaiting_with_deadline_extensions() {
         panic!("expected ScheduleExternalActivity, got {:?}", cmds[0]);
     };
 
-    assert_eq!(*emitted_token, token, "token must be preserved across restart");
+    assert_eq!(
+        *emitted_token, token,
+        "token must be preserved across restart"
+    );
     assert_eq!(*emitted_id, activity_id, "activity_id must be preserved");
     assert_eq!(name, "approve_expense");
 

--- a/autumn-harvest/tests/integration_e2e.rs
+++ b/autumn-harvest/tests/integration_e2e.rs
@@ -59,6 +59,8 @@ const INIT_SQL: &str = concat!(
     include_str!("../migrations/20260429000000_harvest_concurrency_key/up.sql"),
     "\n",
     include_str!("../migrations/20260430000000_harvest_workflow_schedules/up.sql"),
+    "\n",
+    include_str!("../migrations/20260430000001_harvest_external_tasks/up.sql"),
 );
 
 /// The minimal "legacy" migration set used by the upgrade-path regression


### PR DESCRIPTION
## Summary

Implements async/external activity completion for workflows via opaque task tokens. This allows workflows to suspend without occupying a worker slot while waiting for external systems (approvals, webhooks, human decisions) to deliver results through a management API.

## Key Changes

- **New Event Types**: Added four new `WorkflowEvent` variants:
  - `ActivityAwaitingExternal`: Records when a workflow schedules an external activity with a token
  - `ActivityCompletedExternally`: Records successful completion via the management API
  - `ActivityFailedExternally`: Records failure reported by external system
  - `ActivityExternalDeadlineExtended`: Records deadline extensions via heartbeat

- **WorkflowContext API**: Added `execute_activity_external()` method that:
  - Emits a `ScheduleExternalActivity` command with a unique token
  - Suspends the workflow without blocking a worker slot
  - Returns the result when external completion arrives (via oneshot channel)
  - Properly replays from history during workflow re-execution

- **Database Layer**:
  - New `harvest_external_tasks` table with indexed token lookup for O(log n) resolution
  - `external_task` module with functions to record, complete, fail, and extend external activities
  - Transactional state machine (PENDING → COMPLETED/FAILED/TIMED_OUT) with idempotent operations

- **Management API Endpoints** (`autumn-harvest-plugin`):
  - `POST /activities/external/{token}/complete`: Deliver successful result
  - `POST /activities/external/{token}/fail`: Report failure with optional retry flag
  - `POST /activities/external/{token}/heartbeat`: Extend schedule-to-close deadline

- **Replay & History Matching**:
  - `HistoryMatcher::match_external_activity()` handles replay of external activities
  - Skips `ActivityExternalDeadlineExtended` events when scanning for terminal state
  - Returns `AwaitingExternalCompletion` when scheduled but no terminal event exists yet

- **Example & Tests**:
  - New `approval_workflow.rs` example demonstrating manager-approval use case
  - Comprehensive test suite (`external_completion_tests.rs`) covering:
    - Event serialization round-trips
    - Replay scenarios (completed, failed, timed out)
    - Idempotent re-emission of same token when awaiting
    - History matcher behavior with deadline extensions

## Implementation Details

- Tokens are single-use UUIDs embedded in events and round-tripped by external systems
- External activities don't occupy worker slots; the workflow is re-run when completion arrives
- Deadline extensions are recorded as events but don't affect replay logic
- All external-task operations are transactional and idempotent at the worker level
- The `ScheduleExternalActivity` command includes a oneshot channel for same-cycle completion (rare edge case)

https://claude.ai/code/session_01H3RsTFb9mTr6mwKGg2vcd7