### PR TITLE
Implement local activities (issue #98)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,7 @@ Two crates in the workspace. `autumn-harvest` is the public library. `autumn-har
 - **Phase 1** (complete): types, error, event, policy, context stubs, models, macros, builder
 - **Phase 2** (complete): event store, replay engine, workflow context, activity context, task queue (SKIP LOCKED), LISTEN/NOTIFY, worker runtime, heartbeating, timeout enforcement, workflow versioning (ctx.version), LRU workflow cache, dead letter queue, separate worker pool with shared ceiling, testcontainers integration tests
 - **Phase 3** (implemented): DAG scheduler/runtime, `DagBuilder`, `#[dag]` macro, trigger rules, signals/queries, management HTTP API, Autumn adapter crate with `HarvestExt` lifecycle integration
+- **Phase 3.5** (implemented): Local activities (`#[activity(local = true)]`, `ctx.execute_local_activity_raw`, `WorkflowCommand::RunLocalActivity`, three new `WorkflowEvent` variants, builder cap validation) — see issue #98
 - **Phase 4** (next): production hardening -- cancellation/saga semantics, sharding, sticky cross-worker routing, observability, metrics, dashboard (autumn-harvest-ui)
 
 ---
@@ -207,10 +208,47 @@ Supported `#[activity]` attribute keys:
 - `schedule_to_start = "5m"`
 - `retry = RetryPolicy::exponential(3, Duration::from_secs(1))` — any expression
 - `queue = "email-workers"` — task queue name
+- `local = true` — run inline on the workflow worker (see Local Activities below)
 
 Duration strings: `"30s"`, `"5m"`, `"1h"`. Parsed via Harvest core's local `task_duration()` helper.
 
 `#[workflow]` takes no attributes in Phase 1.
+
+### Local Activities
+
+Local activities run **inline on the workflow worker task** — they are never enqueued to `harvest_task_queue` and never dispatched to a remote worker. Their results are still recorded durably in `harvest_events` (`LocalActivityScheduled`, `LocalActivityCompleted`, `LocalActivityFailed`) so deterministic replay works identically to regular activities.
+
+```rust
+#[activity(local = true, start_to_close = "5s", retry = RetryPolicy::fixed(3, Duration::from_millis(100)))]
+async fn compute_checksum(ctx: &ActivityContext, data: Vec<u8>) -> Result<String, String> {
+    // pure CPU work — no I/O, no heartbeats
+    Ok(hex::encode(sha256(&data)))
+}
+```
+
+**Decision matrix — local vs regular activity:**
+
+| | Local activity | Regular activity |
+|---|---|---|
+| Execution location | Inline on the workflow worker | Dispatched to task queue / remote worker |
+| Typical duration | < 1 s | Any duration |
+| Hard timeout cap | `WorkerConfig::max_local_activity_start_to_close` (default 60 s) | No cap enforced by Harvest |
+| Heartbeating | **Not supported** | Supported |
+| `schedule_to_start` timeout | **Not supported** | Supported |
+| Custom task queue | **Not supported** | Supported |
+| Retry policy | Supported | Supported |
+| Durability / replay | Full (events appended to history) | Full (events appended to history) |
+
+**Use a local activity when:**
+- The work is in-process (pure computation, fast cache lookups, format conversions, orchestration glue)
+- Latency matters and you want to avoid round-trips through the task queue
+- The operation reliably completes within the 60 s default cap
+
+**Use a regular activity when:**
+- The work involves real I/O (HTTP, DB, filesystem)
+- You need the activity to run on a different worker pool or machine
+- The operation might take more than 60 s or needs heartbeating to signal liveness
+- You want `schedule_to_start` timeout enforcement
 
 ---
 

--- a/autumn-harvest-macros/src/activity.rs
+++ b/autumn-harvest-macros/src/activity.rs
@@ -12,6 +12,7 @@ struct ActivityAttrs {
     queue: Option<String>,
     max_concurrent: Option<u32>,
     concurrency_key: Option<String>,
+    local: bool,
 }
 
 fn parse_attrs(attr: TokenStream) -> syn::Result<ActivityAttrs> {
@@ -23,6 +24,7 @@ fn parse_attrs(attr: TokenStream) -> syn::Result<ActivityAttrs> {
         queue: None,
         max_concurrent: None,
         concurrency_key: None,
+        local: false,
     };
 
     syn::meta::parser(|meta| {
@@ -60,8 +62,12 @@ fn parse_attrs(attr: TokenStream) -> syn::Result<ActivityAttrs> {
             let value: LitStr = meta.value()?.parse()?;
             result.concurrency_key = Some(value.value());
             Ok(())
+        } else if meta.path.is_ident("local") {
+            let value: syn::LitBool = meta.value()?.parse()?;
+            result.local = value.value();
+            Ok(())
         } else {
-            Err(meta.error("unsupported attribute: expected retry, start_to_close, heartbeat_timeout, schedule_to_start, queue, max_concurrent, or concurrency_key"))
+            Err(meta.error("unsupported attribute: expected retry, start_to_close, heartbeat_timeout, schedule_to_start, queue, max_concurrent, concurrency_key, or local"))
         }
     })
     .parse2(attr)?;
@@ -97,6 +103,35 @@ pub fn activity_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
             "#[activity] functions must be async",
         )
         .to_compile_error();
+    }
+
+    // Local activities may only use start_to_close. Emit a clear compile error
+    // for any unsupported option to prevent silent misconfiguration.
+    if attrs.local {
+        if attrs.heartbeat_timeout.is_some() {
+            return syn::Error::new_spanned(
+                input_fn.sig.fn_token,
+                "local activities do not support heartbeat_timeout; \
+                 use a regular activity if you need heartbeating",
+            )
+            .to_compile_error();
+        }
+        if attrs.schedule_to_start.is_some() {
+            return syn::Error::new_spanned(
+                input_fn.sig.fn_token,
+                "local activities do not support schedule_to_start; \
+                 local activities always run inline on the workflow worker",
+            )
+            .to_compile_error();
+        }
+        if attrs.queue.is_some() {
+            return syn::Error::new_spanned(
+                input_fn.sig.fn_token,
+                "local activities do not support queue; \
+                 local activities always run on the worker executing the workflow",
+            )
+            .to_compile_error();
+        }
     }
 
     let fn_name = &input_fn.sig.ident;
@@ -207,6 +242,8 @@ pub fn activity_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         }
     };
 
+    let is_local = attrs.local;
+
     quote! {
         #input_fn
 
@@ -222,6 +259,7 @@ pub fn activity_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 default_queue: #queue_expr,
                 max_concurrent: #max_concurrent_expr,
                 concurrency_key: #concurrency_key_expr,
+                is_local: #is_local,
                 handler: |ctx, input| {
                     ::std::boxed::Box::pin(async move {
                         #dispatch

--- a/autumn-harvest-plugin/src/plugin.rs
+++ b/autumn-harvest-plugin/src/plugin.rs
@@ -434,6 +434,7 @@ mod tests {
             default_queue: None,
             max_concurrent: None,
             concurrency_key: None,
+            is_local: false,
             handler: |_ctx, input| Box::pin(async move { Ok(input) }),
         }
     }

--- a/autumn-harvest-plugin/tests/api_scheduler_integration.rs
+++ b/autumn-harvest-plugin/tests/api_scheduler_integration.rs
@@ -295,6 +295,7 @@ fn recording_activity_info(name: &'static str) -> ActivityInfo {
         default_queue: Some("default"),
         max_concurrent: None,
         concurrency_key: None,
+        is_local: false,
         handler: record_activity,
     }
 }
@@ -1790,6 +1791,7 @@ async fn scheduler_tick_creates_and_executes_due_interval_runs() {
             default_queue: Some("default"),
             max_concurrent: None,
             concurrency_key: None,
+            is_local: false,
             handler: record_activity,
         }],
         Arc::new(state),

--- a/autumn-harvest/src/builder.rs
+++ b/autumn-harvest/src/builder.rs
@@ -833,6 +833,7 @@ mod tests {
                 default_queue: None,
                 max_concurrent: None,
                 concurrency_key: None,
+                is_local: false,
                 handler: |_ctx, input| Box::pin(async move { Ok(input) }),
             }])
             .state(String::from("haunted"))

--- a/autumn-harvest/src/builder.rs
+++ b/autumn-harvest/src/builder.rs
@@ -157,6 +157,22 @@ pub enum HarvestBuilderError {
         registered: Vec<String>,
     },
 
+    /// A local activity declares a `start_to_close` that exceeds the worker's
+    /// `max_local_activity_start_to_close` cap. Local activities run inline on
+    /// the workflow worker and must not block it indefinitely.
+    #[error(
+        "local activity '{activity}' start_to_close ({actual:?}) exceeds the worker cap \
+         ({cap:?}); lower start_to_close or raise WorkerConfig::max_local_activity_start_to_close"
+    )]
+    LocalActivityStartToCloseExceedsCap {
+        /// The local activity name.
+        activity: String,
+        /// The declared `start_to_close` on the activity.
+        actual: Duration,
+        /// The configured worker cap.
+        cap: Duration,
+    },
+
     /// A [`WorkflowSchedule`] contains an invalid schedule value (malformed cron
     /// expression, zero-length interval, etc.). Caught at build time so the
     /// operator sees a clear error rather than silently-inert or wedging schedules.
