### PR TITLE
ADR 0001: Define OpenTelemetry trace propagation contract

### DIFF
--- a/autumn-harvest/src/telemetry.rs
+++ b/autumn-harvest/src/telemetry.rs
@@ -25,6 +25,69 @@ use std::sync::Arc;
 use serde::{Deserialize, Serialize};
 
 // ---------------------------------------------------------------------------
+// Span attribute name constants
+// Defined by docs/adr/0001-otel-trace-contract.md
+// ---------------------------------------------------------------------------
+
+/// OpenTelemetry span attribute: the logical workflow name (e.g. `"onboarding"`).
+pub const ATTR_WORKFLOW_ID: &str = "harvest.workflow.id";
+
+/// OpenTelemetry span attribute: the unique execution UUID.
+pub const ATTR_EXECUTION_ID: &str = "harvest.execution.id";
+
+/// OpenTelemetry span attribute: the shard number that owns this execution.
+pub const ATTR_SHARD_ID: &str = "harvest.shard.id";
+
+/// OpenTelemetry span attribute: the activity function name (e.g. `"send_email"`).
+pub const ATTR_ACTIVITY_NAME: &str = "harvest.activity.name";
+
+/// OpenTelemetry span attribute: the 1-based attempt number for this activity invocation.
+pub const ATTR_ATTEMPT: &str = "harvest.attempt";
+
+/// OpenTelemetry span attribute: the task queue name the work item was pulled from.
+pub const ATTR_QUEUE: &str = "harvest.queue";
+
+/// OpenTelemetry span attribute for replay-mode spans.
+///
+/// Set to `true` when the span is emitted during deterministic replay rather
+/// than live execution. Consumers must treat such spans as reconstructed
+/// history, not live causality.
+pub const ATTR_REPLAY: &str = "harvest.replay";
+
+// ---------------------------------------------------------------------------
+// Metric name constants
+// Defined by docs/adr/0001-otel-trace-contract.md — OpenTelemetry semantic
+// naming: `harvest.<noun>.<instrument>` in dot-notation.
+// ---------------------------------------------------------------------------
+
+/// Counter: incremented once when a worker starts executing a workflow task.
+pub const METRIC_WORKFLOW_STARTED: &str = "harvest.workflow.started";
+
+/// Histogram: wall-clock seconds a workflow executor cycle took.
+pub const METRIC_WORKFLOW_DURATION: &str = "harvest.workflow.duration";
+
+/// Histogram: wall-clock seconds an activity invocation took (success or failure).
+pub const METRIC_ACTIVITY_DURATION: &str = "harvest.activity.duration";
+
+/// Counter: incremented when a durable timer is persisted.
+pub const METRIC_TIMER_STARTED: &str = "harvest.timer.started";
+
+/// Gauge: current number of pending (unclaimed) tasks in a queue.
+pub const METRIC_QUEUE_DEPTH: &str = "harvest.queue.depth";
+
+/// Gauge: current number of entries in the dead letter queue.
+pub const METRIC_DLQ_ENTRIES: &str = "harvest.dlq.entries";
+
+/// Counter: incremented each time a scheduled run is dispatched.
+pub const METRIC_SCHEDULE_RUNS: &str = "harvest.schedule.runs";
+
+/// Counter: incremented each time a scheduled run is skipped.
+pub const METRIC_SCHEDULE_SKIPPED: &str = "harvest.schedule.skipped";
+
+/// Counter: number of rows deleted by the retention janitor in one tick.
+pub const METRIC_RETENTION_DELETED: &str = "harvest.retention.deleted";
+
+// ---------------------------------------------------------------------------
 // TraceContextCarrier
 // ---------------------------------------------------------------------------
 
@@ -35,16 +98,41 @@ use serde::{Deserialize, Serialize};
 /// `traceparent` (required to join a trace) and `tracestate` (optional
 /// vendor-specific extensions). Storing them as JSONB keeps the schema
 /// flexible if the spec gains additional headers.
