### PR TITLE
⚡ Bolt: Removed unnecessary clone in scheduler tick

### DIFF
--- a/autumn-harvest/src/scheduler.rs
+++ b/autumn-harvest/src/scheduler.rs
@@ -707,7 +707,7 @@ async fn tick_workflow_schedules(
         .map_err(crate::error::database_error)?;
 
     for schedule in due {
-        let Some(ref wf_name) = schedule.workflow_name.clone() else {
+        let Some(ref wf_name) = schedule.workflow_name else {
             continue;
         };
         let Some(logical_date) = schedule.next_run_at else {


### PR DESCRIPTION
💡 What: Removed unnecessary `.clone()` on `schedule.workflow_name` in `scheduler.rs`.
🎯 Why: Inside the `tick_workflow_schedules` loop, `schedule.workflow_name.clone()` was being destructured using a `ref` binding. This was creating a heap allocation per workflow schedule, per scheduler tick, only to immediately borrow the value.
📊 Impact: Removes one heap allocation per workflow schedule every time the scheduler loop iterates.
🔬 Measurement: Run `cargo check`, `cargo clippy`, and `cargo test -p autumn-harvest --lib`. Verify that the change compiles, borrow checker is happy, and tests pass.

---
*PR created automatically by Jules for task [11983083317880730315](https://jules.google.com/task/11983083317880730315) started by @madmax983*