@@ -438,6 +454,10 @@ impl HarvestBuilder {
 
         validate_concurrency_keys(&self.activities)?;
         validate_workflow_schedules(&self.workflow_schedules, &self.workflows)?;
+        validate_local_activity_timeouts(
+            &self.activities,
+            self.worker_config.max_local_activity_start_to_close,
+        )?;
 
         Ok(BuiltHarvest {
             workflows: self.workflows,
@@ -548,6 +568,27 @@ fn validate_concurrency_keys(
     Ok(())
 }
 
+/// Reject local activities whose `default_start_to_close` exceeds the worker
+/// cap. Failing early gives operators a clear error instead of a runtime surprise.
+fn validate_local_activity_timeouts(
+    activities: &[crate::info::ActivityInfo],
+    cap: Duration,
+) -> Result<(), HarvestBuilderError> {
+    for activity in activities {
+        if !activity.is_local {
+            continue;
+        }
+        if activity.default_start_to_close.is_some_and(|stc| stc > cap) {
+            return Err(HarvestBuilderError::LocalActivityStartToCloseExceedsCap {
+                activity: activity.name.to_string(),
+                actual: activity.default_start_to_close.unwrap(),
+                cap,
+            });
+        }
+    }
+    Ok(())
+}
+
 /// Worker concurrency and queue configuration.
 #[derive(Debug, Clone)]
 pub struct WorkerConfig {
@@ -579,6 +620,13 @@ pub struct WorkerConfig {
     /// a `Vec` so future per-process multi-shard workers can list all shards
     /// they should poll without changing the config surface.
     pub shard_assignments: Vec<ShardId>,
+    /// Hard cap on `start_to_close` for local activities.
+    ///
+    /// Local activities run inline on the workflow worker task. An unbounded
+    /// timeout would block the worker indefinitely. Defaults to **60 seconds**.
+    /// Any local activity registered with `start_to_close > cap` is rejected
+    /// at builder `try_build()` time.
+    pub max_local_activity_start_to_close: Duration,
 }
 
 impl Default for WorkerConfig {
@@ -593,6 +641,7 @@ impl Default for WorkerConfig {
             sticky_timeout: Duration::from_secs(5),
             cancellation_grace_period: Duration::from_secs(5),
             shard_assignments: vec![ShardId::new(0)],
+            max_local_activity_start_to_close: Duration::from_secs(60),
         }
     }
 }
@@ -822,6 +871,23 @@ mod tests {
             default_queue: None,
             max_concurrent,
             concurrency_key: key,
+            is_local: false,
+            handler: |_ctx, input| Box::pin(async move { Ok(input) }),
+        }
+    }
+
+    fn make_local_activity(name: &'static str, start_to_close: Option<Duration>) -> ActivityInfo {
+        ActivityInfo {
+            name,
+            module: "test",
+            default_retry_policy: None,
+            default_start_to_close: start_to_close,
+            default_heartbeat_timeout: None,
+            default_schedule_to_start: None,
+            default_queue: None,
+            max_concurrent: None,
+            concurrency_key: None,
+            is_local: true,
             handler: |_ctx, input| Box::pin(async move { Ok(input) }),
         }
     }
@@ -926,5 +992,114 @@ mod tests {
                 if activity == "act_a"
         ));
         assert!(err.to_string().contains("act_a"));
+    }
+
+    // ── Local activity cap tests ──────────────────────────────────────────
+
+    #[test]
+    fn worker_config_max_local_activity_start_to_close_defaults_to_60s() {
+        let config = WorkerConfig::default();
+        assert_eq!(
+            config.max_local_activity_start_to_close,
+            Duration::from_secs(60)
+        );
+    }
+
+    #[test]
+    fn builder_accepts_local_activity_within_cap() {
+        let result = HarvestBuilder::new()
+            .activities(vec![make_local_activity(
+                "compute_hash",
+                Some(Duration::from_secs(30)),
+            )])
+            .try_build();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn builder_accepts_local_activity_with_no_start_to_close() {
+        let result = HarvestBuilder::new()
+            .activities(vec![make_local_activity("compute_hash", None)])
+            .try_build();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn builder_rejects_local_activity_exceeding_cap() {
+        let result = HarvestBuilder::new()
+            .activities(vec![make_local_activity(
+                "slow_local",
+                Some(Duration::from_secs(120)),
+            )])
+            .try_build();
+        let err = result.unwrap_err();
+        assert!(
+            matches!(
+                err,
+                HarvestBuilderError::LocalActivityStartToCloseExceedsCap {
+                    ref activity, ..
+                } if activity == "slow_local"
+            ),
+            "expected LocalActivityStartToCloseExceedsCap, got {err}"
+        );
+        assert!(err.to_string().contains("slow_local"));
+    }
+
+    #[test]
+    fn builder_rejects_local_activity_exactly_at_cap_boundary_when_exceeded() {
+        // Exactly 60s is fine; 61s should fail.
+        let at_cap = HarvestBuilder::new()
+            .activities(vec![make_local_activity(
+                "edge_case",
+                Some(Duration::from_secs(60)),
+            )])
+            .try_build();
+        assert!(at_cap.is_ok());
+
+        let over_cap = HarvestBuilder::new()
+            .activities(vec![make_local_activity(
+                "edge_case",
+                Some(Duration::from_secs(61)),
+            )])
+            .try_build();
+        assert!(over_cap.is_err());
+    }
+
+    #[test]
+    fn builder_accepts_custom_cap_that_fits_activity() {
+        let worker = WorkerConfig {
+            max_local_activity_start_to_close: Duration::from_secs(120),
+            ..WorkerConfig::default()
+        };
+        let result = HarvestBuilder::new()
+            .activities(vec![make_local_activity(
+                "slow_local",
+                Some(Duration::from_secs(90)),
+            )])
+            .worker(worker)
+            .try_build();
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn regular_activity_is_not_subject_to_local_cap() {
+        // A regular activity with start_to_close > 60s should not be rejected
+        // by the local activity cap validator.
+        let result = HarvestBuilder::new()
+            .activities(vec![ActivityInfo {
+                name: "long_running",
+                module: "test",
+                default_retry_policy: None,
+                default_start_to_close: Some(Duration::from_secs(300)),
+                default_heartbeat_timeout: None,
+                default_schedule_to_start: None,
+                default_queue: None,
+                max_concurrent: None,
+                concurrency_key: None,
+                is_local: false,
+                handler: |_ctx, input| Box::pin(async move { Ok(input) }),
+            }])
+            .try_build();
+        assert!(result.is_ok());
     }
 }

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -165,6 +165,28 @@ pub enum WorkflowCommand {
         /// Input passed to the next iteration of the workflow.
         input: Value,
     },
+    /// Run a local activity inline on the workflow worker (never enqueued).
+    ///
+    /// The worker resolves this command by running the named handler directly
+    /// in the workflow dispatch loop, recording `LocalActivityScheduled`,
+    /// zero or more `LocalActivityFailed` (per retry attempt), and finally
+    /// `LocalActivityCompleted` or a terminal `LocalActivityFailed` in
+    /// `harvest_events`. No row is ever written to `harvest_task_queue`.
+    RunLocalActivity {
+        /// The unique execution ID for this local activity invocation.
+        activity_id: ActivityExecId,
+        /// The name of the registered activity handler (looked up by the worker).
+        name: String,
+        /// JSON input for the handler.
+        input: Value,
+        /// Optional start-to-close timeout in seconds. `None` defers to the
+        /// worker's `max_local_activity_start_to_close` cap.
+        start_to_close_secs: Option<u64>,
+        /// Optional retry policy. `None` = no retries (fail immediately).
+        retry_policy: Option<crate::policy::RetryPolicy>,
+        /// The worker sends the final result (success or exhausted retries) here.
+        result_tx: oneshot::Sender<Result<Value, String>>,
+    },
 }
 
 // Manual Debug because oneshot::Sender is not Debug.
@@ -232,6 +254,17 @@ impl std::fmt::Debug for WorkflowCommand {
                 .debug_struct("ContinueAsNew")
                 .field("input", input)
                 .finish(),
+            Self::RunLocalActivity {
+                activity_id,
+                name,
+                start_to_close_secs,
+                ..
+            } => f
+                .debug_struct("RunLocalActivity")
+                .field("activity_id", activity_id)
+                .field("name", name)
+                .field("start_to_close_secs", start_to_close_secs)
+                .finish_non_exhaustive(),
         }
     }
 }
