### PR TITLE
Add worker fleet observability with liveness tracking and heartbeats

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,14 +149,15 @@ Current implementation scope: `ExecutionId`/`ShardId` encoding, `ShardRouter`, `
 | `info.rs` | 1 | `WorkflowInfo`, `ActivityInfo`, `WorkflowHandlerFn`, `ActivityHandlerFn` type aliases |
 | `builder.rs` | 1 | `HarvestBuilder` (fluent), `WorkerConfig` (queues, concurrency, timeouts) |
 | `prelude.rs` | 1 | Core glob re-export surface including macros |
-| `schema.rs` | 1 | Diesel `table!` macros -- 8 tables |
-| `models.rs` | 1 | `Queryable`/`Selectable` read structs and `Insertable` `New*` write structs for all 8 tables |
+| `schema.rs` | 1 | Diesel `table!` macros -- 9 tables |
+| `models.rs` | 1 | `Queryable`/`Selectable` read structs and `Insertable` `New*` write structs for all 9 tables |
 | `store.rs` | 2 | Event store: `append_events`, `load_history`, `events_to_rows` with sequential event IDs |
 | `replay.rs` | 2 | Deterministic replay engine: `HistoryMatcher` walks event history, detects non-determinism |
 | `executor.rs` | 2 | Workflow executor: `run_workflow` drives replay + live execution, handles suspension |
 | `queue.rs` | 2 | Postgres task queue: `enqueue`, `claim` (FOR UPDATE SKIP LOCKED), `complete`, `fail` |
 | `notify.rs` | 2 | LISTEN/NOTIFY wrapper: `Listener` (async stream), `Notifier` (pg_notify), channel naming |
 | `worker.rs` | 2 | Worker runtime: poll loop, semaphore-bounded concurrent dispatch, graceful shutdown |
+| `workers.rs` | 4 | Worker fleet registry: `register_worker`, `heartbeat_worker`, `transition_status`, `list_workers`, `get_worker`, `fleet_health`, `spawn_worker_heartbeat` |
 | `heartbeat.rs` | 2 | Batched heartbeat flusher: debounced channel receiver, bulk DB update |
 | `timeout.rs` | 2 | Timeout enforcement scanner: start-to-close, schedule-to-start, heartbeat timeout queries |
 | `cache.rs` | 2 | LRU workflow state cache: bounded capacity, access-order eviction |
@@ -308,6 +309,7 @@ The `testing` feature in `autumn-harvest/Cargo.toml` gates `WorkflowContext::new
 | `harvest_signals` | `Uuid` | Pending signals queued for delivery |
 | `harvest_timers` | `Uuid` | Durable timers registered by workflows |
 | `harvest_dead_letters` | `Uuid` | Tasks that exhausted all retry attempts |
+| `harvest_workers` | `Text` | Live worker process registrations and heartbeat state |
 
 `harvest_workflow_executions` is the hub — six tables join back to it via `workflow_exec_id`.
 
@@ -367,6 +369,7 @@ Worker pool and web pool are independently sized but share a total connection ce
 
 ## Phase 4 Scope (next)
 
