### PR TITLE
Add bulk dead-letter queue replay and discard operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,9 @@ cargo run -p autumn-harvest-cli -- dag trigger daily_pipeline --conf-json '{"dat
 cargo run -p autumn-harvest-cli -- dag pause daily_pipeline
 cargo run -p autumn-harvest-cli -- dlq list --limit 25
 cargo run -p autumn-harvest-cli -- dlq replay <dead-letter-id>
+cargo run -p autumn-harvest-cli -- dlq bulk-replay --activity-name send_email --dry-run
+cargo run -p autumn-harvest-cli -- dlq bulk-replay --activity-name send_email
+cargo run -p autumn-harvest-cli -- dlq bulk-discard --activity-name send_email --failed-before 2026-04-27T00:00:00Z
 cargo run -p autumn-harvest-cli -- retention status
 cargo run -p autumn-harvest-cli -- retention run-now
 cargo run -p autumn-harvest-cli -- concurrency status
@@ -284,6 +287,55 @@ cargo run -p autumn-harvest-cli -- workflow list \
     --workflow-name onboarding \
     --search-attr tenant=acme
 ```
+
+### Post-incident DLQ drain
+
+After an infrastructure incident (database blip, downstream 503, misconfigured retry policy), many activities end up in the dead-letter queue. Rather than replaying them one-by-one with `dlq replay <id>`, use the bulk endpoints to drain the queue by activity or time window.
+
+**Always dry-run first** to see what will be acted on before committing:
+
+```bash
+# Preview — no writes, returns matched count and IDs
+curl -s -X POST https://api.example.com/api/harvest/dead-letters/replay \
+  -H 'Content-Type: application/json' \
+  -d '{"activity_name":"send_email","failed_after":"2026-04-27T12:00:00Z","dry_run":true}' | jq .
+```
+
+The response reports `matched` (total rows satisfying the filter, before any limit clip), `acted_on`, and any per-row `failures`. When `matched` exceeds `acted_on` after a non-dry run, the limit clipped the result — call again until `matched == 0`.
+
+```bash
+# Real replay: re-enqueue all matching dead-letter entries
+curl -s -X POST https://api.example.com/api/harvest/dead-letters/replay \
+  -H 'Content-Type: application/json' \
+  -d '{"activity_name":"send_email","failed_after":"2026-04-27T12:00:00Z"}' | jq .
+
+# Discard (delete without re-enqueueing) — use when the work is no longer needed
+curl -s -X POST https://api.example.com/api/harvest/dead-letters/discard \
+  -H 'Content-Type: application/json' \
+  -d '{"activity_name":"charge_card","failed_before":"2026-04-27T00:00:00Z"}' | jq .
+```
+
+Or via the CLI:
+
+```bash
+# Dry run first
+cargo run -p autumn-harvest-cli -- dlq bulk-replay \
+    --activity-name send_email \
+    --failed-after 2026-04-27T12:00:00Z \
+    --dry-run
+
+# Commit the replay
+cargo run -p autumn-harvest-cli -- dlq bulk-replay \
+    --activity-name send_email \
+    --failed-after 2026-04-27T12:00:00Z
+
+# Discard stale failures
+cargo run -p autumn-harvest-cli -- dlq bulk-discard \
+    --activity-name charge_card \
+    --failed-before 2026-04-27T00:00:00Z
+```
+
+At least one of `--activity-name`, `--workflow-name`, `--failed-after`, or `--failed-before` is required. A filter with only `--limit` or `--dry-run` is rejected with `400 Bad Request`. The default batch size is 100 rows; pass `--limit N` (max 1000) to replay more per call.
 
 ### Scheduling workflows on a cron
 

--- a/autumn-harvest-cli/src/lib.rs
+++ b/autumn-harvest-cli/src/lib.rs
@@ -375,10 +375,58 @@ enum DeadLetterCommand {
         #[arg(long, value_parser = clap::value_parser!(i64).range(1..=200))]
         limit: Option<i64>,
     },
-    /// Replay a dead-lettered task.
+    /// Replay a single dead-lettered task by ID.
     Replay {
         /// Dead-letter row ID.
         dead_letter_id: String,
+    },
+    /// Bulk-replay dead-lettered tasks matching a filter.
+    ///
+    /// At least one filter criterion must be provided. Use --dry-run to preview
+    /// matching rows without performing any writes.
+    BulkReplay {
+        /// Exact match on activity name.
+        #[arg(long)]
+        activity_name: Option<String>,
+        /// Exact match on workflow name.
+        #[arg(long)]
+        workflow_name: Option<String>,
+        /// Inclusive lower bound on `failed_at` (RFC 3339, e.g. `2026-04-27T12:30:00Z`).
+        #[arg(long)]
+        failed_after: Option<String>,
+        /// Exclusive upper bound on `failed_at` (RFC 3339).
+        #[arg(long)]
+        failed_before: Option<String>,
+        /// Maximum rows to act on per call (default 100, max 1000).
+        #[arg(long, value_parser = clap::value_parser!(u32).range(1..=1000))]
+        limit: Option<u32>,
+        /// Preview matching rows without performing any writes.
+        #[arg(long)]
+        dry_run: bool,
+    },
+    /// Bulk-discard dead-lettered tasks matching a filter (delete without replay).
+    ///
+    /// At least one filter criterion must be provided. Use --dry-run to preview
+    /// matching rows without performing any deletes.
+    BulkDiscard {
+        /// Exact match on activity name.
+        #[arg(long)]
+        activity_name: Option<String>,
+        /// Exact match on workflow name.
+        #[arg(long)]
+        workflow_name: Option<String>,
+        /// Inclusive lower bound on `failed_at` (RFC 3339, e.g. `2026-04-27T12:30:00Z`).
+        #[arg(long)]
+        failed_after: Option<String>,
+        /// Exclusive upper bound on `failed_at` (RFC 3339).
+        #[arg(long)]
+        failed_before: Option<String>,
+        /// Maximum rows to act on per call (default 100, max 1000).
+        #[arg(long, value_parser = clap::value_parser!(u32).range(1..=1000))]
+        limit: Option<u32>,
+        /// Preview matching rows without performing any deletes.
+        #[arg(long)]
+        dry_run: bool,
     },
 }
 
@@ -721,7 +769,65 @@ fn dead_letter_request(command: &DeadLetterCommand) -> ApiRequest {
             format!("/dead-letters/{}/replay", path_segment(dead_letter_id)),
             None,
         ),
+        DeadLetterCommand::BulkReplay {
+            activity_name,
+            workflow_name,
+            failed_after,
+            failed_before,
+            limit,
+            dry_run,
+        } => ApiRequest::post(
+            "/dead-letters/replay",
+            Some(build_bulk_dlq_body(
+                activity_name.as_deref(),
+                workflow_name.as_deref(),
+                failed_after.as_deref(),
+                failed_before.as_deref(),
+                *limit,
+                *dry_run,
+            )),
+        ),
+        DeadLetterCommand::BulkDiscard {
+            activity_name,
+            workflow_name,
+            failed_after,
+            failed_before,
+            limit,
+            dry_run,
+        } => ApiRequest::post(
+            "/dead-letters/discard",
+            Some(build_bulk_dlq_body(
+                activity_name.as_deref(),
+                workflow_name.as_deref(),
+                failed_after.as_deref(),
+                failed_before.as_deref(),
+                *limit,
+                *dry_run,
+            )),
+        ),
     }
+}
+
+fn build_bulk_dlq_body(
+    activity_name: Option<&str>,
+    workflow_name: Option<&str>,
+    failed_after: Option<&str>,
+    failed_before: Option<&str>,
+    limit: Option<u32>,
+    dry_run: bool,
+) -> Value {
+    let mut body = Map::new();
+    insert_string(&mut body, "activity_name", activity_name);
+    insert_string(&mut body, "workflow_name", workflow_name);
+    insert_string(&mut body, "failed_after", failed_after);
+    insert_string(&mut body, "failed_before", failed_before);
+    if let Some(l) = limit {
+        body.insert("limit".to_string(), json!(l));
+    }
+    if dry_run {
+        body.insert("dry_run".to_string(), json!(true));
+    }
+    Value::Object(body)
 }
 
 fn parse_json_source(

--- a/autumn-harvest-cli/tests/request_mapping.rs
+++ b/autumn-harvest-cli/tests/request_mapping.rs
@@ -247,6 +247,90 @@ fn path_segments_are_percent_encoded() {
 }
 
 #[test]
+fn dlq_bulk_replay_maps_to_management_route() {
+    let cli = Cli::try_parse_from([
+        "harvest",
+        "dlq",
+        "bulk-replay",
+        "--activity-name",
+        "send_email",
+        "--dry-run",
+    ])
+    .expect("bulk-replay args should parse");
+
+    let request = cli.api_request().expect("request should build");
+
+    assert_eq!(request.method, ApiMethod::Post);
+    assert_eq!(request.path, "/dead-letters/replay");
+    assert_eq!(
+        request.body,
+        Some(json!({
+            "activity_name": "send_email",
+            "dry_run": true
+        }))
+    );
+}
+
+#[test]
+fn dlq_bulk_discard_maps_to_management_route() {
+    let cli = Cli::try_parse_from([
+        "harvest",
+        "dlq",
+        "bulk-discard",
+        "--activity-name",
+        "send_email",
+        "--failed-after",
+        "2026-04-27T12:30:00Z",
+    ])
+    .expect("bulk-discard args should parse");
+
+    let request = cli.api_request().expect("request should build");
+
+    assert_eq!(request.method, ApiMethod::Post);
+    assert_eq!(request.path, "/dead-letters/discard");
+    assert_eq!(
+        request.body,
+        Some(json!({
+            "activity_name": "send_email",
+            "failed_after": "2026-04-27T12:30:00Z"
+        }))
+    );
+}
+
+#[test]
+fn dlq_bulk_replay_with_all_filters_maps_correctly() {
+    let cli = Cli::try_parse_from([
+        "harvest",
+        "dlq",
+        "bulk-replay",
+        "--activity-name",
+        "charge_card",
+        "--workflow-name",
+        "billing",
+        "--failed-after",
+        "2026-04-27T12:30:00Z",
+        "--failed-before",
+        "2026-04-27T14:30:00Z",
+        "--limit",
+        "500",
+        "--dry-run",
+    ])
+    .expect("bulk-replay with all filters should parse");
+
+    let request = cli.api_request().expect("request should build");
+
+    assert_eq!(request.method, ApiMethod::Post);
+    assert_eq!(request.path, "/dead-letters/replay");
+    let body = request.body.expect("should have body");
+    assert_eq!(body["activity_name"], "charge_card");
+    assert_eq!(body["workflow_name"], "billing");
+    assert_eq!(body["failed_after"], "2026-04-27T12:30:00Z");
+    assert_eq!(body["failed_before"], "2026-04-27T14:30:00Z");
+    assert_eq!(body["limit"], 500);
+    assert_eq!(body["dry_run"], true);
+}
+
+#[test]
 fn retention_commands_match_management_routes() {
     let status = Cli::try_parse_from(["harvest", "retention", "status"])
         .expect("retention status args should parse");

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -1135,15 +1135,22 @@ async fn bulk_replay_from_shards(
         u32::try_from(filter.effective_limit()).unwrap_or(dlq::DEFAULT_BULK_LIMIT);
 
     for (_shard, shard_pool) in pool.iter_shards() {
-        if remaining == 0 {
-            break;
-        }
-        let mut shard_filter = filter.clone();
-        shard_filter.limit = Some(remaining);
         let mut conn = shard_pool
             .get()
             .await
             .map_err(|e| HarvestError::Database(e.to_string()))?;
+
+        if remaining == 0 {
+            // Budget exhausted: count-only so matched reflects all shards.
+            let shard_matched = dlq::count_bulk_filter_matches(&mut conn, filter)
+                .await
+                .map(|n| usize::try_from(n).unwrap_or(0))?;
+            total.matched += shard_matched;
+            continue;
+        }
+
+        let mut shard_filter = filter.clone();
+        shard_filter.limit = Some(remaining);
         let shard_result = dlq::bulk_replay_dead_letters(&mut conn, &shard_filter).await?;
         // Rows consumed = acted + skipped + failed (or preview ids in dry-run).
         let consumed = shard_result.ids.len() + shard_result.skipped + shard_result.failures.len();
@@ -1177,15 +1184,22 @@ async fn bulk_discard_from_shards(
         u32::try_from(filter.effective_limit()).unwrap_or(dlq::DEFAULT_BULK_LIMIT);
 
     for (_shard, shard_pool) in pool.iter_shards() {
-        if remaining == 0 {
-            break;
-        }
-        let mut shard_filter = filter.clone();
-        shard_filter.limit = Some(remaining);
         let mut conn = shard_pool
             .get()
             .await
             .map_err(|e| HarvestError::Database(e.to_string()))?;
+
+        if remaining == 0 {
+            // Budget exhausted: count-only so matched reflects all shards.
+            let shard_matched = dlq::count_bulk_filter_matches(&mut conn, filter)
+                .await
+                .map(|n| usize::try_from(n).unwrap_or(0))?;
+            total.matched += shard_matched;
+            continue;
+        }
+
+        let mut shard_filter = filter.clone();
+        shard_filter.limit = Some(remaining);
         let shard_result = dlq::bulk_discard_dead_letters(&mut conn, &shard_filter).await?;
         let consumed = shard_result.ids.len() + shard_result.skipped + shard_result.failures.len();
         remaining = remaining.saturating_sub(u32::try_from(consumed).unwrap_or(remaining));

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -382,6 +382,14 @@ pub fn harvest_api_router(api_state: HarvestApiState) -> Router<AppState> {
         .route("/dags/{dag_name}/trigger", post(trigger_dag_run))
         .route("/dags/{dag_name}", patch(patch_dag))
         .route("/dead-letters", get(list_dead_letters))
+        .route(
+            "/dead-letters/replay",
+            post(bulk_replay_dead_letters_handler),
+        )
+        .route(
+            "/dead-letters/discard",
+            post(bulk_discard_dead_letters_handler),
+        )
         .route("/dead-letters/{id}/replay", post(replay_dead_letter))
         .route("/health", get(health))
         .route("/admin/retention", get(retention_status))
@@ -1046,6 +1054,126 @@ async fn replay_dead_letter(
     ))
 }
 
+async fn bulk_replay_dead_letters_handler(
+    Extension(api_state): Extension<HarvestApiState>,
+    Json(filter): Json<dlq::BulkDlqFilter>,
+) -> axum::response::Response {
+    use axum::response::IntoResponse as _;
+
+    if filter.is_empty() {
+        return (
+            axum::http::StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "error": "bulk filter must specify at least one criterion: \
+                          activity_name, workflow_name, failed_after, or failed_before"
+            })),
+        )
+            .into_response();
+    }
+
+    match bulk_replay_from_shards(&api_state, &filter).await {
+        Ok(result) => {
+            let status = if result.acted_on == 0 && !result.failures.is_empty() {
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR
+            } else {
+                axum::http::StatusCode::OK
+            };
+            (status, Json(result)).into_response()
+        }
+        Err(e) => map_error(e).into_response(),
+    }
+}
+
+async fn bulk_discard_dead_letters_handler(
+    Extension(api_state): Extension<HarvestApiState>,
+    Json(filter): Json<dlq::BulkDlqFilter>,
+) -> axum::response::Response {
+    use axum::response::IntoResponse as _;
+
+    if filter.is_empty() {
+        return (
+            axum::http::StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "error": "bulk filter must specify at least one criterion: \
+                          activity_name, workflow_name, failed_after, or failed_before"
+            })),
+        )
+            .into_response();
+    }
+
+    match bulk_discard_from_shards(&api_state, &filter).await {
+        Ok(result) => {
+            let status = if result.acted_on == 0 && !result.failures.is_empty() {
+                axum::http::StatusCode::INTERNAL_SERVER_ERROR
+            } else {
+                axum::http::StatusCode::OK
+            };
+            (status, Json(result)).into_response()
+        }
+        Err(e) => map_error(e).into_response(),
+    }
+}
+
+async fn bulk_replay_from_shards(
+    api_state: &HarvestApiState,
+    filter: &dlq::BulkDlqFilter,
+) -> Result<dlq::BulkDlqResult, HarvestError> {
+    let pool = api_state.storage_pool()?;
+    let mut total = dlq::BulkDlqResult {
+        matched: 0,
+        acted_on: 0,
+        skipped: 0,
+        ids: Vec::new(),
+        dry_run: filter.dry_run,
+        failures: Vec::new(),
+    };
+
+    for (_shard, shard_pool) in pool.iter_shards() {
+        let mut conn = shard_pool
+            .get()
+            .await
+            .map_err(|e| HarvestError::Database(e.to_string()))?;
+        let shard_result = dlq::bulk_replay_dead_letters(&mut conn, filter).await?;
+        total.matched += shard_result.matched;
+        total.acted_on += shard_result.acted_on;
+        total.skipped += shard_result.skipped;
+        total.ids.extend(shard_result.ids);
+        total.failures.extend(shard_result.failures);
+    }
+
+    Ok(total)
+}
+
+async fn bulk_discard_from_shards(
+    api_state: &HarvestApiState,
+    filter: &dlq::BulkDlqFilter,
+) -> Result<dlq::BulkDlqResult, HarvestError> {
+    let pool = api_state.storage_pool()?;
+    let mut total = dlq::BulkDlqResult {
+        matched: 0,
+        acted_on: 0,
+        skipped: 0,
+        ids: Vec::new(),
+        dry_run: filter.dry_run,
+        failures: Vec::new(),
+    };
+
+    for (_shard, shard_pool) in pool.iter_shards() {
+        let mut conn = shard_pool
+            .get()
+            .await
+            .map_err(|e| HarvestError::Database(e.to_string()))?;
+        let shard_result = dlq::bulk_discard_dead_letters(&mut conn, filter).await?;
+        total.matched += shard_result.matched;
+        total.acted_on += shard_result.acted_on;
+        total.skipped += shard_result.skipped;
+        total.ids.extend(shard_result.ids);
+        total.failures.extend(shard_result.failures);
+    }
+
+    Ok(total)
+}
+
 async fn retention_status(
     Extension(api_state): Extension<HarvestApiState>,
 ) -> Result<Json<RetentionStatus>, AutumnError> {
@@ -1514,6 +1642,37 @@ mod tests {
             .iter()
             .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
             .collect()
+    }
+
+    #[test]
+    fn bulk_dlq_filter_is_empty_when_only_limit_set() {
+        let filter: autumn_harvest::dlq::BulkDlqFilter =
+            serde_json::from_str(r#"{"limit": 100}"#).unwrap();
+        assert!(
+            filter.is_empty(),
+            "filter with only limit should be considered empty"
+        );
+    }
+
+    #[test]
+    fn bulk_dlq_filter_is_not_empty_when_activity_name_set() {
+        let filter: autumn_harvest::dlq::BulkDlqFilter =
+            serde_json::from_str(r#"{"activity_name": "send_email"}"#).unwrap();
+        assert!(!filter.is_empty());
+    }
+
+    #[test]
+    fn bulk_dlq_filter_effective_limit_defaults_to_100() {
+        let filter: autumn_harvest::dlq::BulkDlqFilter =
+            serde_json::from_str(r#"{"activity_name": "foo"}"#).unwrap();
+        assert_eq!(filter.effective_limit(), 100);
+    }
+
+    #[test]
+    fn bulk_dlq_filter_effective_limit_hard_capped_at_1000() {
+        let filter: autumn_harvest::dlq::BulkDlqFilter =
+            serde_json::from_str(r#"{"activity_name": "foo", "limit": 9999}"#).unwrap();
+        assert_eq!(filter.effective_limit(), 1000);
     }
 
     #[test]

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -1128,12 +1128,26 @@ async fn bulk_replay_from_shards(
         failures: Vec::new(),
     };
 
+    // Enforce the limit as a global cap across all shards, not per-shard.
+    // effective_limit() is guaranteed to be in [1, 1000] so both try_from
+    // conversions below are infallible in practice.
+    let mut remaining: u32 =
+        u32::try_from(filter.effective_limit()).unwrap_or(dlq::DEFAULT_BULK_LIMIT);
+
     for (_shard, shard_pool) in pool.iter_shards() {
+        if remaining == 0 {
+            break;
+        }
+        let mut shard_filter = filter.clone();
+        shard_filter.limit = Some(remaining);
         let mut conn = shard_pool
             .get()
             .await
             .map_err(|e| HarvestError::Database(e.to_string()))?;
-        let shard_result = dlq::bulk_replay_dead_letters(&mut conn, filter).await?;
+        let shard_result = dlq::bulk_replay_dead_letters(&mut conn, &shard_filter).await?;
+        // Rows consumed = acted + skipped + failed (or preview ids in dry-run).
+        let consumed = shard_result.ids.len() + shard_result.skipped + shard_result.failures.len();
+        remaining = remaining.saturating_sub(u32::try_from(consumed).unwrap_or(remaining));
         total.matched += shard_result.matched;
         total.acted_on += shard_result.acted_on;
         total.skipped += shard_result.skipped;
@@ -1158,12 +1172,23 @@ async fn bulk_discard_from_shards(
         failures: Vec::new(),
     };
 
+    // Enforce the limit as a global cap across all shards, not per-shard.
+    let mut remaining: u32 =
+        u32::try_from(filter.effective_limit()).unwrap_or(dlq::DEFAULT_BULK_LIMIT);
+
     for (_shard, shard_pool) in pool.iter_shards() {
+        if remaining == 0 {
+            break;
+        }
+        let mut shard_filter = filter.clone();
+        shard_filter.limit = Some(remaining);
         let mut conn = shard_pool
             .get()
             .await
             .map_err(|e| HarvestError::Database(e.to_string()))?;
-        let shard_result = dlq::bulk_discard_dead_letters(&mut conn, filter).await?;
+        let shard_result = dlq::bulk_discard_dead_letters(&mut conn, &shard_filter).await?;
+        let consumed = shard_result.ids.len() + shard_result.skipped + shard_result.failures.len();
+        remaining = remaining.saturating_sub(u32::try_from(consumed).unwrap_or(remaining));
         total.matched += shard_result.matched;
         total.acted_on += shard_result.acted_on;
         total.skipped += shard_result.skipped;

--- a/autumn-harvest-plugin/tests/dlq_bulk_integration.rs
+++ b/autumn-harvest-plugin/tests/dlq_bulk_integration.rs
@@ -1,0 +1,459 @@
+use std::collections::BTreeMap;
+
+use autumn_harvest::schema::{harvest_dead_letters, harvest_task_queue};
+use autumn_harvest::shard::ShardedDbPool;
+use autumn_harvest::types::ShardId;
+use autumn_harvest::worker::DbPool;
+use autumn_harvest_plugin::HarvestDbPool;
+use autumn_harvest_plugin::api::{HarvestApiState, harvest_api_router};
+use autumn_web::AppState;
+use autumn_web::reexports::axum;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use diesel::ExpressionMethods;
+use diesel::QueryDsl;
+use diesel_async::AsyncConnection;
+use diesel_async::AsyncPgConnection;
+use diesel_async::RunQueryDsl;
+use diesel_async::SimpleAsyncConnection;
+use diesel_async::pooled_connection::AsyncDieselConnectionManager;
+use serde_json::{Value, json};
+use testcontainers::ContainerAsync;
+use testcontainers_modules::postgres::Postgres;
+use testcontainers_modules::testcontainers::runners::AsyncRunner;
+use tower::ServiceExt;
+
+const INIT_SQL: &str = concat!(
+    include_str!("../../autumn-harvest/migrations/20260409000000_harvest_initial/up.sql"),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260424000001_harvest_trace_context/up.sql"),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260427000000_harvest_continue_as_new/up.sql"),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260429000000_harvest_concurrency_key/up.sql"),
+    "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260430000000_harvest_workflow_schedules/up.sql"
+    ),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260430000001_harvest_external_tasks/up.sql"),
+);
+
+type HarvestApiApp = axum::Router;
+
+async fn setup_test_database_url() -> (String, ContainerAsync<Postgres>) {
+    let container = Postgres::default()
+        .with_init_sql(INIT_SQL.to_string().into_bytes())
+        .start()
+        .await
+        .expect("failed to start Postgres container");
+
+    let host = container
+        .get_host()
+        .await
+        .expect("failed to get container host");
+    let port = container
+        .get_host_port_ipv4(5432)
+        .await
+        .expect("failed to get container port");
+    let database_url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+
+    (database_url, container)
+}
+
+async fn setup_sharded_test_database_urls() -> ((String, String), ContainerAsync<Postgres>) {
+    let container = Postgres::default()
+        .start()
+        .await
+        .expect("failed to start Postgres container");
+
+    let host = container
+        .get_host()
+        .await
+        .expect("failed to get container host");
+    let port = container
+        .get_host_port_ipv4(5432)
+        .await
+        .expect("failed to get container port");
+    let admin_url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+    let shard0_db = format!("harvest_shard_{}", uuid::Uuid::new_v4().simple());
+    let shard1_db = format!("harvest_shard_{}", uuid::Uuid::new_v4().simple());
+
+    let mut admin_conn = <AsyncPgConnection as AsyncConnection>::establish(&admin_url)
+        .await
+        .expect("failed to connect to admin database");
+    diesel::sql_query(format!("CREATE DATABASE {shard0_db}"))
+        .execute(&mut admin_conn)
+        .await
+        .expect("failed to create shard 0 database");
+    diesel::sql_query(format!("CREATE DATABASE {shard1_db}"))
+        .execute(&mut admin_conn)
+        .await
+        .expect("failed to create shard 1 database");
+
+    let shard0_url = format!("postgres://postgres:postgres@{host}:{port}/{shard0_db}");
+    let shard1_url = format!("postgres://postgres:postgres@{host}:{port}/{shard1_db}");
+
+    for shard_url in [&shard0_url, &shard1_url] {
+        let mut conn = <AsyncPgConnection as AsyncConnection>::establish(shard_url)
+            .await
+            .expect("failed to connect to shard database");
+        conn.batch_execute(INIT_SQL)
+            .await
+            .expect("failed to apply harvest migrations to shard database");
+    }
+
+    ((shard0_url, shard1_url), container)
+}
+
+fn build_test_pool(database_url: &str) -> DbPool {
+    let manager = AsyncDieselConnectionManager::<AsyncPgConnection>::new(database_url);
+    deadpool::managed::Pool::builder(manager)
+        .max_size(4)
+        .build()
+        .expect("failed to build test pool")
+}
+
+fn build_two_shard_pool(shard0_url: &str, shard1_url: &str) -> HarvestDbPool {
+    let mut pools = BTreeMap::new();
+    pools.insert(ShardId::new(0), build_test_pool(shard0_url));
+    pools.insert(ShardId::new(1), build_test_pool(shard1_url));
+    HarvestDbPool::sharded(ShardedDbPool::from_map(pools, ShardId::new(0)))
+}
+
+fn build_dlq_app(pool: DbPool) -> HarvestApiApp {
+    let api_state = HarvestApiState::new();
+    api_state.install_storage_pool(HarvestDbPool::from(pool));
+    harvest_api_router(api_state).with_state(AppState::for_test().with_profile("test"))
+}
+
+fn build_sharded_dlq_app(shard0_url: &str, shard1_url: &str) -> HarvestApiApp {
+    let api_state = HarvestApiState::new();
+    api_state.install_storage_pool(build_two_shard_pool(shard0_url, shard1_url));
+    harvest_api_router(api_state).with_state(AppState::for_test().with_profile("test"))
+}
+
+async fn read_json_response(response: axum::response::Response) -> Value {
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("failed to read response body");
+    serde_json::from_slice(&body).expect("response must be JSON")
+}
+
+async fn post_json(
+    app: &HarvestApiApp,
+    uri: impl Into<String>,
+    payload: Value,
+) -> (StatusCode, Value) {
+    let uri = uri.into();
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(&uri)
+                .header("content-type", "application/json")
+                .body(Body::from(payload.to_string()))
+                .unwrap(),
+        )
+        .await
+        .expect("POST request failed");
+    let status = response.status();
+    let json = read_json_response(response).await;
+    (status, json)
+}
+
+async fn insert_dlq_row(database_url: &str, activity_name: &str, task_type: &str) -> uuid::Uuid {
+    let mut conn = <AsyncPgConnection as AsyncConnection>::establish(database_url)
+        .await
+        .expect("failed to connect for dead-letter insert");
+    autumn_harvest::dlq::dead_letter(
+        &mut conn,
+        &autumn_harvest::dlq::NewDeadLetterEntry {
+            original_task_id: uuid::Uuid::new_v4(),
+            queue_name: "default".to_string(),
+            task_type: task_type.to_string(),
+            workflow_exec_id: None,
+            activity_name: Some(activity_name.to_string()),
+            input: json!({ "test": true }),
+            error: format!("{activity_name} failed"),
+            attempts: 3,
+        },
+    )
+    .await
+    .expect("dead-letter insert should succeed")
+}
+
+async fn count_dlq_rows(database_url: &str) -> i64 {
+    let mut conn = <AsyncPgConnection as AsyncConnection>::establish(database_url)
+        .await
+        .expect("failed to connect for dead-letter count");
+    harvest_dead_letters::table
+        .count()
+        .get_result(&mut conn)
+        .await
+        .expect("failed to count dead letters")
+}
+
+async fn count_task_queue_rows_by_activity(database_url: &str, activity_name: &str) -> i64 {
+    let mut conn = <AsyncPgConnection as AsyncConnection>::establish(database_url)
+        .await
+        .expect("failed to connect for task queue count");
+    harvest_task_queue::table
+        .filter(harvest_task_queue::activity_name.eq(activity_name))
+        .count()
+        .get_result(&mut conn)
+        .await
+        .expect("failed to count task queue rows")
+}
+
+// ---------------------------------------------------------------------------
+// Test cases
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn bulk_replay_with_empty_filter_returns_400() {
+    let (database_url, _container) = setup_test_database_url().await;
+    let app = build_dlq_app(build_test_pool(&database_url));
+
+    let (status, body) = post_json(&app, "/dead-letters/replay", json!({})).await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(
+        body["error"]
+            .as_str()
+            .unwrap_or("")
+            .contains("bulk filter must specify at least one criterion"),
+        "unexpected error body: {body}"
+    );
+}
+
+#[tokio::test]
+async fn bulk_discard_with_empty_filter_returns_400() {
+    let (database_url, _container) = setup_test_database_url().await;
+    let app = build_dlq_app(build_test_pool(&database_url));
+
+    let (status, body) = post_json(&app, "/dead-letters/discard", json!({})).await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(
+        body["error"]
+            .as_str()
+            .unwrap_or("")
+            .contains("bulk filter must specify at least one criterion"),
+        "unexpected error body: {body}"
+    );
+}
+
+#[tokio::test]
+async fn bulk_replay_dry_run_previews_without_writing() {
+    let (database_url, _container) = setup_test_database_url().await;
+    let app = build_dlq_app(build_test_pool(&database_url));
+
+    for _ in 0..3 {
+        insert_dlq_row(&database_url, "preview_task", "ACTIVITY").await;
+    }
+
+    let (status, body) = post_json(
+        &app,
+        "/dead-letters/replay",
+        json!({ "activity_name": "preview_task", "dry_run": true }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["matched"], 3, "matched should be pre-limit total");
+    assert_eq!(body["acted_on"], 0, "dry-run must not write");
+    assert_eq!(body["dry_run"], true);
+    let ids = body["ids"].as_array().expect("ids must be an array");
+    assert_eq!(ids.len(), 3, "ids should list all matched rows");
+
+    assert_eq!(
+        count_dlq_rows(&database_url).await,
+        3,
+        "dry-run must not remove DLQ rows"
+    );
+    assert_eq!(
+        count_task_queue_rows_by_activity(&database_url, "preview_task").await,
+        0,
+        "dry-run must not enqueue tasks"
+    );
+}
+
+#[tokio::test]
+async fn bulk_replay_single_shard_drains_dlq_and_enqueues_tasks() {
+    let (database_url, _container) = setup_test_database_url().await;
+    let app = build_dlq_app(build_test_pool(&database_url));
+
+    for _ in 0..3 {
+        insert_dlq_row(&database_url, "replay_task", "ACTIVITY").await;
+    }
+
+    let (status, body) = post_json(
+        &app,
+        "/dead-letters/replay",
+        json!({ "activity_name": "replay_task" }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["matched"], 3);
+    assert_eq!(body["acted_on"], 3);
+    assert_eq!(body["skipped"], 0);
+    assert_eq!(body["dry_run"], false);
+    let failures = body["failures"].as_array().expect("failures must be array");
+    assert!(failures.is_empty(), "unexpected failures: {failures:?}");
+
+    assert_eq!(
+        count_dlq_rows(&database_url).await,
+        0,
+        "DLQ must be empty after replay"
+    );
+    assert_eq!(
+        count_task_queue_rows_by_activity(&database_url, "replay_task").await,
+        3,
+        "each replayed DLQ entry must produce one task queue row"
+    );
+}
+
+#[tokio::test]
+async fn bulk_replay_across_shards_drains_both_shards() {
+    let ((shard0_url, shard1_url), _container) = setup_sharded_test_database_urls().await;
+    let app = build_sharded_dlq_app(&shard0_url, &shard1_url);
+
+    for _ in 0..2 {
+        insert_dlq_row(&shard0_url, "cross_shard_task", "ACTIVITY").await;
+        insert_dlq_row(&shard1_url, "cross_shard_task", "ACTIVITY").await;
+    }
+
+    let (status, body) = post_json(
+        &app,
+        "/dead-letters/replay",
+        json!({ "activity_name": "cross_shard_task" }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["matched"], 4, "matched must sum across both shards");
+    assert_eq!(body["acted_on"], 4);
+    let failures = body["failures"].as_array().expect("failures must be array");
+    assert!(failures.is_empty(), "unexpected failures: {failures:?}");
+
+    assert_eq!(
+        count_dlq_rows(&shard0_url).await,
+        0,
+        "shard 0 DLQ must be empty"
+    );
+    assert_eq!(
+        count_dlq_rows(&shard1_url).await,
+        0,
+        "shard 1 DLQ must be empty"
+    );
+}
+
+#[tokio::test]
+async fn bulk_discard_removes_entries_without_enqueueing() {
+    let (database_url, _container) = setup_test_database_url().await;
+    let app = build_dlq_app(build_test_pool(&database_url));
+
+    for _ in 0..3 {
+        insert_dlq_row(&database_url, "discard_task", "ACTIVITY").await;
+    }
+
+    let (status, body) = post_json(
+        &app,
+        "/dead-letters/discard",
+        json!({ "activity_name": "discard_task" }),
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["matched"], 3);
+    assert_eq!(body["acted_on"], 3);
+    let failures = body["failures"].as_array().expect("failures must be array");
+    assert!(failures.is_empty(), "unexpected failures: {failures:?}");
+
+    assert_eq!(
+        count_dlq_rows(&database_url).await,
+        0,
+        "DLQ must be empty after discard"
+    );
+    assert_eq!(
+        count_task_queue_rows_by_activity(&database_url, "discard_task").await,
+        0,
+        "discard must not enqueue tasks"
+    );
+}
+
+#[tokio::test]
+async fn bulk_replay_per_row_failure_does_not_halt_other_rows() {
+    let (database_url, _container) = setup_test_database_url().await;
+    let app = build_dlq_app(build_test_pool(&database_url));
+
+    insert_dlq_row(&database_url, "mixed_task", "ACTIVITY").await;
+    let bad_id = insert_dlq_row(&database_url, "mixed_task", "INVALID").await;
+    insert_dlq_row(&database_url, "mixed_task", "ACTIVITY").await;
+
+    let (status, body) = post_json(
+        &app,
+        "/dead-letters/replay",
+        json!({ "activity_name": "mixed_task" }),
+    )
+    .await;
+
+    // acted_on > 0 so handler must return 200, not 500
+    assert_eq!(status, StatusCode::OK, "response body: {body}");
+    assert_eq!(body["matched"], 3, "all 3 rows matched");
+    assert_eq!(body["acted_on"], 2, "only the 2 valid rows were replayed");
+    assert_eq!(body["skipped"], 0);
+    let failures = body["failures"].as_array().expect("failures must be array");
+    assert_eq!(failures.len(), 1, "one per-row failure expected");
+    assert_eq!(
+        failures[0]["id"].as_str().unwrap_or(""),
+        bad_id.to_string(),
+        "failure must identify the bad row"
+    );
+
+    assert_eq!(
+        count_dlq_rows(&database_url).await,
+        1,
+        "invalid row must remain in DLQ after per-row failure"
+    );
+    assert_eq!(
+        count_task_queue_rows_by_activity(&database_url, "mixed_task").await,
+        2,
+        "valid rows must have been enqueued despite the per-row failure"
+    );
+}
+
+#[tokio::test]
+async fn bulk_replay_after_drain_returns_zero_matched() {
+    let (database_url, _container) = setup_test_database_url().await;
+    let app = build_dlq_app(build_test_pool(&database_url));
+
+    insert_dlq_row(&database_url, "idempotent_task", "ACTIVITY").await;
+    insert_dlq_row(&database_url, "idempotent_task", "ACTIVITY").await;
+
+    // First call drains the DLQ
+    let (first_status, first_body) = post_json(
+        &app,
+        "/dead-letters/replay",
+        json!({ "activity_name": "idempotent_task" }),
+    )
+    .await;
+    assert_eq!(first_status, StatusCode::OK);
+    assert_eq!(first_body["acted_on"], 2);
+
+    // Second call with same filter — rows are gone, nothing to match
+    let (second_status, second_body) = post_json(
+        &app,
+        "/dead-letters/replay",
+        json!({ "activity_name": "idempotent_task" }),
+    )
+    .await;
+    assert_eq!(second_status, StatusCode::OK);
+    assert_eq!(second_body["matched"], 0, "no rows remain to match");
+    assert_eq!(second_body["acted_on"], 0);
+    let ids = second_body["ids"].as_array().expect("ids must be an array");
+    assert!(ids.is_empty(), "no ids expected when nothing matched");
+}

--- a/autumn-harvest/src/dlq.rs
+++ b/autumn-harvest/src/dlq.rs
@@ -248,6 +248,44 @@ pub async fn replay_dead_letter(
 // Bulk operations
 // ---------------------------------------------------------------------------
 
+/// Count dead-letter rows matching `filter` without applying a row limit.
+///
+/// Used to populate `BulkDlqResult::matched` so callers can detect when the
+/// limit clips the result set.
+async fn count_dead_letters_for_bulk(
+    conn: &mut AsyncPgConnection,
+    filter: &BulkDlqFilter,
+) -> HarvestResult<i64> {
+    use crate::schema::harvest_dead_letters::dsl;
+    use diesel::dsl::sql;
+    use diesel::sql_types::{Bool, Text};
+
+    let mut query = dsl::harvest_dead_letters.into_boxed();
+
+    if let Some(ref name) = filter.activity_name {
+        query = query.filter(dsl::activity_name.eq(name.clone()));
+    }
+    if let Some(ref wf_name) = filter.workflow_name {
+        query = query.filter(
+            sql::<Bool>("workflow_exec_id IN (SELECT id FROM harvest_workflow_executions WHERE workflow_name = ")
+                .bind::<Text, _>(wf_name.clone())
+                .sql(")"),
+        );
+    }
+    if let Some(after) = filter.failed_after {
+        query = query.filter(dsl::failed_at.ge(after));
+    }
+    if let Some(before) = filter.failed_before {
+        query = query.filter(dsl::failed_at.lt(before));
+    }
+
+    query
+        .count()
+        .get_result(conn)
+        .await
+        .map_err(crate::error::database_error)
+}
+
 /// Query dead-letter rows matching `filter`, ordered oldest-first, up to
 /// `filter.effective_limit()` rows.
 async fn query_dead_letters_for_bulk(
@@ -301,8 +339,8 @@ pub async fn bulk_replay_dead_letters(
     conn: &mut AsyncPgConnection,
     filter: &BulkDlqFilter,
 ) -> HarvestResult<BulkDlqResult> {
+    let matched = usize::try_from(count_dead_letters_for_bulk(conn, filter).await?).unwrap_or(0);
     let rows = query_dead_letters_for_bulk(conn, filter).await?;
-    let matched = rows.len();
     let preview_ids: Vec<String> = rows.iter().map(|r| r.id.to_string()).collect();
 
     if filter.dry_run {
@@ -365,8 +403,8 @@ pub async fn bulk_discard_dead_letters(
 ) -> HarvestResult<BulkDlqResult> {
     use crate::schema::harvest_dead_letters::dsl;
 
+    let matched = usize::try_from(count_dead_letters_for_bulk(conn, filter).await?).unwrap_or(0);
     let rows = query_dead_letters_for_bulk(conn, filter).await?;
-    let matched = rows.len();
     let preview_ids: Vec<String> = rows.iter().map(|r| r.id.to_string()).collect();
 
     if filter.dry_run {

--- a/autumn-harvest/src/dlq.rs
+++ b/autumn-harvest/src/dlq.rs
@@ -18,7 +18,7 @@ use crate::error::{HarvestError, HarvestResult};
 use crate::models::{DeadLetter, NewDeadLetter};
 use crate::queue::{EnqueueParams, TaskType};
 
-const DEFAULT_BULK_LIMIT: u32 = 100;
+pub const DEFAULT_BULK_LIMIT: u32 = 100;
 const MAX_BULK_LIMIT: u32 = 1000;
 
 /// Filter for bulk DLQ operations.
@@ -56,10 +56,15 @@ impl BulkDlqFilter {
     }
 
     /// Effective row limit: uses the provided value clamped to [1, 1000],
-    /// defaulting to 100 when not set.
+    /// defaulting to 100 when not set. Zero is treated as 1 so callers never
+    /// get a silent no-op from `LIMIT 0`.
     #[must_use]
     pub fn effective_limit(&self) -> i64 {
-        i64::from(self.limit.unwrap_or(DEFAULT_BULK_LIMIT).min(MAX_BULK_LIMIT))
+        i64::from(
+            self.limit
+                .unwrap_or(DEFAULT_BULK_LIMIT)
+                .clamp(1, MAX_BULK_LIMIT),
+        )
     }
 }
 
@@ -567,6 +572,15 @@ mod tests {
             ..BulkDlqFilter::default()
         };
         assert_eq!(filter.effective_limit(), 250);
+    }
+
+    #[test]
+    fn bulk_filter_effective_limit_floors_at_1_for_zero() {
+        let filter = BulkDlqFilter {
+            limit: Some(0),
+            ..BulkDlqFilter::default()
+        };
+        assert_eq!(filter.effective_limit(), 1);
     }
 
     #[test]

--- a/autumn-harvest/src/dlq.rs
+++ b/autumn-harvest/src/dlq.rs
@@ -255,9 +255,15 @@ pub async fn replay_dead_letter(
 
 /// Count dead-letter rows matching `filter` without applying a row limit.
 ///
-/// Used to populate `BulkDlqResult::matched` so callers can detect when the
-/// limit clips the result set.
-async fn count_dead_letters_for_bulk(
+/// Used both internally (to populate `BulkDlqResult::matched`) and by the
+/// API fan-out layer to count matches on shards where the global limit is
+/// already exhausted, so that `matched` in the aggregated response always
+/// reflects the true pre-limit total across all shards.
+///
+/// # Errors
+///
+/// Returns [`HarvestError::Database`] on query failure.
+pub async fn count_bulk_filter_matches(
     conn: &mut AsyncPgConnection,
     filter: &BulkDlqFilter,
 ) -> HarvestResult<i64> {
@@ -344,7 +350,7 @@ pub async fn bulk_replay_dead_letters(
     conn: &mut AsyncPgConnection,
     filter: &BulkDlqFilter,
 ) -> HarvestResult<BulkDlqResult> {
-    let matched = usize::try_from(count_dead_letters_for_bulk(conn, filter).await?).unwrap_or(0);
+    let matched = usize::try_from(count_bulk_filter_matches(conn, filter).await?).unwrap_or(0);
     let rows = query_dead_letters_for_bulk(conn, filter).await?;
     let preview_ids: Vec<String> = rows.iter().map(|r| r.id.to_string()).collect();
 
@@ -408,7 +414,7 @@ pub async fn bulk_discard_dead_letters(
 ) -> HarvestResult<BulkDlqResult> {
     use crate::schema::harvest_dead_letters::dsl;
 
-    let matched = usize::try_from(count_dead_letters_for_bulk(conn, filter).await?).unwrap_or(0);
+    let matched = usize::try_from(count_bulk_filter_matches(conn, filter).await?).unwrap_or(0);
     let rows = query_dead_letters_for_bulk(conn, filter).await?;
     let preview_ids: Vec<String> = rows.iter().map(|r| r.id.to_string()).collect();
 

--- a/autumn-harvest/src/dlq.rs
+++ b/autumn-harvest/src/dlq.rs
@@ -18,6 +18,77 @@ use crate::error::{HarvestError, HarvestResult};
 use crate::models::{DeadLetter, NewDeadLetter};
 use crate::queue::{EnqueueParams, TaskType};
 
+const DEFAULT_BULK_LIMIT: u32 = 100;
+const MAX_BULK_LIMIT: u32 = 1000;
+
+/// Filter for bulk DLQ operations.
+///
+/// At least one of `activity_name`, `workflow_name`, `failed_after`, or
+/// `failed_before` must be set. A filter with only `limit` or `dry_run` is
+/// considered empty and rejected with 400 at the API layer.
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct BulkDlqFilter {
+    /// Exact match on `activity_name`.
+    pub activity_name: Option<String>,
+    /// Exact match on the workflow name of the parent execution.
+    pub workflow_name: Option<String>,
+    /// Inclusive lower bound on `failed_at`.
+    pub failed_after: Option<chrono::DateTime<chrono::Utc>>,
+    /// Exclusive upper bound on `failed_at`.
+    pub failed_before: Option<chrono::DateTime<chrono::Utc>>,
+    /// Cap on rows acted on per call. Defaults to 100, hard-capped at 1000.
+    pub limit: Option<u32>,
+    /// When `true`, return matching rows and count without writing.
+    #[serde(default)]
+    pub dry_run: bool,
+}
+
+impl BulkDlqFilter {
+    /// Returns `true` if no substantive filter criterion is specified.
+    ///
+    /// `limit` and `dry_run` alone do not count as criteria.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.activity_name.is_none()
+            && self.workflow_name.is_none()
+            && self.failed_after.is_none()
+            && self.failed_before.is_none()
+    }
+
+    /// Effective row limit: uses the provided value clamped to [1, 1000],
+    /// defaulting to 100 when not set.
+    #[must_use]
+    pub fn effective_limit(&self) -> i64 {
+        i64::from(self.limit.unwrap_or(DEFAULT_BULK_LIMIT).min(MAX_BULK_LIMIT))
+    }
+}
+
+/// A single per-row failure within a bulk DLQ operation.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct BulkDlqFailure {
+    /// Dead-letter row ID that failed.
+    pub id: String,
+    /// Error message for this row.
+    pub reason: String,
+}
+
+/// Structured result of a bulk DLQ replay or discard operation.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct BulkDlqResult {
+    /// Total rows matching the filter (before limit clip).
+    pub matched: usize,
+    /// Rows successfully acted on.
+    pub acted_on: usize,
+    /// Rows that matched but were skipped (e.g. already replayed concurrently).
+    pub skipped: usize,
+    /// IDs of rows successfully acted on.
+    pub ids: Vec<String>,
+    /// Whether this was a dry-run (no writes performed).
+    pub dry_run: bool,
+    /// Per-row failures that did not roll back other rows.
+    pub failures: Vec<BulkDlqFailure>,
+}
+
 fn dead_letter_task_type(dead_letter_id: Uuid, task_type: &str) -> HarvestResult<TaskType> {
     if task_type.eq_ignore_ascii_case("workflow") {
         Ok(TaskType::Workflow)
@@ -174,6 +245,179 @@ pub async fn replay_dead_letter(
 }
 
 // ---------------------------------------------------------------------------
+// Bulk operations
+// ---------------------------------------------------------------------------
+
+/// Query dead-letter rows matching `filter`, ordered oldest-first, up to
+/// `filter.effective_limit()` rows.
+async fn query_dead_letters_for_bulk(
+    conn: &mut AsyncPgConnection,
+    filter: &BulkDlqFilter,
+) -> HarvestResult<Vec<DeadLetter>> {
+    use crate::schema::harvest_dead_letters::dsl;
+    use diesel::dsl::sql;
+    use diesel::sql_types::{Bool, Text};
+
+    let mut query = dsl::harvest_dead_letters
+        .into_boxed()
+        .order(dsl::failed_at.asc())
+        .limit(filter.effective_limit());
+
+    if let Some(ref name) = filter.activity_name {
+        query = query.filter(dsl::activity_name.eq(name.clone()));
+    }
+    if let Some(ref wf_name) = filter.workflow_name {
+        query = query.filter(
+            sql::<Bool>("workflow_exec_id IN (SELECT id FROM harvest_workflow_executions WHERE workflow_name = ")
+                .bind::<Text, _>(wf_name.clone())
+                .sql(")"),
+        );
+    }
+    if let Some(after) = filter.failed_after {
+        query = query.filter(dsl::failed_at.ge(after));
+    }
+    if let Some(before) = filter.failed_before {
+        query = query.filter(dsl::failed_at.lt(before));
+    }
+
+    query
+        .select(DeadLetter::as_select())
+        .load(conn)
+        .await
+        .map_err(crate::error::database_error)
+}
+
+/// Bulk replay dead-letter entries matching `filter`.
+///
+/// Each row is replayed independently through the same path as
+/// [`replay_dead_letter`]. A per-row failure does not roll back already-replayed
+/// rows. When `filter.dry_run` is `true`, no writes are performed.
+///
+/// # Errors
+///
+/// Returns [`HarvestError::Database`] if the initial filter query fails.
+/// Per-row replay errors are captured in [`BulkDlqResult::failures`].
+pub async fn bulk_replay_dead_letters(
+    conn: &mut AsyncPgConnection,
+    filter: &BulkDlqFilter,
+) -> HarvestResult<BulkDlqResult> {
+    let rows = query_dead_letters_for_bulk(conn, filter).await?;
+    let matched = rows.len();
+    let preview_ids: Vec<String> = rows.iter().map(|r| r.id.to_string()).collect();
+
+    if filter.dry_run {
+        return Ok(BulkDlqResult {
+            matched,
+            acted_on: 0,
+            skipped: 0,
+            ids: preview_ids,
+            dry_run: true,
+            failures: Vec::new(),
+        });
+    }
+
+    let mut acted_on = 0usize;
+    let mut skipped = 0usize;
+    let mut acted_ids: Vec<String> = Vec::new();
+    let mut failures: Vec<BulkDlqFailure> = Vec::new();
+
+    for row in &rows {
+        match replay_dead_letter(conn, row.id).await {
+            Ok(_task_id) => {
+                acted_on += 1;
+                acted_ids.push(row.id.to_string());
+            }
+            Err(HarvestError::NotFound(_)) => {
+                skipped += 1;
+            }
+            Err(e) => {
+                failures.push(BulkDlqFailure {
+                    id: row.id.to_string(),
+                    reason: e.to_string(),
+                });
+            }
+        }
+    }
+
+    Ok(BulkDlqResult {
+        matched,
+        acted_on,
+        skipped,
+        ids: acted_ids,
+        dry_run: false,
+        failures,
+    })
+}
+
+/// Bulk discard dead-letter entries matching `filter`.
+///
+/// Each matching row is deleted from `harvest_dead_letters` without
+/// re-enqueueing. A per-row failure does not affect other rows. When
+/// `filter.dry_run` is `true`, no deletes are performed.
+///
+/// # Errors
+///
+/// Returns [`HarvestError::Database`] if the initial filter query fails.
+/// Per-row delete errors are captured in [`BulkDlqResult::failures`].
+pub async fn bulk_discard_dead_letters(
+    conn: &mut AsyncPgConnection,
+    filter: &BulkDlqFilter,
+) -> HarvestResult<BulkDlqResult> {
+    use crate::schema::harvest_dead_letters::dsl;
+
+    let rows = query_dead_letters_for_bulk(conn, filter).await?;
+    let matched = rows.len();
+    let preview_ids: Vec<String> = rows.iter().map(|r| r.id.to_string()).collect();
+
+    if filter.dry_run {
+        return Ok(BulkDlqResult {
+            matched,
+            acted_on: 0,
+            skipped: 0,
+            ids: preview_ids,
+            dry_run: true,
+            failures: Vec::new(),
+        });
+    }
+
+    let mut acted_on = 0usize;
+    let mut skipped = 0usize;
+    let mut acted_ids: Vec<String> = Vec::new();
+    let mut failures: Vec<BulkDlqFailure> = Vec::new();
+
+    for row in &rows {
+        match diesel::delete(dsl::harvest_dead_letters.find(row.id))
+            .execute(conn)
+            .await
+            .map_err(crate::error::database_error)
+        {
+            Ok(0) => {
+                skipped += 1;
+            }
+            Ok(_) => {
+                acted_on += 1;
+                acted_ids.push(row.id.to_string());
+            }
+            Err(e) => {
+                failures.push(BulkDlqFailure {
+                    id: row.id.to_string(),
+                    reason: e.to_string(),
+                });
+            }
+        }
+    }
+
+    Ok(BulkDlqResult {
+        matched,
+        acted_on,
+        skipped,
+        ids: acted_ids,
+        dry_run: false,
+        failures,
+    })
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -228,6 +472,96 @@ mod tests {
         assert!(
             matches!(error, HarvestError::Config(message) if message.contains("invalid task_type"))
         );
+    }
+
+    #[test]
+    fn bulk_filter_is_empty_when_no_criteria_set() {
+        let filter = BulkDlqFilter::default();
+        assert!(filter.is_empty());
+    }
+
+    #[test]
+    fn bulk_filter_is_not_empty_when_activity_name_set() {
+        let filter = BulkDlqFilter {
+            activity_name: Some("send_email".into()),
+            ..BulkDlqFilter::default()
+        };
+        assert!(!filter.is_empty());
+    }
+
+    #[test]
+    fn bulk_filter_is_not_empty_when_workflow_name_set() {
+        let filter = BulkDlqFilter {
+            workflow_name: Some("onboarding".into()),
+            ..BulkDlqFilter::default()
+        };
+        assert!(!filter.is_empty());
+    }
+
+    #[test]
+    fn bulk_filter_is_not_empty_when_failed_after_set() {
+        let filter = BulkDlqFilter {
+            failed_after: Some(chrono::Utc::now()),
+            ..BulkDlqFilter::default()
+        };
+        assert!(!filter.is_empty());
+    }
+
+    #[test]
+    fn bulk_filter_is_not_empty_when_failed_before_set() {
+        let filter = BulkDlqFilter {
+            failed_before: Some(chrono::Utc::now()),
+            ..BulkDlqFilter::default()
+        };
+        assert!(!filter.is_empty());
+    }
+
+    #[test]
+    fn bulk_filter_effective_limit_defaults_to_100() {
+        let filter = BulkDlqFilter::default();
+        assert_eq!(filter.effective_limit(), 100);
+    }
+
+    #[test]
+    fn bulk_filter_effective_limit_uses_provided_value() {
+        let filter = BulkDlqFilter {
+            limit: Some(250),
+            ..BulkDlqFilter::default()
+        };
+        assert_eq!(filter.effective_limit(), 250);
+    }
+
+    #[test]
+    fn bulk_filter_effective_limit_clamps_at_1000() {
+        let filter = BulkDlqFilter {
+            limit: Some(9999),
+            ..BulkDlqFilter::default()
+        };
+        assert_eq!(filter.effective_limit(), 1000);
+    }
+
+    #[test]
+    fn bulk_filter_dry_run_defaults_to_false_from_json() {
+        let filter: BulkDlqFilter = serde_json::from_str(r#"{"activity_name":"foo"}"#).unwrap();
+        assert!(!filter.dry_run);
+    }
+
+    #[test]
+    fn bulk_filter_serialization_roundtrip() {
+        let filter = BulkDlqFilter {
+            activity_name: Some("charge_card".into()),
+            workflow_name: Some("billing".into()),
+            failed_after: None,
+            failed_before: None,
+            limit: Some(200),
+            dry_run: true,
+        };
+        let json = serde_json::to_string(&filter).unwrap();
+        let back: BulkDlqFilter = serde_json::from_str(&json).unwrap();
+        assert_eq!(back.activity_name.as_deref(), Some("charge_card"));
+        assert_eq!(back.workflow_name.as_deref(), Some("billing"));
+        assert_eq!(back.limit, Some(200));
+        assert!(back.dry_run);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

This PR adds bulk operations for managing the dead-letter queue (DLQ), allowing operators to replay or discard multiple dead-lettered tasks at once based on filter criteria rather than processing them individually.

## Key Changes

- **New DLQ bulk operations** (`autumn-harvest/src/dlq.rs`):
  - `BulkDlqFilter`: Struct for filtering dead-letter entries by activity name, workflow name, or time window (`failed_after`/`failed_before`), with configurable row limit (default 100, max 1000) and dry-run mode
  - `BulkDlqResult`: Structured response containing matched count, acted-on count, skipped count, IDs, per-row failures, and dry-run flag
  - `bulk_replay_dead_letters()`: Replays matching entries without rolling back on per-row failures
  - `bulk_discard_dead_letters()`: Deletes matching entries without re-enqueueing
  - Helper functions `count_dead_letters_for_bulk()` and `query_dead_letters_for_bulk()` for filtering with support for workflow name joins

- **API endpoints** (`autumn-harvest-plugin/src/api.rs`):
  - `POST /dead-letters/replay`: Bulk replay with filter validation (rejects empty filters with 400)
  - `POST /dead-letters/discard`: Bulk discard with filter validation
  - `bulk_replay_from_shards()` and `bulk_discard_from_shards()`: Aggregate results across all shards in a sharded deployment

- **CLI commands** (`autumn-harvest-cli/src/lib.rs`):
  - `dlq bulk-replay`: Command-line interface for bulk replay with `--activity-name`, `--workflow-name`, `--failed-after`, `--failed-before`, `--limit`, and `--dry-run` flags
  - `dlq bulk-discard`: Command-line interface for bulk discard with same filter options
  - `build_bulk_dlq_body()`: Helper to construct request payloads from CLI arguments

- **Comprehensive integration tests** (`autumn-harvest-plugin/tests/dlq_bulk_integration.rs`):
  - Tests for empty filter rejection, dry-run preview behavior, single-shard and cross-shard operations
  - Tests for per-row failure handling (failures don't halt other rows)
  - Tests for idempotency (repeated calls on empty DLQ)
  - Database setup helpers for single and sharded test environments

- **Documentation** (README.md):
  - Added examples of bulk replay/discard commands
  - New "Post-incident DLQ drain" section explaining the workflow and response structure

## Implementation Details

- **Per-row error handling**: Failures during individual row processing are captured in `BulkDlqResult::failures` without rolling back already-processed rows, allowing partial success
- **Dry-run support**: When enabled, returns matching IDs and counts without performing any writes
- **Sharding support**: Bulk operations transparently aggregate results across all shards in a sharded deployment
- **Filter validation**: Empty filters (no criteria beyond `limit` and `dry_run`) are rejected at the API layer with a 400 error
- **Row limit enforcement**: Effective limit defaults to 100 and is hard-capped at 1000 to prevent runaway queries
- **Workflow name filtering**: Uses a subquery join to `harvest_workflow_executions` for workflow name matching

https://claude.ai/code/session_01AT12xUBGpGkZ4Vn3123wzt