@@ -733,6 +766,90 @@ impl WorkflowContext {
                     }),
                     Err(_) => Err(HarvestError::Cancelled(format!(
                         "activity '{name}' cancelled: result channel dropped"
+                    ))),
+                }
+            }
+        }
+    }
+
+    // ── Local activity dispatch ───────────────────────────────────────
+
+    /// Execute a *local* activity inline on the workflow worker — never enqueued.
+    ///
+    /// During **replay**, returns the recorded outcome from `harvest_events`
+    /// without running the handler body.
+    ///
+    /// During **live execution**, emits a [`WorkflowCommand::RunLocalActivity`]
+    /// command and suspends the coroutine until the worker runs the handler
+    /// inline and resolves the result channel.
+    ///
+    /// Local activities respect only `start_to_close`. They do not support
+    /// heartbeats, `schedule_to_start`, or a named task queue (they always
+    /// run on the same worker task driving the workflow).
+    ///
+    /// # Errors
+    ///
+    /// - [`HarvestError::NonDeterministic`] if history at this position does
+    ///   not match `name`.
+    /// - [`HarvestError::ActivityFailed`] if recorded history shows exhausted retries.
+    /// - [`HarvestError::Cancelled`] if the result channel was dropped.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal matcher or commands mutex is poisoned.
+    pub async fn execute_local_activity_raw(
+        &self,
+        name: &str,
+        input: Value,
+        retry_policy: Option<crate::policy::RetryPolicy>,
+        start_to_close_secs: Option<u64>,
+    ) -> HarvestResult<Value> {
+        let history_match = self.match_history(|m| m.match_local_activity(name));
+
+        match history_match {
+            HistoryMatch::Matched { output } => Ok(output),
+
+            HistoryMatch::Failed { error, attempt } => Err(HarvestError::ActivityFailed {
+                name: name.to_string(),
+                attempt,
+                source: error.into(),
+            }),
+
+            HistoryMatch::TimedOut { timeout_type } => Err(HarvestError::Timeout {
+                timeout_type,
+                task_name: name.to_string(),
+            }),
+
+            HistoryMatch::Diverged { expected, actual } => Err(HarvestError::NonDeterministic(
+                format!("local activity mismatch: expected {expected}, got {actual}"),
+            )),
+
+            HistoryMatch::AwaitingExternalCompletion { .. } => {
+                unreachable!("match_local_activity never returns AwaitingExternalCompletion")
+            }
+
+            HistoryMatch::NoMatch => {
+                let activity_id = self.next_activity_id();
+                let (tx, rx) = oneshot::channel();
+
+                self.push_command(WorkflowCommand::RunLocalActivity {
+                    activity_id,
+                    name: name.to_string(),
+                    input,
+                    start_to_close_secs,
+                    retry_policy,
+                    result_tx: tx,
+                });
+
+                match rx.await {
+                    Ok(Ok(output)) => Ok(output),
+                    Ok(Err(error)) => Err(HarvestError::ActivityFailed {
+                        name: name.to_string(),
+                        attempt: 1,
+                        source: error.into(),
+                    }),
+                    Err(_) => Err(HarvestError::Cancelled(format!(
+                        "local activity '{name}' cancelled: result channel dropped"
                     ))),
                 }
             }
@@ -2523,5 +2640,109 @@ mod tests {
     fn context_check_cancellation_returns_ok_when_not_cancelled() {
         let ctx = WorkflowContext::new_test();
         assert!(ctx.check_cancellation().is_ok());
+    }
+
+    // ── Local activity tests ──────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn execute_local_activity_emits_run_local_command_during_live_execution() {
+        let ctx = WorkflowContext::new_test();
+
+        // Race the future against a short sleep — it should suspend (not complete)
+        // because no history provides a result.
+        let fut = ctx.execute_local_activity_raw("format_data", Value::Null, None, None);
+        tokio::pin!(fut);
+        tokio::select! {
+            _ = &mut fut => panic!("should suspend, not complete"),
+            () = tokio::time::sleep(std::time::Duration::from_millis(20)) => {}
+        }
+
+        let commands = ctx.drain_commands();
+        assert_eq!(commands.len(), 1);
+        match &commands[0] {
+            WorkflowCommand::RunLocalActivity { name, .. } => {
+                assert_eq!(name, "format_data");
+            }
+            other => panic!("expected RunLocalActivity, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn execute_local_activity_returns_history_result_during_replay() {
+        let id = ActivityExecId::new();
+        let expected = serde_json::json!({"formatted": "hello"});
+        let events = vec![
+            WorkflowEvent::WorkflowStarted {
+                input: Value::Null,
+                timestamp: chrono::Utc::now(),
+            },
+            WorkflowEvent::LocalActivityScheduled {
+                activity_id: id,
+                name: "format_data".into(),
+                input: Value::Null,
+            },
+            WorkflowEvent::LocalActivityCompleted {
+                activity_id: id,
+                output: expected.clone(),
+            },
+        ];
+        let ctx = WorkflowContext::for_replay(crate::types::ExecutionId::new(), events);
+        let result = ctx
+            .execute_local_activity_raw("format_data", Value::Null, None, None)
+            .await
+            .expect("replay should succeed");
+        assert_eq!(result, expected);
+        assert!(!ctx.is_replaying());
+    }
+
+    #[tokio::test]
+    async fn execute_local_activity_returns_error_for_exhausted_retries_in_history() {
+        let id = ActivityExecId::new();
+        let events = vec![
+            WorkflowEvent::WorkflowStarted {
+                input: Value::Null,
+                timestamp: chrono::Utc::now(),
+            },
+            WorkflowEvent::LocalActivityScheduled {
+                activity_id: id,
+                name: "format_data".into(),
+                input: Value::Null,
+            },
+            WorkflowEvent::LocalActivityFailed {
+                activity_id: id,
+                error: "always fails".into(),
+                attempt: 1,
+            },
+        ];
+        let ctx = WorkflowContext::for_replay(crate::types::ExecutionId::new(), events);
+        let result = ctx
+            .execute_local_activity_raw("format_data", Value::Null, None, None)
+            .await;
+        assert!(
+            matches!(result, Err(HarvestError::ActivityFailed { attempt: 1, .. })),
+            "expected ActivityFailed, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn execute_local_activity_divergence_is_nondeterministic() {
+        let activity_id = ActivityExecId::new();
+        let events = vec![
+            WorkflowEvent::WorkflowStarted {
+                input: Value::Null,
+                timestamp: chrono::Utc::now(),
+            },
+            WorkflowEvent::ActivityScheduled {
+                activity_id,
+                name: "other_activity".into(),
+                input: Value::Null,
+                queue: "default".into(),
+            },
+        ];
+        let ctx = WorkflowContext::for_replay(crate::types::ExecutionId::new(), events);
+        let result = ctx
+            .execute_local_activity_raw("format_data", Value::Null, None, None)
+            .await;
+        assert!(matches!(result, Err(HarvestError::NonDeterministic(_))));
     }
 }

--- a/autumn-harvest/src/dag_linter.rs
+++ b/autumn-harvest/src/dag_linter.rs
@@ -335,6 +335,7 @@ mod tests {
                 default_queue: None,
                 max_concurrent: None,
                 concurrency_key: None,
+                is_local: false,
                 handler: dummy_handler,
             },
         );

--- a/autumn-harvest/src/event.rs
+++ b/autumn-harvest/src/event.rs
@@ -160,6 +160,41 @@ pub enum WorkflowEvent {
         input: serde_json::Value,
     },
 
+    // ── Local activities (issue #98) ─────────────────────────────────────
+    /// A local activity was dispatched for inline execution on the workflow
+    /// worker. Unlike regular activities, local activities never write a row to
+    /// `harvest_task_queue`; the worker runs the handler in the same Tokio task
+    /// that drives the workflow loop.
+    LocalActivityScheduled {
+        /// Unique ID for this local activity attempt sequence.
+        activity_id: ActivityExecId,
+        /// The name of the registered activity handler.
+        name: String,
+        /// JSON input for the activity.
+        input: serde_json::Value,
+    },
+    /// A local activity finished executing successfully.
+    LocalActivityCompleted {
+        /// Unique ID matching the corresponding `LocalActivityScheduled`.
+        activity_id: ActivityExecId,
+        /// The JSON result returned by the activity handler.
+        output: serde_json::Value,
+    },
+    /// A local activity attempt returned an error or the handler panicked.
+    ///
+    /// Multiple `LocalActivityFailed` events may appear in sequence (one per
+    /// attempt) before a terminal `LocalActivityCompleted` (retry eventually
+    /// succeeded) or before the retry budget is exhausted (the last
+    /// `LocalActivityFailed` with no following `LocalActivityCompleted`).
+    LocalActivityFailed {
+        /// Unique ID matching the corresponding `LocalActivityScheduled`.
+        activity_id: ActivityExecId,
+        /// String representation of the failure.
+        error: String,
+        /// How many attempts have been made so far (1-based).
+        attempt: u32,
+    },
+
     // ── External activity completion (issue #92) ──────────────────────
     /// An external activity was scheduled and is awaiting completion via the
     /// management API task-token endpoint. The `token` is a single-use handle
@@ -232,6 +267,9 @@ impl WorkflowEvent {
             Self::ChildWorkflowFailed { .. } => "ChildWorkflowFailed",
             Self::MarkerRecorded { .. } => "MarkerRecorded",
             Self::WorkflowContinuedAsNew { .. } => "WorkflowContinuedAsNew",
+            Self::LocalActivityScheduled { .. } => "LocalActivityScheduled",
+            Self::LocalActivityCompleted { .. } => "LocalActivityCompleted",
+            Self::LocalActivityFailed { .. } => "LocalActivityFailed",
             Self::ActivityAwaitingExternal { .. } => "ActivityAwaitingExternal",
             Self::ActivityCompletedExternally { .. } => "ActivityCompletedExternally",
             Self::ActivityFailedExternally { .. } => "ActivityFailedExternally",
@@ -269,6 +307,47 @@ mod tests {
         let json = serde_json::to_string(&event)?;
         let back: WorkflowEvent = serde_json::from_str(&json)?;
         assert!(matches!(back, WorkflowEvent::ActivityScheduled { .. }));
+        Ok(())
+    }
+
+    #[test]
+    fn local_activity_scheduled_round_trips() -> Result<(), serde_json::Error> {
+        let event = WorkflowEvent::LocalActivityScheduled {
+            activity_id: ActivityExecId::new(),
+            name: "format_data".into(),
+            input: serde_json::json!({"x": 1}),
+        };
+        let json = serde_json::to_string(&event)?;
+        let back: WorkflowEvent = serde_json::from_str(&json)?;
+        assert!(matches!(back, WorkflowEvent::LocalActivityScheduled { .. }));
+        Ok(())
+    }
+
+    #[test]
+    fn local_activity_completed_round_trips() -> Result<(), serde_json::Error> {
+        let event = WorkflowEvent::LocalActivityCompleted {
+            activity_id: ActivityExecId::new(),
+            output: serde_json::json!({"result": 42}),
+        };
+        let json = serde_json::to_string(&event)?;
+        let back: WorkflowEvent = serde_json::from_str(&json)?;
+        assert!(matches!(back, WorkflowEvent::LocalActivityCompleted { .. }));
+        Ok(())
+    }
+
+    #[test]
+    fn local_activity_failed_round_trips() -> Result<(), serde_json::Error> {
+        let event = WorkflowEvent::LocalActivityFailed {
+            activity_id: ActivityExecId::new(),
+            error: "db connection refused".into(),
+            attempt: 3,
+        };
+        let json = serde_json::to_string(&event)?;
+        let back: WorkflowEvent = serde_json::from_str(&json)?;
+        assert!(matches!(
+            back,
+            WorkflowEvent::LocalActivityFailed { attempt: 3, .. }
+        ));
         Ok(())
     }
 
@@ -377,10 +456,24 @@ mod tests {
                 activity_id: ActivityExecId::new(),
                 token: crate::types::ExternalActivityToken::new(),
             },
+            WorkflowEvent::LocalActivityScheduled {
+                activity_id: ActivityExecId::new(),
+                name: "format_data".into(),
+                input: serde_json::Value::Null,
+            },
+            WorkflowEvent::LocalActivityCompleted {
+                activity_id: ActivityExecId::new(),
+                output: serde_json::Value::Null,
+            },
+            WorkflowEvent::LocalActivityFailed {
+                activity_id: ActivityExecId::new(),
+                error: "transient".into(),
+                attempt: 1,
+            },
         ];
 
-        assert_eq!(events.len(), 22);
+        assert_eq!(events.len(), 25);
         let names: HashSet<_> = events.iter().map(WorkflowEvent::type_name).collect();
-        assert_eq!(names.len(), 22, "duplicate type names detected");
+        assert_eq!(names.len(), 25, "duplicate type names detected");
     }
 }

--- a/autumn-harvest/src/event.rs
+++ b/autumn-harvest/src/event.rs
@@ -360,6 +360,7 @@ mod tests {
     }
 
     #[test]
+    #[allow(clippy::too_many_lines)]
     fn all_type_names_are_unique() {
         use crate::types::{ActivityExecId, ExecutionId, TimerId, WorkerId};
         use std::collections::HashSet;

--- a/autumn-harvest/src/history_export.rs
+++ b/autumn-harvest/src/history_export.rs
@@ -72,6 +72,11 @@ impl MermaidExporter {
                 | WorkflowEvent::ActivityExternalDeadlineExtended { .. } => {
                     self.handle_external_activity_event(event)?;
                 }
+                WorkflowEvent::LocalActivityScheduled { .. }
+                | WorkflowEvent::LocalActivityCompleted { .. }
+                | WorkflowEvent::LocalActivityFailed { .. } => {
+                    self.handle_local_activity_event(event)?;
+                }
             }
         }
         Ok(())
@@ -253,6 +258,41 @@ impl MermaidExporter {
             }
             WorkflowEvent::MarkerRecorded { name, .. } => {
                 writeln!(self.out, "    Note over WF: Marker: {name}")?;
+            }
+            _ => unreachable!(),
+        }
+        Ok(())
+    }
+
+    fn handle_local_activity_event(
+        &mut self,
+        event: &WorkflowEvent,
+    ) -> Result<(), std::fmt::Error> {
+        match event {
+            WorkflowEvent::LocalActivityScheduled {
+                name, activity_id, ..
+            } => {
+                writeln!(
+                    self.out,
+                    "    Note right of WF: Local Activity Scheduled: {name} (ID: {activity_id})"
+                )?;
+            }
+            WorkflowEvent::LocalActivityCompleted { activity_id, .. } => {
+                writeln!(
+                    self.out,
+                    "    Note right of WF: Local Activity Completed (ID: {activity_id})"
+                )?;
+            }
+            WorkflowEvent::LocalActivityFailed {
+                activity_id,
+                error,
+                attempt,
+            } => {
+                let safe_error = error.replace('\n', " ").replace('"', "'");
+                writeln!(
+                    self.out,
+                    "    Note right of WF: Local Activity Failed (ID: {activity_id}, Attempt: {attempt}): {safe_error}"
+                )?;
             }
             _ => unreachable!(),
         }

--- a/autumn-harvest/src/info.rs
+++ b/autumn-harvest/src/info.rs
@@ -64,6 +64,10 @@ pub struct ActivityInfo {
     /// `max_concurrent` budget. Defaults to the activity's own name when
     /// `max_concurrent` is set and `concurrency_key` is not specified.
     pub concurrency_key: Option<&'static str>,
+    /// When `true`, the worker runs this activity inline on the workflow task
+    /// (never enqueued). Local activities must not set `heartbeat_timeout`,
+    /// `schedule_to_start`, or `queue` — the macro enforces this at compile time.
+    pub is_local: bool,
     /// Type-erased dispatch function.
     pub handler: ActivityHandlerFn,
 }
@@ -123,6 +127,7 @@ impl std::fmt::Debug for ActivityInfo {
             .field("default_queue", &self.default_queue)
             .field("max_concurrent", &self.max_concurrent)
             .field("concurrency_key", &self.concurrency_key)
+            .field("is_local", &self.is_local)
             .field("handler", &"<fn>")
             .finish()
     }
@@ -169,12 +174,44 @@ mod tests {
             default_queue: None,
             max_concurrent: None,
             concurrency_key: None,
+            is_local: false,
             handler: |_ctx, input| Box::pin(async move { Ok(input) }),
         };
         assert!(info.default_retry_policy.is_none());
         assert_eq!(info.default_queue, None);
         assert!(info.max_concurrent.is_none());
         assert!(info.concurrency_key.is_none());
+        assert!(!info.is_local);
+    }
+
+    #[test]
+    fn activity_info_is_local_true() {
+        let info = ActivityInfo {
+            name: "compute_hash",
+            module: "my_app::activities",
+            default_retry_policy: None,
+            default_start_to_close: Some(std::time::Duration::from_secs(10)),
+            default_heartbeat_timeout: None,
+            default_schedule_to_start: None,
+            default_queue: None,
+            max_concurrent: None,
+            concurrency_key: None,
+            is_local: true,
+            handler: |_ctx, input| Box::pin(async move { Ok(input) }),
+        };
+        assert!(info.is_local);
+        assert!(
+            info.default_heartbeat_timeout.is_none(),
+            "local activities must not have heartbeat_timeout"
+        );
+        assert!(
+            info.default_schedule_to_start.is_none(),
+            "local activities must not have schedule_to_start"
+        );
+        assert!(
+            info.default_queue.is_none(),
+            "local activities must not have a queue"
+        );
     }
 
     #[test]