+- **Worker fleet observability** (implemented, issue #100): `harvest_workers` table, per-worker heartbeat upsert, `Active → Draining → Stopped` lifecycle, `GET /workers`, `GET /workers/{id}`, `GET /workers/health` management routes, cross-shard aggregation via `iter_shards()`.
 - **Cancellation semantics**: explicit workflow/activity cancellation and propagation
 - **Saga primitives**: compensations and failure orchestration
 - **Cross-worker routing**: sticky execution affinity and shard-aware placement

--- a/README.md
+++ b/README.md
@@ -395,6 +395,38 @@ POST /api/harvest/admin/schedules/{id}/resume
 DELETE /api/harvest/admin/schedules/{id}
 ```
 
+### Worker Fleet
+
+The management API exposes three routes for observing the live worker fleet. Workers register on startup and heartbeat every 5 s (configurable via `WorkerConfig`). Workers that have not heartbeated within `2 × heartbeat_interval` (default 10 s) are classified as `stale` at query time but are not auto-deleted.
+
+```bash
+# List all workers (supports ?queue=, ?shard_id=, ?status=, ?health= filters)
+GET /api/harvest/workers
+
+# Filter to workers polling a specific queue on a specific shard
+GET /api/harvest/workers?queue=email-workers&shard_id=0
+
+# Single worker detail — includes currently claimed task-queue item IDs
+GET /api/harvest/workers/{worker_id}
+
+# Fleet health roll-up
+GET /api/harvest/workers/health
+# → { "healthy": 4, "stale": 1, "draining": 0, "by_queue": {"default": 5}, "by_shard": {"0": 5} }
+```
+
+Equivalent CLI (thin HTTP client, no direct Postgres access required):
+
+```bash
+cargo run -p autumn-harvest-cli -- worker list
+cargo run -p autumn-harvest-cli -- worker list --queue email-workers --shard-id 0
+cargo run -p autumn-harvest-cli -- worker get <worker-id>
+cargo run -p autumn-harvest-cli -- worker health
+```
+
+Worker lifecycle status values: `Active` (normal operation), `Draining` (received SIGTERM, waiting for in-flight tasks to complete), `Stopped` (shutdown complete). The `health` field in responses is derived at query time: `healthy` or `stale`.
+
+In sharded deployments the API merges results across all shards via `iter_shards()`. The `harvest_workers` table lives on every shard; each worker row is pinned to the shard the worker is polling.
+
 ## Requirements
 
 - Rust 1.88.0 or newer (MSRV)

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -131,16 +131,50 @@ impl HarvestApiRuntime {
     }
 }
 
-#[derive(Clone, Default)]
+#[derive(Clone)]
 pub struct HarvestApiState {
     runtime: Arc<Mutex<Option<HarvestApiRuntime>>>,
     storage_pool: Arc<Mutex<Option<HarvestDbPool>>>,
+    /// `2 × worker_heartbeat_interval`; derived from `WorkerConfig` at startup.
+    worker_stale_threshold: Arc<Mutex<std::time::Duration>>,
+}
+
+impl Default for HarvestApiState {
+    fn default() -> Self {
+        Self {
+            runtime: Arc::default(),
+            storage_pool: Arc::default(),
+            worker_stale_threshold: Arc::new(Mutex::new(std::time::Duration::from_secs(10))),
+        }
+    }
 }
 
 impl HarvestApiState {
     #[must_use]
     pub fn new() -> Self {
         Self::default()
+    }
+
+    /// Update the worker stale threshold used by `/workers` routes.
+    ///
+    /// Call this during startup with `2 × WorkerConfig::worker_heartbeat_interval`
+    /// so the API correctly reflects the configured heartbeat cadence.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal mutex is poisoned.
+    pub fn set_worker_stale_threshold(&self, threshold: std::time::Duration) {
+        *self
+            .worker_stale_threshold
+            .lock()
+            .expect("harvest api state lock poisoned") = threshold;
+    }
+
+    fn worker_stale_threshold(&self) -> std::time::Duration {
+        *self
+            .worker_stale_threshold
+            .lock()
+            .expect("harvest api state lock poisoned")
     }
 
     /// Install the currently running Harvest runtime snapshot.
@@ -1686,27 +1720,32 @@ where
 // Worker fleet observability (issue #100)
 // ---------------------------------------------------------------------------
 
-/// Workers that have not sent a heartbeat within this window are classified
-/// as stale. Equals `2 × default heartbeat_interval (5s)`.
-const WORKER_STALE_THRESHOLD: std::time::Duration = std::time::Duration::from_secs(10);
-
 async fn list_workers_handler(
     Extension(api_state): Extension<HarvestApiState>,
     Query(pairs): Query<Vec<(String, String)>>,
 ) -> Result<Json<Vec<WorkerRow>>, AutumnError> {
     let filters = parse_worker_filters_api(&pairs)?;
+    let stale_threshold = api_state.worker_stale_threshold();
     let pool = api_state.storage_pool().map_err(map_error)?;
     let mut results: Vec<WorkerRow> = Vec::new();
 
+    // Query each shard without a per-shard limit so that the global sort +
+    // truncate below sees every matching worker. Per-shard limiting would
+    // silently drop valid workers on large shards before the merge.
+    let per_shard_filters = WorkerFilters {
+        limit: WorkerFilters::MAX_LIMIT,
+        ..filters.clone()
+    };
     for (_shard, shard_pool) in pool.iter_shards() {
         let mut conn = acquire_conn(shard_pool).await?;
-        let mut rows = list_workers(&mut conn, &filters, WORKER_STALE_THRESHOLD)
+        let mut rows = list_workers(&mut conn, &per_shard_filters, stale_threshold)
             .await
             .map_err(map_error)?;
         results.append(&mut rows);
     }
 
-    // Sort by worker_id for deterministic output across shards.
+    // Sort by worker_id for deterministic output across shards, then apply the
+    // real limit globally.
     results.sort_by(|a, b| a.worker.worker_id.cmp(&b.worker.worker_id));
     results.truncate(usize::try_from(filters.limit).unwrap_or(usize::MAX));
     Ok(Json(results))
@@ -1716,11 +1755,12 @@ async fn get_worker_handler(
     Extension(api_state): Extension<HarvestApiState>,
     Path(worker_id): Path<String>,
 ) -> Result<Json<WorkerRow>, AutumnError> {
+    let stale_threshold = api_state.worker_stale_threshold();
     let pool = api_state.storage_pool().map_err(map_error)?;
 
     for (_shard, shard_pool) in pool.iter_shards() {
         let mut conn = acquire_conn(shard_pool).await?;
-        if let Some(row) = get_worker(&mut conn, &worker_id, WORKER_STALE_THRESHOLD)
+        if let Some(row) = get_worker(&mut conn, &worker_id, stale_threshold)
             .await
             .map_err(map_error)?
         {
@@ -1734,6 +1774,7 @@ async fn get_worker_handler(
 async fn workers_health(
     Extension(api_state): Extension<HarvestApiState>,
 ) -> Result<Json<FleetHealth>, AutumnError> {
+    let stale_threshold = api_state.worker_stale_threshold();
     let pool = api_state.storage_pool().map_err(map_error)?;
     let mut combined = FleetHealth {
         healthy: 0,
@@ -1745,7 +1786,7 @@ async fn workers_health(
 
     for (_shard, shard_pool) in pool.iter_shards() {
         let mut conn = acquire_conn(shard_pool).await?;
-        let shard_health = fleet_health(&mut conn, WORKER_STALE_THRESHOLD)
+        let shard_health = fleet_health(&mut conn, stale_threshold)
             .await
             .map_err(map_error)?;
         combined.healthy += shard_health.healthy;
@@ -2018,5 +2059,24 @@ mod tests {
 
         let f = parse_worker_filters_api(&pairs(&[("limit", "0")])).unwrap();
         assert_eq!(f.limit, 1);
+    }
+
+    #[test]
+    fn harvest_api_state_stale_threshold_defaults_to_10s() {
+        let state = HarvestApiState::new();
+        assert_eq!(
+            state.worker_stale_threshold(),
+            std::time::Duration::from_secs(10)
+        );
+    }
+
+    #[test]
+    fn harvest_api_state_stale_threshold_can_be_overridden() {
+        let state = HarvestApiState::new();
+        state.set_worker_stale_threshold(std::time::Duration::from_secs(20));
+        assert_eq!(
+            state.worker_stale_threshold(),
+            std::time::Duration::from_secs(20)
+        );
     }
 }

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -1729,11 +1729,13 @@ async fn list_workers_handler(
     let pool = api_state.storage_pool().map_err(map_error)?;
     let mut results: Vec<WorkerRow> = Vec::new();
 
-    // Query each shard without a per-shard limit so that the global sort +
-    // truncate below sees every matching worker. Per-shard limiting would
-    // silently drop valid workers on large shards before the merge.
+    // Use i64::MAX as the per-shard limit so apply_worker_filters performs no
+    // truncation inside list_workers. Any MAX_LIMIT cap would silently drop
+    // workers on a large shard before the global sort+truncate below, producing
+    // incomplete results for fleets with more than MAX_LIMIT matching workers on
+    // a single shard.
     let per_shard_filters = WorkerFilters {
-        limit: WorkerFilters::MAX_LIMIT,
+        limit: i64::MAX,
         ..filters.clone()
     };
     for (_shard, shard_pool) in pool.iter_shards() {

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -37,6 +37,10 @@ use autumn_harvest::signal;
 use autumn_harvest::store;
 use autumn_harvest::types::{ExecutionId, ExternalActivityToken, ShardId, WorkflowIdReusePolicy};
 use autumn_harvest::worker::{DbPool, HandlerRegistry};
+use autumn_harvest::workers::{
+    FleetHealth, WorkerFilters, WorkerRow, fleet_health, get_worker, list_workers,
+    parse_worker_filters,
+};
 use autumn_harvest::{
     StartWorkflowParams, cancel_workflow_execution, start_or_load_workflow_execution,
 };
@@ -414,6 +418,12 @@ pub fn harvest_api_router(api_state: HarvestApiState) -> Router<AppState> {
             "/activities/external/{token}/heartbeat",
             post(heartbeat_external_activity),
         )
+        // Worker fleet observability (issue #100).
+        // /workers/health must be registered before /workers/{worker_id} so axum
+        // does not treat the literal "health" segment as a worker_id capture.
+        .route("/workers/health", get(workers_health))
+        .route("/workers", get(list_workers_handler))
+        .route("/workers/{worker_id}", get(get_worker_handler))
         .layer(Extension(api_state))
 }
 
@@ -1672,9 +1682,95 @@ where
     )))
 }
 
+// ---------------------------------------------------------------------------
+// Worker fleet observability (issue #100)
+// ---------------------------------------------------------------------------
+
+/// Workers that have not sent a heartbeat within this window are classified
+/// as stale. Equals `2 × default heartbeat_interval (5s)`.
+const WORKER_STALE_THRESHOLD: std::time::Duration = std::time::Duration::from_secs(10);
+
+async fn list_workers_handler(
+    Extension(api_state): Extension<HarvestApiState>,
+    Query(pairs): Query<Vec<(String, String)>>,
+) -> Result<Json<Vec<WorkerRow>>, AutumnError> {
+    let filters = parse_worker_filters_api(&pairs)?;
+    let pool = api_state.storage_pool().map_err(map_error)?;
+    let mut results: Vec<WorkerRow> = Vec::new();
+
+    for (_shard, shard_pool) in pool.iter_shards() {
+        let mut conn = acquire_conn(shard_pool).await?;
+        let mut rows = list_workers(&mut conn, &filters, WORKER_STALE_THRESHOLD)
+            .await
+            .map_err(map_error)?;
+        results.append(&mut rows);
+    }
+
+    // Sort by worker_id for deterministic output across shards.
+    results.sort_by(|a, b| a.worker.worker_id.cmp(&b.worker.worker_id));
+    results.truncate(usize::try_from(filters.limit).unwrap_or(usize::MAX));
+    Ok(Json(results))
+}
+
+async fn get_worker_handler(
+    Extension(api_state): Extension<HarvestApiState>,
+    Path(worker_id): Path<String>,
+) -> Result<Json<WorkerRow>, AutumnError> {
+    let pool = api_state.storage_pool().map_err(map_error)?;
+
+    for (_shard, shard_pool) in pool.iter_shards() {
+        let mut conn = acquire_conn(shard_pool).await?;
+        if let Some(row) = get_worker(&mut conn, &worker_id, WORKER_STALE_THRESHOLD)
+            .await
+            .map_err(map_error)?
+        {
+            return Ok(Json(row));
+        }
+    }
+
+    Err(AutumnError::not_found_msg(format!("worker '{worker_id}'")))
+}
+
+async fn workers_health(
+    Extension(api_state): Extension<HarvestApiState>,
+) -> Result<Json<FleetHealth>, AutumnError> {
+    let pool = api_state.storage_pool().map_err(map_error)?;
+    let mut combined = FleetHealth {
+        healthy: 0,
+        stale: 0,
+        draining: 0,
+        by_queue: std::collections::HashMap::new(),
+        by_shard: std::collections::HashMap::new(),
+    };
+
+    for (_shard, shard_pool) in pool.iter_shards() {
+        let mut conn = acquire_conn(shard_pool).await?;
+        let shard_health = fleet_health(&mut conn, WORKER_STALE_THRESHOLD)
+            .await
+            .map_err(map_error)?;
+        combined.healthy += shard_health.healthy;
+        combined.stale += shard_health.stale;
+        combined.draining += shard_health.draining;
+        for (queue, count) in shard_health.by_queue {
+            *combined.by_queue.entry(queue).or_default() += count;
+        }
+        for (shard, count) in shard_health.by_shard {
+            *combined.by_shard.entry(shard).or_default() += count;
+        }
+    }
+
+    Ok(Json(combined))
+}
+
+/// Parse worker query-string parameters, mapping errors to `400 Bad Request`.
+fn parse_worker_filters_api(pairs: &[(String, String)]) -> Result<WorkerFilters, AutumnError> {
+    parse_worker_filters(pairs).map_err(AutumnError::bad_request_msg)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
+    use autumn_harvest::workers::WorkerHealth;
 
     fn pairs(values: &[(&str, &str)]) -> Vec<(String, String)> {
         values
@@ -1854,5 +1950,73 @@ mod tests {
             parse_reuse_policy(Some("allow_DUPLICATE")).is_err(),
             "wrong case must not silently fall back"
         );
+    }
+
+    // -- Worker filter parsing via API wrapper --
+
+    #[test]
+    fn parse_worker_filters_api_defaults_when_no_params() {
+        let f = parse_worker_filters_api(&[]).expect("empty params should succeed");
+        assert_eq!(f.limit, WorkerFilters::DEFAULT_LIMIT);
+        assert!(f.queue.is_none());
+        assert!(f.shard_id.is_none());
+        assert!(f.status.is_none());
+        assert!(f.health.is_none());
+    }
+
+    #[test]
+    fn parse_worker_filters_api_accepts_queue_filter() {
+        let f = parse_worker_filters_api(&pairs(&[("queue", "email-workers")])).unwrap();
+        assert_eq!(f.queue.as_deref(), Some("email-workers"));
+    }
+
+    #[test]
+    fn parse_worker_filters_api_accepts_all_status_values() {
+        for status in ["Active", "Draining", "Stopped"] {
+            let f = parse_worker_filters_api(&pairs(&[("status", status)])).unwrap();
+            assert_eq!(f.status.as_deref(), Some(status), "failed for {status}");
+        }
+    }
+
+    #[test]
+    fn parse_worker_filters_api_rejects_unknown_status_with_400() {
+        let err = parse_worker_filters_api(&pairs(&[("status", "zombie")])).unwrap_err();
+        assert!(err.to_string().contains("unknown status"), "error: {err}");
+    }
+
+    #[test]
+    fn parse_worker_filters_api_accepts_health_healthy_and_stale() {
+        let f = parse_worker_filters_api(&pairs(&[("health", "healthy")])).unwrap();
+        assert_eq!(f.health, Some(WorkerHealth::Healthy));
+
+        let f = parse_worker_filters_api(&pairs(&[("health", "stale")])).unwrap();
+        assert_eq!(f.health, Some(WorkerHealth::Stale));
+    }
+
+    #[test]
+    fn parse_worker_filters_api_rejects_unknown_health_with_400() {
+        let err = parse_worker_filters_api(&pairs(&[("health", "unknown")])).unwrap_err();
+        assert!(err.to_string().contains("unknown health"), "error: {err}");
+    }
+
+    #[test]
+    fn parse_worker_filters_api_accepts_shard_id() {
+        let f = parse_worker_filters_api(&pairs(&[("shard_id", "2")])).unwrap();
+        assert_eq!(f.shard_id, Some(2));
+    }
+
+    #[test]
+    fn parse_worker_filters_api_rejects_non_integer_shard_id() {
+        let err = parse_worker_filters_api(&pairs(&[("shard_id", "bad")])).unwrap_err();
+        assert!(err.to_string().contains("invalid shard_id"), "error: {err}");
+    }
+
+    #[test]
+    fn parse_worker_filters_api_clamps_limit() {
+        let f = parse_worker_filters_api(&pairs(&[("limit", "99999")])).unwrap();
+        assert_eq!(f.limit, WorkerFilters::MAX_LIMIT);
+
+        let f = parse_worker_filters_api(&pairs(&[("limit", "0")])).unwrap();
+        assert_eq!(f.limit, 1);
     }
 }

--- a/autumn-harvest-plugin/src/plugin.rs
+++ b/autumn-harvest-plugin/src/plugin.rs
@@ -248,6 +248,11 @@ fn start_harvest_runtime(
     let built = builder
         .try_build()
         .map_err(|error| AutumnError::service_unavailable_msg(error.to_string()))?;
+
+    // Derive the API stale threshold from the worker heartbeat interval so that
+    // /workers correctly classifies workers under non-default configurations.
+    api_state.set_worker_stale_threshold(built.worker_config().worker_heartbeat_interval * 2);
+
     state.insert_extension(harvest_config.outbox.clone());
     state.insert_extension(router.clone());
     let mut runner_resources = HarvestRunnerResources::new(harvest_pool)

--- a/autumn-harvest/migrations/20260501000000_harvest_workers/down.sql
+++ b/autumn-harvest/migrations/20260501000000_harvest_workers/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS harvest_workers;

--- a/autumn-harvest/migrations/20260501000000_harvest_workers/up.sql
+++ b/autumn-harvest/migrations/20260501000000_harvest_workers/up.sql
@@ -1,0 +1,39 @@
+-- Worker fleet registry.
+--
+-- One row per worker process. Workers upsert this row on startup and heartbeat
+-- every heartbeat_interval (default 5s). Stale workers (no heartbeat for
+-- 2 × interval = 10s) are surfaced by the management API as `unhealthy` but
+-- are NOT auto-deleted here — operators want churn visibility.
+--
+-- `harvest_workers` lives on every shard. The management API merges across
+-- shards via iter_shards() to present a unified fleet view.
+--
+-- No foreign keys to other harvest tables: worker liveness is operational
+-- metadata, not workflow history. The append-only event invariant is untouched.
+CREATE TABLE IF NOT EXISTS harvest_workers (
+    worker_id           TEXT PRIMARY KEY,
+    started_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    last_heartbeat_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    -- JSON array of queue names this worker polls, e.g. ["default","email-workers"]
+    queues              JSONB       NOT NULL DEFAULT '[]',
+    -- JSON array of shard IDs this worker is assigned to, e.g. [0]
+    shard_assignments   JSONB       NOT NULL DEFAULT '[]',
+    -- max_concurrent_workflows + max_concurrent_activities
+    max_concurrency     INT4        NOT NULL,
+    -- currently executing tasks (updated on every heartbeat)
+    in_flight_count     INT4        NOT NULL DEFAULT 0,
+    -- hostname or $HOSTNAME env var of the process
+    host                TEXT        NOT NULL,
+    -- optional crate version string for observability
+    version             TEXT,
+    -- lifecycle: Active | Draining | Stopped
+    status              TEXT        NOT NULL DEFAULT 'Active'
+);
+
+-- Fast lookup by lifecycle status (list-by-status is the most common query).
+CREATE INDEX IF NOT EXISTS harvest_workers_status_idx
+    ON harvest_workers (status);
+
+-- Index for stale-worker detection: scan rows with old last_heartbeat_at.
+CREATE INDEX IF NOT EXISTS harvest_workers_last_heartbeat_at_idx
+    ON harvest_workers (last_heartbeat_at);

--- a/autumn-harvest/src/builder.rs
+++ b/autumn-harvest/src/builder.rs
@@ -183,6 +183,10 @@ pub enum HarvestBuilderError {
         /// Human-readable reason the schedule was rejected.
         reason: String,
     },
+
+    /// A [`WorkerConfig`] field has an invalid value.
+    #[error("invalid worker configuration: {0}")]
+    InvalidWorkerConfig(String),
 }
 
 impl BuiltHarvest {
@@ -451,6 +455,12 @@ impl HarvestBuilder {
         self.retention
             .validate()
             .map_err(HarvestBuilderError::InvalidRetention)?;
+
+        if self.worker_config.worker_heartbeat_interval.is_zero() {
+            return Err(HarvestBuilderError::InvalidWorkerConfig(
+                "worker_heartbeat_interval must be greater than zero".to_string(),
+            ));
+        }
 
         validate_concurrency_keys(&self.activities)?;
         validate_workflow_schedules(&self.workflow_schedules, &self.workflows)?;
@@ -748,6 +758,25 @@ mod tests {
     fn harvest_builder_collects_workflows() {
         let builder = HarvestBuilder::new().workflows(vec![fake_workflow_info()]);
         assert_eq!(builder.workflow_count(), 1);
+    }
+
+    #[test]
+    fn worker_heartbeat_interval_defaults_to_5s() {
+        assert_eq!(
+            WorkerConfig::default().worker_heartbeat_interval,
+            Duration::from_secs(5)
+        );
+    }
+
+    #[test]
+    fn worker_heartbeat_interval_zero_is_rejected() {
+        let result = HarvestBuilder::new()
+            .worker(WorkerConfig::default().with_worker_heartbeat_interval(Duration::ZERO))
+            .try_build();
+        assert!(
+            matches!(result, Err(HarvestBuilderError::InvalidWorkerConfig(_))),
+            "expected InvalidWorkerConfig but got {result:?}"
+        );
     }
 
     #[test]

--- a/autumn-harvest/src/builder.rs
+++ b/autumn-harvest/src/builder.rs
@@ -627,6 +627,10 @@ pub struct WorkerConfig {
     /// Any local activity registered with `start_to_close > cap` is rejected
     /// at builder `try_build()` time.
     pub max_local_activity_start_to_close: Duration,
+    /// How often the worker upserts its liveness row in `harvest_workers`.
+    /// Defaults to **5 seconds**. The API classifies a worker as stale after
+    /// `2 × worker_heartbeat_interval` without a heartbeat.
+    pub worker_heartbeat_interval: Duration,
 }
 
 impl Default for WorkerConfig {
@@ -642,6 +646,7 @@ impl Default for WorkerConfig {
             cancellation_grace_period: Duration::from_secs(5),
             shard_assignments: vec![ShardId::new(0)],
             max_local_activity_start_to_close: Duration::from_secs(60),
+            worker_heartbeat_interval: Duration::from_secs(5),
         }
     }
 }
@@ -696,6 +701,16 @@ impl WorkerConfig {
         } else {
             shards
         };
+        self
+    }
+
+    /// Override the worker heartbeat interval (default 5 s).
+    ///
+    /// The management API classifies a worker as stale after
+    /// `2 × worker_heartbeat_interval` without a heartbeat write.
+    #[must_use]
+    pub const fn with_worker_heartbeat_interval(mut self, interval: Duration) -> Self {
+        self.worker_heartbeat_interval = interval;
         self
     }
 }

--- a/autumn-harvest/src/lib.rs
+++ b/autumn-harvest/src/lib.rs
@@ -85,6 +85,8 @@ pub mod timeout;
 #[cfg(feature = "db")]
 #[doc(hidden)]
 pub mod worker;
+#[cfg(feature = "db")]
+pub mod workers;
 
 pub use analyzer::{
     AnalyzerRule, AnalyzerWarning, ExcessiveRetriesRule, HistoryAnalyzer, LargePayloadRule,

--- a/autumn-harvest/src/models.rs
+++ b/autumn-harvest/src/models.rs
@@ -11,7 +11,7 @@ use uuid::Uuid;
 
 use crate::schema::{
     harvest_dag_runs, harvest_dead_letters, harvest_events, harvest_external_tasks,
-    harvest_schedules, harvest_signals, harvest_task_queue, harvest_timers,
+    harvest_schedules, harvest_signals, harvest_task_queue, harvest_timers, harvest_workers,
     harvest_workflow_executions,
 };
 
@@ -361,4 +361,43 @@ pub struct NewExternalTask<'a> {
     pub queue: &'a str,
     pub schedule_to_close_at: DateTime<Utc>,
     pub schedule_to_close_secs: i64,
+}
+
+// ── HarvestWorker ─────────────────────────────────────────────────────────────
+
+/// A live or recently-stopped worker process registered in the fleet table.
+#[derive(
+    Debug, Clone, Queryable, Selectable, Identifiable, serde::Serialize, serde::Deserialize,
+)]
+#[diesel(table_name = harvest_workers)]
+#[diesel(primary_key(worker_id))]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct HarvestWorker {
+    pub worker_id: String,
+    pub started_at: DateTime<Utc>,
+    pub last_heartbeat_at: DateTime<Utc>,
+    /// JSON array of queue names polled by this worker.
+    pub queues: serde_json::Value,
+    /// JSON array of `ShardId` integers assigned to this worker.
+    pub shard_assignments: serde_json::Value,
+    /// `max_concurrent_workflows + max_concurrent_activities`.
+    pub max_concurrency: i32,
+    /// Currently executing tasks (refreshed on every heartbeat).
+    pub in_flight_count: i32,
+    pub host: String,
+    pub version: Option<String>,
+    /// Lifecycle status: `Active`, `Draining`, or `Stopped`.
+    pub status: String,
+}
+
+/// Insert struct for registering a new worker process.
+#[derive(Debug, Insertable)]
+#[diesel(table_name = harvest_workers)]
+pub struct NewHarvestWorker<'a> {
+    pub worker_id: &'a str,
+    pub queues: serde_json::Value,
+    pub shard_assignments: serde_json::Value,
+    pub max_concurrency: i32,
+    pub host: &'a str,
+    pub version: Option<&'a str>,
 }

--- a/autumn-harvest/src/schema.rs
+++ b/autumn-harvest/src/schema.rs
@@ -177,6 +177,23 @@ diesel::table! {
     }
 }
 
+diesel::table! {
+    use diesel::sql_types::*;
+
+    harvest_workers (worker_id) {
+        worker_id -> Text,
+        started_at -> Timestamptz,
+        last_heartbeat_at -> Timestamptz,
+        queues -> Jsonb,
+        shard_assignments -> Jsonb,
+        max_concurrency -> Int4,
+        in_flight_count -> Int4,
+        host -> Text,
+        version -> Nullable<Text>,
+        status -> Text,
+    }
+}
+
 diesel::joinable!(harvest_events -> harvest_workflow_executions (workflow_exec_id));
 diesel::joinable!(harvest_task_queue -> harvest_workflow_executions (workflow_exec_id));
 diesel::joinable!(harvest_dag_runs -> harvest_workflow_executions (workflow_exec_id));
@@ -194,4 +211,5 @@ diesel::allow_tables_to_appear_in_same_query!(
     harvest_timers,
     harvest_dead_letters,
     harvest_external_tasks,
+    harvest_workers,
 );

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -2529,9 +2529,20 @@ impl Worker {
             .iter()
             .map(|s| s.as_i32())
             .collect();
+        let max_concurrency = i32::try_from(
+            self.config.max_concurrent_workflows + self.config.max_concurrent_activities,
+        )
+        .unwrap_or(i32::MAX);
         let heartbeat_handle = crate::workers::spawn_worker_heartbeat(
             pool.clone(),
-            self.config.worker_id.clone(),
+            crate::workers::WorkerRegistration {
+                worker_id: self.config.worker_id.clone(),
+                queues: self.config.queues.clone(),
+                shard_assignments: shard_ids,
+                max_concurrency,
+                host: crate::workers::local_hostname(),
+                version: Some(env!("CARGO_PKG_VERSION").to_string()),
+            },
             Arc::clone(&self.workflow_semaphore),
             self.config.max_concurrent_workflows,
             Arc::clone(&self.activity_semaphore),
@@ -2539,7 +2550,6 @@ impl Worker {
             self.config.worker_heartbeat_interval,
             self.shutdown.clone(),
         );
-        let _ = shard_ids; // used during registration only
 
         while !self.shutdown.is_cancelled() {
             if self.poll_once(pool).await {

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -117,7 +117,7 @@ impl From<WorkerConfig> for WorkerRuntimeConfig {
             sticky_timeout: cfg.sticky_timeout,
             max_local_activity_start_to_close: cfg.max_local_activity_start_to_close,
             shard_assignments: cfg.shard_assignments,
-            worker_heartbeat_interval: Duration::from_secs(5),
+            worker_heartbeat_interval: cfg.worker_heartbeat_interval,
         }
     }
 }
@@ -2522,7 +2522,10 @@ impl Worker {
             self.config.poll_interval,
         );
 
-        // Spawn the heartbeat background task.
+        // Spawn the heartbeat background task with a dedicated cancel token so
+        // that liveness updates continue during the Draining phase and only stop
+        // after the Stopped transition is written.
+        let heartbeat_cancel = CancellationToken::new();
         let shard_ids: Vec<i32> = self
             .config
             .shard_assignments
@@ -2548,7 +2551,7 @@ impl Worker {
             Arc::clone(&self.activity_semaphore),
             self.config.max_concurrent_activities,
             self.config.worker_heartbeat_interval,
-            self.shutdown.clone(),
+            heartbeat_cancel.clone(),
         );
 
         while !self.shutdown.is_cancelled() {
@@ -2590,9 +2593,10 @@ impl Worker {
         tracing::info!(worker_id = %self.config.worker_id, "draining in-flight tasks");
         self.drain_in_flight().await;
 
-        // All tasks complete — mark Stopped.
+        // All tasks complete — mark Stopped, then stop the heartbeat task.
         self.transition_fleet_status(pool, crate::workers::WorkerStatus::Stopped)
             .await;
+        heartbeat_cancel.cancel();
 
         if let Err(error) = heartbeat_handle.await {
             tracing::warn!(
@@ -2921,6 +2925,7 @@ mod tests {
             cancellation_grace_period: Duration::from_secs(10),
             shard_assignments: vec![crate::types::ShardId::new(0)],
             max_local_activity_start_to_close: Duration::from_secs(60),
+            worker_heartbeat_interval: Duration::from_secs(5),
         };
 
         let runtime_cfg: WorkerRuntimeConfig = builder_cfg.into();

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -79,6 +79,12 @@ pub struct WorkerRuntimeConfig {
     /// not complete within this window it is treated as a failure and retried
     /// (or the workflow fails if retries are exhausted).
     pub max_local_activity_start_to_close: Duration,
+    /// Shard IDs this worker polls. Recorded in `harvest_workers` for fleet
+    /// observability. Defaults to `[0]` for single-shard deployments.
+    pub shard_assignments: Vec<crate::types::ShardId>,
+    /// Heartbeat interval for worker liveness records in `harvest_workers`.
+    /// Defaults to 5 seconds. Stale threshold is `2 × heartbeat_interval`.
+    pub worker_heartbeat_interval: Duration,
 }
 
 impl WorkerRuntimeConfig {
@@ -110,6 +116,8 @@ impl From<WorkerConfig> for WorkerRuntimeConfig {
             cancellation_grace_period: cfg.cancellation_grace_period,
             sticky_timeout: cfg.sticky_timeout,
             max_local_activity_start_to_close: cfg.max_local_activity_start_to_close,
+            shard_assignments: cfg.shard_assignments,
+            worker_heartbeat_interval: Duration::from_secs(5),
         }
     }
 }
@@ -2479,6 +2487,7 @@ impl Worker {
     ///
     /// This lets callers separate listener startup from task polling when they
     /// need tighter control over startup sequencing.
+    #[allow(clippy::too_many_lines)]
     pub async fn run_with_listener(
         &self,
         pool: &DbPool,
@@ -2489,6 +2498,10 @@ impl Worker {
             queues = ?self.config.queues,
             "worker starting"
         );
+
+        // Register this worker in the fleet table.
+        self.register_in_fleet(pool).await;
+
         let queue_depth_sampler = spawn_queue_depth_sampler(
             pool.clone(),
             self.shutdown.clone(),
@@ -2508,6 +2521,25 @@ impl Worker {
             self.shutdown.clone(),
             self.config.poll_interval,
         );
+
+        // Spawn the heartbeat background task.
+        let shard_ids: Vec<i32> = self
+            .config
+            .shard_assignments
+            .iter()
+            .map(|s| s.as_i32())
+            .collect();
+        let heartbeat_handle = crate::workers::spawn_worker_heartbeat(
+            pool.clone(),
+            self.config.worker_id.clone(),
+            Arc::clone(&self.workflow_semaphore),
+            self.config.max_concurrent_workflows,
+            Arc::clone(&self.activity_semaphore),
+            self.config.max_concurrent_activities,
+            self.config.worker_heartbeat_interval,
+            self.shutdown.clone(),
+        );
+        let _ = shard_ids; // used during registration only
 
         while !self.shutdown.is_cancelled() {
             if self.poll_once(pool).await {
@@ -2541,8 +2573,24 @@ impl Worker {
 
         tracing::info!(worker_id = %self.config.worker_id, "shutdown signal received");
 
+        // Transition to Draining before waiting for in-flight tasks.
+        self.transition_fleet_status(pool, crate::workers::WorkerStatus::Draining)
+            .await;
+
         tracing::info!(worker_id = %self.config.worker_id, "draining in-flight tasks");
         self.drain_in_flight().await;
+
+        // All tasks complete — mark Stopped.
+        self.transition_fleet_status(pool, crate::workers::WorkerStatus::Stopped)
+            .await;
+
+        if let Err(error) = heartbeat_handle.await {
+            tracing::warn!(
+                worker_id = %self.config.worker_id,
+                error = %error,
+                "worker heartbeat task failed during shutdown"
+            );
+        }
         if let Err(error) = timeout_checker.await {
             tracing::warn!(
                 worker_id = %self.config.worker_id,
@@ -2565,6 +2613,84 @@ impl Worker {
             );
         }
         tracing::info!(worker_id = %self.config.worker_id, "worker stopped");
+    }
+
+    /// Register or re-register this worker in the fleet table.
+    async fn register_in_fleet(&self, pool: &DbPool) {
+        let shard_ids: Vec<i32> = self
+            .config
+            .shard_assignments
+            .iter()
+            .map(|s| s.as_i32())
+            .collect();
+        let max_concurrency = i32::try_from(
+            self.config.max_concurrent_workflows + self.config.max_concurrent_activities,
+        )
+        .unwrap_or(i32::MAX);
+        let host = crate::workers::local_hostname();
+        let version = env!("CARGO_PKG_VERSION");
+
+        match pool.get().await {
+            Ok(mut conn) => {
+                if let Err(error) = crate::workers::register_worker(
+                    &mut conn,
+                    &self.config.worker_id,
+                    &self.config.queues,
+                    &shard_ids,
+                    max_concurrency,
+                    &host,
+                    Some(version),
+                )
+                .await
+                {
+                    tracing::warn!(
+                        worker_id = %self.config.worker_id,
+                        error = %error,
+                        "failed to register worker in fleet table; continuing without fleet registration"
+                    );
+                } else {
+                    tracing::info!(
+                        worker_id = %self.config.worker_id,
+                        host = %host,
+                        max_concurrency,
+                        "worker registered in fleet"
+                    );
+                }
+            }
+            Err(error) => {
+                tracing::warn!(
+                    worker_id = %self.config.worker_id,
+                    error = %error,
+                    "failed to get pool connection for fleet registration"
+                );
+            }
+        }
+    }
+
+    /// Transition this worker's status in the fleet table.
+    async fn transition_fleet_status(&self, pool: &DbPool, status: crate::workers::WorkerStatus) {
+        match pool.get().await {
+            Ok(mut conn) => {
+                if let Err(error) =
+                    crate::workers::transition_status(&mut conn, &self.config.worker_id, status)
+                        .await
+                {
+                    tracing::warn!(
+                        worker_id = %self.config.worker_id,
+                        ?status,
+                        error = %error,
+                        "failed to update worker fleet status"
+                    );
+                }
+            }
+            Err(error) => {
+                tracing::warn!(
+                    worker_id = %self.config.worker_id,
+                    error = %error,
+                    "failed to get pool connection for fleet status update"
+                );
+            }
+        }
     }
 
     /// Execute a single poll iteration.
@@ -2730,6 +2856,8 @@ mod tests {
             cancellation_grace_period: Duration::from_secs(5),
             sticky_timeout: Duration::from_secs(5),
             max_local_activity_start_to_close: Duration::from_secs(60),
+            shard_assignments: vec![crate::types::ShardId::new(0)],
+            worker_heartbeat_interval: Duration::from_secs(5),
         }
     }
 

--- a/autumn-harvest/src/workers.rs
+++ b/autumn-harvest/src/workers.rs
@@ -17,9 +17,11 @@ use tokio::sync::Semaphore;
 use tokio::task::JoinHandle;
 use tokio_util::sync::CancellationToken;
 
+use uuid::Uuid;
+
 use crate::error::{HarvestError, HarvestResult};
 use crate::models::{HarvestWorker, NewHarvestWorker};
-use crate::schema::harvest_workers;
+use crate::schema::{harvest_task_queue, harvest_workers};
 use crate::worker::DbPool;
 
 // ---------------------------------------------------------------------------
@@ -314,7 +316,11 @@ pub async fn list_workers(
         .into_iter()
         .map(|w| {
             let health = WorkerHealth::classify(w.last_heartbeat_at, stale_threshold);
-            WorkerRow { worker: w, health }
+            WorkerRow {
+                worker: w,
+                health,
+                active_task_ids: vec![],
+            }
         })
         .collect();
 
@@ -360,9 +366,23 @@ pub async fn get_worker(
         .optional()
         .map_err(crate::error::database_error)?;
 
-    Ok(row.map(|w| {
-        let health = WorkerHealth::classify(w.last_heartbeat_at, stale_threshold);
-        WorkerRow { worker: w, health }
+    let Some(w) = row else {
+        return Ok(None);
+    };
+
+    let active_task_ids = harvest_task_queue::table
+        .filter(harvest_task_queue::worker_id.eq(Some(worker_id)))
+        .filter(harvest_task_queue::state.eq("RUNNING"))
+        .select(harvest_task_queue::id)
+        .load::<Uuid>(conn)
+        .await
+        .map_err(crate::error::database_error)?;
+
+    let health = WorkerHealth::classify(w.last_heartbeat_at, stale_threshold);
+    Ok(Some(WorkerRow {
+        worker: w,
+        health,
+        active_task_ids,
     }))
 }
 
@@ -431,6 +451,9 @@ pub struct WorkerRow {
     #[serde(flatten)]
     pub worker: HarvestWorker,
     pub health: WorkerHealth,
+    /// IDs of task-queue items currently claimed by this worker (`state = RUNNING`).
+    /// Populated only by `get_worker`; the list endpoint returns an empty vec.
+    pub active_task_ids: Vec<Uuid>,
 }
 
 /// Aggregated fleet health roll-up.
@@ -672,6 +695,49 @@ mod tests {
         let f = parse_worker_filters(&pairs(&[("unknown_param", "value")])).unwrap();
         assert!(f.queue.is_none());
         assert!(f.status.is_none());
+    }
+
+    // -- WorkerRow active_task_ids --
+
+    fn make_test_worker_row(active_task_ids: Vec<uuid::Uuid>) -> WorkerRow {
+        WorkerRow {
+            worker: HarvestWorker {
+                worker_id: "test-worker".to_string(),
+                started_at: Utc::now(),
+                last_heartbeat_at: Utc::now(),
+                queues: serde_json::json!(["default"]),
+                shard_assignments: serde_json::json!([0]),
+                max_concurrency: 10,
+                in_flight_count: 0,
+                host: "localhost".to_string(),
+                version: None,
+                status: "Active".to_string(),
+            },
+            health: WorkerHealth::Healthy,
+            active_task_ids,
+        }
+    }
+
+    #[test]
+    fn worker_row_active_task_ids_serializes_empty() {
+        let row = make_test_worker_row(vec![]);
+        let json = serde_json::to_value(&row).unwrap();
+        let ids = json["active_task_ids"]
+            .as_array()
+            .expect("active_task_ids should be array");
+        assert!(ids.is_empty());
+    }
+
+    #[test]
+    fn worker_row_active_task_ids_serializes_uuids() {
+        let tid = uuid::Uuid::new_v4();
+        let row = make_test_worker_row(vec![tid]);
+        let json = serde_json::to_value(&row).unwrap();
+        let ids = json["active_task_ids"]
+            .as_array()
+            .expect("active_task_ids should be array");
+        assert_eq!(ids.len(), 1);
+        assert_eq!(ids[0].as_str().unwrap(), tid.to_string());
     }
 
     // -- compute_in_flight --

--- a/autumn-harvest/src/workers.rs
+++ b/autumn-harvest/src/workers.rs
@@ -20,6 +20,22 @@ use tokio_util::sync::CancellationToken;
 use uuid::Uuid;
 
 use crate::error::{HarvestError, HarvestResult};
+
+// ---------------------------------------------------------------------------
+// WorkerRegistration
+// ---------------------------------------------------------------------------
+
+/// Static fields that identify a worker process, used for initial registration
+/// and heartbeat self-healing.
+#[derive(Debug, Clone)]
+pub struct WorkerRegistration {
+    pub worker_id: String,
+    pub queues: Vec<String>,
+    pub shard_assignments: Vec<i32>,
+    pub max_concurrency: i32,
+    pub host: String,
+    pub version: Option<String>,
+}
 use crate::models::{HarvestWorker, NewHarvestWorker};
 use crate::schema::{harvest_task_queue, harvest_workers};
 use crate::worker::DbPool;
@@ -251,6 +267,10 @@ pub async fn register_worker(
 
 /// Upsert `last_heartbeat_at` and `in_flight_count` for a worker.
 ///
+/// Returns the number of rows updated (1 if the worker row exists, 0 if it is
+/// missing). Callers that receive 0 should re-register the worker to self-heal
+/// after a failed startup registration.
+///
 /// # Errors
 ///
 /// Returns [`HarvestError`] on database failure.
@@ -258,8 +278,8 @@ pub async fn heartbeat_worker(
     conn: &mut AsyncPgConnection,
     worker_id: &str,
     in_flight_count: i32,
-) -> HarvestResult<()> {
-    diesel::update(harvest_workers::table.find(worker_id))
+) -> HarvestResult<usize> {
+    let affected = diesel::update(harvest_workers::table.find(worker_id))
         .set((
             harvest_workers::last_heartbeat_at.eq(Utc::now()),
             harvest_workers::in_flight_count.eq(in_flight_count),
@@ -267,7 +287,7 @@ pub async fn heartbeat_worker(
         .execute(conn)
         .await
         .map_err(crate::error::database_error)?;
-    Ok(())
+    Ok(affected)
 }
 
 /// Transition a worker's lifecycle status.
@@ -288,43 +308,12 @@ pub async fn transition_status(
     Ok(())
 }
 
-/// Query the fleet table with optional filters.
+/// Apply queue, shard, health, and limit filters to an already-loaded worker list.
 ///
-/// # Errors
-///
-/// Returns [`HarvestError`] on database failure.
-pub async fn list_workers(
-    conn: &mut AsyncPgConnection,
-    filters: &WorkerFilters,
-    stale_threshold: Duration,
-) -> HarvestResult<Vec<WorkerRow>> {
-    let mut query = harvest_workers::table
-        .select(HarvestWorker::as_select())
-        .into_boxed();
-
-    if let Some(ref status) = filters.status {
-        query = query.filter(harvest_workers::status.eq(status));
-    }
-
-    let rows: Vec<HarvestWorker> = query
-        .limit(filters.limit)
-        .load(conn)
-        .await
-        .map_err(crate::error::database_error)?;
-
-    let mut results: Vec<WorkerRow> = rows
-        .into_iter()
-        .map(|w| {
-            let health = WorkerHealth::classify(w.last_heartbeat_at, stale_threshold);
-            WorkerRow {
-                worker: w,
-                health,
-                active_task_ids: vec![],
-            }
-        })
-        .collect();
-
-    // Apply post-query filters that need in-process evaluation.
+/// The limit is intentionally applied **after** the in-process `retain` passes so
+/// that a SQL-level page size cannot silently exclude matching rows that appear
+/// beyond the first N rows of the unfiltered table.
+fn apply_worker_filters(mut results: Vec<WorkerRow>, filters: &WorkerFilters) -> Vec<WorkerRow> {
     if let Some(ref queue) = filters.queue {
         results.retain(|r| {
             r.worker
@@ -344,8 +333,50 @@ pub async fn list_workers(
     if let Some(health_filter) = filters.health {
         results.retain(|r| r.health == health_filter);
     }
+    results.truncate(usize::try_from(filters.limit).unwrap_or(usize::MAX));
+    results
+}
 
-    Ok(results)
+/// Query the fleet table with optional filters.
+///
+/// The SQL query applies only the `status` filter (an indexed column). Queue,
+/// shard, health, and limit filters are applied in-process after loading so
+/// that the limit is never evaluated before the JSONB/derived-field filters.
+///
+/// # Errors
+///
+/// Returns [`HarvestError`] on database failure.
+pub async fn list_workers(
+    conn: &mut AsyncPgConnection,
+    filters: &WorkerFilters,
+    stale_threshold: Duration,
+) -> HarvestResult<Vec<WorkerRow>> {
+    let mut query = harvest_workers::table
+        .select(HarvestWorker::as_select())
+        .into_boxed();
+
+    if let Some(ref status) = filters.status {
+        query = query.filter(harvest_workers::status.eq(status));
+    }
+
+    let rows: Vec<HarvestWorker> = query
+        .load(conn)
+        .await
+        .map_err(crate::error::database_error)?;
+
+    let results: Vec<WorkerRow> = rows
+        .into_iter()
+        .map(|w| {
+            let health = WorkerHealth::classify(w.last_heartbeat_at, stale_threshold);
+            WorkerRow {
+                worker: w,
+                health,
+                active_task_ids: vec![],
+            }
+        })
+        .collect();
+
+    Ok(apply_worker_filters(results, filters))
 }
 
 /// Get a single worker detail row.
@@ -473,12 +504,14 @@ pub struct FleetHealth {
 /// Spawn a background task that upserts worker heartbeats on a regular interval.
 ///
 /// The task reads the current `in_flight_count` from the semaphores, then
-/// writes it to the database. It stops when `cancel` is triggered.
+/// writes it to the database. If the worker row is missing (0 rows updated —
+/// e.g. because startup registration failed transiently), the task re-registers
+/// the worker automatically. It stops when `cancel` is triggered.
 #[must_use]
 #[allow(clippy::too_many_arguments)]
 pub fn spawn_worker_heartbeat(
     pool: DbPool,
-    worker_id: String,
+    registration: WorkerRegistration,
     wf_semaphore: Arc<Semaphore>,
     wf_max: usize,
     act_semaphore: Arc<Semaphore>,
@@ -497,17 +530,43 @@ pub fn spawn_worker_heartbeat(
 
             match pool.get().await {
                 Ok(mut conn) => {
-                    if let Err(error) = heartbeat_worker(&mut conn, &worker_id, in_flight).await {
-                        tracing::warn!(
-                            worker_id = %worker_id,
-                            error = %error,
-                            "worker heartbeat write failed"
-                        );
+                    match heartbeat_worker(&mut conn, &registration.worker_id, in_flight).await {
+                        Ok(0) => {
+                            tracing::info!(
+                                worker_id = %registration.worker_id,
+                                "worker row missing; re-registering"
+                            );
+                            if let Err(error) = register_worker(
+                                &mut conn,
+                                &registration.worker_id,
+                                &registration.queues,
+                                &registration.shard_assignments,
+                                registration.max_concurrency,
+                                &registration.host,
+                                registration.version.as_deref(),
+                            )
+                            .await
+                            {
+                                tracing::warn!(
+                                    worker_id = %registration.worker_id,
+                                    error = %error,
+                                    "worker re-registration failed"
+                                );
+                            }
+                        }
+                        Ok(_) => {}
+                        Err(error) => {
+                            tracing::warn!(
+                                worker_id = %registration.worker_id,
+                                error = %error,
+                                "worker heartbeat write failed"
+                            );
+                        }
                     }
                 }
                 Err(error) => {
                     tracing::warn!(
-                        worker_id = %worker_id,
+                        worker_id = %registration.worker_id,
                         error = %error,
                         "worker heartbeat failed to get pool connection"
                     );
@@ -695,6 +754,89 @@ mod tests {
         let f = parse_worker_filters(&pairs(&[("unknown_param", "value")])).unwrap();
         assert!(f.queue.is_none());
         assert!(f.status.is_none());
+    }
+
+    // -- WorkerRegistration --
+
+    #[test]
+    fn worker_registration_captures_all_fields() {
+        let reg = WorkerRegistration {
+            worker_id: "w1".to_string(),
+            queues: vec!["default".to_string()],
+            shard_assignments: vec![0],
+            max_concurrency: 10,
+            host: "localhost".to_string(),
+            version: Some("0.2.0".to_string()),
+        };
+        assert_eq!(reg.worker_id, "w1");
+        assert_eq!(reg.queues, vec!["default"]);
+        assert_eq!(reg.max_concurrency, 10);
+        assert_eq!(reg.version.as_deref(), Some("0.2.0"));
+    }
+
+    // -- apply_worker_filters (limit is applied after queue/shard/health filtering) --
+
+    fn make_queue_row(worker_id: &str, queue: &str) -> WorkerRow {
+        WorkerRow {
+            worker: HarvestWorker {
+                worker_id: worker_id.to_string(),
+                started_at: Utc::now(),
+                last_heartbeat_at: Utc::now(),
+                queues: serde_json::json!([queue]),
+                shard_assignments: serde_json::json!([0]),
+                max_concurrency: 10,
+                in_flight_count: 0,
+                host: "localhost".to_string(),
+                version: None,
+                status: "Active".to_string(),
+            },
+            health: WorkerHealth::Healthy,
+            active_task_ids: vec![],
+        }
+    }
+
+    #[test]
+    fn apply_filters_limit_is_applied_after_queue_filter() {
+        // 3 rows total; only 1 matches "email-workers". With limit=2 applied
+        // BEFORE filtering, the email-workers row might be outside the window.
+        // apply_worker_filters must truncate AFTER retaining.
+        let rows = vec![
+            make_queue_row("w-default-1", "default"),
+            make_queue_row("w-default-2", "default"),
+            make_queue_row("w-email", "email-workers"),
+        ];
+        let mut filters = WorkerFilters::new();
+        filters.queue = Some("email-workers".to_string());
+        filters.limit = 2;
+        let result = apply_worker_filters(rows, &filters);
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].worker.worker_id, "w-email");
+    }
+
+    #[test]
+    fn apply_filters_limit_truncates_matched_results() {
+        let rows = vec![
+            make_queue_row("w1", "email-workers"),
+            make_queue_row("w2", "email-workers"),
+            make_queue_row("w3", "email-workers"),
+        ];
+        let mut filters = WorkerFilters::new();
+        filters.queue = Some("email-workers".to_string());
+        filters.limit = 2;
+        let result = apply_worker_filters(rows, &filters);
+        assert_eq!(result.len(), 2);
+    }
+
+    #[test]
+    fn apply_filters_no_match_returns_empty() {
+        let rows = vec![
+            make_queue_row("w1", "default"),
+            make_queue_row("w2", "default"),
+        ];
+        let mut filters = WorkerFilters::new();
+        filters.queue = Some("email-workers".to_string());
+        let result = apply_worker_filters(rows, &filters);
+        assert!(result.is_empty());
     }
 
     // -- WorkerRow active_task_ids --

--- a/autumn-harvest/src/workers.rs
+++ b/autumn-harvest/src/workers.rs
@@ -1,0 +1,697 @@
+//! Worker fleet registry — liveness tracking, heartbeat, and fleet queries.
+//!
+//! Each `Worker` registers a row in `harvest_workers` on startup, upserts
+//! `last_heartbeat_at` and `in_flight_count` on a regular interval, and
+//! transitions through `Active → Draining → Stopped` on graceful shutdown.
+//!
+//! The API layer queries this table (per-shard) to surface fleet status to
+//! operators via the management HTTP routes.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use chrono::{DateTime, Utc};
+use diesel::prelude::*;
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
+use tokio::sync::Semaphore;
+use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
+
+use crate::error::{HarvestError, HarvestResult};
+use crate::models::{HarvestWorker, NewHarvestWorker};
+use crate::schema::harvest_workers;
+use crate::worker::DbPool;
+
+// ---------------------------------------------------------------------------
+// WorkerStatus
+// ---------------------------------------------------------------------------
+
+/// Lifecycle status of a worker process.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum WorkerStatus {
+    Active,
+    Draining,
+    Stopped,
+}
+
+impl WorkerStatus {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Active => "Active",
+            Self::Draining => "Draining",
+            Self::Stopped => "Stopped",
+        }
+    }
+
+    #[must_use]
+    #[allow(clippy::should_implement_trait)]
+    pub fn from_str(s: &str) -> Option<Self> {
+        match s {
+            "Active" => Some(Self::Active),
+            "Draining" => Some(Self::Draining),
+            "Stopped" => Some(Self::Stopped),
+            _ => None,
+        }
+    }
+}
+
+impl std::fmt::Display for WorkerStatus {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.as_str())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// WorkerHealth (derived from last_heartbeat_at)
+// ---------------------------------------------------------------------------
+
+/// Health classification derived from `last_heartbeat_at`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum WorkerHealth {
+    Healthy,
+    Stale,
+}
+
+impl WorkerHealth {
+    /// Classify a worker as healthy or stale given the threshold.
+    ///
+    /// A worker is considered stale when it has not sent a heartbeat within
+    /// `stale_threshold` (typically `2 × heartbeat_interval`).
+    #[must_use]
+    pub fn classify(last_heartbeat_at: DateTime<Utc>, stale_threshold: Duration) -> Self {
+        let elapsed = Utc::now()
+            .signed_duration_since(last_heartbeat_at)
+            .to_std()
+            .unwrap_or(Duration::MAX);
+        if elapsed > stale_threshold {
+            Self::Stale
+        } else {
+            Self::Healthy
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Worker filter for list queries
+// ---------------------------------------------------------------------------
+
+/// Filters for `list_workers` queries from the management API.
+#[derive(Debug, Default, Clone)]
+pub struct WorkerFilters {
+    pub queue: Option<String>,
+    pub shard_id: Option<i32>,
+    pub status: Option<String>,
+    pub health: Option<WorkerHealth>,
+    pub limit: i64,
+}
+
+impl WorkerFilters {
+    pub const DEFAULT_LIMIT: i64 = 100;
+    pub const MAX_LIMIT: i64 = 500;
+
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            limit: Self::DEFAULT_LIMIT,
+            ..Default::default()
+        }
+    }
+}
+
+/// Parse management API query parameters into `WorkerFilters`.
+///
+/// Accepts `queue=`, `shard_id=`, `status=`, `health=` and `limit=` keys.
+/// Unknown keys are silently ignored for forward compatibility.
+///
+/// # Errors
+///
+/// Returns a descriptive error string when:
+/// - `status` is not one of `Active`, `Draining`, or `Stopped`
+/// - `health` is not one of `healthy` or `stale`
+/// - `shard_id` is not a valid i32
+/// - `limit` is not a valid positive integer
+pub fn parse_worker_filters(pairs: &[(String, String)]) -> Result<WorkerFilters, String> {
+    let mut filters = WorkerFilters::new();
+    let mut limit_raw: Option<i64> = None;
+
+    for (key, value) in pairs {
+        match key.as_str() {
+            "queue" => {
+                let trimmed = value.trim();
+                if !trimmed.is_empty() {
+                    filters.queue = Some(trimmed.to_string());
+                }
+            }
+            "shard_id" => {
+                let parsed = value
+                    .trim()
+                    .parse::<i32>()
+                    .map_err(|_| format!("invalid shard_id '{value}'; expected integer"))?;
+                filters.shard_id = Some(parsed);
+            }
+            "status" => {
+                let trimmed = value.trim();
+                if WorkerStatus::from_str(trimmed).is_none() {
+                    return Err(format!(
+                        "unknown status '{trimmed}'; expected one of Active, Draining, Stopped"
+                    ));
+                }
+                filters.status = Some(trimmed.to_string());
+            }
+            "health" => {
+                let trimmed = value.trim();
+                filters.health = Some(match trimmed {
+                    "healthy" => WorkerHealth::Healthy,
+                    "stale" => WorkerHealth::Stale,
+                    other => {
+                        return Err(format!(
+                            "unknown health '{other}'; expected one of healthy, stale"
+                        ));
+                    }
+                });
+            }
+            "limit" => {
+                let parsed = value
+                    .trim()
+                    .parse::<i64>()
+                    .map_err(|_| format!("invalid limit '{value}'; expected integer"))?;
+                limit_raw = Some(parsed);
+            }
+            _ => {}
+        }
+    }
+
+    filters.limit = limit_raw
+        .unwrap_or(WorkerFilters::DEFAULT_LIMIT)
+        .clamp(1, WorkerFilters::MAX_LIMIT);
+    Ok(filters)
+}
+
+// ---------------------------------------------------------------------------
+// DB operations
+// ---------------------------------------------------------------------------
+
+/// Register a worker in the fleet table on startup.
+///
+/// Uses `INSERT ... ON CONFLICT DO UPDATE` so a crashed-and-restarted worker
+/// with the same `worker_id` overwrites the stale row.
+///
+/// # Errors
+///
+/// Returns [`HarvestError`] on serialization or database failure.
+pub async fn register_worker(
+    conn: &mut AsyncPgConnection,
+    worker_id: &str,
+    queues: &[String],
+    shard_assignments: &[i32],
+    max_concurrency: i32,
+    host: &str,
+    version: Option<&str>,
+) -> HarvestResult<()> {
+    use diesel::pg::upsert::excluded;
+
+    let queues_json = serde_json::to_value(queues).map_err(HarvestError::Serialization)?;
+    let shards_json =
+        serde_json::to_value(shard_assignments).map_err(HarvestError::Serialization)?;
+
+    let row = NewHarvestWorker {
+        worker_id,
+        queues: queues_json,
+        shard_assignments: shards_json,
+        max_concurrency,
+        host,
+        version,
+    };
+
+    diesel::insert_into(harvest_workers::table)
+        .values(&row)
+        .on_conflict(harvest_workers::worker_id)
+        .do_update()
+        .set((
+            harvest_workers::started_at.eq(excluded(harvest_workers::started_at)),
+            harvest_workers::last_heartbeat_at.eq(Utc::now()),
+            harvest_workers::queues.eq(excluded(harvest_workers::queues)),
+            harvest_workers::shard_assignments.eq(excluded(harvest_workers::shard_assignments)),
+            harvest_workers::max_concurrency.eq(excluded(harvest_workers::max_concurrency)),
+            harvest_workers::in_flight_count.eq(0_i32),
+            harvest_workers::host.eq(excluded(harvest_workers::host)),
+            harvest_workers::version.eq(excluded(harvest_workers::version)),
+            harvest_workers::status.eq(WorkerStatus::Active.as_str()),
+        ))
+        .execute(conn)
+        .await
+        .map_err(crate::error::database_error)?;
+
+    Ok(())
+}
+
+/// Upsert `last_heartbeat_at` and `in_flight_count` for a worker.
+///
+/// # Errors
+///
+/// Returns [`HarvestError`] on database failure.
+pub async fn heartbeat_worker(
+    conn: &mut AsyncPgConnection,
+    worker_id: &str,
+    in_flight_count: i32,
+) -> HarvestResult<()> {
+    diesel::update(harvest_workers::table.find(worker_id))
+        .set((
+            harvest_workers::last_heartbeat_at.eq(Utc::now()),
+            harvest_workers::in_flight_count.eq(in_flight_count),
+        ))
+        .execute(conn)
+        .await
+        .map_err(crate::error::database_error)?;
+    Ok(())
+}
+
+/// Transition a worker's lifecycle status.
+///
+/// # Errors
+///
+/// Returns [`HarvestError`] on database failure.
+pub async fn transition_status(
+    conn: &mut AsyncPgConnection,
+    worker_id: &str,
+    status: WorkerStatus,
+) -> HarvestResult<()> {
+    diesel::update(harvest_workers::table.find(worker_id))
+        .set(harvest_workers::status.eq(status.as_str()))
+        .execute(conn)
+        .await
+        .map_err(crate::error::database_error)?;
+    Ok(())
+}
+
+/// Query the fleet table with optional filters.
+///
+/// # Errors
+///
+/// Returns [`HarvestError`] on database failure.
+pub async fn list_workers(
+    conn: &mut AsyncPgConnection,
+    filters: &WorkerFilters,
+    stale_threshold: Duration,
+) -> HarvestResult<Vec<WorkerRow>> {
+    let mut query = harvest_workers::table
+        .select(HarvestWorker::as_select())
+        .into_boxed();
+
+    if let Some(ref status) = filters.status {
+        query = query.filter(harvest_workers::status.eq(status));
+    }
+
+    let rows: Vec<HarvestWorker> = query
+        .limit(filters.limit)
+        .load(conn)
+        .await
+        .map_err(crate::error::database_error)?;
+
+    let mut results: Vec<WorkerRow> = rows
+        .into_iter()
+        .map(|w| {
+            let health = WorkerHealth::classify(w.last_heartbeat_at, stale_threshold);
+            WorkerRow { worker: w, health }
+        })
+        .collect();
+
+    // Apply post-query filters that need in-process evaluation.
+    if let Some(ref queue) = filters.queue {
+        results.retain(|r| {
+            r.worker
+                .queues
+                .as_array()
+                .is_some_and(|arr| arr.iter().any(|v| v.as_str() == Some(queue.as_str())))
+        });
+    }
+    if let Some(shard_val) = filters.shard_id {
+        results.retain(|r| {
+            r.worker
+                .shard_assignments
+                .as_array()
+                .is_some_and(|arr| arr.iter().any(|v| v.as_i64() == Some(i64::from(shard_val))))
+        });
+    }
+    if let Some(health_filter) = filters.health {
+        results.retain(|r| r.health == health_filter);
+    }
+
+    Ok(results)
+}
+
+/// Get a single worker detail row.
+///
+/// # Errors
+///
+/// Returns [`HarvestError`] on database failure.
+pub async fn get_worker(
+    conn: &mut AsyncPgConnection,
+    worker_id: &str,
+    stale_threshold: Duration,
+) -> HarvestResult<Option<WorkerRow>> {
+    let row = harvest_workers::table
+        .find(worker_id)
+        .select(HarvestWorker::as_select())
+        .first::<HarvestWorker>(conn)
+        .await
+        .optional()
+        .map_err(crate::error::database_error)?;
+
+    Ok(row.map(|w| {
+        let health = WorkerHealth::classify(w.last_heartbeat_at, stale_threshold);
+        WorkerRow { worker: w, health }
+    }))
+}
+
+/// Aggregate fleet health statistics across workers visible to this connection.
+///
+/// # Errors
+///
+/// Returns [`HarvestError`] on database failure.
+pub async fn fleet_health(
+    conn: &mut AsyncPgConnection,
+    stale_threshold: Duration,
+) -> HarvestResult<FleetHealth> {
+    let all_workers = harvest_workers::table
+        .select(HarvestWorker::as_select())
+        .load::<HarvestWorker>(conn)
+        .await
+        .map_err(crate::error::database_error)?;
+
+    let mut healthy: usize = 0;
+    let mut stale: usize = 0;
+    let mut draining: usize = 0;
+    let mut by_queue: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+    let mut by_shard: std::collections::HashMap<i32, usize> = std::collections::HashMap::new();
+
+    for w in &all_workers {
+        let health = WorkerHealth::classify(w.last_heartbeat_at, stale_threshold);
+        match health {
+            WorkerHealth::Healthy => healthy += 1,
+            WorkerHealth::Stale => stale += 1,
+        }
+        if w.status == WorkerStatus::Draining.as_str() {
+            draining += 1;
+        }
+        if let Some(queues) = w.queues.as_array() {
+            for q in queues {
+                if let Some(name) = q.as_str() {
+                    *by_queue.entry(name.to_string()).or_default() += 1;
+                }
+            }
+        }
+        if let Some(shards) = w.shard_assignments.as_array() {
+            for s in shards {
+                if let Some(id) = s.as_i64().and_then(|v| i32::try_from(v).ok()) {
+                    *by_shard.entry(id).or_default() += 1;
+                }
+            }
+        }
+    }
+
+    Ok(FleetHealth {
+        healthy,
+        stale,
+        draining,
+        by_queue,
+        by_shard,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Response types
+// ---------------------------------------------------------------------------
+
+/// A worker row enriched with the derived health classification.
+#[derive(Debug, serde::Serialize)]
+pub struct WorkerRow {
+    #[serde(flatten)]
+    pub worker: HarvestWorker,
+    pub health: WorkerHealth,
+}
+
+/// Aggregated fleet health roll-up.
+#[derive(Debug, serde::Serialize)]
+pub struct FleetHealth {
+    pub healthy: usize,
+    pub stale: usize,
+    pub draining: usize,
+    pub by_queue: std::collections::HashMap<String, usize>,
+    pub by_shard: std::collections::HashMap<i32, usize>,
+}
+
+// ---------------------------------------------------------------------------
+// Background heartbeat task
+// ---------------------------------------------------------------------------
+
+/// Spawn a background task that upserts worker heartbeats on a regular interval.
+///
+/// The task reads the current `in_flight_count` from the semaphores, then
+/// writes it to the database. It stops when `cancel` is triggered.
+#[must_use]
+#[allow(clippy::too_many_arguments)]
+pub fn spawn_worker_heartbeat(
+    pool: DbPool,
+    worker_id: String,
+    wf_semaphore: Arc<Semaphore>,
+    wf_max: usize,
+    act_semaphore: Arc<Semaphore>,
+    act_max: usize,
+    interval: Duration,
+    cancel: CancellationToken,
+) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                () = cancel.cancelled() => break,
+                () = tokio::time::sleep(interval) => {}
+            }
+
+            let in_flight = compute_in_flight(&wf_semaphore, wf_max, &act_semaphore, act_max);
+
+            match pool.get().await {
+                Ok(mut conn) => {
+                    if let Err(error) = heartbeat_worker(&mut conn, &worker_id, in_flight).await {
+                        tracing::warn!(
+                            worker_id = %worker_id,
+                            error = %error,
+                            "worker heartbeat write failed"
+                        );
+                    }
+                }
+                Err(error) => {
+                    tracing::warn!(
+                        worker_id = %worker_id,
+                        error = %error,
+                        "worker heartbeat failed to get pool connection"
+                    );
+                }
+            }
+        }
+    })
+}
+
+/// Compute the number of tasks currently in flight from semaphore permits.
+#[must_use]
+pub fn compute_in_flight(
+    wf_semaphore: &Semaphore,
+    wf_max: usize,
+    act_semaphore: &Semaphore,
+    act_max: usize,
+) -> i32 {
+    let wf_in_flight = wf_max.saturating_sub(wf_semaphore.available_permits());
+    let act_in_flight = act_max.saturating_sub(act_semaphore.available_permits());
+    i32::try_from(wf_in_flight + act_in_flight).unwrap_or(i32::MAX)
+}
+
+/// Return the local machine hostname, best-effort.
+#[must_use]
+pub fn local_hostname() -> String {
+    std::fs::read_to_string("/proc/sys/kernel/hostname")
+        .map(|s| s.trim().to_string())
+        .or_else(|_| std::env::var("HOSTNAME"))
+        .unwrap_or_else(|_| "unknown".to_string())
+}
+
+// ---------------------------------------------------------------------------
+// Tests — Red phase: written before the implementation compiles
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- WorkerStatus --
+
+    #[test]
+    fn worker_status_round_trips_via_str() {
+        for status in [
+            WorkerStatus::Active,
+            WorkerStatus::Draining,
+            WorkerStatus::Stopped,
+        ] {
+            let s = status.as_str();
+            let parsed = WorkerStatus::from_str(s);
+            assert_eq!(parsed, Some(status), "round-trip failed for {s}");
+        }
+    }
+
+    #[test]
+    fn worker_status_rejects_unknown_string() {
+        assert_eq!(WorkerStatus::from_str("zombie"), None);
+        assert_eq!(WorkerStatus::from_str(""), None);
+        assert_eq!(WorkerStatus::from_str("active"), None); // case-sensitive
+    }
+
+    #[test]
+    fn worker_status_display_matches_as_str() {
+        assert_eq!(WorkerStatus::Active.to_string(), "Active");
+        assert_eq!(WorkerStatus::Draining.to_string(), "Draining");
+        assert_eq!(WorkerStatus::Stopped.to_string(), "Stopped");
+    }
+
+    // -- WorkerHealth --
+
+    #[test]
+    fn worker_health_healthy_when_recently_seen() {
+        let threshold = Duration::from_secs(10);
+        let recent = Utc::now() - chrono::Duration::seconds(3);
+        assert_eq!(
+            WorkerHealth::classify(recent, threshold),
+            WorkerHealth::Healthy
+        );
+    }
+
+    #[test]
+    fn worker_health_stale_when_past_threshold() {
+        let threshold = Duration::from_secs(10);
+        let old = Utc::now() - chrono::Duration::seconds(15);
+        assert_eq!(WorkerHealth::classify(old, threshold), WorkerHealth::Stale);
+    }
+
+    #[test]
+    fn worker_health_stale_at_exact_threshold_boundary() {
+        let threshold = Duration::from_secs(10);
+        // exactly at the threshold boundary is still stale (> check)
+        let at_boundary = Utc::now() - chrono::Duration::seconds(11);
+        assert_eq!(
+            WorkerHealth::classify(at_boundary, threshold),
+            WorkerHealth::Stale
+        );
+    }
+
+    // -- parse_worker_filters --
+
+    fn pairs(items: &[(&str, &str)]) -> Vec<(String, String)> {
+        items
+            .iter()
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect()
+    }
+
+    #[test]
+    fn parse_worker_filters_defaults_when_empty() {
+        let f = parse_worker_filters(&[]).expect("empty should parse");
+        assert_eq!(f.limit, WorkerFilters::DEFAULT_LIMIT);
+        assert!(f.queue.is_none());
+        assert!(f.shard_id.is_none());
+        assert!(f.status.is_none());
+        assert!(f.health.is_none());
+    }
+
+    #[test]
+    fn parse_worker_filters_accepts_queue() {
+        let f = parse_worker_filters(&pairs(&[("queue", "email-workers")])).unwrap();
+        assert_eq!(f.queue.as_deref(), Some("email-workers"));
+    }
+
+    #[test]
+    fn parse_worker_filters_accepts_valid_status() {
+        for status in ["Active", "Draining", "Stopped"] {
+            let f = parse_worker_filters(&pairs(&[("status", status)])).unwrap();
+            assert_eq!(f.status.as_deref(), Some(status));
+        }
+    }
+
+    #[test]
+    fn parse_worker_filters_rejects_unknown_status() {
+        let err = parse_worker_filters(&pairs(&[("status", "zombie")])).unwrap_err();
+        assert!(err.contains("unknown status"), "error: {err}");
+    }
+
+    #[test]
+    fn parse_worker_filters_accepts_health_healthy() {
+        let f = parse_worker_filters(&pairs(&[("health", "healthy")])).unwrap();
+        assert_eq!(f.health, Some(WorkerHealth::Healthy));
+    }
+
+    #[test]
+    fn parse_worker_filters_accepts_health_stale() {
+        let f = parse_worker_filters(&pairs(&[("health", "stale")])).unwrap();
+        assert_eq!(f.health, Some(WorkerHealth::Stale));
+    }
+
+    #[test]
+    fn parse_worker_filters_rejects_unknown_health() {
+        let err = parse_worker_filters(&pairs(&[("health", "dead")])).unwrap_err();
+        assert!(err.contains("unknown health"), "error: {err}");
+    }
+
+    #[test]
+    fn parse_worker_filters_accepts_valid_shard_id() {
+        let f = parse_worker_filters(&pairs(&[("shard_id", "3")])).unwrap();
+        assert_eq!(f.shard_id, Some(3));
+    }
+
+    #[test]
+    fn parse_worker_filters_rejects_non_integer_shard_id() {
+        let err = parse_worker_filters(&pairs(&[("shard_id", "not-a-number")])).unwrap_err();
+        assert!(err.contains("invalid shard_id"), "error: {err}");
+    }
+
+    #[test]
+    fn parse_worker_filters_clamps_limit() {
+        let f = parse_worker_filters(&pairs(&[("limit", "9999")])).unwrap();
+        assert_eq!(f.limit, WorkerFilters::MAX_LIMIT);
+
+        let f = parse_worker_filters(&pairs(&[("limit", "0")])).unwrap();
+        assert_eq!(f.limit, 1);
+    }
+
+    #[test]
+    fn parse_worker_filters_rejects_non_numeric_limit() {
+        let err = parse_worker_filters(&pairs(&[("limit", "abc")])).unwrap_err();
+        assert!(err.contains("invalid limit"), "error: {err}");
+    }
+
+    #[test]
+    fn parse_worker_filters_ignores_unknown_keys() {
+        let f = parse_worker_filters(&pairs(&[("unknown_param", "value")])).unwrap();
+        assert!(f.queue.is_none());
+        assert!(f.status.is_none());
+    }
+
+    // -- compute_in_flight --
+
+    #[test]
+    fn compute_in_flight_zero_when_idle() {
+        let wf_sem = Semaphore::new(10);
+        let act_sem = Semaphore::new(20);
+        assert_eq!(compute_in_flight(&wf_sem, 10, &act_sem, 20), 0);
+    }
+
+    #[test]
+    fn compute_in_flight_counts_acquired_permits() {
+        let wf_sem = Arc::new(Semaphore::new(10));
+        let act_sem = Arc::new(Semaphore::new(20));
+
+        // Acquire 3 workflow permits and 5 activity permits.
+        let _wf_permits = wf_sem.try_acquire_many(3).unwrap();
+        let _act_permits = act_sem.try_acquire_many(5).unwrap();
+
+        assert_eq!(compute_in_flight(&wf_sem, 10, &act_sem, 20), 8);
+    }
+}

--- a/autumn-harvest/src/workers.rs
+++ b/autumn-harvest/src/workers.rs
@@ -99,10 +99,13 @@ impl WorkerHealth {
     /// `stale_threshold` (typically `2 × heartbeat_interval`).
     #[must_use]
     pub fn classify(last_heartbeat_at: DateTime<Utc>, stale_threshold: Duration) -> Self {
+        // Negative durations arise from clock skew (worker host slightly ahead of
+        // the API host). Treat them as zero elapsed time so a freshly-heartbeating
+        // worker is never misclassified as stale.
         let elapsed = Utc::now()
             .signed_duration_since(last_heartbeat_at)
             .to_std()
-            .unwrap_or(Duration::MAX);
+            .unwrap_or(Duration::ZERO);
         if elapsed > stale_threshold {
             Self::Stale
         } else {
@@ -672,6 +675,18 @@ mod tests {
             .iter()
             .map(|(k, v)| (k.to_string(), v.to_string()))
             .collect()
+    }
+
+    #[test]
+    fn worker_health_healthy_when_timestamp_is_in_future() {
+        // Clock skew: last_heartbeat_at is slightly ahead of "now".
+        // Should be treated as zero elapsed time (Healthy), not Duration::MAX (Stale).
+        let threshold = Duration::from_secs(10);
+        let future = Utc::now() + chrono::Duration::seconds(2);
+        assert_eq!(
+            WorkerHealth::classify(future, threshold),
+            WorkerHealth::Healthy
+        );
     }
 
     #[test]

--- a/autumn-harvest/tests/cancellation_tests.rs
+++ b/autumn-harvest/tests/cancellation_tests.rs
@@ -404,6 +404,8 @@ async fn running_activity_heartbeat_observes_workflow_cancellation() {
                 cancellation_grace_period: Duration::from_secs(1),
                 sticky_timeout: Duration::from_secs(5),
                 max_local_activity_start_to_close: Duration::from_secs(60),
+                shard_assignments: vec![autumn_harvest::types::ShardId::new(0)],
+                worker_heartbeat_interval: Duration::from_secs(5),
             },
             registry,
         )
@@ -557,6 +559,8 @@ async fn uncooperative_activity_is_hard_aborted_after_grace_period() {
                 cancellation_grace_period: Duration::from_millis(500),
                 sticky_timeout: Duration::from_secs(5),
                 max_local_activity_start_to_close: Duration::from_secs(60),
+                shard_assignments: vec![autumn_harvest::types::ShardId::new(0)],
+                worker_heartbeat_interval: Duration::from_secs(5),
             },
             registry,
         )

--- a/autumn-harvest/tests/integration_e2e.rs
+++ b/autumn-harvest/tests/integration_e2e.rs
@@ -408,6 +408,8 @@ fn build_runtime_worker(
                 cancellation_grace_period: Duration::from_secs(1),
                 sticky_timeout: Duration::from_secs(5),
                 max_local_activity_start_to_close: Duration::from_secs(60),
+                shard_assignments: vec![autumn_harvest::types::ShardId::new(0)],
+                worker_heartbeat_interval: Duration::from_secs(5),
             },
             registry,
         )
@@ -860,6 +862,8 @@ async fn worker_completes_workflow_task_and_persists_result() {
                 cancellation_grace_period: Duration::from_secs(1),
                 sticky_timeout: Duration::from_secs(5),
                 max_local_activity_start_to_close: Duration::from_secs(60),
+                shard_assignments: vec![autumn_harvest::types::ShardId::new(0)],
+                worker_heartbeat_interval: Duration::from_secs(5),
             },
             registry,
         )
@@ -952,6 +956,8 @@ async fn worker_marks_workflow_failed_when_handler_errors() {
                 cancellation_grace_period: Duration::from_secs(1),
                 sticky_timeout: Duration::from_secs(5),
                 max_local_activity_start_to_close: Duration::from_secs(60),
+                shard_assignments: vec![autumn_harvest::types::ShardId::new(0)],
+                worker_heartbeat_interval: Duration::from_secs(5),
             },
             registry,
         )
@@ -1069,6 +1075,8 @@ async fn worker_completes_workflow_with_activity_round_trip() {
                 cancellation_grace_period: Duration::from_secs(1),
                 sticky_timeout: Duration::from_secs(5),
                 max_local_activity_start_to_close: Duration::from_secs(60),
+                shard_assignments: vec![autumn_harvest::types::ShardId::new(0)],
+                worker_heartbeat_interval: Duration::from_secs(5),
             },
             registry,
         )
@@ -1159,6 +1167,8 @@ async fn worker_fails_orphaned_activity_task_without_scheduled_event() {
                 cancellation_grace_period: Duration::from_secs(1),
                 sticky_timeout: Duration::from_secs(5),
                 max_local_activity_start_to_close: Duration::from_secs(60),
+                shard_assignments: vec![autumn_harvest::types::ShardId::new(0)],
+                worker_heartbeat_interval: Duration::from_secs(5),
             },
             Arc::new(HandlerRegistry::new(
                 vec![],
@@ -1366,6 +1376,8 @@ async fn worker_fails_workflow_when_activity_start_to_close_timeout_elapses() {
                 cancellation_grace_period: Duration::from_secs(1),
                 sticky_timeout: Duration::from_secs(5),
                 max_local_activity_start_to_close: Duration::from_secs(60),
+                shard_assignments: vec![autumn_harvest::types::ShardId::new(0)],
+                worker_heartbeat_interval: Duration::from_secs(5),
             },
             Arc::new(HandlerRegistry::new(
                 vec![WorkflowInfo {
@@ -1484,6 +1496,8 @@ async fn worker_completes_workflow_with_timer_round_trip() {
                 cancellation_grace_period: Duration::from_secs(1),
                 sticky_timeout: Duration::from_secs(5),
                 max_local_activity_start_to_close: Duration::from_secs(60),
+                shard_assignments: vec![autumn_harvest::types::ShardId::new(0)],
+                worker_heartbeat_interval: Duration::from_secs(5),
             },
             Arc::new(HandlerRegistry::new(
                 vec![WorkflowInfo {
@@ -3700,6 +3714,8 @@ async fn workflow_schedule_baseline_dispatches_multiple_runs() {
                 cancellation_grace_period: Duration::from_secs(1),
                 sticky_timeout: Duration::from_secs(5),
                 max_local_activity_start_to_close: Duration::from_secs(60),
+                shard_assignments: vec![autumn_harvest::types::ShardId::new(0)],
+                worker_heartbeat_interval: Duration::from_secs(5),
             },
             Arc::clone(&registry),
         )
@@ -3791,6 +3807,8 @@ async fn workflow_schedule_max_active_runs_enforced() {
                 cancellation_grace_period: Duration::from_secs(1),
                 sticky_timeout: Duration::from_secs(5),
                 max_local_activity_start_to_close: Duration::from_secs(60),
+                shard_assignments: vec![autumn_harvest::types::ShardId::new(0)],
+                worker_heartbeat_interval: Duration::from_secs(5),
             },
             Arc::clone(&registry),
         )
@@ -3870,6 +3888,8 @@ async fn workflow_schedule_pause_and_resume() {
                 cancellation_grace_period: Duration::from_secs(1),
                 sticky_timeout: Duration::from_secs(5),
                 max_local_activity_start_to_close: Duration::from_secs(60),
+                shard_assignments: vec![autumn_harvest::types::ShardId::new(0)],
+                worker_heartbeat_interval: Duration::from_secs(5),
             },
             Arc::clone(&registry),
         )


### PR DESCRIPTION
## Summary

Implements worker fleet observability for the autumn-harvest task scheduler, enabling operators to monitor worker liveness, health status, and fleet composition via management API endpoints. Workers now register themselves on startup, send periodic heartbeats, and transition through a lifecycle (Active → Draining → Stopped) during graceful shutdown.

## Key Changes

- **New `workers` module** (`autumn-harvest/src/workers.rs`): Core fleet registry logic including:
  - `WorkerStatus` enum (Active, Draining, Stopped) with string serialization
  - `WorkerHealth` classification (Healthy/Stale) based on heartbeat recency
  - `WorkerFilters` for querying workers by queue, shard, status, and health
  - Database operations: `register_worker()`, `heartbeat_worker()`, `transition_status()`, `list_workers()`, `get_worker()`, `fleet_health()`
  - Background task `spawn_worker_heartbeat()` that periodically upserts liveness records
  - Comprehensive unit tests for all public APIs

- **Database schema** (`harvest_workers` table):
  - Tracks worker_id (PK), started_at, last_heartbeat_at, queues (JSONB array), shard_assignments (JSONB array), max_concurrency, in_flight_count, host, version, and status
  - Lives on every shard; management API merges results across shards
  - No foreign keys—operational metadata independent of workflow history

- **Worker integration** (`autumn-harvest/src/worker.rs`):
  - Added `shard_assignments` and `worker_heartbeat_interval` to `WorkerRuntimeConfig`
  - Worker registers in fleet table on startup via `register_in_fleet()`
  - Spawns heartbeat background task during `run_with_listener()`
  - Transitions to Draining before draining in-flight tasks, then to Stopped on shutdown
  - Computes in-flight count from semaphore permits and sends to database

- **Management API endpoints** (`autumn-harvest-plugin/src/api.rs`):
  - `GET /api/harvest/workers` — list workers with optional filters (?queue=, ?shard_id=, ?status=, ?health=, ?limit=)
  - `GET /api/harvest/workers/{worker_id}` — single worker detail including active task IDs
  - `GET /api/harvest/workers/health` — fleet health roll-up (healthy/stale/draining counts, by_queue, by_shard)
  - Aggregates results across all shards for unified fleet view

- **Models and schema**:
  - `HarvestWorker` struct in models.rs with Diesel Queryable/Selectable derives
  - `NewHarvestWorker` for inserts
  - Diesel schema table definition for `harvest_workers`

- **Documentation**:
  - Updated README.md with worker fleet API examples and CLI equivalents
  - Comprehensive module-level docs explaining lifecycle and query patterns

## Notable Implementation Details

- **Stale threshold**: Workers without heartbeat for `2 × heartbeat_interval` (default 10s) are classified as stale but not auto-deleted—operators want churn visibility
- **Upsert on restart**: Crashed-and-restarted workers with same worker_id overwrite stale rows
- **In-flight computation**: Derived from semaphore available permits, not persisted state
- **Post-query filtering**: Queue and shard filters applied in-process after database load (JSON array inspection)
- **Graceful shutdown**: Transitions Active → Draining → Stopped, allowing operators to observe drain progress
- **Hostname detection**: Best-effort via `/proc/sys/kernel/hostname` or `$HOSTNAME` env var

https://claude.ai/code/session_01KAhejMCxQ5kzsa6WbDmrRV