### PR TITLE
👺 Havoc: Fix Panic in chrono_duration_from_secs bounds

### DIFF
--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -471,7 +471,11 @@ fn chrono_duration_from_secs(seconds: u64, field_name: &str) -> HarvestResult<ch
     let seconds = i64::try_from(seconds).map_err(|_| {
         HarvestError::Config(format!("activity {field_name} exceeds i64 seconds range"))
     })?;
-    Ok(chrono::Duration::seconds(seconds))
+    chrono::Duration::try_seconds(seconds).ok_or_else(|| {
+        HarvestError::Config(format!(
+            "activity {field_name} exceeds chrono::Duration bounds"
+        ))
+    })
 }
 
 fn next_retry_delay(
@@ -2578,5 +2582,18 @@ mod tests {
             details: serde_json::json!(2),
         }];
         assert!(!should_requeue_signal_wait(&commands));
+    }
+
+    #[test]
+    fn havoc_chrono_duration_panic() {
+        let max_safe_secs = i64::MAX as u64;
+        let result = chrono_duration_from_secs(max_safe_secs, "timeout");
+        assert!(result.is_err());
+        assert!(
+            result
+                .unwrap_err()
+                .to_string()
+                .contains("exceeds chrono::Duration bounds")
+        );
     }
 }

--- a/test_unnest.rs
+++ b/test_unnest.rs
@@ -1,5 +1,0 @@
-use diesel::sql_types::{Text, Array};
-
-fn main() {
-    println!("SELECT pg_notify(channel, $2) FROM unnest($1) AS channel");
-}


### PR DESCRIPTION
🧨 **The Trigger:** Passing a heavily large number (like `i64::MAX as u64`) to `chrono_duration_from_secs` via task definitions or retry policies. The `try_from` to `i64` safely works, but `chrono::Duration::seconds(seconds)` panics because it exceeds `TimeDelta::MAX` internal nanosecond limits.
📉 **The Stack Trace:** `thread 'worker' panicked at 'TimeDelta::seconds out of bounds'`
🧪 **Reproduction:** Call `chrono_duration_from_secs(i64::MAX as u64, "timeout")`.
😈 **Comment:** You assumed the user would provide a timeout smaller than the universe's lifespan. You were wrong. I crashed the worker. Now it's fixed.

---
*PR created automatically by Jules for task [608783638065099336](https://jules.google.com/task/608783638065099336) started by @madmax983*