@@ -189,6 +226,7 @@ mod tests {
             default_queue: None,
             max_concurrent: Some(5),
             concurrency_key: Some("email"),
+            is_local: false,
             handler: |_ctx, input| Box::pin(async move { Ok(input) }),
         };
         assert_eq!(info.max_concurrent, Some(5));
@@ -242,6 +280,7 @@ mod tests {
             default_queue: None,
             max_concurrent: None,
             concurrency_key: None,
+            is_local: false,
             handler: |_ctx, input| Box::pin(async move { Ok(input) }),
         };
         let debug_str = format!("{activity_info:?}");

--- a/autumn-harvest/src/replay.rs
+++ b/autumn-harvest/src/replay.rs
@@ -714,6 +714,103 @@ impl HistoryMatcher {
         }
     }
 
+    /// Match a local activity command against history.
+    ///
+    /// Expects `LocalActivityScheduled { name }` at the current cursor, then
+    /// scans forward for `LocalActivityCompleted` (returns [`HistoryMatch::Matched`])
+    /// or exhausts `LocalActivityFailed` events and returns the last failure
+    /// (returns [`HistoryMatch::Failed`]).
+    ///
+    /// Intermediate `LocalActivityFailed` events (when the handler was retried
+    /// inline) are skipped; only the final outcome is surfaced to the workflow.
+    ///
+    /// Returns:
+    /// - [`HistoryMatch::Matched`] if the activity eventually succeeded
+    /// - [`HistoryMatch::Failed`] if retries were exhausted (last recorded failure)
+    /// - [`HistoryMatch::NoMatch`] if past end of history (first-time execution)
+    /// - [`HistoryMatch::Diverged`] if history has a different event at this position
+    pub fn match_local_activity(&mut self, activity_name: &str) -> HistoryMatch {
+        if !self.prepare_match() {
+            return HistoryMatch::NoMatch;
+        }
+
+        let WorkflowEvent::LocalActivityScheduled {
+            activity_id,
+            name: recorded_name,
+            ..
+        } = &self.events[self.cursor]
+        else {
+            return HistoryMatch::Diverged {
+                expected: format!("LocalActivityScheduled({activity_name})"),
+                actual: self.events[self.cursor].type_name().to_string(),
+            };
+        };
+        let activity_id = *activity_id;
+
+        if recorded_name != activity_name {
+            return HistoryMatch::Diverged {
+                expected: format!("LocalActivityScheduled({activity_name})"),
+                actual: format!("LocalActivityScheduled({recorded_name})"),
+            };
+        }
+
+        // Advance past LocalActivityScheduled
+        self.cursor += 1;
+        let mut scan_cursor = self.cursor;
+        let mut last_failure: Option<HistoryMatch> = None;
+
+        while scan_cursor < self.events.len() {
+            if self.is_consumed(scan_cursor) {
+                scan_cursor += 1;
+                continue;
+            }
+
+            match &self.events[scan_cursor] {
+                WorkflowEvent::LocalActivityCompleted {
+                    activity_id: id,
+                    output,
+                } if *id == activity_id => {
+                    let output = output.clone();
+                    self.cursor = scan_cursor + 1;
+                    self.advance_to_next_unconsumed_event();
+                    return HistoryMatch::Matched { output };
+                }
+                WorkflowEvent::LocalActivityFailed {
+                    activity_id: id,
+                    error,
+                    attempt,
+                } if *id == activity_id => {
+                    last_failure = Some(HistoryMatch::Failed {
+                        error: error.clone(),
+                        attempt: *attempt,
+                    });
+                    scan_cursor += 1;
+                }
+                // Signals can be ingested while a local activity is retrying
+                WorkflowEvent::SignalReceived {
+                    signal_name,
+                    payload,
+                } => {
+                    let signal_name = signal_name.clone();
+                    let payload = payload.clone();
+                    self.stash_signal(scan_cursor, signal_name, payload);
+                    scan_cursor += 1;
+                }
+                _ => break,
+            }
+        }
+
+        if let Some(failure) = last_failure {
+            // Scanned past all retry failures with no completion — this is terminal.
+            self.cursor = scan_cursor;
+            self.advance_to_next_unconsumed_event();
+            return failure;
+        }
+
+        // LocalActivityScheduled found but no terminal event yet — incomplete history.
+        HistoryMatch::NoMatch
+    }
+
     /// Versioning mechanism for safe workflow code changes.
     ///
     /// Checks the recorded history for a version marker. If the marker is present
@@ -1747,6 +1844,212 @@ mod tests {
             },
             "signal buffered during timer scan should be returned by match_signal"
         );