+///
+/// The two extra fields (`is_replay`, `link_traceparent`) implement the replay
+/// semantics defined in `docs/adr/0001-otel-trace-contract.md`: replay spans
+/// must NOT inherit the original trace as a parent (it may have long expired),
+/// but they SHOULD carry the original `traceparent` as an OpenTelemetry span
+/// *link* so operators can navigate from a replay span to the original trace
+/// in their APM tool.
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct TraceContextCarrier {
-    /// The W3C `traceparent` header, e.g.
-    /// `00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01`.
+    /// The W3C `traceparent` header for the *parent* span.
+    ///
+    /// During replay this field is `None` — the replay span roots itself and
+    /// links to [`link_traceparent`] instead.
+    ///
+    /// [`link_traceparent`]: TraceContextCarrier::link_traceparent
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub traceparent: Option<String>,
 
     /// The optional W3C `tracestate` header.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub tracestate: Option<String>,
+
+    /// When `true`, the worker must emit the span with attribute
+    /// `harvest.replay = true` and must NOT restore `traceparent` as the
+    /// parent context. Instead, it should create a new root span and attach a
+    /// span *link* pointing at [`link_traceparent`].
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub is_replay: bool,
+
+    /// The original `traceparent` preserved for use as a span *link*.
+    ///
+    /// Only populated when `is_replay == true`. Enables APM navigation from a
+    /// replay-emitted span back to the original (possibly expired) trace root.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub link_traceparent: Option<String>,
 }
 
 impl TraceContextCarrier {
@@ -54,13 +142,36 @@ impl TraceContextCarrier {
         Self {
             traceparent: Some(traceparent.into()),
             tracestate: None,
+            is_replay: false,
+            link_traceparent: None,
         }
     }
 
-    /// Returns `true` when neither `traceparent` nor `tracestate` is set.
+    /// Convert this carrier into a replay carrier.
+    ///
+    /// Per the OpenTelemetry trace contract ADR (`docs/adr/0001-otel-trace-contract.md`):
+    /// - `traceparent` is cleared so the replay span becomes a new root.
+    /// - `link_traceparent` is set to the original `traceparent` so the worker
+    ///   can attach a span *link* for APM navigation.
+    /// - `is_replay` is set to `true` so workers know to emit
+    ///   `harvest.replay = true` and skip parent context installation.
+    #[must_use]
+    pub fn into_replay_context(self) -> Self {
+        Self {
+            link_traceparent: self.traceparent,
+            traceparent: None,
+            tracestate: None,
+            is_replay: true,
+        }
+    }
+
+    /// Returns `true` when no context fields are set (ignoring the replay flag).
     #[must_use]
     pub const fn is_empty(&self) -> bool {
-        self.traceparent.is_none() && self.tracestate.is_none()
+        self.traceparent.is_none()
+            && self.tracestate.is_none()
+            && self.link_traceparent.is_none()
+            && !self.is_replay
     }
 
     /// Serialise to a JSONB-compatible [`serde_json::Value`] suitable for
@@ -409,6 +520,91 @@ impl TelemetryConfigBuilder {
 mod tests {
     use super::*;
 
+    // -----------------------------------------------------------------------
+    // RED-phase tests: these assert the spec-mandated constants and
+    // replay-aware carrier shape defined in docs/adr/0001-otel-trace-contract.md
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn span_attribute_constants_have_correct_names() {
+        // The OTel trace contract ADR mandates these exact attribute keys.
+        assert_eq!(ATTR_WORKFLOW_ID, "harvest.workflow.id");
+        assert_eq!(ATTR_EXECUTION_ID, "harvest.execution.id");
+        assert_eq!(ATTR_SHARD_ID, "harvest.shard.id");
+        assert_eq!(ATTR_ACTIVITY_NAME, "harvest.activity.name");
+        assert_eq!(ATTR_ATTEMPT, "harvest.attempt");
+        assert_eq!(ATTR_QUEUE, "harvest.queue");
+        assert_eq!(ATTR_REPLAY, "harvest.replay");
+    }
+
+    #[test]
+    fn metric_name_constants_have_correct_names() {
+        // OTel semantic naming: instrument.noun (dot-separated).
+        assert_eq!(METRIC_WORKFLOW_STARTED, "harvest.workflow.started");
+        assert_eq!(METRIC_WORKFLOW_DURATION, "harvest.workflow.duration");
+        assert_eq!(METRIC_ACTIVITY_DURATION, "harvest.activity.duration");
+        assert_eq!(METRIC_TIMER_STARTED, "harvest.timer.started");
+        assert_eq!(METRIC_QUEUE_DEPTH, "harvest.queue.depth");
+        assert_eq!(METRIC_DLQ_ENTRIES, "harvest.dlq.entries");
+        assert_eq!(METRIC_SCHEDULE_RUNS, "harvest.schedule.runs");
+        assert_eq!(METRIC_SCHEDULE_SKIPPED, "harvest.schedule.skipped");
+        assert_eq!(METRIC_RETENTION_DELETED, "harvest.retention.deleted");
+    }
+
+    #[test]
+    fn replay_carrier_strips_traceparent_and_preserves_link() {
+        // Per spec: replay spans MUST NOT be parented to the original
+        // (potentially expired) trace — they link to it instead.
+        let original = TraceContextCarrier::from_traceparent(
+            "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+        );
+        let replay = original.into_replay_context();
+        assert!(
+            replay.traceparent.is_none(),
+            "replay carrier must not carry original traceparent as parent"
+        );
+        assert_eq!(
+            replay.link_traceparent.as_deref(),
+            Some("00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"),
+            "replay carrier must preserve original as a span link"
+        );
+        assert!(replay.is_replay, "replay carrier must be flagged harvest.replay = true");
+    }
+
+    #[test]
+    fn non_replay_carrier_has_is_replay_false_and_no_link() {
+        let carrier = TraceContextCarrier::from_traceparent("00-abcd-ef01-01");
+        assert!(!carrier.is_replay);
+        assert!(carrier.link_traceparent.is_none());
+    }
+
+    #[test]
+    fn replay_carrier_from_empty_original_has_no_link() {
+        let empty = TraceContextCarrier::default();
+        let replay = empty.into_replay_context();
+        assert!(replay.traceparent.is_none());
+        assert!(replay.link_traceparent.is_none(), "no link when original had no traceparent");
+        assert!(replay.is_replay);
+    }
+
+    #[test]
+    fn replay_carrier_roundtrips_through_json() {
+        let original = TraceContextCarrier::from_traceparent(
+            "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+        );
+        let replay = original.into_replay_context();
+        // A replay carrier must still serialise / deserialise so it can
+        // travel on harvest_task_queue.trace_context.
+        let json = replay.to_json().expect("replay carrier serialises");
+        let decoded = TraceContextCarrier::from_json(&json).expect("valid JSON roundtrips");
+        assert!(decoded.is_replay);
+        assert_eq!(
+            decoded.link_traceparent.as_deref(),
+            Some("00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"),
+        );
+        assert!(decoded.traceparent.is_none());
+    }
+
     #[test]
     fn carrier_roundtrips_through_json() {
         let carrier = TraceContextCarrier {
@@ -416,6 +612,7 @@ mod tests {
                 "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01".to_string(),
             ),
             tracestate: Some("vendor=abc".to_string()),
+            ..Default::default()
         };
 
         let json = carrier.to_json().expect("non-empty carrier serialises");

--- a/autumn-harvest/src/telemetry.rs
+++ b/autumn-harvest/src/telemetry.rs
@@ -568,7 +568,10 @@ mod tests {
             Some("00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"),
             "replay carrier must preserve original as a span link"
         );
-        assert!(replay.is_replay, "replay carrier must be flagged harvest.replay = true");
+        assert!(
+            replay.is_replay,
+            "replay carrier must be flagged harvest.replay = true"
+        );
     }
 
     #[test]
@@ -583,7 +586,10 @@ mod tests {
         let empty = TraceContextCarrier::default();
         let replay = empty.into_replay_context();
         assert!(replay.traceparent.is_none());
-        assert!(replay.link_traceparent.is_none(), "no link when original had no traceparent");
+        assert!(
+            replay.link_traceparent.is_none(),
+            "no link when original had no traceparent"
+        );
         assert!(replay.is_replay);
     }
 

--- a/autumn-harvest/src/telemetry.rs
+++ b/autumn-harvest/src/telemetry.rs
@@ -158,7 +158,7 @@ impl TraceContextCarrier {
     #[must_use]
     pub fn into_replay_context(self) -> Self {
         Self {
-            link_traceparent: self.traceparent,
+            link_traceparent: self.traceparent.or(self.link_traceparent),
             traceparent: None,
             tracestate: None,
             is_replay: true,
@@ -609,6 +609,26 @@ mod tests {
             Some("00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"),
         );
         assert!(decoded.traceparent.is_none());
+    }
+
+    #[test]
+    fn into_replay_context_on_already_replay_carrier_preserves_link() {
+        // If into_replay_context() is called defensively on a carrier that is
+        // already in replay form (traceparent=None, link_traceparent=Some),
+        // the existing link must not be erased.
+        let original = TraceContextCarrier::from_traceparent(
+            "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
+        );
+        let replay = original.into_replay_context();
+        // Call again — should be idempotent, link must survive.
+        let replay2 = replay.into_replay_context();
+        assert!(replay2.traceparent.is_none());
+        assert!(replay2.is_replay);
+        assert_eq!(
+            replay2.link_traceparent.as_deref(),
+            Some("00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01"),
+            "double-converting a replay carrier must not erase the original link"
+        );
     }
 
     #[test]

--- a/docs/adr/0001-otel-trace-contract.md
+++ b/docs/adr/0001-otel-trace-contract.md
@@ -1,0 +1,358 @@
+# ADR 0001 — OpenTelemetry Trace Propagation Contract
+
+**Status**: Accepted  
+**Date**: 2026-05-01  
+**Issue**: [#93](https://github.com/madmax983/autumn-harvest/issues/93)
+
+---
+
+## Context
+
+The telemetry scaffolding (`TraceContextCarrier`, `TraceContextPropagator`,
+`MetricsRecorder`, `TelemetryConfig`) shipped in `telemetry.rs` with no-op
+defaults and no contract defining *which spans* Harvest emits, *which attributes*
+operators can rely on, or *how trace context interacts with replay*. Without this
+contract, downstream apps cannot wire existing OTel pipelines into Harvest with
+confidence. A trace that begins at the autumn-web HTTP handler vanishes the
+moment it crosses into a workflow, leaving the on-call operator to grep event
+JSON across shards.
+
+This ADR defines the stable, versioned contract for:
+
+- Every span Harvest emits (name, kind, parent rules, required attributes)
+- Trace context propagation across every workflow boundary
+- Replay semantics for spans
+- Where trace context is durably stored and where it is explicitly **not**
+- Metric names and cardinality constraints
+
+---
+
+## Decision
+
+### 1. Span attribute schema
+
+The following constants are defined in `telemetry.rs` and must be used
+verbatim on every span Harvest emits. The concrete Rust constants are the
+source of truth — the strings below repeat them for documentation clarity.
+
+| Rust constant          | Attribute key              | Type      | Cardinality          | Notes                                                  |
+|------------------------|----------------------------|-----------|----------------------|--------------------------------------------------------|
+| `ATTR_WORKFLOW_ID`     | `harvest.workflow.id`      | `string`  | bounded by reg.      | Logical workflow name (e.g. `"onboarding"`)            |
+| `ATTR_EXECUTION_ID`    | `harvest.execution.id`     | `string`  | unbounded — no label | UUID of this specific run; see §7 for label guidance   |
+| `ATTR_SHARD_ID`        | `harvest.shard.id`         | `int`     | bounded (≤ 256)      | Shard number encoding in execution UUID                |
+| `ATTR_ACTIVITY_NAME`   | `harvest.activity.name`    | `string`  | bounded by reg.      | Activity function name (e.g. `"send_email"`)           |
+| `ATTR_ATTEMPT`         | `harvest.attempt`          | `int`     | bounded (≤ max_retry)| 1-based attempt number                                 |
+| `ATTR_QUEUE`           | `harvest.queue`            | `string`  | bounded by config    | Task queue name                                        |
+| `ATTR_REPLAY`          | `harvest.replay`           | `bool`    | 2 values             | `true` on spans emitted during deterministic replay    |
+
+**OTel semantic convention alignment**: Harvest does not yet have upstream OTel
+semconv entries. Until registered, the `harvest.*` namespace is used to avoid
+conflicts with `workflow.*` (reserved by OTel SIG-Workflow) and `db.*`.
+
+---
+
+### 2. Span catalogue
+
+Every span Harvest emits is listed below.  Spans using the `db` feature are
+only emitted when the `db` Cargo feature is active (the default).
+
+#### 2.1 `harvest.workflow.execute` — workflow executor cycle
+
+| Property        | Value                                                     |
+|-----------------|-----------------------------------------------------------|
+| Kind            | `INTERNAL`                                                |
+| Parent          | Restored from `harvest_task_queue.trace_context` carrier  |
+| Attributes      | `harvest.workflow.id`, `harvest.execution.id`, `harvest.shard.id`, `harvest.queue`, `harvest.replay` |
+| On replay       | New root span (no parent); `harvest.replay = true`; link to original (§4) |
+| End condition   | After executor cycle completes or suspends                |
+
+#### 2.2 `harvest.activity.execute` — activity invocation
+
+| Property        | Value                                                     |
+|-----------------|-----------------------------------------------------------|
+| Kind            | `INTERNAL`                                                |
+| Parent          | The enclosing `harvest.workflow.execute` span             |
+| Attributes      | `harvest.activity.name`, `harvest.execution.id`, `harvest.attempt`, `harvest.queue` |
+| On replay       | Omitted — activities are not re-executed during replay    |
+
+#### 2.3 `harvest.workflow.schedule` — workflow start / enqueue
+
+| Property        | Value                                                     |
+|-----------------|-----------------------------------------------------------|
+| Kind            | `PRODUCER`                                                |
+| Parent          | Active span at call site (the HTTP handler span, etc.)    |
+| Attributes      | `harvest.workflow.id`, `harvest.execution.id`, `harvest.shard.id`, `harvest.queue` |
+| Notes           | Created when a caller starts a workflow; the `traceparent` of this span is captured and stored on `harvest_task_queue.trace_context` to be restored by the worker (§3) |
+
+#### 2.4 `harvest.activity.schedule` — activity enqueue
+
+| Property        | Value                                                     |
+|-----------------|-----------------------------------------------------------|
+| Kind            | `PRODUCER`                                                |
+| Parent          | The enclosing `harvest.workflow.execute` span             |
+| Attributes      | `harvest.activity.name`, `harvest.execution.id`, `harvest.queue` |
+
+#### 2.5 `harvest.signal.send` — signal delivery
+
+| Property        | Value                                                     |
+|-----------------|-----------------------------------------------------------|
+| Kind            | `PRODUCER`                                                |
+| Parent          | Active span at call site                                  |
+| Attributes      | `harvest.workflow.id`, `harvest.execution.id`             |
+
+#### 2.6 `harvest.signal.deliver` — signal received by workflow
+
+| Property        | Value                                                     |
+|-----------------|-----------------------------------------------------------|
+| Kind            | `CONSUMER`                                                |
+| Parent          | Restored from signal row's `trace_context` column         |
+| Attributes      | `harvest.workflow.id`, `harvest.execution.id`             |
+
+#### 2.7 `harvest.timer.fire` — durable timer expiry
+
+| Property        | Value                                                     |
+|-----------------|-----------------------------------------------------------|
+| Kind            | `INTERNAL`                                                |
+| Parent          | Enclosing `harvest.workflow.execute` span                 |
+| Attributes      | `harvest.execution.id`                                    |
+
+#### 2.8 `harvest.child_workflow.start` — child workflow invocation
+
+| Property        | Value                                                     |
+|-----------------|-----------------------------------------------------------|
+| Kind            | `PRODUCER`                                                |
+| Parent          | Enclosing `harvest.workflow.execute` span of the parent   |
+| Attributes      | `harvest.workflow.id` (child), `harvest.execution.id` (child), `harvest.shard.id` (child) |
+
+---
+
+### 3. Trace context propagation boundaries
+
+The following table describes exactly how context travels at each boundary.
+
+| Boundary                      | How context travels                                             | Notes                                                      |
+|-------------------------------|-----------------------------------------------------------------|------------------------------------------------------------|
+| HTTP handler → workflow start | `TraceContextPropagator::capture()` at `start_workflow` call site; stored on `harvest_task_queue.trace_context` (JSONB) | Carried via `TraceContextCarrier`                         |
+| Worker task pop → workflow execute | `TraceContextPropagator::install(carrier)` before invoking handler; guard dropped after executor cycle | Returns `Box<dyn Any + Send>` so it survives `.await`     |
+| Workflow → activity enqueue   | `TraceContextPropagator::capture()` inside executor; new carrier stored on the activity's task row | Captures the `harvest.workflow.execute` span context       |
+| Worker task pop → activity execute | Same as workflow execute path                              |                                                            |
+| Workflow → child workflow     | Caller captures context at `ctx.start_child_workflow()` call   | Same pattern as HTTP handler → workflow start              |
+| Signal send → signal deliver  | Caller captures context; stored on `harvest_signals.trace_context` column | Transient; deleted after delivery                         |
+| Timer fire                    | No context propagation; timer fires inside the workflow executor cycle span | Inherits parent span from workflow executor               |
+
+---
+
+### 4. Replay semantics
+
+**The problem**: A workflow can be replayed 24 hours after original execution.
+The original trace in the APM collector has long since expired. If replay naively
+calls `install(original_carrier)`, the worker emits spans parented to a
+non-existent trace — silently broken linkage.
+
+**The contract**:
+
+1. Before a workflow task is popped for replay, the worker converts the carrier:
+   ```rust
+   let live_carrier = /* loaded from harvest_task_queue.trace_context */;
+   let replay_carrier = live_carrier.into_replay_context();
+   // replay_carrier.traceparent == None
+   // replay_carrier.is_replay   == true
+   // replay_carrier.link_traceparent == Some(original_traceparent)
+   ```
+
+2. The worker detects `carrier.is_replay == true` and **does not** call
+   `propagator.install(carrier)` for parent context. Instead:
+   - It creates a new root span.
+   - It attaches an OTel span *link* referencing `link_traceparent` (best-effort;
+     skipped gracefully if the propagator doesn't support span links).
+   - It sets `harvest.replay = true` on the span.
+
+3. Activity spans are **not emitted** during replay — activities are not
+   re-executed, only their recorded results are replayed.
+
+**Worked example (24-hour replay)**:
+
+```
+T=0h (original execution)
+  [HTTP span] POST /api/start
+    └─ [harvest.workflow.schedule] harvest.workflow.id="onboarding"
+         traceparent stored on task row
+
+T=0h (worker pops task)
+  [harvest.workflow.execute] harvest.workflow.id="onboarding"
+    harvest.replay=false, parent=<HTTP span>
+    └─ [harvest.activity.schedule] harvest.activity.name="send_welcome"
+    └─ [harvest.activity.execute] harvest.activity.name="send_welcome"
+
+T=24h (replay after crash recovery)
+  [harvest.workflow.execute] harvest.workflow.id="onboarding"   ← NEW ROOT SPAN
+    harvest.replay=true
+    links=[<original traceparent from T=0h>]     ← link, not parent
+    (no activity spans — replay replays results, does not re-execute)
+```
+
+---
+
+### 5. Trace context storage rules
+
+| Location                           | Allowed | Rationale                                                             |
+|------------------------------------|---------|-----------------------------------------------------------------------|
+| `harvest_task_queue.trace_context` | **YES** | Transient; row is deleted after task completion. Replay can convert carrier with `into_replay_context()` before installing. |
+| `harvest_signals.trace_context`    | **YES** | Transient; row is deleted after signal delivery.                      |
+| `harvest_workflow_executions`      | optional| An opaque `initial_traceparent` column may be added for observability. Not required by this ADR. |
+| `harvest_events.event_data`        | **NO**  | Append-only invariant must not be compromised. Trace context is transient by nature; storing it in the event log would permanently couple the event history to a potentially-expired trace. |
+
+The `TraceContextCarrier` struct is the sole wire format for all allowed
+locations. It serialises to JSONB via `serde_json`.
+
+---
+
+### 6. No-op contract
+
+When `TelemetryConfig::default()` is used (the default when no telemetry is
+configured):
+
+- `NoOpPropagator::capture()` returns `None` — no carrier is written to task
+  rows; the `trace_context` column is left `NULL`.
+- `NoOpPropagator::install()` is never called on `NULL` rows — zero context
+  restoration work.
+- `NoOpMetrics` discards every sample with default no-op method bodies; the
+  compiler eliminates these calls.
+- **Zero span allocations** on the hot path beyond today's baseline.
+- The `ATTR_*` and `METRIC_*` constants are compile-time `&str` slices — zero
+  run-time cost whether or not telemetry is configured.
+
+---
+
+### 7. Metric catalogue
+
+The following metrics are defined by the constants in `telemetry.rs`. The
+`MetricsRecorder` trait method that drives each metric is listed alongside it.
+
+| Rust constant              | Metric name                   | Instrument   | Labels (cardinality)                          | Forbidden labels      |
+|----------------------------|-------------------------------|--------------|-----------------------------------------------|-----------------------|
+| `METRIC_WORKFLOW_STARTED`  | `harvest.workflow.started`    | Counter      | `workflow.name` (bounded), `queue` (bounded)  | `execution.id`        |
+| `METRIC_WORKFLOW_DURATION` | `harvest.workflow.duration`   | Histogram    | `workflow.name`, `queue`, `status`            | `execution.id`        |
+| `METRIC_ACTIVITY_DURATION` | `harvest.activity.duration`   | Histogram    | `activity.name` (bounded), `queue`, `status` | `execution.id`        |
+| `METRIC_TIMER_STARTED`     | `harvest.timer.started`       | Counter      | _(none)_                                      |                       |
+| `METRIC_QUEUE_DEPTH`       | `harvest.queue.depth`         | Gauge        | `queue` (bounded)                             | `execution.id`        |
+| `METRIC_DLQ_ENTRIES`       | `harvest.dlq.entries`         | Gauge        | `shard` (≤ 256)                               |                       |
+| `METRIC_SCHEDULE_RUNS`     | `harvest.schedule.runs`       | Counter      | `kind` (2 values), `name` (bounded)           |                       |
+| `METRIC_SCHEDULE_SKIPPED`  | `harvest.schedule.skipped`    | Counter      | `kind`, `name`, `reason` (3 values)           |                       |
+| `METRIC_RETENTION_DELETED` | `harvest.retention.deleted`   | Counter      | `shard` (≤ 256)                               |                       |
+
+**Cardinality rule**: `execution.id` (a UUID) is **explicitly forbidden** as a
+metric label. It is unbounded and would explode the metric time-series in any
+production APM. Use `ATTR_EXECUTION_ID` only on *spans*, never on *metrics*.
+
+---
+
+### 8. Worked example — full end-to-end trace
+
+An autumn-web HTTP handler starts `onboarding`. Two activities run on different
+workers. `send_welcome` fails once and retries.
+
+```
+[HTTP span] POST /api/onboarding  (trace-id: 0af7651916cd43dd)
+  │
+  └─ [harvest.workflow.schedule] PRODUCER
+       harvest.workflow.id = "onboarding"
+       harvest.execution.id = "exec-uuid-1"
+       harvest.shard.id = 0
+       harvest.queue = "default"
+       ← traceparent captured here, stored on task row
+       │
+       ╔══════════════ (Postgres task queue boundary) ══════════════╗
+       │
+       └─ [harvest.workflow.execute] INTERNAL  (Worker-A)
+            harvest.workflow.id = "onboarding"
+            harvest.execution.id = "exec-uuid-1"
+            harvest.replay = false
+            │
+            ├─ [harvest.activity.schedule] PRODUCER
+            │    harvest.activity.name = "send_welcome"
+            │    harvest.attempt = 1
+            │    harvest.queue = "email-workers"
+            │    ← traceparent captured, stored on activity task row
+            │    │
+            │    ╔═════ (Postgres task queue boundary) ═════╗
+            │    │
+            │    └─ [harvest.activity.execute] INTERNAL  (Worker-B)
+            │         harvest.activity.name = "send_welcome"
+            │         harvest.attempt = 1
+            │         harvest.queue = "email-workers"
+            │         status: FAILED → retry scheduled
+            │    │
+            │    └─ [harvest.activity.execute] INTERNAL  (Worker-B, attempt 2)
+            │         harvest.activity.name = "send_welcome"
+            │         harvest.attempt = 2
+            │         status: OK
+            │
+            └─ [harvest.activity.schedule] PRODUCER
+                 harvest.activity.name = "update_crm"
+                 harvest.attempt = 1
+                 harvest.queue = "default"
+                 │
+                 └─ [harvest.activity.execute] INTERNAL  (Worker-A)
+                      harvest.activity.name = "update_crm"
+                      harvest.attempt = 1
+                      status: OK
+```
+
+---
+
+### 9. Out of scope
+
+The following are **explicitly not** covered by this ADR:
+
+- **Implementation**: span emission code in `worker.rs`, `executor.rs`,
+  `queue.rs`. This is the next ticket (implementation will be **M** complexity).
+- **New `WorkflowEvent` variants**: trace context never enters the event log.
+- **Vendor-specific exporters** (Jaeger, Honeycomb, Datadog, Tempo). The OTel
+  Rust SDK is the boundary; exporters are the application's concern.
+- **Log correlation** with `tracing` log records — separate spec.
+- **Custom user-defined spans** inside `#[activity]` bodies. These are additive
+  and the application's responsibility.
+- **Cross-language trace propagation**: W3C `traceparent` is the wire format and
+  implicitly handles this, but no Rust-SDK-level guarantees are made.
+- **Profiling, exemplars, continuous profiling**.
+- **Cross-worker sticky routing** for trace continuity across workers.
+
+---
+
+### 10. Consequences
+
+**Positive**:
+
+- Operators can trace an HTTP request end-to-end from autumn-web through any
+  number of activities and child workflows using their existing APM tool.
+- The append-only `harvest_events` invariant is preserved — trace context never
+  enters the event log.
+- The replay footgun (parenting a replay span to a long-expired trace) is
+  eliminated at the data-model level: `into_replay_context()` strips the parent
+  and sets `is_replay = true` before the worker can call `install`.
+- The no-op contract (zero allocations on unconfigured path) is preserved.
+- `execution.id` cardinality danger is explicitly called out — metric cardinality
+  budget is protected from day one.
+
+**Negative / trade-offs**:
+
+- An extra nullable `trace_context` column on `harvest_task_queue` is required
+  (one migration). This is a transient table; the column is cheap.
+- Implementers must check `carrier.is_replay` before calling `install`. Failing
+  to do so silently parents replay spans to expired traces — the test suite for
+  the implementation ticket should assert this guard.
+- Span links are best-effort: some APM tools render span links poorly. Operators
+  lose the APM-level navigation from replay spans to original execution in such
+  tools, falling back to manual trace-ID lookup.
+
+---
+
+## References
+
+- [W3C Trace Context](https://www.w3.org/TR/trace-context/)
+- [OTel Rust SDK](https://docs.rs/opentelemetry)
+- [Temporal trace propagation (Headers + interceptors)](https://docs.temporal.io/concepts/what-is-a-workflow#tracing-and-context-propagation)
+- [DBOS OTel-native workflows](https://docs.dbos.dev/concepts/workflows)
+- `autumn-harvest/src/telemetry.rs` — `ATTR_*` and `METRIC_*` constants (the
+  code-level source of truth for this ADR)


### PR DESCRIPTION
## Summary

This PR establishes the stable, versioned contract for OpenTelemetry trace propagation in autumn-harvest. It defines the complete span catalogue, attribute schema, metric names, and replay semantics that operators can rely on when integrating their APM tools.

## Key Changes

- **New ADR document** (`docs/adr/0001-otel-trace-contract.md`): Comprehensive 358-line specification covering:
  - Span attribute schema with 7 required attributes (`harvest.workflow.id`, `harvest.execution.id`, `harvest.shard.id`, `harvest.activity.name`, `harvest.attempt`, `harvest.queue`, `harvest.replay`)
  - Complete span catalogue (8 span types: workflow execute/schedule, activity execute/schedule, signal send/deliver, timer fire, child workflow start)
  - Trace context propagation boundaries across HTTP handlers, task queues, and workflow boundaries
  - Replay semantics: replay spans become new roots with span *links* to original traces (preventing parent linkage to expired traces)
  - Trace context storage rules (allowed on transient tables only; forbidden in append-only event log)
  - Metric catalogue (9 metrics with cardinality constraints; `execution.id` explicitly forbidden as a label)
  - Worked examples and consequences

- **Telemetry constants** (`src/telemetry.rs`): Added 16 public constants:
  - 7 span attribute name constants (`ATTR_WORKFLOW_ID`, `ATTR_EXECUTION_ID`, etc.)
  - 9 metric name constants (`METRIC_WORKFLOW_STARTED`, `METRIC_WORKFLOW_DURATION`, etc.)

- **TraceContextCarrier enhancements** (`src/telemetry.rs`):
  - Added `is_replay: bool` field to flag replay-mode spans
  - Added `link_traceparent: Option<String>` field to preserve original trace for span linking
  - New `into_replay_context()` method that converts a carrier for replay: clears `traceparent` (new root), preserves it in `link_traceparent`, sets `is_replay = true`
  - Updated `is_empty()` to account for new fields
  - Updated `from_traceparent()` to initialize new fields to defaults

- **Specification-level tests** (`src/telemetry.rs`):
  - RED-phase tests asserting exact constant values per ADR
  - Replay carrier semantics: `traceparent` stripped, `link_traceparent` preserved, `is_replay` set
  - JSON roundtrip tests for replay carriers
  - Non-replay carriers have `is_replay = false` and no link

## Notable Implementation Details

- **Replay footgun prevention**: The `into_replay_context()` method enforces the contract at the data-model level — workers cannot accidentally parent replay spans to expired traces because the parent context is explicitly cleared before installation.
- **No-op contract preserved**: All new constants are compile-time `&str` slices with zero runtime cost on unconfigured paths.
- **Cardinality safety**: ADR explicitly forbids `execution.id` (unbounded UUID) as a metric label, protecting metric time-series budgets.
- **Append-only invariant**: Trace context is restricted to transient tables (`harvest_task_queue`, `harvest_signals`); never stored in the append-only event log.
- **APM tool compatibility**: Span links enable navigation from replay spans back to original traces in tools that support them; graceful degradation for tools that don't.

This ADR is the foundation for the implementation ticket (worker.rs, executor.rs, queue.rs span emission code).

https://claude.ai/code/session_01Q3X3C959YgCZHDdR6YmwxH