+    }
+
+    // ── Local activity tests ──────────────────────────────────────────────
+
+    #[test]
+    fn matcher_replays_completed_local_activity() {
+        let id = ActivityExecId::new();
+        let output = serde_json::json!({"formatted": "hello"});
+        let events = vec![
+            WorkflowEvent::LocalActivityScheduled {
+                activity_id: id,
+                name: "format_data".into(),
+                input: Value::Null,
+            },
+            WorkflowEvent::LocalActivityCompleted {
+                activity_id: id,
+                output: output.clone(),
+            },
+        ];
+        let mut matcher = HistoryMatcher::new(events);
+        let result = matcher.match_local_activity("format_data");
+        assert_eq!(result, HistoryMatch::Matched { output });
+        assert_eq!(matcher.position(), 2);
+        assert!(!matcher.is_replaying());
+    }
+
+    #[test]
+    fn matcher_replays_failed_local_activity_retries_exhausted() {
+        let id = ActivityExecId::new();
+        let events = vec![
+            WorkflowEvent::LocalActivityScheduled {
+                activity_id: id,
+                name: "format_data".into(),
+                input: Value::Null,
+            },
+            WorkflowEvent::LocalActivityFailed {
+                activity_id: id,
+                error: "transient".into(),
+                attempt: 1,
+            },
+            WorkflowEvent::LocalActivityFailed {
+                activity_id: id,
+                error: "still failing".into(),
+                attempt: 2,
+            },
+        ];
+        let mut matcher = HistoryMatcher::new(events);
+        let result = matcher.match_local_activity("format_data");
+        assert_eq!(
+            result,
+            HistoryMatch::Failed {
+                error: "still failing".into(),
+                attempt: 2,
+            }
+        );
+    }
+
+    #[test]
+    fn matcher_local_activity_skips_intermediate_failures_and_returns_completion() {
+        let id = ActivityExecId::new();
+        let output = serde_json::json!({"ok": true});
+        let events = vec![
+            WorkflowEvent::LocalActivityScheduled {
+                activity_id: id,
+                name: "format_data".into(),
+                input: Value::Null,
+            },
+            WorkflowEvent::LocalActivityFailed {
+                activity_id: id,
+                error: "transient".into(),
+                attempt: 1,
+            },
+            WorkflowEvent::LocalActivityFailed {
+                activity_id: id,
+                error: "still transient".into(),
+                attempt: 2,
+            },
+            WorkflowEvent::LocalActivityCompleted {
+                activity_id: id,
+                output: output.clone(),
+            },
+        ];
+        let mut matcher = HistoryMatcher::new(events);
+        let result = matcher.match_local_activity("format_data");
+        assert_eq!(result, HistoryMatch::Matched { output });
+        assert_eq!(matcher.position(), 4);
+    }
+
+    #[test]
+    fn matcher_local_activity_no_match_at_end_of_history() {
+        let mut matcher = HistoryMatcher::new(vec![]);
+        let result = matcher.match_local_activity("format_data");
+        assert_eq!(result, HistoryMatch::NoMatch);
+    }
+
+    #[test]
+    fn matcher_local_activity_detects_divergence_wrong_event_type() {
+        let timer_id = TimerId::new("t1");
+        let events = vec![WorkflowEvent::TimerStarted {
+            timer_id,
+            duration_secs: 10,
+        }];
+        let mut matcher = HistoryMatcher::new(events);
+        let result = matcher.match_local_activity("format_data");
+        assert!(matches!(result, HistoryMatch::Diverged { .. }));
+        if let HistoryMatch::Diverged { expected, actual } = result {
+            assert!(expected.contains("format_data"));
+            assert!(actual.contains("TimerStarted"));
+        }
+    }
+
+    #[test]
+    fn matcher_local_activity_detects_divergence_wrong_name() {
+        let id = ActivityExecId::new();
+        let events = vec![WorkflowEvent::LocalActivityScheduled {
+            activity_id: id,
+            name: "other_activity".into(),
+            input: Value::Null,
+        }];
+        let mut matcher = HistoryMatcher::new(events);
+        let result = matcher.match_local_activity("format_data");
+        assert!(matches!(result, HistoryMatch::Diverged { .. }));
+        if let HistoryMatch::Diverged { expected, actual } = result {
+            assert!(expected.contains("format_data"));
+            assert!(actual.contains("other_activity"));
+        }
+    }
+
+    #[test]
+    fn matcher_local_activity_stashes_signals_during_retry_scan() {
+        let id = ActivityExecId::new();
+        let output = serde_json::json!({"ok": true});
+        let events = vec![
+            WorkflowEvent::LocalActivityScheduled {
+                activity_id: id,
+                name: "format_data".into(),
+                input: Value::Null,
+            },
+            WorkflowEvent::LocalActivityFailed {
+                activity_id: id,
+                error: "transient".into(),
+                attempt: 1,
+            },
+            WorkflowEvent::SignalReceived {
+                signal_name: "abort".into(),
+                payload: serde_json::json!({"reason": "user"}),
+            },
+            WorkflowEvent::LocalActivityCompleted {
+                activity_id: id,
+                output: output.clone(),
+            },
+        ];
+        let mut matcher = HistoryMatcher::new(events);
+        let result = matcher.match_local_activity("format_data");
+        assert_eq!(result, HistoryMatch::Matched { output });
+
+        // Signal buffered during scan must be deliverable later.
+        let signal = matcher.match_signal("abort");
+        assert_eq!(
+            signal,
+            HistoryMatch::Matched {
+                output: serde_json::json!({"reason": "user"})
+            }
+        );
+    }
+
+    #[test]
+    fn matcher_replays_sequential_local_and_regular_activities() {
+        let local_id = ActivityExecId::new();
+        let regular_id = ActivityExecId::new();
+        let local_out = serde_json::json!("formatted");
+        let regular_out = serde_json::json!({"sent": true});
+        let events = vec![
+            WorkflowEvent::LocalActivityScheduled {
+                activity_id: local_id,
+                name: "format_data".into(),
+                input: Value::Null,
+            },
+            WorkflowEvent::LocalActivityCompleted {
+                activity_id: local_id,
+                output: local_out.clone(),
+            },
+            WorkflowEvent::ActivityScheduled {
+                activity_id: regular_id,
+                name: "send_email".into(),
+                input: Value::Null,
+                queue: "default".into(),
+            },
+            WorkflowEvent::ActivityCompleted {
+                activity_id: regular_id,
+                output: regular_out.clone(),
+            },
+        ];
+        let mut matcher = HistoryMatcher::new(events);
+
+        let r1 = matcher.match_local_activity("format_data");
+        assert_eq!(r1, HistoryMatch::Matched { output: local_out });
+
+        let r2 = matcher.match_activity("send_email");
+        assert_eq!(
+            r2,
+            HistoryMatch::Matched {
+                output: regular_out
+            }
+        );
+        assert!(!matcher.is_replaying());
     }
 
     #[test]

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -75,6 +75,10 @@ pub struct WorkerRuntimeConfig {
     /// preferentially to this worker so its in-process LRU cache stays warm.
     /// Zero disables sticky routing entirely.
     pub sticky_timeout: Duration,
+    /// Hard cap applied to each local activity attempt. If the activity does
+    /// not complete within this window it is treated as a failure and retried
+    /// (or the workflow fails if retries are exhausted).
+    pub max_local_activity_start_to_close: Duration,
 }
 
 impl WorkerRuntimeConfig {
@@ -105,6 +109,7 @@ impl From<WorkerConfig> for WorkerRuntimeConfig {
             shutdown_timeout: cfg.shutdown_timeout,
             cancellation_grace_period: cfg.cancellation_grace_period,
             sticky_timeout: cfg.sticky_timeout,
+            max_local_activity_start_to_close: cfg.max_local_activity_start_to_close,
         }
     }
 }
@@ -245,6 +250,7 @@ const fn workflow_command_name(command: &WorkflowCommand) -> &'static str {
         WorkflowCommand::Complete { .. } => "Complete",
         WorkflowCommand::Fail { .. } => "Fail",
         WorkflowCommand::ContinueAsNew { .. } => "ContinueAsNew",
+        WorkflowCommand::RunLocalActivity { .. } => "RunLocalActivity",
     }
 }
 
@@ -482,6 +488,161 @@ fn extract_single_schedule_external_activity(
             schedule_to_close_secs: *schedule_to_close_secs,
         })
     })
+}
+
+// ── Local activity support ──────────────────────────────────────────────────
+
+struct LocalActivityRun {
+    activity_id: crate::types::ActivityExecId,
+    name: String,
+    input: serde_json::Value,
+    start_to_close_secs: Option<u64>,
+    retry_policy: Option<crate::policy::RetryPolicy>,
+}
+
+/// Extract a `RunLocalActivity` command from an owned command list.
+///
+/// Marker (`RecordMarker`) events are also extracted and returned so the
+/// caller can append them to the event log before the local-activity events.
+/// The `result_tx` inside the command is dropped immediately — the workflow
+/// coroutine was already dropped when the 100 ms suspension timeout fired, so
+/// nobody is listening on the receiving end.
+fn extract_run_local_activity(
+    commands: Vec<WorkflowCommand>,
+) -> (Vec<WorkflowEvent>, LocalActivityRun) {
+    let mut markers = Vec::new();
+    let mut local_run = None;
+    for cmd in commands {
+        match cmd {
+            WorkflowCommand::RecordMarker { name, details } => {
+                markers.push(WorkflowEvent::MarkerRecorded { name, details });
+            }
+            WorkflowCommand::RunLocalActivity {
+                activity_id,
+                name,
+                input,
+                start_to_close_secs,
+                retry_policy,
+                result_tx,
+            } => {
+                drop(result_tx); // coroutine already dropped; close the channel
+                local_run = Some(LocalActivityRun {
+                    activity_id,
+                    name,
+                    input,
+                    start_to_close_secs,
+                    retry_policy,
+                });
+            }
+            _ => {} // unexpected alongside RunLocalActivity; ignore
+        }
+    }
+    (
+        markers,
+        local_run.expect("called only after confirming RunLocalActivity is present"),
+    )
+}
+
+/// Run a local activity inline, appending durability events to `harvest_events`.
+///
+/// Retries the handler up to `max_attempts` times (per the retry policy),
+/// sleeping the computed backoff between attempts. Each attempt appends a
+/// `LocalActivityFailed` event; on success a `LocalActivityCompleted` event is
+/// appended. Returns all newly-appended events so the caller can extend its
+/// in-memory replay history and avoid a DB round-trip.
+async fn run_local_activity_inline(
+    conn: &mut AsyncPgConnection,
+    registry: &HandlerRegistry,
+    exec_id: ExecutionId,
+    marker_events: Vec<WorkflowEvent>,
+    run: LocalActivityRun,
+    max_start_to_close: Duration,
+    next_event_id: &mut i32,
+) -> HarvestResult<Vec<WorkflowEvent>> {
+    let activity = registry.activities.get(&run.name).ok_or_else(|| {
+        HarvestError::Config(format!("no activity handler registered for '{}'", run.name))
+    })?;
+
+    let per_attempt_timeout = run
+        .start_to_close_secs
+        .map_or(max_start_to_close, Duration::from_secs)
+        .min(max_start_to_close);
+
+    let max_attempts = run.retry_policy.as_ref().map_or(1, |p| p.max_attempts);
+
+    let scheduled_event = WorkflowEvent::LocalActivityScheduled {
+        activity_id: run.activity_id,
+        name: run.name.clone(),
+        input: run.input.clone(),
+    };
+
+    // Append marker events + scheduled event in a single call.
+    let mut prefix_events = marker_events;
+    prefix_events.push(scheduled_event);
+    store::append_events(conn, exec_id, &prefix_events, *next_event_id).await?;
+    *next_event_id += i32::try_from(prefix_events.len())
+        .map_err(|_| HarvestError::Config("event count overflow".into()))?;
+
+    let mut all_new_events = prefix_events;
+    let ctx = ActivityContext::new(registry.shared_state(), None, CancellationToken::new());
+    let handler = activity.handler;
+
+    for attempt in 1..=max_attempts {
+        let result = tokio::time::timeout(per_attempt_timeout, (handler)(&ctx, run.input.clone()))
+            .await
+            .unwrap_or_else(|_| {
+                Err(format!(
+                    "local activity '{}' timed out after {:?}",
+                    run.name, per_attempt_timeout
+                ))
+            });
+
+        match result {
+            Ok(output) => {
+                let completed_event = WorkflowEvent::LocalActivityCompleted {
+                    activity_id: run.activity_id,
+                    output,
+                };
+                store::append_events(
+                    conn,
+                    exec_id,
+                    std::slice::from_ref(&completed_event),
+                    *next_event_id,
+                )
+                .await?;
+                *next_event_id += 1;
+                all_new_events.push(completed_event);
+                return Ok(all_new_events);
+            }
+            Err(error) => {
+                let failed_event = WorkflowEvent::LocalActivityFailed {
+                    activity_id: run.activity_id,
+                    error: error.clone(),
+                    attempt,
+                };
+                store::append_events(
+                    conn,
+                    exec_id,
+                    std::slice::from_ref(&failed_event),
+                    *next_event_id,
+                )
+                .await?;
+                *next_event_id += 1;
+                all_new_events.push(failed_event);
+
+                if attempt < max_attempts
+                    && let Some(delay) = run
+                        .retry_policy
+                        .as_ref()
+                        .and_then(|p| p.next_delay(attempt))
+                {
+                    tokio::time::sleep(delay).await;
+                }
+            }
+        }
+    }
+
+    Ok(all_new_events)
 }
 
 fn chrono_duration_from_std(
@@ -1976,6 +2137,7 @@ async fn process_workflow_task(
     task: &TaskQueueItem,
     worker_id: &str,
     sticky_timeout: Duration,
+    max_local_activity_start_to_close: Duration,
 ) -> HarvestResult<()> {
     let prepared = prepare_workflow_task(conn, task, worker_id).await?;
     let Some(workflow) = registry.workflows.get(&prepared.execution.workflow_name) else {
@@ -2004,14 +2166,48 @@ async fn process_workflow_task(
         .record_workflow_started(&prepared.execution.workflow_name, &task.queue_name);
     let started_at = std::time::Instant::now();
 
-    let outcome = run_workflow_with_state(
-        prepared.exec_id,
-        prepared.history_events,
-        workflow.handler,
-        task.input.clone(),
-        registry.shared_state(),
-    )
-    .await;
+    // Drive the workflow in a loop so that local activities can be executed
+    // inline without parking the task. Each iteration runs the workflow until
+    // it suspends; if it suspends on a RunLocalActivity command the handler
+    // is executed here, its events are appended to history, and the workflow
+    // is re-run with the extended history. Any other suspension (regular
+    // activity, timer, signal wait, …) breaks out of the loop.
+    let mut history_events = prepared.history_events;
+    let mut next_event_id = prepared.next_event_id;
+
+    let outcome = loop {
+        let run_outcome = run_workflow_with_state(
+            prepared.exec_id,
+            history_events.clone(),
+            workflow.handler,
+            task.input.clone(),
+            registry.shared_state(),
+        )
+        .await;
+
+        match run_outcome {
+            WorkflowOutcome::Suspended { commands }
+                if commands
+                    .iter()
+                    .any(|c| matches!(c, WorkflowCommand::RunLocalActivity { .. })) =>
+            {
+                let (markers, local_run) = extract_run_local_activity(commands);
+                let new_events = run_local_activity_inline(
+                    conn,
+                    registry,
+                    prepared.exec_id,
+                    markers,
+                    local_run,
+                    max_local_activity_start_to_close,
+                    &mut next_event_id,
+                )
+                .await?;
+                history_events.extend(new_events);
+                // Loop: re-run the workflow with the extended history.
+            }
+            other => break other,
+        }
+    };
 
     let status = match &outcome {
         WorkflowOutcome::Completed { .. } => WorkflowStatus::Completed,
@@ -2034,7 +2230,7 @@ async fn process_workflow_task(
             task,
             worker_id,
             exec_id: prepared.exec_id,
-            next_event_id: prepared.next_event_id,
+            next_event_id,
             sticky_timeout,
         },
         outcome,
@@ -2049,6 +2245,7 @@ async fn process_task(
     worker_id: &str,
     cancellation_grace_period: Duration,
     sticky_timeout: Duration,
+    max_local_activity_start_to_close: Duration,
 ) -> HarvestResult<()> {
     let mut conn = pool.get().await.map_err(crate::error::database_error)?;
 
@@ -2060,6 +2257,7 @@ async fn process_task(
                 &task,
                 worker_id,
                 sticky_timeout,
+                max_local_activity_start_to_close,
             )
             .await
         }
@@ -2427,6 +2625,7 @@ impl Worker {
         let worker_id = self.config.worker_id.clone();
         let cancellation_grace_period = self.config.cancellation_grace_period;
         let sticky_timeout = self.config.sticky_timeout;
+        let max_local_activity_start_to_close = self.config.max_local_activity_start_to_close;
 
         tokio::spawn(async move {
             // Acquire semaphore permit — blocks if at concurrency limit.
@@ -2449,6 +2648,7 @@ impl Worker {
                 &worker_id,
                 cancellation_grace_period,
                 sticky_timeout,
+                max_local_activity_start_to_close,
             )
             .await
             {
@@ -2529,6 +2729,7 @@ mod tests {
             shutdown_timeout: Duration::from_secs(5),
             cancellation_grace_period: Duration::from_secs(5),
             sticky_timeout: Duration::from_secs(5),
+            max_local_activity_start_to_close: Duration::from_secs(60),
         }
     }
 
@@ -2581,6 +2782,7 @@ mod tests {
             sticky_timeout: Duration::from_secs(3),
             cancellation_grace_period: Duration::from_secs(10),
             shard_assignments: vec![crate::types::ShardId::new(0)],
+            max_local_activity_start_to_close: Duration::from_secs(60),
         };
 
         let runtime_cfg: WorkerRuntimeConfig = builder_cfg.into();

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -2822,6 +2822,7 @@ mod tests {
             default_queue: None,
             max_concurrent: None,
             concurrency_key: None,
+            is_local: false,
             handler: |_ctx, input| Box::pin(async move { Ok(input) }),
         };
 

--- a/autumn-harvest/tests/cancellation_tests.rs
+++ b/autumn-harvest/tests/cancellation_tests.rs
@@ -198,6 +198,7 @@ fn heartbeat_registry(probe: HeartbeatCancellationProbe) -> Arc<HandlerRegistry>
             default_queue: Some("default"),
             max_concurrent: None,
             concurrency_key: None,
+            is_local: false,
             handler: heartbeat_activity,
         }],
         Arc::new(state),
@@ -402,6 +403,7 @@ async fn running_activity_heartbeat_observes_workflow_cancellation() {
                 shutdown_timeout: Duration::from_secs(1),
                 cancellation_grace_period: Duration::from_secs(1),
                 sticky_timeout: Duration::from_secs(5),
+                max_local_activity_start_to_close: Duration::from_secs(60),
             },
             registry,
         )
@@ -525,6 +527,7 @@ fn uncooperative_registry(probe: UncooperativeActivityProbe) -> Arc<HandlerRegis
             default_queue: Some("default"),
             max_concurrent: None,
             concurrency_key: None,
+            is_local: false,
             handler: uncooperative_activity,
         }],
         Arc::new(state),
@@ -553,6 +556,7 @@ async fn uncooperative_activity_is_hard_aborted_after_grace_period() {
                 // Short grace period so the test completes quickly.
                 cancellation_grace_period: Duration::from_millis(500),
                 sticky_timeout: Duration::from_secs(5),
+                max_local_activity_start_to_close: Duration::from_secs(60),
             },
             registry,
         )

--- a/autumn-harvest/tests/integration_e2e.rs
+++ b/autumn-harvest/tests/integration_e2e.rs
@@ -407,6 +407,7 @@ fn build_runtime_worker(
                 shutdown_timeout: Duration::from_secs(1),
                 cancellation_grace_period: Duration::from_secs(1),
                 sticky_timeout: Duration::from_secs(5),
+                max_local_activity_start_to_close: Duration::from_secs(60),
             },
             registry,
         )
@@ -858,6 +859,7 @@ async fn worker_completes_workflow_task_and_persists_result() {
                 shutdown_timeout: Duration::from_secs(1),
                 cancellation_grace_period: Duration::from_secs(1),
                 sticky_timeout: Duration::from_secs(5),
+                max_local_activity_start_to_close: Duration::from_secs(60),
             },
             registry,
         )
@@ -949,6 +951,7 @@ async fn worker_marks_workflow_failed_when_handler_errors() {
                 shutdown_timeout: Duration::from_secs(1),
                 cancellation_grace_period: Duration::from_secs(1),
                 sticky_timeout: Duration::from_secs(5),
+                max_local_activity_start_to_close: Duration::from_secs(60),
             },
             registry,
         )
@@ -1049,6 +1052,7 @@ async fn worker_completes_workflow_with_activity_round_trip() {
             default_queue: Some("default"),
             max_concurrent: None,
             concurrency_key: None,
+            is_local: false,
             handler: send_email_activity,
         }],
     ));
@@ -1064,6 +1068,7 @@ async fn worker_completes_workflow_with_activity_round_trip() {
                 shutdown_timeout: Duration::from_secs(1),
                 cancellation_grace_period: Duration::from_secs(1),
                 sticky_timeout: Duration::from_secs(5),
+                max_local_activity_start_to_close: Duration::from_secs(60),
             },
             registry,
         )
@@ -1153,6 +1158,7 @@ async fn worker_fails_orphaned_activity_task_without_scheduled_event() {
                 shutdown_timeout: Duration::from_secs(1),
                 cancellation_grace_period: Duration::from_secs(1),
                 sticky_timeout: Duration::from_secs(5),
+                max_local_activity_start_to_close: Duration::from_secs(60),
             },
             Arc::new(HandlerRegistry::new(
                 vec![],
@@ -1166,6 +1172,7 @@ async fn worker_fails_orphaned_activity_task_without_scheduled_event() {
                     default_queue: Some("default"),
                     max_concurrent: None,
                     concurrency_key: None,
+                    is_local: false,
                     handler: send_email_activity,
                 }],
             )),
@@ -1316,6 +1323,7 @@ async fn timeout_enforcement_fails_pending_activity_and_wakes_workflow() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[allow(clippy::too_many_lines)]
 async fn worker_fails_workflow_when_activity_start_to_close_timeout_elapses() {
     let (database_url, _container) = setup_test_database_url().await;
     let mut conn = <AsyncPgConnection as diesel_async::AsyncConnection>::establish(&database_url)
@@ -1357,6 +1365,7 @@ async fn worker_fails_workflow_when_activity_start_to_close_timeout_elapses() {
                 shutdown_timeout: Duration::from_secs(1),
                 cancellation_grace_period: Duration::from_secs(1),
                 sticky_timeout: Duration::from_secs(5),
+                max_local_activity_start_to_close: Duration::from_secs(60),
             },
             Arc::new(HandlerRegistry::new(
                 vec![WorkflowInfo {
@@ -1374,6 +1383,7 @@ async fn worker_fails_workflow_when_activity_start_to_close_timeout_elapses() {
                     default_queue: Some("default"),
                     max_concurrent: None,
                     concurrency_key: None,
+                    is_local: false,
                     handler: slow_activity,
                 }],
             )),
@@ -1473,6 +1483,7 @@ async fn worker_completes_workflow_with_timer_round_trip() {
                 shutdown_timeout: Duration::from_secs(1),
                 cancellation_grace_period: Duration::from_secs(1),
                 sticky_timeout: Duration::from_secs(5),
+                max_local_activity_start_to_close: Duration::from_secs(60),
             },
             Arc::new(HandlerRegistry::new(
                 vec![WorkflowInfo {
@@ -1734,6 +1745,7 @@ async fn worker_builder_state_is_visible_to_workflow_and_activity() {
             default_queue: Some("default"),
             max_concurrent: None,
             concurrency_key: None,
+            is_local: false,
             handler: stateful_activity,
         }])
         .state(String::from("haunted"))
@@ -2312,6 +2324,7 @@ async fn worker_handles_early_ingested_signal_before_activity() {
             default_queue: Some("default"),
             max_concurrent: None,
             concurrency_key: None,
+            is_local: false,
             handler: send_email_activity,
         }],
     ));
@@ -3686,6 +3699,7 @@ async fn workflow_schedule_baseline_dispatches_multiple_runs() {
                 shutdown_timeout: Duration::from_secs(2),
                 cancellation_grace_period: Duration::from_secs(1),
                 sticky_timeout: Duration::from_secs(5),
+                max_local_activity_start_to_close: Duration::from_secs(60),
             },
             Arc::clone(&registry),
         )
@@ -3776,6 +3790,7 @@ async fn workflow_schedule_max_active_runs_enforced() {
                 shutdown_timeout: Duration::from_secs(2),
                 cancellation_grace_period: Duration::from_secs(1),
                 sticky_timeout: Duration::from_secs(5),
+                max_local_activity_start_to_close: Duration::from_secs(60),
             },
             Arc::clone(&registry),
         )
@@ -3854,6 +3869,7 @@ async fn workflow_schedule_pause_and_resume() {
                 shutdown_timeout: Duration::from_secs(2),
                 cancellation_grace_period: Duration::from_secs(1),
                 sticky_timeout: Duration::from_secs(5),
+                max_local_activity_start_to_close: Duration::from_secs(60),
             },
             Arc::clone(&registry),
         )

--- a/autumn-harvest/tests/macros_activity.rs
+++ b/autumn-harvest/tests/macros_activity.rs
@@ -17,12 +17,31 @@ async fn configured_activity(_ctx: &ActivityContext, input: String) -> Result<St
     Ok(input)
 }
 
+// Local activity — no queue, no heartbeat, no schedule_to_start
+#[activity(local = true)]
+async fn pure_local(_ctx: &ActivityContext, x: i64) -> Result<i64, String> {
+    Ok(x * 2)
+}
+
+// Local activity with start_to_close (the only timeout local activities support)
+#[activity(local = true, start_to_close = "10s")]
+async fn timed_local(_ctx: &ActivityContext, val: String) -> Result<String, String> {
+    Ok(val.to_uppercase())
+}
+
+// Local activity with a retry policy
+#[activity(local = true, retry = RetryPolicy::fixed(3, Duration::from_secs(1)))]
+async fn retryable_local(_ctx: &ActivityContext) -> Result<(), String> {
+    Ok(())
+}
+
 #[test]
 fn activity_companion_returns_name() {
     let info = __autumn_activity_info_simple_activity();
     assert_eq!(info.name, "simple_activity");
     assert!(info.default_retry_policy.is_none());
     assert_eq!(info.default_queue, None);
+    assert!(!info.is_local);
 }
 
 #[test]
@@ -32,4 +51,37 @@ fn configured_activity_companion_has_policy() {
     assert!(info.default_retry_policy.is_some());
     assert_eq!(info.default_queue, Some("email-workers"));
     assert_eq!(info.default_start_to_close, Some(Duration::from_secs(30)));
+    assert!(!info.is_local);
+}
+
+#[test]
+fn local_activity_companion_has_is_local_true() {
+    let info = __autumn_activity_info_pure_local();
+    assert_eq!(info.name, "pure_local");
+    assert!(info.is_local);
+    assert!(info.default_heartbeat_timeout.is_none());
+    assert!(info.default_schedule_to_start.is_none());
+    assert!(info.default_queue.is_none());
+}
+
+#[test]
+fn local_activity_with_start_to_close_is_local() {
+    let info = __autumn_activity_info_timed_local();
+    assert!(info.is_local);
+    assert_eq!(info.default_start_to_close, Some(Duration::from_secs(10)));
+}
+
+#[test]
+fn local_activity_with_retry_policy_is_local() {
+    let info = __autumn_activity_info_retryable_local();
+    assert!(info.is_local);
+    assert!(info.default_retry_policy.is_some());
+}
+
+#[test]
+fn regular_activity_is_not_local() {
+    let simple = __autumn_activity_info_simple_activity();
+    assert!(!simple.is_local);
+    let configured = __autumn_activity_info_configured_activity();
+    assert!(!configured.is_local);
 }

--- a/autumn-harvest/tests/replay_tests.rs
+++ b/autumn-harvest/tests/replay_tests.rs
@@ -327,3 +327,252 @@ async fn replay_handles_failed_activity() {
         other => panic!("expected Failed, got {other:?}"),
     }
 }
+
+// ---------------------------------------------------------------------------
+// Local activity replay tests
+// ---------------------------------------------------------------------------
+
+/// Workflow that uses one local activity (format) followed by one regular activity.
+fn mixed_local_regular_workflow<'a>(
+    ctx: &'a WorkflowContext,
+    _input: Value,
+) -> Pin<Box<dyn Future<Output = Result<Value, String>> + Send + 'a>> {
+    Box::pin(async move {
+        let formatted = ctx
+            .execute_local_activity_raw("format_data", Value::Null, None, None)
+            .await
+            .map_err(|e| e.to_string())?;
+
+        let sent = ctx
+            .execute_activity_raw("send_email", formatted.clone(), "default")
+            .await
+            .map_err(|e| e.to_string())?;
+
+        Ok(serde_json::json!({"formatted": formatted, "sent": sent}))
+    })
+}
+
+/// Workflow that uses only local activities (no regular queue activities).
+fn all_local_workflow<'a>(
+    ctx: &'a WorkflowContext,
+    _input: Value,
+) -> Pin<Box<dyn Future<Output = Result<Value, String>> + Send + 'a>> {
+    Box::pin(async move {
+        let r1 = ctx
+            .execute_local_activity_raw("step_1", Value::Null, None, None)
+            .await
+            .map_err(|e| e.to_string())?;
+        let r2 = ctx
+            .execute_local_activity_raw("step_2", r1.clone(), None, None)
+            .await
+            .map_err(|e| e.to_string())?;
+        Ok(serde_json::json!({"first": r1, "second": r2}))
+    })
+}
+
+#[tokio::test]
+async fn local_activity_completes_from_full_history() {
+    let local_id = ActivityExecId::new();
+    let regular_id = ActivityExecId::new();
+    let local_out = serde_json::json!("formatted-text");
+    let regular_out = serde_json::json!({"email_id": "msg-999"});
+    let exec_id = ExecutionId::new();
+
+    let history = vec![
+        WorkflowEvent::WorkflowStarted {
+            input: Value::Null,
+            timestamp: Utc::now(),
+        },
+        WorkflowEvent::LocalActivityScheduled {
+            activity_id: local_id,
+            name: "format_data".into(),
+            input: Value::Null,
+        },
+        WorkflowEvent::LocalActivityCompleted {
+            activity_id: local_id,
+            output: local_out.clone(),
+        },
+        WorkflowEvent::ActivityScheduled {
+            activity_id: regular_id,
+            name: "send_email".into(),
+            input: local_out.clone(),
+            queue: "default".into(),
+        },
+        WorkflowEvent::ActivityCompleted {
+            activity_id: regular_id,
+            output: regular_out.clone(),
+        },
+    ];
+
+    let outcome = run_workflow(exec_id, history, mixed_local_regular_workflow, Value::Null).await;
+
+    match outcome {
+        WorkflowOutcome::Completed { output } => {
+            assert_eq!(output["formatted"], local_out);
+            assert_eq!(output["sent"], regular_out);
+        }
+        other => panic!("expected Completed, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn local_activity_suspends_when_not_in_history() {
+    let exec_id = ExecutionId::new();
+
+    // History has only WorkflowStarted — local activity is new.
+    let history = vec![WorkflowEvent::WorkflowStarted {
+        input: Value::Null,
+        timestamp: Utc::now(),
+    }];
+
+    let outcome = run_workflow(exec_id, history, mixed_local_regular_workflow, Value::Null).await;
+
+    match outcome {
+        WorkflowOutcome::Suspended { commands } => {
+            assert_eq!(commands.len(), 1);
+            assert!(
+                matches!(
+                    &commands[0],
+                    autumn_harvest::context::WorkflowCommand::RunLocalActivity { name, .. }
+                    if name == "format_data"
+                ),
+                "expected RunLocalActivity for format_data, got {commands:?}"
+            );
+        }
+        other => panic!("expected Suspended, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn local_activity_replays_correctly_across_simulated_worker_restart() {
+    let id1 = ActivityExecId::new();
+    let id2 = ActivityExecId::new();
+    let out1 = serde_json::json!("step1-result");
+    let out2 = serde_json::json!("step2-result");
+    let exec_id = ExecutionId::new();
+
+    // Full history: both local activities completed.
+    let history = vec![
+        WorkflowEvent::WorkflowStarted {
+            input: Value::Null,
+            timestamp: Utc::now(),
+        },
+        WorkflowEvent::LocalActivityScheduled {
+            activity_id: id1,
+            name: "step_1".into(),
+            input: Value::Null,
+        },
+        WorkflowEvent::LocalActivityCompleted {
+            activity_id: id1,
+            output: out1.clone(),
+        },
+        WorkflowEvent::LocalActivityScheduled {
+            activity_id: id2,
+            name: "step_2".into(),
+            input: out1.clone(),
+        },
+        WorkflowEvent::LocalActivityCompleted {
+            activity_id: id2,
+            output: out2.clone(),
+        },
+    ];
+
+    let outcome = run_workflow(exec_id, history, all_local_workflow, Value::Null).await;
+
+    match outcome {
+        WorkflowOutcome::Completed { output } => {
+            assert_eq!(output["first"], out1);
+            assert_eq!(output["second"], out2);
+        }
+        other => panic!("expected Completed, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn local_activity_with_retry_in_history_replays_final_success() {
+    let id1 = ActivityExecId::new();
+    let id2 = ActivityExecId::new();
+    let final_out = serde_json::json!("ok");
+    let exec_id = ExecutionId::new();
+
+    // History shows two failed attempts for step_1, then success, then step_2.
+    let history = vec![
+        WorkflowEvent::WorkflowStarted {
+            input: Value::Null,
+            timestamp: Utc::now(),
+        },
+        WorkflowEvent::LocalActivityScheduled {
+            activity_id: id1,
+            name: "step_1".into(),
+            input: Value::Null,
+        },
+        WorkflowEvent::LocalActivityFailed {
+            activity_id: id1,
+            error: "transient".into(),
+            attempt: 1,
+        },
+        WorkflowEvent::LocalActivityFailed {
+            activity_id: id1,
+            error: "still transient".into(),
+            attempt: 2,
+        },
+        WorkflowEvent::LocalActivityCompleted {
+            activity_id: id1,
+            output: final_out.clone(),
+        },
+        WorkflowEvent::LocalActivityScheduled {
+            activity_id: id2,
+            name: "step_2".into(),
+            input: final_out.clone(),
+        },
+        WorkflowEvent::LocalActivityCompleted {
+            activity_id: id2,
+            output: serde_json::json!("done"),
+        },
+    ];
+
+    let outcome = run_workflow(exec_id, history, all_local_workflow, Value::Null).await;
+
+    match outcome {
+        WorkflowOutcome::Completed { output } => {
+            assert_eq!(output["first"], final_out);
+        }
+        other => panic!("expected Completed, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn local_activity_exhausted_retries_fails_the_workflow() {
+    let id = ActivityExecId::new();
+    let exec_id = ExecutionId::new();
+
+    // History shows one failed attempt with no completion (retries exhausted).
+    let history = vec![
+        WorkflowEvent::WorkflowStarted {
+            input: Value::Null,
+            timestamp: Utc::now(),
+        },
+        WorkflowEvent::LocalActivityScheduled {
+            activity_id: id,
+            name: "step_1".into(),
+            input: Value::Null,
+        },
+        WorkflowEvent::LocalActivityFailed {
+            activity_id: id,
+            error: "permanent failure".into(),
+            attempt: 1,
+        },
+    ];
+
+    let outcome = run_workflow(exec_id, history, all_local_workflow, Value::Null).await;
+
+    match outcome {
+        WorkflowOutcome::Failed { error } => {
+            assert!(
+                error.contains("permanent failure") || error.contains("step_1"),
+                "error should mention failure, got: {error}"
+            );
+        }
+        other => panic!("expected Failed, got {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary

Adds support for **local activities** — activities that execute inline on the workflow worker task rather than being enqueued to a task queue. Local activities are useful for lightweight, synchronous operations that should not be distributed.

## Key Changes

### Event Types
- Added three new `WorkflowEvent` variants:
  - `LocalActivityScheduled` — records when a local activity is dispatched
  - `LocalActivityCompleted` — records successful completion with output
  - `LocalActivityFailed` — records a failed attempt (may be followed by retries or terminal failure)

### Workflow Context API
- Added `execute_local_activity_raw()` method to `WorkflowContext` that:
  - Returns recorded output during replay (via `HistoryMatch::Matched`)
  - Returns recorded failure during replay (via `HistoryMatch::Failed`)
  - Emits `WorkflowCommand::RunLocalActivity` during live execution
  - Suspends the coroutine until the worker resolves the result channel

### History Matching
- Implemented `HistoryMatcher::match_local_activity()` that:
  - Expects `LocalActivityScheduled` at the current cursor
  - Scans forward for `LocalActivityCompleted` (success) or exhausts `LocalActivityFailed` events (terminal failure)
  - Skips intermediate `LocalActivityFailed` events (retries) and surfaces only the final outcome
  - Stashes `SignalReceived` events encountered during the scan for later delivery
  - Returns `NoMatch` if history is incomplete (first-time execution)

### Worker Runtime
- Added `max_local_activity_start_to_close` configuration cap (defaults to 60 seconds)
- Implemented `run_local_activity_inline()` that:
  - Runs the activity handler directly in the workflow dispatch loop
  - Respects per-attempt timeout and retry policy
  - Appends `LocalActivityScheduled`, zero or more `LocalActivityFailed`, and finally `LocalActivityCompleted` (or terminal `LocalActivityFailed`) to the event log
  - Returns all newly-appended events to avoid DB round-trip during replay

### Activity Macro
- Added `local = true` attribute to `#[activity]` macro
- Enforces at compile time that local activities do not declare `heartbeat_timeout`, `schedule_to_start`, or `queue`
- Sets `is_local: true` in the generated `ActivityInfo`

### Builder Validation
- Added `validate_local_activity_timeouts()` that rejects any local activity with `default_start_to_close > worker cap` at build time
- New error variant `HarvestBuilderError::LocalActivityStartToCloseExceedsCap`

### Testing
- Added comprehensive unit tests for `HistoryMatcher::match_local_activity()` covering:
  - Successful completion
  - Exhausted retries
  - Intermediate failures followed by success
  - End-of-history (NoMatch)
  - Divergence detection (wrong event type, wrong activity name)
  - Signal stashing during retry scan
- Added integration tests in `replay_tests.rs` covering:
  - Mixed local + regular activity workflows
  - All-local activity workflows
  - Retry scenarios with eventual success
  - Exhausted retries causing workflow failure
  - Suspension when local activity is not yet in history

### Documentation
- Updated `CLAUDE.md` to reflect Phase 3.5 completion
- Added comprehensive doc comments for all new public APIs

## Notable Implementation Details

- Local activities never write to `harvest_task_queue`; they are purely in-memory operations recorded in `harvest_events`
- The worker suspends the workflow coroutine for 100 ms to allow it to emit the `RunLocalActivity` command, then drops the coroutine and runs the handler inline
- Retry logic is built into the inline execution path; intermediate failures are recorded but only the final outcome is surfaced to the workflow
- Signals can be ingested while a local activity is retrying; they are stashed and delivered after the activity completes
- The `start_to_close` timeout is capped by the worker's `max_local_activity_start_to_close` to prevent indefinite blocking of the workflow task

https://claude.ai/code/session_01N7b19LhmJV1SWpCB9Fa1h7