### PR TITLE
Add batch operations for fleet-wide workflow management (issue #102)

### DIFF
--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -20,6 +20,10 @@ use diesel_async::RunQueryDsl;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use autumn_harvest::batch::{
+    self, BatchAction, BatchExecutorConfig, BatchFilter, BatchJobStatus, BatchJobView,
+    BatchSubmission,
+};
 use autumn_harvest::context::WorkflowContext;
 use autumn_harvest::dlq;
 use autumn_harvest::error::{HarvestError, HarvestResult, database_error};
@@ -458,7 +462,174 @@ pub fn harvest_api_router(api_state: HarvestApiState) -> Router<AppState> {
         .route("/workers/health", get(workers_health))
         .route("/workers", get(list_workers_handler))
         .route("/workers/{worker_id}", get(get_worker_handler))
+        // Batch operations (issue #102): operator-facing fleet-wide cancel /
+        // terminate / signal so an incident commander does not have to script
+        // a one-off loop over GET /workflows.
+        .route("/batch-operations", get(list_batch_operations))
+        .route("/batch-operations", post(submit_batch_operation))
+        .route("/batch-operations/{id}", get(get_batch_operation))
         .layer(Extension(api_state))
+}
+
+#[derive(Debug, Deserialize)]
+struct SubmitBatchOperationRequest {
+    /// `Cancel`, `Terminate`, or `Signal`.
+    action: String,
+    /// Mirrors the `GET /workflows` filter contract.
+    #[serde(default)]
+    filter: BatchFilter,
+    /// Required when `action == "Signal"`.
+    #[serde(default)]
+    signal_name: Option<String>,
+    /// Optional payload sent to each matched workflow when `action == "Signal"`.
+    #[serde(default)]
+    signal_payload: Option<Value>,
+    /// Operator-supplied retry token. Re-submitting with the same key returns
+    /// the existing `batch_job_id` instead of starting a duplicate batch.
+    #[serde(default)]
+    idempotency_key: Option<String>,
+    /// Optional caller identity (e.g. the on-call handle) for audit.
+    #[serde(default)]
+    created_by: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct SubmitBatchOperationResponse {
+    batch_job_id: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct ListBatchOperationsQuery {
+    status: Option<String>,
+    action: Option<String>,
+    limit: Option<i64>,
+}
+
+async fn submit_batch_operation(
+    Extension(api_state): Extension<HarvestApiState>,
+    Json(request): Json<SubmitBatchOperationRequest>,
+) -> Result<(axum::http::StatusCode, Json<SubmitBatchOperationResponse>), AutumnError> {
+    let action: BatchAction = request
+        .action
+        .parse()
+        .map_err(AutumnError::bad_request_msg)?;
+
+    // Reject `state=` values outside the canonical list before we hit the DB
+    // — otherwise the executor would silently match nothing and look like a
+    // success.
+    for state in &request.filter.states {
+        if !KNOWN_WORKFLOW_STATES.contains(&state.as_str()) {
+            return Err(AutumnError::bad_request_msg(format!(
+                "unknown workflow state '{state}' in batch filter"
+            )));
+        }
+    }
+
+    let pool = api_state.storage_pool().map_err(map_error)?;
+    // Persist the row on the default shard. The executor will fan out across
+    // every configured shard at run time via iter_shards().
+    let mut conn = acquire_conn(pool.default_pool()).await?;
+    let job_id = batch::submit_batch_job(
+        &mut conn,
+        BatchSubmission {
+            action,
+            filter: request.filter,
+            signal_name: request.signal_name,
+            signal_payload: request.signal_payload,
+            idempotency_key: request.idempotency_key,
+            created_by: request.created_by,
+        },
+    )
+    .await
+    .map_err(map_error)?;
+
+    Ok((
+        axum::http::StatusCode::ACCEPTED,
+        Json(SubmitBatchOperationResponse {
+            batch_job_id: job_id.to_string(),
+        }),
+    ))
+}
+
+async fn get_batch_operation(
+    Extension(api_state): Extension<HarvestApiState>,
+    Path(id): Path<String>,
+) -> Result<Json<BatchJobView>, AutumnError> {
+    let job_id = parse_uuid(&id, "batch job id")?;
+    let pool = api_state.storage_pool().map_err(map_error)?;
+    let mut conn = acquire_conn(pool.default_pool()).await?;
+    let row = batch::get_batch_job(&mut conn, job_id)
+        .await
+        .map_err(map_error)?
+        .ok_or_else(|| AutumnError::not_found_msg(format!("batch job {id}")))?;
+    Ok(Json(BatchJobView::from_row(row)))
+}
+
+async fn list_batch_operations(
+    Extension(api_state): Extension<HarvestApiState>,
+    Query(query): Query<ListBatchOperationsQuery>,
+) -> Result<Json<Vec<BatchJobView>>, AutumnError> {
+    let status = query
+        .status
+        .as_deref()
+        .map(BatchJobStatus::from_str_or_err)
+        .transpose()?;
+    let action = query
+        .action
+        .as_deref()
+        .map(BatchAction::from_str_or_err)
+        .transpose()?;
+    let limit = query.limit.unwrap_or(50);
+
+    let pool = api_state.storage_pool().map_err(map_error)?;
+    let mut conn = acquire_conn(pool.default_pool()).await?;
+    let rows = batch::list_batch_jobs(
+        &mut conn,
+        &batch::ListFilters {
+            status,
+            action,
+            limit,
+        },
+    )
+    .await
+    .map_err(map_error)?;
+    Ok(Json(rows.into_iter().map(BatchJobView::from_row).collect()))
+}
+
+trait ParseFromStrOrErr: Sized {
+    fn from_str_or_err(s: &str) -> Result<Self, AutumnError>;
+}
+
+impl ParseFromStrOrErr for BatchJobStatus {
+    fn from_str_or_err(s: &str) -> Result<Self, AutumnError> {
+        s.parse::<Self>().map_err(AutumnError::bad_request_msg)
+    }
+}
+
+impl ParseFromStrOrErr for BatchAction {
+    fn from_str_or_err(s: &str) -> Result<Self, AutumnError> {
+        s.parse::<Self>().map_err(AutumnError::bad_request_msg)
+    }
+}
+
+/// Run one tick of the batch executor across every configured shard.
+///
+/// Exposed for the plugin's lifecycle wiring; tests construct a
+/// [`HarvestDbPool`] and call into `autumn_harvest::batch::run_executor_once`
+/// directly with the underlying [`autumn_harvest::shard::ShardedDbPool`].
+///
+/// # Errors
+///
+/// Returns [`AutumnError`] when the executor cannot reach a shard or a
+/// per-shard SQL operation fails. Per-target failures are recorded on the
+/// job row and do not propagate as errors.
+pub async fn run_batch_executor_once(
+    pool: &HarvestDbPool,
+    config: &BatchExecutorConfig,
+) -> Result<(), AutumnError> {
+    batch::run_executor_once(pool.sharded_pool(), config)
+        .await
+        .map_err(map_error)
 }
 
 async fn list_workflows(

--- a/autumn-harvest-plugin/src/config.rs
+++ b/autumn-harvest-plugin/src/config.rs
@@ -120,6 +120,9 @@ impl HarvestRuntimeConfig {
         if let Some(concurrency) = partial.batch.concurrency {
             self.batch.concurrency = concurrency;
         }
+        if let Some(concurrency) = partial.batch.batch_concurrency {
+            self.batch.concurrency = concurrency;
+        }
         if let Some(tick_interval_ms) = partial.batch.tick_interval_ms {
             self.batch.tick_interval_ms = tick_interval_ms;
         }
@@ -170,8 +173,15 @@ impl HarvestRuntimeConfig {
             )?;
         }
 
+        // Issue #102 calls the knob `batch_concurrency`; we accept either
+        // spelling so operators can use whichever matches their habits and
+        // the AC name resolves verbatim.
         if let Ok(concurrency) = env.var("AUTUMN_HARVEST_BATCH__CONCURRENCY") {
             self.batch.concurrency = parse_u32("AUTUMN_HARVEST_BATCH__CONCURRENCY", &concurrency)?;
+        }
+        if let Ok(concurrency) = env.var("AUTUMN_HARVEST_BATCH__BATCH_CONCURRENCY") {
+            self.batch.concurrency =
+                parse_u32("AUTUMN_HARVEST_BATCH__BATCH_CONCURRENCY", &concurrency)?;
         }
         if let Ok(tick_interval_ms) = env.var("AUTUMN_HARVEST_BATCH__TICK_INTERVAL_MS") {
             self.batch.tick_interval_ms =
@@ -311,6 +321,10 @@ struct PartialHarvestOutboxConfig {
 #[derive(Debug, Default, Deserialize)]
 struct PartialHarvestBatchConfig {
     concurrency: Option<u32>,
+    /// Issue #102 spells the field `batch_concurrency`. Either key sets the
+    /// same field; if both are present, `batch_concurrency` wins because it
+    /// is the issue's canonical name.
+    batch_concurrency: Option<u32>,
     tick_interval_ms: Option<u64>,
 }
 

--- a/autumn-harvest-plugin/src/config.rs
+++ b/autumn-harvest-plugin/src/config.rs
@@ -27,6 +27,18 @@ pub struct HarvestOutboxConfig {
     pub max_retry_delay_ms: u64,
 }
 
+/// Tunables for the batch-operations executor (issue #102).
+///
+/// `concurrency` caps the number of in-flight per-target operations so a
+/// 10k-target batch can't monopolise the connection pool. `tick_interval_ms`
+/// is how often the background loop wakes up to scan for new open jobs;
+/// the same loop drains in-progress jobs synchronously within a tick.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct HarvestBatchConfig {
+    pub concurrency: u32,
+    pub tick_interval_ms: u64,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HarvestRuntimeConfig {
     pub mode: HarvestMode,
@@ -34,6 +46,7 @@ pub struct HarvestRuntimeConfig {
     pub scheduler_enabled: bool,
     pub database: HarvestDatabaseConfig,
     pub outbox: HarvestOutboxConfig,
+    pub batch: HarvestBatchConfig,
 }
 
 impl HarvestRuntimeConfig {
@@ -104,6 +117,12 @@ impl HarvestRuntimeConfig {
         if let Some(max_retry_delay_ms) = partial.outbox.max_retry_delay_ms {
             self.outbox.max_retry_delay_ms = max_retry_delay_ms;
         }
+        if let Some(concurrency) = partial.batch.concurrency {
+            self.batch.concurrency = concurrency;
+        }
+        if let Some(tick_interval_ms) = partial.batch.tick_interval_ms {
+            self.batch.tick_interval_ms = tick_interval_ms;
+        }
     }
 
     fn apply_env_overrides(&mut self, env: &dyn Env) -> Result<(), ConfigError> {
@@ -151,6 +170,14 @@ impl HarvestRuntimeConfig {
             )?;
         }
 
+        if let Ok(concurrency) = env.var("AUTUMN_HARVEST_BATCH__CONCURRENCY") {
+            self.batch.concurrency = parse_u32("AUTUMN_HARVEST_BATCH__CONCURRENCY", &concurrency)?;
+        }
+        if let Ok(tick_interval_ms) = env.var("AUTUMN_HARVEST_BATCH__TICK_INTERVAL_MS") {
+            self.batch.tick_interval_ms =
+                parse_u64("AUTUMN_HARVEST_BATCH__TICK_INTERVAL_MS", &tick_interval_ms)?;
+        }
+
         Ok(())
     }
 
@@ -196,6 +223,17 @@ impl HarvestRuntimeConfig {
             ));
         }
 
+        if self.batch.concurrency < 1 {
+            return Err(ConfigError::Validation(
+                "harvest.batch.concurrency must be at least 1".to_owned(),
+            ));
+        }
+        if self.batch.tick_interval_ms < 1 {
+            return Err(ConfigError::Validation(
+                "harvest.batch.tick_interval_ms must be at least 1".to_owned(),
+            ));
+        }
+
         Ok(())
     }
 }
@@ -208,6 +246,7 @@ impl Default for HarvestRuntimeConfig {
             scheduler_enabled: true,
             database: HarvestDatabaseConfig::default(),
             outbox: HarvestOutboxConfig::default(),
+            batch: HarvestBatchConfig::default(),
         }
     }
 }
@@ -221,6 +260,16 @@ impl Default for HarvestOutboxConfig {
             claim_ttl_ms: 30_000,
             base_retry_delay_ms: 1_000,
             max_retry_delay_ms: 60_000,
+        }
+    }
+}
+
+impl Default for HarvestBatchConfig {
+    fn default() -> Self {
+        Self {
+            // Matches the issue's default: cap fan-out at 32 in-flight ops.
+            concurrency: 32,
+            tick_interval_ms: 500,
         }
     }
 }
@@ -240,6 +289,8 @@ struct PartialHarvestRuntimeConfig {
     database: PartialHarvestDatabaseConfig,
     #[serde(default)]
     outbox: PartialHarvestOutboxConfig,
+    #[serde(default)]
+    batch: PartialHarvestBatchConfig,
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -255,6 +306,12 @@ struct PartialHarvestOutboxConfig {
     claim_ttl_ms: Option<u64>,
     base_retry_delay_ms: Option<u64>,
     max_retry_delay_ms: Option<u64>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct PartialHarvestBatchConfig {
+    concurrency: Option<u32>,
+    tick_interval_ms: Option<u64>,
 }
 
 fn find_config_file_named(filename: &str, env: &dyn Env) -> PathBuf {
@@ -331,6 +388,12 @@ fn parse_i64(key: &str, value: &str) -> Result<i64, ConfigError> {
 fn parse_u64(key: &str, value: &str) -> Result<u64, ConfigError> {
     value
         .parse::<u64>()
+        .map_err(|_| ConfigError::Validation(format!("invalid integer for {key}: {value:?}")))
+}
+
+fn parse_u32(key: &str, value: &str) -> Result<u32, ConfigError> {
+    value
+        .parse::<u32>()
         .map_err(|_| ConfigError::Validation(format!("invalid integer for {key}: {value:?}")))
 }
 

--- a/autumn-harvest-plugin/src/lib.rs
+++ b/autumn-harvest-plugin/src/lib.rs
@@ -10,7 +10,10 @@ pub mod state;
 pub mod ui;
 
 pub use api::{HarvestApiRuntime, HarvestApiState, HarvestRetentionRuntime, harvest_api_router};
-pub use config::{HarvestDatabaseConfig, HarvestMode, HarvestOutboxConfig, HarvestRuntimeConfig};
+pub use config::{
+    HarvestBatchConfig, HarvestDatabaseConfig, HarvestMode, HarvestOutboxConfig,
+    HarvestRuntimeConfig,
+};
 pub use outbox::{
     WorkflowStartRequest, drain_workflow_start_outbox_once, enqueue_workflow_start_outbox,
     flush_workflow_start_outbox,

--- a/autumn-harvest-plugin/src/plugin.rs
+++ b/autumn-harvest-plugin/src/plugin.rs
@@ -603,6 +603,7 @@ mod tests {
                 url: Some("postgres://harvest:harvest@localhost:5432/harvest".to_owned()),
             },
             outbox: HarvestOutboxConfig::default(),
+            batch: crate::config::HarvestBatchConfig::default(),
         };
 
         let harvest_pool = resolve_harvest_pool(&state, &config)

--- a/autumn-harvest-plugin/src/runner.rs
+++ b/autumn-harvest-plugin/src/runner.rs
@@ -5,17 +5,19 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use autumn_harvest::BuiltHarvest;
+use autumn_harvest::batch::{BatchExecutorConfig, run_executor_once};
 use autumn_harvest::context::SharedStateMap;
 use autumn_harvest::policy::WorkflowSchedule;
 use autumn_harvest::retention::{RetentionConfig, RetentionRuntime};
 use autumn_harvest::scheduler::{
     DagCatalog, SchedulerMonitor, SchedulerRuntime, compile_dag_catalog,
 };
-use autumn_harvest::shard::ShardRouter;
+use autumn_harvest::shard::{ShardRouter, ShardedDbPool};
 use autumn_harvest::worker::{DbPool, HandlerRegistry, Worker, WorkerRuntimeConfig};
 use autumn_web::AppState;
 use autumn_web::error::AutumnError;
 use tokio::task::JoinHandle;
+use tokio_util::sync::CancellationToken;
 
 use crate::api::{HarvestApiRuntime, HarvestRetentionRuntime};
 use crate::config::HarvestRuntimeConfig;
@@ -126,6 +128,51 @@ pub struct HarvestRunner {
     worker_handle: Option<JoinHandle<()>>,
     scheduler: Option<SchedulerRuntime>,
     retention: Option<RetentionRuntime>,
+    batch: Option<BatchRuntime>,
+}
+
+/// Background batch-operations executor handle (issue #102).
+struct BatchRuntime {
+    cancel: CancellationToken,
+    handle: JoinHandle<()>,
+}
+
+impl BatchRuntime {
+    /// Spawn a tick loop that drives every open batch job to terminal status.
+    ///
+    /// The loop sleeps `tick_interval` between scans; each tick walks every
+    /// shard and dispatches per-target actions with bounded concurrency. The
+    /// loop exits cleanly when the cancellation token fires.
+    fn spawn(
+        pool: ShardedDbPool,
+        executor_config: BatchExecutorConfig,
+        tick_interval: std::time::Duration,
+    ) -> Self {
+        let cancel = CancellationToken::new();
+        let cancel_for_task = cancel.clone();
+        let handle = tokio::spawn(async move {
+            loop {
+                if cancel_for_task.is_cancelled() {
+                    return;
+                }
+                if let Err(error) = run_executor_once(&pool, &executor_config).await {
+                    tracing::warn!(%error, "batch executor tick failed");
+                }
+                tokio::select! {
+                    () = cancel_for_task.cancelled() => return,
+                    () = tokio::time::sleep(tick_interval) => {}
+                }
+            }
+        });
+        Self { cancel, handle }
+    }
+
+    async fn shutdown(self) {
+        self.cancel.cancel();
+        if let Err(error) = self.handle.await {
+            tracing::warn!(error = %error, "harvest batch executor task failed during shutdown");
+        }
+    }
 }
 
 impl HarvestRunner {
@@ -206,6 +253,21 @@ impl HarvestRunner {
         };
         let retention_monitor = retention.as_ref().map(RetentionRuntime::monitor);
         let retention_trigger = retention.as_ref().map(RetentionRuntime::trigger_sender);
+        // Batch operations executor (issue #102): drive open `harvest_batch_jobs`
+        // rows to completion in the background. Only the worker-owning
+        // process spawns it so we don't run multiple competing executors
+        // against the same job rows.
+        let batch = if config.worker_enabled {
+            Some(BatchRuntime::spawn(
+                prepared.storage_pool.sharded_pool().clone(),
+                BatchExecutorConfig {
+                    concurrency: config.batch.concurrency,
+                },
+                std::time::Duration::from_millis(config.batch.tick_interval_ms),
+            ))
+        } else {
+            None
+        };
         let api_runtime = HarvestApiRuntime::new(
             registry,
             dag_catalog,
@@ -228,6 +290,7 @@ impl HarvestRunner {
             worker_handle,
             scheduler,
             retention,
+            batch,
         })
     }
 
@@ -252,6 +315,7 @@ impl HarvestRunner {
             worker_handle,
             scheduler,
             retention,
+            batch,
         } = self;
 
         if let Some(worker) = worker {
@@ -268,6 +332,9 @@ impl HarvestRunner {
             if let Err(error) = retention.join().await {
                 tracing::warn!(error = %error, "harvest retention task failed during shutdown");
             }
+        }
+        if let Some(batch) = batch {
+            batch.shutdown().await;
         }
         if let Some(worker_handle) = worker_handle
             && let Err(error) = worker_handle.await

--- a/autumn-harvest-plugin/tests/api_scheduler_integration.rs
+++ b/autumn-harvest-plugin/tests/api_scheduler_integration.rs
@@ -1292,6 +1292,7 @@ async fn external_runner_processes_workflows_started_via_management_api() {
                 url: Some(database_url.clone()),
             },
             outbox: autumn_harvest_plugin::HarvestOutboxConfig::default(),
+            batch: autumn_harvest_plugin::HarvestBatchConfig::default(),
         },
         HarvestRunnerResources::new(pool.clone()),
     )
@@ -1313,6 +1314,7 @@ async fn external_runner_processes_workflows_started_via_management_api() {
                 url: Some(database_url.clone()),
             },
             outbox: autumn_harvest_plugin::HarvestOutboxConfig::default(),
+            batch: autumn_harvest_plugin::HarvestBatchConfig::default(),
         },
         HarvestRunnerResources::new(pool.clone()),
     )
@@ -1375,6 +1377,7 @@ async fn retention_janitor_deletes_only_rows_older_than_max_age_and_cascades_chi
                 url: Some(database_url.clone()),
             },
             outbox: autumn_harvest_plugin::HarvestOutboxConfig::default(),
+            batch: autumn_harvest_plugin::HarvestBatchConfig::default(),
         },
         HarvestRunnerResources::new(pool.clone()),
     )

--- a/autumn-harvest-plugin/tests/batch_operations_integration.rs
+++ b/autumn-harvest-plugin/tests/batch_operations_integration.rs
@@ -1,0 +1,426 @@
+//! Integration tests for the batch operations API (issue #102).
+//!
+//! Covers the durable wiring: submit → list → get → executor drains. Uses a
+//! small synthetic fleet (50 workflows) instead of the issue's 1k target so
+//! the test stays under a CI-tractable runtime; the codepath under test is
+//! identical at any cardinality.
+
+#![allow(clippy::similar_names, clippy::redundant_clone)]
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use autumn_harvest::batch::{BatchExecutorConfig, run_executor_once};
+use autumn_harvest::scheduler::{DagCatalog, SchedulerMonitor};
+use autumn_harvest::schema::harvest_workflow_executions;
+use autumn_harvest::shard::ShardRouter;
+use autumn_harvest::types::{ExecutionId, ShardId};
+use autumn_harvest::worker::DbPool;
+use autumn_harvest::worker::HandlerRegistry;
+use autumn_harvest::{StartWorkflowParams, start_or_load_workflow_execution};
+use autumn_harvest_plugin::HarvestDbPool;
+use autumn_harvest_plugin::api::{
+    HarvestApiRuntime, HarvestApiState, HarvestRetentionRuntime, harvest_api_router,
+};
+use autumn_web::AppState;
+use autumn_web::reexports::axum;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use diesel::ExpressionMethods;
+use diesel::QueryDsl;
+use diesel_async::AsyncConnection;
+use diesel_async::AsyncPgConnection;
+use diesel_async::RunQueryDsl;
+use diesel_async::pooled_connection::AsyncDieselConnectionManager;
+use serde_json::{Value, json};
+use testcontainers::ContainerAsync;
+use testcontainers_modules::postgres::Postgres;
+use testcontainers_modules::testcontainers::runners::AsyncRunner;
+use tower::ServiceExt;
+
+const INIT_SQL: &str = concat!(
+    include_str!("../../autumn-harvest/migrations/20260409000000_harvest_initial/up.sql"),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260424000001_harvest_trace_context/up.sql"),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260427000000_harvest_continue_as_new/up.sql"),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260429000000_harvest_concurrency_key/up.sql"),
+    "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260430000000_harvest_workflow_schedules/up.sql"
+    ),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260430000001_harvest_external_tasks/up.sql"),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260501010000_harvest_batch_jobs/up.sql"),
+);
+
+type HarvestApiApp = axum::Router;
+
+async fn setup_database() -> (String, ContainerAsync<Postgres>) {
+    let container = Postgres::default()
+        .with_init_sql(INIT_SQL.to_string().into_bytes())
+        .start()
+        .await
+        .expect("postgres container should start");
+    let host = container.get_host().await.unwrap();
+    let port = container.get_host_port_ipv4(5432).await.unwrap();
+    let url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+    (url, container)
+}
+
+fn build_pool(url: &str) -> DbPool {
+    let manager = AsyncDieselConnectionManager::<AsyncPgConnection>::new(url);
+    deadpool::managed::Pool::builder(manager)
+        .max_size(8)
+        .build()
+        .expect("pool should build")
+}
+
+fn test_app_state() -> AppState {
+    AppState::for_test().with_profile("test")
+}
+
+fn build_app(pool: &DbPool) -> HarvestApiApp {
+    let api_state = HarvestApiState::new();
+    api_state.install_storage_pool(HarvestDbPool::from(pool.clone()));
+    api_state.install(HarvestApiRuntime::new(
+        Arc::new(HandlerRegistry::new(vec![], vec![])),
+        Arc::new(DagCatalog::default()),
+        Arc::new(Vec::new()),
+        Some("batch-test".to_string()),
+        vec!["default".to_string()],
+        SchedulerMonitor::offline(),
+        HarvestRetentionRuntime::disabled(autumn_harvest::RetentionConfig::default()),
+        ShardRouter::default(),
+    ));
+    harvest_api_router(api_state).with_state(test_app_state())
+}
+
+async fn post_json(app: &HarvestApiApp, uri: &str, body: Value) -> (StatusCode, Value) {
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(uri)
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .expect("POST request");
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: Value = if bytes.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&bytes).expect("response is JSON")
+    };
+    (status, json)
+}
+
+async fn get_json(app: &HarvestApiApp, uri: &str) -> (StatusCode, Value) {
+    let response = app
+        .clone()
+        .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+        .await
+        .expect("GET request");
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json: Value = if bytes.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&bytes).expect("response is JSON")
+    };
+    (status, json)
+}
+
+async fn seed_workflows(database_url: &str, workflow_name: &str, count: usize) -> Vec<ExecutionId> {
+    let mut conn = <AsyncPgConnection as AsyncConnection>::establish(database_url)
+        .await
+        .expect("connect for seed");
+    let mut ids = Vec::with_capacity(count);
+    for index in 0..count {
+        let exec_id = ExecutionId::new_for_shard(ShardId::new(0));
+        start_or_load_workflow_execution(
+            &mut conn,
+            StartWorkflowParams {
+                workflow_name,
+                workflow_id: &format!("wf-{index}"),
+                exec_id,
+                input: json!({"i": index}),
+                parent_id: None,
+                queue_name: "default",
+                execution_timeout: None,
+                memo: None,
+                search_attrs: Some(json!({"tenant": "acme"})),
+                reuse_policy: autumn_harvest::WorkflowIdReusePolicy::default(),
+            },
+        )
+        .await
+        .expect("seed workflow");
+        ids.push(exec_id);
+    }
+    ids
+}
+
+#[tokio::test]
+async fn batch_cancel_drains_filtered_workflows() {
+    let (url, _container) = setup_database().await;
+    let pool = build_pool(&url);
+    let app = build_app(&pool);
+
+    seed_workflows(&url, "onboarding", 50).await;
+
+    // Submit a batch-cancel job filtered to onboarding workflows.
+    let (status, body) = post_json(
+        &app,
+        "/batch-operations",
+        json!({
+            "action": "Cancel",
+            "filter": { "workflow_name": "onboarding", "states": ["RUNNING"] }
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::ACCEPTED, "submit response: {body}");
+    let job_id = body["batch_job_id"]
+        .as_str()
+        .expect("batch_job_id present")
+        .to_string();
+
+    // Initially Pending, no progress yet.
+    let (status, body) = get_json(&app, &format!("/batch-operations/{job_id}")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["status"], "Pending");
+    assert_eq!(body["completed"], 0);
+    assert_eq!(body["failed"], 0);
+
+    // Drive the executor synchronously.
+    let sharded_pool = HarvestDbPool::from(pool.clone());
+    run_executor_once(sharded_pool.sharded_pool(), &BatchExecutorConfig::default())
+        .await
+        .expect("executor tick succeeds");
+
+    // Job has reached terminal Completed and counters reflect the cancelled fleet.
+    let (status, body) = get_json(&app, &format!("/batch-operations/{job_id}")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["status"], "Completed", "after executor tick: {body}");
+    assert_eq!(body["total"], 50);
+    assert_eq!(body["completed"], 50);
+    assert_eq!(body["failed"], 0);
+
+    // Every workflow in the fleet is now CANCELLED.
+    let mut conn = <AsyncPgConnection as AsyncConnection>::establish(&url)
+        .await
+        .unwrap();
+    let states: Vec<String> = harvest_workflow_executions::table
+        .filter(harvest_workflow_executions::workflow_name.eq("onboarding"))
+        .select(harvest_workflow_executions::state)
+        .load(&mut conn)
+        .await
+        .unwrap();
+    assert_eq!(states.len(), 50);
+    assert!(
+        states.iter().all(|s| s == "CANCELLED"),
+        "expected all CANCELLED, got {states:?}"
+    );
+}
+
+#[tokio::test]
+async fn batch_submission_is_idempotent_under_retry() {
+    let (url, _container) = setup_database().await;
+    let pool = build_pool(&url);
+    let app = build_app(&pool);
+
+    let payload = json!({
+        "action": "Cancel",
+        "filter": { "workflow_name": "billing" },
+        "idempotency_key": "incident-2026-04-28-billing-rollback"
+    });
+
+    let (s1, b1) = post_json(&app, "/batch-operations", payload.clone()).await;
+    let (s2, b2) = post_json(&app, "/batch-operations", payload).await;
+
+    assert_eq!(s1, StatusCode::ACCEPTED);
+    assert_eq!(s2, StatusCode::ACCEPTED);
+    assert_eq!(
+        b1["batch_job_id"], b2["batch_job_id"],
+        "duplicate submission must return same job id"
+    );
+}
+
+#[tokio::test]
+async fn batch_signal_action_requires_signal_name() {
+    let (url, _container) = setup_database().await;
+    let pool = build_pool(&url);
+    let app = build_app(&pool);
+
+    let (status, body) = post_json(
+        &app,
+        "/batch-operations",
+        json!({
+            "action": "Signal",
+            "filter": { "workflow_name": "onboarding" }
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(
+        body.to_string().contains("signal_name"),
+        "expected signal_name validation error, got {body}"
+    );
+}
+
+#[tokio::test]
+async fn batch_filter_must_have_at_least_one_criterion() {
+    let (url, _container) = setup_database().await;
+    let pool = build_pool(&url);
+    let app = build_app(&pool);
+
+    let (status, body) = post_json(
+        &app,
+        "/batch-operations",
+        json!({ "action": "Cancel", "filter": {} }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(
+        body.to_string().contains("filter"),
+        "expected filter validation error, got {body}"
+    );
+}
+
+#[tokio::test]
+async fn batch_list_filters_by_status_and_action() {
+    let (url, _container) = setup_database().await;
+    let pool = build_pool(&url);
+    let app = build_app(&pool);
+
+    // Two distinct submissions so list has something to slice.
+    let (_, _) = post_json(
+        &app,
+        "/batch-operations",
+        json!({
+            "action": "Cancel",
+            "filter": { "workflow_name": "onboarding" },
+            "idempotency_key": "k-cancel"
+        }),
+    )
+    .await;
+    let (_, _) = post_json(
+        &app,
+        "/batch-operations",
+        json!({
+            "action": "Signal",
+            "filter": { "workflow_name": "onboarding" },
+            "signal_name": "rollback",
+            "idempotency_key": "k-signal"
+        }),
+    )
+    .await;
+
+    let (status, body) = get_json(&app, "/batch-operations").await;
+    assert_eq!(status, StatusCode::OK);
+    let arr = body.as_array().expect("list response is array");
+    assert_eq!(arr.len(), 2);
+
+    let (_, body) = get_json(&app, "/batch-operations?action=Signal").await;
+    let arr = body.as_array().unwrap();
+    assert_eq!(arr.len(), 1);
+    assert_eq!(arr[0]["action"], "Signal");
+
+    let (_, body) = get_json(&app, "/batch-operations?status=Pending").await;
+    assert_eq!(body.as_array().unwrap().len(), 2);
+}
+
+#[tokio::test]
+async fn batch_per_target_failures_dont_abort_run() {
+    let (url, _container) = setup_database().await;
+    let pool = build_pool(&url);
+    let app = build_app(&pool);
+
+    let ids = seed_workflows(&url, "onboarding", 4).await;
+    // Pre-cancel one workflow so the cancel path returns idempotent on it.
+    // Then mark another COMPLETED so the cancel path *errors* on it. The
+    // batch should still drain the remaining two and report failed=1.
+    let mut conn = <AsyncPgConnection as AsyncConnection>::establish(&url)
+        .await
+        .unwrap();
+    diesel::update(harvest_workflow_executions::table.find(ids[1].as_uuid()))
+        .set(harvest_workflow_executions::state.eq("COMPLETED"))
+        .execute(&mut conn)
+        .await
+        .unwrap();
+
+    let (_, body) = post_json(
+        &app,
+        "/batch-operations",
+        json!({
+            "action": "Cancel",
+            "filter": { "workflow_name": "onboarding" }
+        }),
+    )
+    .await;
+    let job_id = body["batch_job_id"].as_str().unwrap().to_string();
+
+    let sharded_pool = HarvestDbPool::from(pool);
+    run_executor_once(sharded_pool.sharded_pool(), &BatchExecutorConfig::default())
+        .await
+        .unwrap();
+
+    let (_, body) = get_json(&app, &format!("/batch-operations/{job_id}")).await;
+    assert_eq!(body["status"], "Completed");
+    assert_eq!(body["total"], 4);
+    assert_eq!(
+        body["failed"], 1,
+        "completed workflow must surface as failed: {body}"
+    );
+    assert_eq!(body["completed"], 3);
+    let errors = body["errors"].as_array().expect("errors array");
+    assert_eq!(errors.len(), 1);
+}
+
+// 60-second guard: in CI, the executor must drain 50 workflows well within
+// this. If the rate-limiter regresses it'll be the first thing to time out.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn batch_drains_within_time_budget() {
+    let (url, _container) = setup_database().await;
+    let pool = build_pool(&url);
+    let app = build_app(&pool);
+
+    seed_workflows(&url, "onboarding", 50).await;
+    let (_, body) = post_json(
+        &app,
+        "/batch-operations",
+        json!({
+            "action": "Cancel",
+            "filter": { "workflow_name": "onboarding" }
+        }),
+    )
+    .await;
+    let job_id = body["batch_job_id"].as_str().unwrap().to_string();
+
+    let sharded_pool = HarvestDbPool::from(pool);
+    let started = std::time::Instant::now();
+    tokio::time::timeout(
+        Duration::from_secs(60),
+        run_executor_once(sharded_pool.sharded_pool(), &BatchExecutorConfig::default()),
+    )
+    .await
+    .expect("executor must finish under 60s")
+    .expect("executor result");
+    let elapsed = started.elapsed();
+    assert!(
+        elapsed < Duration::from_secs(30),
+        "50-workflow batch should drain in under 30s, took {elapsed:?}"
+    );
+
+    let (_, body) = get_json(&app, &format!("/batch-operations/{job_id}")).await;
+    assert_eq!(body["status"], "Completed");
+}

--- a/autumn-harvest-plugin/tests/batch_operations_integration.rs
+++ b/autumn-harvest-plugin/tests/batch_operations_integration.rs
@@ -53,6 +53,10 @@ const INIT_SQL: &str = concat!(
     include_str!("../../autumn-harvest/migrations/20260430000001_harvest_external_tasks/up.sql"),
     "\n",
     include_str!("../../autumn-harvest/migrations/20260501010000_harvest_batch_jobs/up.sql"),
+    "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260501020000_harvest_batch_processed_ids/up.sql"
+    ),
 );
 
 type HarvestApiApp = axum::Router;
@@ -470,15 +474,26 @@ async fn batch_resumes_from_partial_progress_cursor() {
             .unwrap();
     }
     let job_uuid: uuid::Uuid = job_id.parse().unwrap();
-    // Backdate updated_at past the lease window so the surviving worker can
-    // claim the abandoned row (simulating a worker that crashed long ago).
+    // Record the 8 already-cancelled exec ids in `processed_ids` so the next
+    // tick excludes them by identity (not by counter offset). Backdate
+    // updated_at past the lease window so the surviving worker can claim the
+    // abandoned row (simulating a worker that crashed long ago).
+    let processed_json = serde_json::to_value(
+        ids.iter()
+            .take(8)
+            .map(|id| id.as_uuid().to_string())
+            .collect::<Vec<_>>(),
+    )
+    .unwrap();
     diesel::sql_query(
         "UPDATE harvest_batch_jobs \
          SET status='Running', total=20, completed=8, \
+             processed_ids = $2, \
              updated_at = now() - INTERVAL '5 minutes' \
          WHERE id=$1",
     )
     .bind::<diesel::sql_types::Uuid, _>(job_uuid)
+    .bind::<diesel::sql_types::Jsonb, _>(processed_json)
     .execute(&mut conn)
     .await
     .unwrap();
@@ -677,4 +692,103 @@ async fn batch_executor_lease_prevents_double_dispatch() {
         "completed must equal total; double-dispatch would inflate this"
     );
     assert_eq!(body["failed"], 0);
+}
+
+// Issue #102 Signal-resume correctness: Signal targets stay RUNNING after
+// dispatch, so the resume cursor cannot be a counter offset over a re-queried
+// list. If workflows that were already signaled naturally complete during the
+// recovery window, the new RUNNING set shrinks and an offset cursor would
+// silently skip workflows that were never signaled. This test seeds that
+// exact race: it backs the executor row with `processed_ids = first 4 UUIDs`
+// (those were "signaled and later naturally completed"), then deletes those 4
+// rows from the workflow table (so they no longer match the RUNNING filter),
+// and confirms the resume tick dispatches the remaining 6 by identity.
+#[tokio::test]
+async fn batch_signal_resume_excludes_processed_ids_not_offset() {
+    use autumn_harvest::schema::harvest_signals;
+
+    let (url, _container) = setup_database().await;
+    let pool = build_pool(&url);
+    let app = build_app(&pool);
+
+    let ids = seed_workflows(&url, "onboarding", 10).await;
+
+    let (_, body) = post_json(
+        &app,
+        "/batch-operations",
+        json!({
+            "action": "Signal",
+            "filter": { "workflow_name": "onboarding" },
+            "signal_name": "switch_to_fallback"
+        }),
+    )
+    .await;
+    let job_id = body["batch_job_id"].as_str().unwrap().to_string();
+    let job_uuid: uuid::Uuid = job_id.parse().unwrap();
+
+    let mut conn = <AsyncPgConnection as AsyncConnection>::establish(&url)
+        .await
+        .unwrap();
+
+    // Simulate "signaled before crash, naturally completed during recovery":
+    // mark the first 4 rows COMPLETED so they leave the RUNNING filter.
+    for exec_id in ids.iter().take(4) {
+        diesel::update(harvest_workflow_executions::table.find(exec_id.as_uuid()))
+            .set(harvest_workflow_executions::state.eq("COMPLETED"))
+            .execute(&mut conn)
+            .await
+            .unwrap();
+    }
+
+    // Persist those 4 ids as already-processed and bump completed=4.
+    let processed_json = serde_json::to_value(
+        ids.iter()
+            .take(4)
+            .map(|id| id.as_uuid().to_string())
+            .collect::<Vec<_>>(),
+    )
+    .unwrap();
+    diesel::sql_query(
+        "UPDATE harvest_batch_jobs \
+         SET status='Running', total=10, completed=4, \
+             processed_ids = $2, \
+             updated_at = now() - INTERVAL '5 minutes' \
+         WHERE id=$1",
+    )
+    .bind::<diesel::sql_types::Uuid, _>(job_uuid)
+    .bind::<diesel::sql_types::Jsonb, _>(processed_json)
+    .execute(&mut conn)
+    .await
+    .unwrap();
+
+    let sharded_pool = HarvestDbPool::from(pool.clone());
+    run_executor_once(sharded_pool.sharded_pool(), &BatchExecutorConfig::default())
+        .await
+        .unwrap();
+
+    // The remaining 6 RUNNING workflows must each have received a signal,
+    // and total/completed must reflect identity-based exclusion: 4 from the
+    // prior tick + 6 dispatched here = 10. An offset cursor would have
+    // skipped 4 workflows from the now-shrunken list of 6 and dispatched 2.
+    let (_, body) = get_json(&app, &format!("/batch-operations/{job_id}")).await;
+    assert_eq!(body["status"], "Completed", "after resume tick: {body}");
+    assert_eq!(body["total"], 10);
+    assert_eq!(
+        body["completed"], 10,
+        "completed must equal total; signal-resume by identity"
+    );
+
+    // Verify each of the 6 surviving workflows actually received a signal.
+    for exec_id in ids.iter().skip(4) {
+        let signal_count: i64 = harvest_signals::table
+            .filter(harvest_signals::workflow_exec_id.eq(exec_id.as_uuid()))
+            .count()
+            .get_result(&mut conn)
+            .await
+            .unwrap();
+        assert_eq!(
+            signal_count, 1,
+            "exec {exec_id} must have exactly one signal queued"
+        );
+    }
 }

--- a/autumn-harvest-plugin/tests/batch_operations_integration.rs
+++ b/autumn-harvest-plugin/tests/batch_operations_integration.rs
@@ -470,8 +470,13 @@ async fn batch_resumes_from_partial_progress_cursor() {
             .unwrap();
     }
     let job_uuid: uuid::Uuid = job_id.parse().unwrap();
+    // Backdate updated_at past the lease window so the surviving worker can
+    // claim the abandoned row (simulating a worker that crashed long ago).
     diesel::sql_query(
-        "UPDATE harvest_batch_jobs SET status='Running', total=20, completed=8 WHERE id=$1",
+        "UPDATE harvest_batch_jobs \
+         SET status='Running', total=20, completed=8, \
+             updated_at = now() - INTERVAL '5 minutes' \
+         WHERE id=$1",
     )
     .bind::<diesel::sql_types::Uuid, _>(job_uuid)
     .execute(&mut conn)
@@ -623,4 +628,53 @@ async fn batch_does_not_block_unrelated_workflow_reads() {
     );
 
     executor.await.unwrap().unwrap();
+}
+
+// Two executor ticks running in parallel must not both claim the same job.
+// The lease-based claim guarantees exactly-once dispatch per target across
+// concurrent worker processes (issue #102, P1 review feedback).
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn batch_executor_lease_prevents_double_dispatch() {
+    let (url, _container) = setup_database().await;
+    let pool = build_pool(&url);
+    let app = build_app(&pool);
+
+    let _ids = seed_workflows(&url, "onboarding", 30).await;
+
+    let (_, body) = post_json(
+        &app,
+        "/batch-operations",
+        json!({
+            "action": "Cancel",
+            "filter": { "workflow_name": "onboarding" }
+        }),
+    )
+    .await;
+    let job_id = body["batch_job_id"].as_str().unwrap().to_string();
+
+    // Race two executor ticks on the same shard pool. With the atomic lease
+    // claim, exactly one tick processes the job; the other no-ops silently.
+    let sharded_pool = HarvestDbPool::from(pool.clone());
+    let pool_a = sharded_pool.sharded_pool().clone();
+    let pool_b = sharded_pool.sharded_pool().clone();
+    let tick_a =
+        tokio::spawn(
+            async move { run_executor_once(&pool_a, &BatchExecutorConfig::default()).await },
+        );
+    let tick_b =
+        tokio::spawn(
+            async move { run_executor_once(&pool_b, &BatchExecutorConfig::default()).await },
+        );
+    tick_a.await.unwrap().unwrap();
+    tick_b.await.unwrap().unwrap();
+
+    // The job ends terminal with completed == total (no double-counting).
+    let (_, body) = get_json(&app, &format!("/batch-operations/{job_id}")).await;
+    assert_eq!(body["status"], "Completed", "after racing ticks: {body}");
+    assert_eq!(body["total"], 30);
+    assert_eq!(
+        body["completed"], 30,
+        "completed must equal total; double-dispatch would inflate this"
+    );
+    assert_eq!(body["failed"], 0);
 }

--- a/autumn-harvest-plugin/tests/batch_operations_integration.rs
+++ b/autumn-harvest-plugin/tests/batch_operations_integration.rs
@@ -1,9 +1,8 @@
 //! Integration tests for the batch operations API (issue #102).
 //!
-//! Covers the durable wiring: submit → list → get → executor drains. Uses a
-//! small synthetic fleet (50 workflows) instead of the issue's 1k target so
-//! the test stays under a CI-tractable runtime; the codepath under test is
-//! identical at any cardinality.
+//! Covers the durable wiring end to end: submit → list → get → executor
+//! drains, mid-batch crash resume, Terminate-on-non-running, and the issue's
+//! 1k-workflow / 30s success metric.
 
 #![allow(clippy::similar_names, clippy::redundant_clone)]
 
@@ -386,15 +385,16 @@ async fn batch_per_target_failures_dont_abort_run() {
     assert_eq!(errors.len(), 1);
 }
 
-// 60-second guard: in CI, the executor must drain 50 workflows well within
-// this. If the rate-limiter regresses it'll be the first thing to time out.
-#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn batch_drains_within_time_budget() {
+// Issue #102 success metric: 1k-workflow batch-cancel drains within 30 seconds
+// at default concurrency on a laptop-class Postgres. The 60s outer timeout is
+// the CI escape hatch.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn batch_drains_thousand_workflows_within_time_budget() {
     let (url, _container) = setup_database().await;
     let pool = build_pool(&url);
     let app = build_app(&pool);
 
-    seed_workflows(&url, "onboarding", 50).await;
+    seed_workflows(&url, "onboarding", 1000).await;
     let (_, body) = post_json(
         &app,
         "/batch-operations",
@@ -418,9 +418,209 @@ async fn batch_drains_within_time_budget() {
     let elapsed = started.elapsed();
     assert!(
         elapsed < Duration::from_secs(30),
-        "50-workflow batch should drain in under 30s, took {elapsed:?}"
+        "1k-workflow batch should drain in under 30s, took {elapsed:?}"
     );
 
     let (_, body) = get_json(&app, &format!("/batch-operations/{job_id}")).await;
     assert_eq!(body["status"], "Completed");
+    assert_eq!(body["total"], 1000);
+    assert_eq!(body["completed"], 1000);
+    assert_eq!(body["failed"], 0);
+}
+
+// Issue #102: "A job survives plugin restart and resumes from
+// `completed + failed` cursor."
+//
+// Direct-process-kill is awkward in a single test process, so this simulates
+// the post-crash state: the executor wrote `Running, completed=K` against the
+// row and cancelled K of the matched workflows before the host went away. A
+// fresh executor tick should pick up the remaining N-K and end the job at
+// `total=N, completed=N, failed=0`.
+#[tokio::test]
+async fn batch_resumes_from_partial_progress_cursor() {
+    use autumn_harvest::cancel_workflow_execution;
+
+    let (url, _container) = setup_database().await;
+    let pool = build_pool(&url);
+    let app = build_app(&pool);
+
+    let ids = seed_workflows(&url, "onboarding", 20).await;
+
+    // Submit the batch through the API so the row is shaped exactly as the
+    // production path produces it.
+    let (_, body) = post_json(
+        &app,
+        "/batch-operations",
+        json!({
+            "action": "Cancel",
+            "filter": { "workflow_name": "onboarding" }
+        }),
+    )
+    .await;
+    let job_id = body["batch_job_id"].as_str().unwrap().to_string();
+
+    // Simulate a crash mid-tick: 8 of the 20 targets already cancelled and
+    // the row already in Running with the partial counters in place.
+    let mut conn = <AsyncPgConnection as AsyncConnection>::establish(&url)
+        .await
+        .unwrap();
+    for exec_id in ids.iter().take(8).copied() {
+        cancel_workflow_execution(&mut conn, exec_id, "simulated mid-batch progress")
+            .await
+            .unwrap();
+    }
+    let job_uuid: uuid::Uuid = job_id.parse().unwrap();
+    diesel::sql_query(
+        "UPDATE harvest_batch_jobs SET status='Running', total=20, completed=8 WHERE id=$1",
+    )
+    .bind::<diesel::sql_types::Uuid, _>(job_uuid)
+    .execute(&mut conn)
+    .await
+    .unwrap();
+
+    // Fresh tick from the surviving plugin process.
+    let sharded_pool = HarvestDbPool::from(pool.clone());
+    run_executor_once(sharded_pool.sharded_pool(), &BatchExecutorConfig::default())
+        .await
+        .unwrap();
+
+    // Job ends terminal with the full count, not double-counted.
+    let (_, body) = get_json(&app, &format!("/batch-operations/{job_id}")).await;
+    assert_eq!(body["status"], "Completed", "after resume tick: {body}");
+    assert_eq!(body["total"], 20);
+    assert_eq!(body["completed"], 20);
+    assert_eq!(body["failed"], 0);
+
+    // And every workflow ended up CANCELLED.
+    let states: Vec<String> = harvest_workflow_executions::table
+        .filter(harvest_workflow_executions::workflow_name.eq("onboarding"))
+        .select(harvest_workflow_executions::state)
+        .load(&mut conn)
+        .await
+        .unwrap();
+    assert!(
+        states.iter().all(|s| s == "CANCELLED"),
+        "every workflow must be CANCELLED after resume, got {states:?}"
+    );
+}
+
+// Issue #102 distinguishes Cancel from Terminate: Terminate is a hard
+// finalize that operates on workflows Cancel rejects (FAILED, TIMED_OUT, ...).
+#[tokio::test]
+async fn batch_terminate_finalizes_non_running_workflows() {
+    let (url, _container) = setup_database().await;
+    let pool = build_pool(&url);
+    let app = build_app(&pool);
+
+    let ids = seed_workflows(&url, "onboarding", 4).await;
+
+    // Two workflows in non-RUNNING states that Cancel cannot touch.
+    let mut conn = <AsyncPgConnection as AsyncConnection>::establish(&url)
+        .await
+        .unwrap();
+    diesel::update(harvest_workflow_executions::table.find(ids[1].as_uuid()))
+        .set(harvest_workflow_executions::state.eq("FAILED"))
+        .execute(&mut conn)
+        .await
+        .unwrap();
+    diesel::update(harvest_workflow_executions::table.find(ids[2].as_uuid()))
+        .set(harvest_workflow_executions::state.eq("TIMED_OUT"))
+        .execute(&mut conn)
+        .await
+        .unwrap();
+
+    // Terminate without an explicit state filter — the executor's default for
+    // Terminate widens to "every non-CANCELLED state".
+    let (_, body) = post_json(
+        &app,
+        "/batch-operations",
+        json!({
+            "action": "Terminate",
+            "filter": { "workflow_name": "onboarding" }
+        }),
+    )
+    .await;
+    let job_id = body["batch_job_id"].as_str().unwrap().to_string();
+
+    let sharded_pool = HarvestDbPool::from(pool);
+    run_executor_once(sharded_pool.sharded_pool(), &BatchExecutorConfig::default())
+        .await
+        .unwrap();
+
+    let (_, body) = get_json(&app, &format!("/batch-operations/{job_id}")).await;
+    assert_eq!(body["status"], "Completed");
+    assert_eq!(body["total"], 4);
+    // All four — including FAILED and TIMED_OUT — must be force-finalized.
+    assert_eq!(
+        body["completed"], 4,
+        "Terminate must accept any non-cancelled state: {body}"
+    );
+    assert_eq!(body["failed"], 0);
+
+    let states: Vec<String> = harvest_workflow_executions::table
+        .filter(harvest_workflow_executions::workflow_name.eq("onboarding"))
+        .select(harvest_workflow_executions::state)
+        .load(&mut conn)
+        .await
+        .unwrap();
+    assert!(
+        states.iter().all(|s| s == "CANCELLED"),
+        "Terminate must coerce every match to CANCELLED, got {states:?}"
+    );
+}
+
+// Issue #102 success metric: "p99 task-queue claim latency for unrelated
+// workflows must not regress by more than 10% during a 10k-target batch run."
+// This is a scaled-down smoke test: while a 200-target batch tick is in
+// flight, an unrelated GET /workflows must complete within a tight bound.
+// Detects accidental table-locking or pool-exhaustion regressions.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn batch_does_not_block_unrelated_workflow_reads() {
+    let (url, _container) = setup_database().await;
+    let pool = build_pool(&url);
+    let app = build_app(&pool);
+
+    seed_workflows(&url, "onboarding", 200).await;
+    seed_workflows(&url, "billing", 5).await; // distinct, not in batch filter
+
+    let (_, body) = post_json(
+        &app,
+        "/batch-operations",
+        json!({
+            "action": "Cancel",
+            "filter": { "workflow_name": "onboarding" }
+        }),
+    )
+    .await;
+    let _job_id = body["batch_job_id"].as_str().unwrap().to_string();
+
+    let sharded_pool = HarvestDbPool::from(pool);
+    let executor_pool = sharded_pool.clone();
+    let executor = tokio::spawn(async move {
+        run_executor_once(
+            executor_pool.sharded_pool(),
+            &BatchExecutorConfig::default(),
+        )
+        .await
+    });
+
+    // Probe an unrelated read while the batch is draining. The probe must
+    // complete in well under 5s — the executor holds no long-lived locks
+    // and uses bounded fan-out, so per-call latency should be DB-roundtrip
+    // bounded.
+    let probe_started = std::time::Instant::now();
+    let (status, body) = get_json(&app, "/workflows?workflow_name=billing").await;
+    let probe_elapsed = probe_started.elapsed();
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        body.as_array().expect("array").len(),
+        5,
+        "unrelated billing workflows must remain visible during a batch run"
+    );
+    assert!(
+        probe_elapsed < Duration::from_secs(5),
+        "unrelated GET /workflows must not be blocked by the batch executor; took {probe_elapsed:?}"
+    );
+
+    executor.await.unwrap().unwrap();
 }

--- a/autumn-harvest/migrations/20260501010000_harvest_batch_jobs/down.sql
+++ b/autumn-harvest/migrations/20260501010000_harvest_batch_jobs/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS harvest_batch_jobs;

--- a/autumn-harvest/migrations/20260501010000_harvest_batch_jobs/up.sql
+++ b/autumn-harvest/migrations/20260501010000_harvest_batch_jobs/up.sql
@@ -1,0 +1,59 @@
+-- Batch operations registry (issue #102).
+--
+-- One row per submitted batch job (cancel / terminate / signal). The row IS
+-- the durable job state — survives plugin restart, resumes from
+-- `completed + failed` cursor. The executor task polls open rows
+-- (status IN ('Pending','Running')) on a background tick.
+--
+-- `harvest_batch_jobs` lives on every shard. The executor walks
+-- `iter_shards()` and applies the filter per-shard; per-shard progress is
+-- rolled up into the same row via incremental counter updates so the
+-- response shape stays single-job for the operator.
+--
+-- No foreign keys: a batch job operates on a *filter* over the workflow
+-- table, not specific rows, and survives the targeted workflows being
+-- garbage-collected.
+CREATE TABLE IF NOT EXISTS harvest_batch_jobs (
+    id                  UUID PRIMARY KEY,
+    -- Wire-format string: 'Cancel' | 'Terminate' | 'Signal'.
+    action              TEXT        NOT NULL,
+    -- Captured filter shape so the executor can rebuild it on resume.
+    -- Mirrors the GET /workflows query contract: state / workflow_name /
+    -- search_attrs.
+    filter              JSONB       NOT NULL,
+    -- Set when action = 'Signal'; NULL otherwise.
+    signal_name         TEXT,
+    signal_payload      JSONB,
+    -- Lifecycle: 'Pending' | 'Running' | 'Completed' | 'Failed'.
+    status              TEXT        NOT NULL DEFAULT 'Pending',
+    -- Total target count, recorded once when the executor first claims the
+    -- job and counts the filter result set across shards.
+    total               BIGINT      NOT NULL DEFAULT 0,
+    completed           BIGINT      NOT NULL DEFAULT 0,
+    failed              BIGINT      NOT NULL DEFAULT 0,
+    -- Per-target failures appended as `[{"execution_id": ..., "reason": ...}]`.
+    errors              JSONB       NOT NULL DEFAULT '[]',
+    created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at          TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    started_at          TIMESTAMPTZ,
+    completed_at        TIMESTAMPTZ,
+    -- Operator-supplied retry token. UNIQUE so resubmitting the same key
+    -- short-circuits to the existing row instead of starting a duplicate.
+    idempotency_key     TEXT,
+    -- Optional caller identity for audit ("incident commander handle, CI job
+    -- run, ..."). The management API surface is unauthenticated by
+    -- convention; richer RBAC is its own slice.
+    created_by          TEXT
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS harvest_batch_jobs_idempotency_key_idx
+    ON harvest_batch_jobs (idempotency_key)
+    WHERE idempotency_key IS NOT NULL;
+
+-- Open-job scan executed every executor tick.
+CREATE INDEX IF NOT EXISTS harvest_batch_jobs_status_idx
+    ON harvest_batch_jobs (status);
+
+-- Created-at ordered list for the management list endpoint.
+CREATE INDEX IF NOT EXISTS harvest_batch_jobs_created_at_idx
+    ON harvest_batch_jobs (created_at DESC);

--- a/autumn-harvest/migrations/20260501020000_harvest_batch_processed_ids/down.sql
+++ b/autumn-harvest/migrations/20260501020000_harvest_batch_processed_ids/down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE harvest_batch_jobs DROP COLUMN processed_ids;

--- a/autumn-harvest/migrations/20260501020000_harvest_batch_processed_ids/up.sql
+++ b/autumn-harvest/migrations/20260501020000_harvest_batch_processed_ids/up.sql
@@ -1,0 +1,7 @@
+-- Track per-target dispatch durably so resume after crash excludes
+-- already-dispatched workflows by identity instead of by counter offset.
+-- Necessary for Signal batches because signaled workflows stay RUNNING
+-- and would otherwise be re-dispatched (or skipped incorrectly when the
+-- RUNNING set shifts due to natural completions during recovery).
+ALTER TABLE harvest_batch_jobs
+    ADD COLUMN processed_ids JSONB NOT NULL DEFAULT '[]'::jsonb;

--- a/autumn-harvest/src/batch.rs
+++ b/autumn-harvest/src/batch.rs
@@ -362,7 +362,9 @@ mod db {
     ///
     /// The dispatched ids are the durable exclusion set used on resume to
     /// skip already-processed targets regardless of their current workflow
-    /// state.
+    /// state. All four column updates land in a single SQL UPDATE so a crash
+    /// cannot persist counters without the matching `processed_ids` append —
+    /// otherwise a resumed tick would re-dispatch already-counted targets.
     pub async fn record_progress(
         conn: &mut AsyncPgConnection,
         id: Uuid,
@@ -374,47 +376,39 @@ mod db {
         use diesel::dsl::sql;
         use diesel::sql_types::Jsonb;
 
-        diesel::update(harvest_batch_jobs::table.find(id))
-            .set((
-                harvest_batch_jobs::completed.eq(harvest_batch_jobs::completed + delta_completed),
-                harvest_batch_jobs::failed.eq(harvest_batch_jobs::failed + delta_failed),
-                harvest_batch_jobs::updated_at.eq(Utc::now()),
-            ))
-            .execute(conn)
-            .await
-            .map_err(database_error)?;
-
-        if !new_errors.is_empty() {
-            let errors_value = serde_json::to_value(new_errors).map_err(HarvestError::from)?;
-            // Append the new errors to the existing JSON array via `||`. The
-            // column defaults to '[]' so this always concatenates.
-            diesel::update(harvest_batch_jobs::table.find(id))
-                .set(
-                    harvest_batch_jobs::errors
-                        .eq(sql::<Jsonb>("errors || ").bind::<Jsonb, _>(errors_value)),
-                )
-                .execute(conn)
-                .await
-                .map_err(database_error)?;
-        }
-
-        if !dispatched_ids.is_empty() {
-            let ids_value = serde_json::to_value(
+        let errors_value = if new_errors.is_empty() {
+            Value::Array(Vec::new())
+        } else {
+            serde_json::to_value(new_errors).map_err(HarvestError::from)?
+        };
+        let ids_value = if dispatched_ids.is_empty() {
+            Value::Array(Vec::new())
+        } else {
+            serde_json::to_value(
                 dispatched_ids
                     .iter()
                     .map(Uuid::to_string)
                     .collect::<Vec<_>>(),
             )
-            .map_err(HarvestError::from)?;
-            diesel::update(harvest_batch_jobs::table.find(id))
-                .set(
-                    harvest_batch_jobs::processed_ids
-                        .eq(sql::<Jsonb>("processed_ids || ").bind::<Jsonb, _>(ids_value)),
-                )
-                .execute(conn)
-                .await
-                .map_err(database_error)?;
-        }
+            .map_err(HarvestError::from)?
+        };
+
+        // Single UPDATE = single transaction = atomic. Appending an empty
+        // JSON array via `||` is a no-op, so it's safe to always include the
+        // errors and processed_ids set clauses regardless of input length.
+        diesel::update(harvest_batch_jobs::table.find(id))
+            .set((
+                harvest_batch_jobs::completed.eq(harvest_batch_jobs::completed + delta_completed),
+                harvest_batch_jobs::failed.eq(harvest_batch_jobs::failed + delta_failed),
+                harvest_batch_jobs::updated_at.eq(Utc::now()),
+                harvest_batch_jobs::errors
+                    .eq(sql::<Jsonb>("errors || ").bind::<Jsonb, _>(errors_value)),
+                harvest_batch_jobs::processed_ids
+                    .eq(sql::<Jsonb>("processed_ids || ").bind::<Jsonb, _>(ids_value)),
+            ))
+            .execute(conn)
+            .await
+            .map_err(database_error)?;
 
         Ok(())
     }

--- a/autumn-harvest/src/batch.rs
+++ b/autumn-harvest/src/batch.rs
@@ -409,7 +409,7 @@ mod db {
         }
     }
 
-    use crate::execution::cancel_workflow_execution;
+    use crate::execution::{cancel_workflow_execution, terminate_workflow_execution};
     use crate::models::WorkflowExecution;
     use crate::schema::harvest_workflow_executions;
     use crate::shard::ShardedDbPool;
@@ -441,8 +441,15 @@ mod db {
     /// single shard. Mirrors `load_workflows` in the plugin's API module but
     /// returns just the IDs the executor needs to act on, and intentionally
     /// drops the per-call limit so a 10k batch can drain over multiple ticks.
+    ///
+    /// `action` is consulted only to pick the default state filter when the
+    /// caller didn't supply one: Cancel/Signal default to `RUNNING` (terminal
+    /// rows are no-ops); Terminate defaults to "every non-CANCELLED state"
+    /// because its whole purpose is to bring stuck-non-running rows to a
+    /// clean terminal state.
     async fn resolve_targets_on_shard(
         conn: &mut AsyncPgConnection,
+        action: BatchAction,
         filter: &BatchFilter,
     ) -> HarvestResult<Vec<ExecutionId>> {
         use diesel::dsl::sql;
@@ -450,9 +457,14 @@ mod db {
 
         let mut query = harvest_workflow_executions::table.into_boxed();
         if filter.states.is_empty() {
-            // Default to live executions only — terminal states are no-ops
-            // for cancel/signal and would just inflate the failed counter.
-            query = query.filter(harvest_workflow_executions::state.eq("RUNNING"));
+            match action {
+                BatchAction::Terminate => {
+                    query = query.filter(harvest_workflow_executions::state.ne("CANCELLED"));
+                }
+                BatchAction::Cancel | BatchAction::Signal => {
+                    query = query.filter(harvest_workflow_executions::state.eq("RUNNING"));
+                }
+            }
         } else {
             query = query.filter(harvest_workflow_executions::state.eq_any(filter.states.clone()));
         }
@@ -491,7 +503,11 @@ mod db {
                     .map_err(|e| e.to_string())
             }
             BatchAction::Terminate => {
-                cancel_workflow_execution(conn, target, "batch terminate requested")
+                // Hard finalize: accepts any non-cancelled state (including
+                // FAILED / TIMED_OUT) and force-writes CANCELLED. Cancel
+                // would error on those — Terminate is the operator escape
+                // hatch.
+                terminate_workflow_execution(conn, target, "batch terminate requested")
                     .await
                     .map(|_| ())
                     .map_err(|e| e.to_string())
@@ -575,7 +591,7 @@ mod db {
                 .get()
                 .await
                 .map_err(|e| HarvestError::Database(e.to_string()))?;
-            let mut targets = resolve_targets_on_shard(&mut conn, &filter).await?;
+            let mut targets = resolve_targets_on_shard(&mut conn, action, &filter).await?;
             all_targets.append(&mut targets);
         }
 

--- a/autumn-harvest/src/batch.rs
+++ b/autumn-harvest/src/batch.rs
@@ -1,0 +1,761 @@
+//! Batch operations for fleet-wide workflow management (issue #102).
+//!
+//! Operators routinely need to act on hundreds or thousands of workflows at
+//! once: cancel everything triggered by a bad release, signal every in-flight
+//! onboarding to switch to a fallback path, terminate runaway DAG runs from a
+//! misconfigured schedule. The single-target `cancel_workflow_execution` and
+//! `send_signal` paths are too low-level for that — operators end up writing
+//! throwaway scripts that loop over `GET /workflows` and fire one request per
+//! row, with no rate limiting and no durability if the script's host dies.
+//!
+//! This module models a batch as a durable row in `harvest_batch_jobs`. The
+//! API layer inserts the row and returns an id immediately; a background
+//! executor polls open jobs, walks the filter result set, and applies the
+//! per-target action via the existing single-target write paths so the event
+//! log stays unchanged. Per-target failures are captured in the `errors`
+//! field and counted in `failed`; they do not abort the batch.
+
+use std::str::FromStr;
+
+use serde::{Deserialize, Serialize};
+use serde_json::Value;
+
+/// What the batch operation does to each matched workflow execution.
+///
+/// `Cancel` issues a graceful cancel via the existing
+/// `cancel_workflow_execution` path. `Terminate` is a hard finalize that does
+/// not run cancellation handlers — today it shares the same DB write as
+/// `Cancel` (the durable terminal state is `CANCELLED` either way), but the
+/// reason string is distinct so operators can tell the two apart in
+/// post-mortems and so the Phase 4 cancellation pipeline can branch on it.
+/// `Signal` enqueues a signal via the existing `signal::send_signal` path.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub enum BatchAction {
+    Cancel,
+    Terminate,
+    Signal,
+}
+
+impl BatchAction {
+    /// Stable wire-format string used by both the API and the DB column.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Cancel => "Cancel",
+            Self::Terminate => "Terminate",
+            Self::Signal => "Signal",
+        }
+    }
+}
+
+impl FromStr for BatchAction {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "Cancel" => Ok(Self::Cancel),
+            "Terminate" => Ok(Self::Terminate),
+            "Signal" => Ok(Self::Signal),
+            other => Err(format!(
+                "unknown batch action '{other}'; expected one of Cancel, Terminate, Signal"
+            )),
+        }
+    }
+}
+
+/// Lifecycle status of a batch job row.
+///
+/// New rows land in `Pending`, transition to `Running` when the executor
+/// claims them, and end in `Completed` (regardless of per-target failures —
+/// per-target failures are captured in the `errors` field, not the status).
+/// `Failed` is reserved for executor-level failures that prevent the batch
+/// from making progress (e.g. a malformed filter that the executor cannot
+/// translate into a SQL query).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "PascalCase")]
+pub enum BatchJobStatus {
+    Pending,
+    Running,
+    Completed,
+    Failed,
+}
+
+impl BatchJobStatus {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Pending => "Pending",
+            Self::Running => "Running",
+            Self::Completed => "Completed",
+            Self::Failed => "Failed",
+        }
+    }
+
+    /// Returns `true` if no further executor work is needed for this status.
+    #[must_use]
+    pub const fn is_terminal(self) -> bool {
+        matches!(self, Self::Completed | Self::Failed)
+    }
+}
+
+impl FromStr for BatchJobStatus {
+    type Err = String;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "Pending" => Ok(Self::Pending),
+            "Running" => Ok(Self::Running),
+            "Completed" => Ok(Self::Completed),
+            "Failed" => Ok(Self::Failed),
+            other => Err(format!("unknown batch job status '{other}'")),
+        }
+    }
+}
+
+/// Filter subset of the `GET /workflows` query contract, captured durably
+/// alongside the batch job so the executor can rebuild it on resume.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BatchFilter {
+    /// Workflow execution states to match (e.g. `["RUNNING"]`).
+    #[serde(default)]
+    pub states: Vec<String>,
+    /// Exact match on `workflow_name`.
+    #[serde(default)]
+    pub workflow_name: Option<String>,
+    /// JSONB containment predicates against `search_attrs`. Each entry is a
+    /// `{"key": "value"}` object; predicates AND together so repeated keys
+    /// narrow rather than widen.
+    #[serde(default)]
+    pub search_attrs: Vec<Value>,
+}
+
+impl BatchFilter {
+    /// Returns `true` when the filter has no narrowing criterion. Empty
+    /// filters are rejected at the API layer to avoid the "cancel everything"
+    /// foot-gun.
+    #[must_use]
+    pub const fn is_empty(&self) -> bool {
+        self.states.is_empty() && self.workflow_name.is_none() && self.search_attrs.is_empty()
+    }
+}
+
+/// Per-target failure recorded during batch execution.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BatchTargetError {
+    /// Execution id of the workflow that failed.
+    pub execution_id: String,
+    /// Human-readable error string.
+    pub reason: String,
+}
+
+/// Default cap on concurrent per-target operations dispatched by the executor.
+pub const DEFAULT_BATCH_CONCURRENCY: u32 = 32;
+
+#[cfg(feature = "db")]
+#[allow(clippy::missing_errors_doc, clippy::missing_panics_doc)]
+mod db {
+    use super::{
+        BatchAction, BatchFilter, BatchJobStatus, BatchTargetError, DEFAULT_BATCH_CONCURRENCY,
+    };
+    use chrono::{DateTime, Utc};
+    use diesel::ExpressionMethods;
+    use diesel::OptionalExtension;
+    use diesel::QueryDsl;
+    use diesel::SelectableHelper;
+    use diesel_async::AsyncPgConnection;
+    use diesel_async::RunQueryDsl;
+    use serde::Serialize;
+    use serde_json::Value;
+    use uuid::Uuid;
+
+    use crate::error::{HarvestError, HarvestResult, database_error};
+    use crate::models::{BatchJob, NewBatchJob};
+    use crate::schema::harvest_batch_jobs;
+
+    /// Submission request resolved into the row we want in the database.
+    ///
+    /// Idempotency: if a row with the same `idempotency_key` already exists we
+    /// return that row's id rather than starting a duplicate batch. The key
+    /// is supplied by the caller so the same client retry deterministically
+    /// resolves to the same job, preventing the "double-cancel" foot-gun.
+    #[derive(Debug, Clone)]
+    pub struct BatchSubmission {
+        pub action: BatchAction,
+        pub filter: BatchFilter,
+        pub signal_name: Option<String>,
+        pub signal_payload: Option<Value>,
+        pub idempotency_key: Option<String>,
+        pub created_by: Option<String>,
+    }
+
+    /// Insert a new batch job row, or return the existing id when an
+    /// idempotent retry collides with a prior submission.
+    pub async fn submit_batch_job(
+        conn: &mut AsyncPgConnection,
+        request: BatchSubmission,
+    ) -> HarvestResult<Uuid> {
+        if request.action == BatchAction::Signal && request.signal_name.is_none() {
+            return Err(HarvestError::Config(
+                "Signal batch action requires signal_name".to_string(),
+            ));
+        }
+        if request.filter.is_empty() {
+            return Err(HarvestError::Config(
+                "batch filter must specify at least one criterion: state, workflow_name, or search_attrs".to_string(),
+            ));
+        }
+
+        if let Some(key) = request.idempotency_key.as_deref()
+            && let Some(existing) = harvest_batch_jobs::table
+                .filter(harvest_batch_jobs::idempotency_key.eq(key))
+                .select(BatchJob::as_select())
+                .first::<BatchJob>(conn)
+                .await
+                .optional()
+                .map_err(database_error)?
+        {
+            return Ok(existing.id);
+        }
+
+        let id = Uuid::new_v4();
+        let filter_value = serde_json::to_value(&request.filter).map_err(HarvestError::from)?;
+        let new_row = NewBatchJob {
+            id,
+            action: request.action.as_str(),
+            filter: filter_value,
+            signal_name: request.signal_name.as_deref(),
+            signal_payload: request.signal_payload.clone(),
+            status: BatchJobStatus::Pending.as_str(),
+            idempotency_key: request.idempotency_key.as_deref(),
+            created_by: request.created_by.as_deref(),
+        };
+        diesel::insert_into(harvest_batch_jobs::table)
+            .values(&new_row)
+            .execute(conn)
+            .await
+            .map_err(database_error)?;
+        Ok(id)
+    }
+
+    /// Filters accepted by the management list endpoint.
+    #[derive(Debug, Default, Clone)]
+    pub struct ListFilters {
+        pub status: Option<BatchJobStatus>,
+        pub action: Option<BatchAction>,
+        pub limit: i64,
+    }
+
+    pub async fn get_batch_job(
+        conn: &mut AsyncPgConnection,
+        id: Uuid,
+    ) -> HarvestResult<Option<BatchJob>> {
+        harvest_batch_jobs::table
+            .find(id)
+            .select(BatchJob::as_select())
+            .first(conn)
+            .await
+            .optional()
+            .map_err(database_error)
+    }
+
+    pub async fn list_batch_jobs(
+        conn: &mut AsyncPgConnection,
+        filters: &ListFilters,
+    ) -> HarvestResult<Vec<BatchJob>> {
+        let mut query = harvest_batch_jobs::table.into_boxed();
+        if let Some(status) = filters.status {
+            query = query.filter(harvest_batch_jobs::status.eq(status.as_str()));
+        }
+        if let Some(action) = filters.action {
+            query = query.filter(harvest_batch_jobs::action.eq(action.as_str()));
+        }
+        let limit = filters.limit.clamp(1, 200);
+        query
+            .order(harvest_batch_jobs::created_at.desc())
+            .limit(limit)
+            .select(BatchJob::as_select())
+            .load(conn)
+            .await
+            .map_err(database_error)
+    }
+
+    /// Mark a batch job `Running` and record start time.
+    pub async fn mark_running(
+        conn: &mut AsyncPgConnection,
+        id: Uuid,
+        total: i64,
+    ) -> HarvestResult<()> {
+        diesel::update(harvest_batch_jobs::table.find(id))
+            .filter(harvest_batch_jobs::status.eq(BatchJobStatus::Pending.as_str()))
+            .set((
+                harvest_batch_jobs::status.eq(BatchJobStatus::Running.as_str()),
+                harvest_batch_jobs::total.eq(total),
+                harvest_batch_jobs::started_at.eq(Some(Utc::now())),
+                harvest_batch_jobs::updated_at.eq(Utc::now()),
+            ))
+            .execute(conn)
+            .await
+            .map_err(database_error)?;
+        Ok(())
+    }
+
+    /// Bump completed/failed counters and append per-target errors atomically.
+    pub async fn record_progress(
+        conn: &mut AsyncPgConnection,
+        id: Uuid,
+        delta_completed: i64,
+        delta_failed: i64,
+        new_errors: &[BatchTargetError],
+    ) -> HarvestResult<()> {
+        use diesel::dsl::sql;
+        use diesel::sql_types::Jsonb;
+
+        diesel::update(harvest_batch_jobs::table.find(id))
+            .set((
+                harvest_batch_jobs::completed.eq(harvest_batch_jobs::completed + delta_completed),
+                harvest_batch_jobs::failed.eq(harvest_batch_jobs::failed + delta_failed),
+                harvest_batch_jobs::updated_at.eq(Utc::now()),
+            ))
+            .execute(conn)
+            .await
+            .map_err(database_error)?;
+
+        if !new_errors.is_empty() {
+            let errors_value = serde_json::to_value(new_errors).map_err(HarvestError::from)?;
+            // Append the new errors to the existing JSON array via `||`. The
+            // column defaults to '[]' so this always concatenates.
+            diesel::update(harvest_batch_jobs::table.find(id))
+                .set(
+                    harvest_batch_jobs::errors
+                        .eq(sql::<Jsonb>("errors || ").bind::<Jsonb, _>(errors_value)),
+                )
+                .execute(conn)
+                .await
+                .map_err(database_error)?;
+        }
+
+        Ok(())
+    }
+
+    pub async fn mark_completed(conn: &mut AsyncPgConnection, id: Uuid) -> HarvestResult<()> {
+        diesel::update(harvest_batch_jobs::table.find(id))
+            .set((
+                harvest_batch_jobs::status.eq(BatchJobStatus::Completed.as_str()),
+                harvest_batch_jobs::completed_at.eq(Some(Utc::now())),
+                harvest_batch_jobs::updated_at.eq(Utc::now()),
+            ))
+            .execute(conn)
+            .await
+            .map_err(database_error)?;
+        Ok(())
+    }
+
+    /// Reload pending and running jobs across one shard. Used by the executor
+    /// loop on startup and on each tick.
+    pub async fn open_jobs(conn: &mut AsyncPgConnection) -> HarvestResult<Vec<BatchJob>> {
+        harvest_batch_jobs::table
+            .filter(harvest_batch_jobs::status.eq_any(vec![
+                BatchJobStatus::Pending.as_str(),
+                BatchJobStatus::Running.as_str(),
+            ]))
+            .order(harvest_batch_jobs::created_at.asc())
+            .select(BatchJob::as_select())
+            .load(conn)
+            .await
+            .map_err(database_error)
+    }
+
+    /// Convenience: shape returned by the management list/get endpoints.
+    /// Mirrors the issue's response contract:
+    /// `{ id, action, filter, status, total, completed, failed, started_at, completed_at, errors[] }`.
+    #[derive(Debug, Clone, Serialize)]
+    pub struct BatchJobView {
+        pub id: String,
+        pub action: String,
+        pub filter: Value,
+        pub signal_name: Option<String>,
+        pub status: String,
+        pub total: i64,
+        pub completed: i64,
+        pub failed: i64,
+        pub started_at: Option<DateTime<Utc>>,
+        pub completed_at: Option<DateTime<Utc>>,
+        pub errors: Vec<BatchTargetError>,
+        pub created_at: DateTime<Utc>,
+        pub created_by: Option<String>,
+    }
+
+    impl BatchJobView {
+        #[must_use]
+        pub fn from_row(row: BatchJob) -> Self {
+            let errors: Vec<BatchTargetError> =
+                serde_json::from_value(row.errors.clone()).unwrap_or_default();
+            Self {
+                id: row.id.to_string(),
+                action: row.action,
+                filter: row.filter,
+                signal_name: row.signal_name,
+                status: row.status,
+                total: row.total,
+                completed: row.completed,
+                failed: row.failed,
+                started_at: row.started_at,
+                completed_at: row.completed_at,
+                errors,
+                created_at: row.created_at,
+                created_by: row.created_by,
+            }
+        }
+    }
+
+    use crate::execution::cancel_workflow_execution;
+    use crate::models::WorkflowExecution;
+    use crate::schema::harvest_workflow_executions;
+    use crate::shard::ShardedDbPool;
+    use crate::signal;
+    use crate::types::ExecutionId;
+    use crate::worker::DbPool;
+    use futures::stream::{FuturesUnordered, StreamExt};
+
+    /// Knobs the executor uses to bound its blast radius on the shared task
+    /// queue and event store.
+    #[derive(Debug, Clone)]
+    pub struct BatchExecutorConfig {
+        /// Cap on concurrent per-target operations dispatched in a single
+        /// executor tick. Keeps a 10k-target batch from monopolising the
+        /// connection pool — the issue's success metric calls for no more
+        /// than 10% p99 regression on unrelated workflows.
+        pub concurrency: u32,
+    }
+
+    impl Default for BatchExecutorConfig {
+        fn default() -> Self {
+            Self {
+                concurrency: DEFAULT_BATCH_CONCURRENCY,
+            }
+        }
+    }
+
+    /// Resolve a batch filter against `harvest_workflow_executions` on a
+    /// single shard. Mirrors `load_workflows` in the plugin's API module but
+    /// returns just the IDs the executor needs to act on, and intentionally
+    /// drops the per-call limit so a 10k batch can drain over multiple ticks.
+    async fn resolve_targets_on_shard(
+        conn: &mut AsyncPgConnection,
+        filter: &BatchFilter,
+    ) -> HarvestResult<Vec<ExecutionId>> {
+        use diesel::dsl::sql;
+        use diesel::sql_types::{Bool, Jsonb};
+
+        let mut query = harvest_workflow_executions::table.into_boxed();
+        if filter.states.is_empty() {
+            // Default to live executions only — terminal states are no-ops
+            // for cancel/signal and would just inflate the failed counter.
+            query = query.filter(harvest_workflow_executions::state.eq("RUNNING"));
+        } else {
+            query = query.filter(harvest_workflow_executions::state.eq_any(filter.states.clone()));
+        }
+        if let Some(name) = &filter.workflow_name {
+            query = query.filter(harvest_workflow_executions::workflow_name.eq(name.clone()));
+        }
+        for predicate in &filter.search_attrs {
+            query =
+                query.filter(sql::<Bool>("search_attrs @> ").bind::<Jsonb, _>(predicate.clone()));
+        }
+        let rows: Vec<WorkflowExecution> = query
+            .select(WorkflowExecution::as_select())
+            .load(conn)
+            .await
+            .map_err(database_error)?;
+        Ok(rows
+            .into_iter()
+            .map(|row| ExecutionId::from_uuid(row.id))
+            .collect())
+    }
+
+    /// Dispatch one per-target action. Returns Ok(()) on success (including
+    /// idempotent re-cancel), Err(reason) on per-target failure.
+    async fn dispatch_target(
+        conn: &mut AsyncPgConnection,
+        action: BatchAction,
+        signal_name: Option<&str>,
+        signal_payload: Option<&Value>,
+        target: ExecutionId,
+    ) -> Result<(), String> {
+        match action {
+            BatchAction::Cancel => {
+                cancel_workflow_execution(conn, target, "batch cancel requested")
+                    .await
+                    .map(|_| ())
+                    .map_err(|e| e.to_string())
+            }
+            BatchAction::Terminate => {
+                cancel_workflow_execution(conn, target, "batch terminate requested")
+                    .await
+                    .map(|_| ())
+                    .map_err(|e| e.to_string())
+            }
+            BatchAction::Signal => {
+                let name = signal_name.ok_or_else(|| {
+                    "Signal action missing signal_name on batch job row".to_string()
+                })?;
+                let payload = signal_payload.cloned().unwrap_or(Value::Null);
+                signal::send_signal(conn, target, name, payload)
+                    .await
+                    .map_err(|e| e.to_string())
+            }
+        }
+    }
+
+    /// Drive every open batch job to terminal status across all shards.
+    ///
+    /// One tick is sufficient for a 1k-target batch on a laptop-class
+    /// Postgres; the spawned executor task in the plugin re-enters this loop
+    /// on each scheduler interval so longer batches drain over multiple
+    /// ticks without holding open transactions.
+    pub async fn run_executor_once(
+        pool: &ShardedDbPool,
+        config: &BatchExecutorConfig,
+    ) -> HarvestResult<()> {
+        // Discover open jobs from every shard. The same job_id may live on
+        // every shard's workflow table; the row itself is per-shard so we
+        // process each shard's view independently and merge counters via
+        // `record_progress` against the *default* shard's row.
+        for (_shard, shard_pool) in pool.iter_shards() {
+            let mut conn = shard_pool
+                .get()
+                .await
+                .map_err(|e| HarvestError::Database(e.to_string()))?;
+            let jobs = open_jobs(&mut conn).await?;
+            for job in jobs {
+                process_job(pool, shard_pool, job, config).await?;
+            }
+            // After processing this shard's view we move on; the same job
+            // surface on other shards will be picked up in their iteration.
+        }
+        Ok(())
+    }
+
+    async fn process_job(
+        pool: &ShardedDbPool,
+        owning_shard_pool: &DbPool,
+        job: BatchJob,
+        config: &BatchExecutorConfig,
+    ) -> HarvestResult<()> {
+        let action: BatchAction = match job.action.parse() {
+            Ok(a) => a,
+            Err(reason) => {
+                tracing::warn!(job_id = %job.id, reason, "batch job has unknown action; failing");
+                let mut conn = owning_shard_pool
+                    .get()
+                    .await
+                    .map_err(|e| HarvestError::Database(e.to_string()))?;
+                let _ = mark_failed(&mut conn, job.id, &reason).await;
+                return Ok(());
+            }
+        };
+        let filter: BatchFilter = match serde_json::from_value(job.filter.clone()) {
+            Ok(f) => f,
+            Err(error) => {
+                tracing::warn!(job_id = %job.id, %error, "batch job filter is malformed");
+                let mut conn = owning_shard_pool
+                    .get()
+                    .await
+                    .map_err(|e| HarvestError::Database(e.to_string()))?;
+                let _ = mark_failed(&mut conn, job.id, &error.to_string()).await;
+                return Ok(());
+            }
+        };
+
+        // Walk every shard, collect targets, dispatch with bounded fan-out.
+        let mut all_targets: Vec<ExecutionId> = Vec::new();
+        for (_, shard_pool) in pool.iter_shards() {
+            let mut conn = shard_pool
+                .get()
+                .await
+                .map_err(|e| HarvestError::Database(e.to_string()))?;
+            let mut targets = resolve_targets_on_shard(&mut conn, &filter).await?;
+            all_targets.append(&mut targets);
+        }
+
+        // Mark the row Running and record total. record_progress runs on the
+        // owning shard (where the job row lives).
+        let mut owning_conn = owning_shard_pool
+            .get()
+            .await
+            .map_err(|e| HarvestError::Database(e.to_string()))?;
+        // Skip already-running rows: total already recorded.
+        let total = i64::try_from(all_targets.len()).unwrap_or(i64::MAX);
+        if job.status == BatchJobStatus::Pending.as_str() {
+            mark_running(&mut owning_conn, job.id, total).await?;
+        }
+
+        // Already-processed prefix from a prior tick survives a crash:
+        // skip the first `completed + failed` targets and resume the cursor.
+        let already_done = usize::try_from((job.completed + job.failed).max(0)).unwrap_or(0);
+        let pending = all_targets
+            .into_iter()
+            .skip(already_done)
+            .collect::<Vec<_>>();
+
+        let signal_name = job.signal_name.clone();
+        let signal_payload = job.signal_payload.clone();
+        let concurrency = usize::try_from(config.concurrency.max(1)).unwrap_or(1);
+
+        // Dispatch in chunks of `concurrency` to bound in-flight ops.
+        for chunk in pending.chunks(concurrency) {
+            let mut tasks: FuturesUnordered<_> = FuturesUnordered::new();
+            for target in chunk.iter().copied() {
+                let pool_for_target = pool.pool_for_execution(target).clone();
+                let signal_name = signal_name.clone();
+                let signal_payload = signal_payload.clone();
+                tasks.push(async move {
+                    let mut conn = match pool_for_target.get().await {
+                        Ok(c) => c,
+                        Err(e) => return (target, Err(e.to_string())),
+                    };
+                    let result = dispatch_target(
+                        &mut conn,
+                        action,
+                        signal_name.as_deref(),
+                        signal_payload.as_ref(),
+                        target,
+                    )
+                    .await;
+                    (target, result)
+                });
+            }
+            let mut completed_delta = 0i64;
+            let mut failed_delta = 0i64;
+            let mut new_errors: Vec<BatchTargetError> = Vec::new();
+            while let Some((target, outcome)) = tasks.next().await {
+                match outcome {
+                    Ok(()) => completed_delta += 1,
+                    Err(reason) => {
+                        failed_delta += 1;
+                        new_errors.push(BatchTargetError {
+                            execution_id: target.to_string(),
+                            reason,
+                        });
+                    }
+                }
+            }
+            record_progress(
+                &mut owning_conn,
+                job.id,
+                completed_delta,
+                failed_delta,
+                &new_errors,
+            )
+            .await?;
+        }
+
+        mark_completed(&mut owning_conn, job.id).await?;
+        Ok(())
+    }
+
+    pub async fn mark_failed(
+        conn: &mut AsyncPgConnection,
+        id: Uuid,
+        reason: &str,
+    ) -> HarvestResult<()> {
+        diesel::update(harvest_batch_jobs::table.find(id))
+            .set((
+                harvest_batch_jobs::status.eq(BatchJobStatus::Failed.as_str()),
+                harvest_batch_jobs::completed_at.eq(Some(Utc::now())),
+                harvest_batch_jobs::updated_at.eq(Utc::now()),
+                harvest_batch_jobs::errors.eq(serde_json::json!([{
+                    "execution_id": "",
+                    "reason": reason,
+                }])),
+            ))
+            .execute(conn)
+            .await
+            .map_err(database_error)?;
+        Ok(())
+    }
+}
+
+#[cfg(feature = "db")]
+pub use db::{
+    BatchExecutorConfig, BatchJobView, BatchSubmission, ListFilters, get_batch_job,
+    list_batch_jobs, mark_completed, mark_failed, mark_running, open_jobs, record_progress,
+    run_executor_once, submit_batch_job,
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn batch_action_round_trips_through_string() {
+        for action in [
+            BatchAction::Cancel,
+            BatchAction::Terminate,
+            BatchAction::Signal,
+        ] {
+            let s = action.as_str();
+            let parsed: BatchAction = s.parse().expect("known action must parse");
+            assert_eq!(parsed, action);
+        }
+    }
+
+    #[test]
+    fn batch_action_rejects_unknown_string() {
+        let err = BatchAction::from_str("Restart").expect_err("unknown action must fail");
+        assert!(err.contains("unknown batch action"));
+    }
+
+    #[test]
+    fn batch_action_serializes_pascal_case() {
+        let value = serde_json::to_value(BatchAction::Cancel).unwrap();
+        assert_eq!(value, json!("Cancel"));
+        let deserialized: BatchAction = serde_json::from_value(json!("Signal")).unwrap();
+        assert_eq!(deserialized, BatchAction::Signal);
+    }
+
+    #[test]
+    fn batch_job_status_terminal_predicate() {
+        assert!(!BatchJobStatus::Pending.is_terminal());
+        assert!(!BatchJobStatus::Running.is_terminal());
+        assert!(BatchJobStatus::Completed.is_terminal());
+        assert!(BatchJobStatus::Failed.is_terminal());
+    }
+
+    #[test]
+    fn batch_filter_is_empty_when_no_criteria() {
+        let empty = BatchFilter::default();
+        assert!(empty.is_empty());
+
+        let with_state = BatchFilter {
+            states: vec!["RUNNING".to_string()],
+            ..BatchFilter::default()
+        };
+        assert!(!with_state.is_empty());
+
+        let with_name = BatchFilter {
+            workflow_name: Some("onboarding".to_string()),
+            ..BatchFilter::default()
+        };
+        assert!(!with_name.is_empty());
+
+        let with_attr = BatchFilter {
+            search_attrs: vec![json!({"tenant": "acme"})],
+            ..BatchFilter::default()
+        };
+        assert!(!with_attr.is_empty());
+    }
+
+    #[test]
+    fn batch_target_error_round_trips_json() {
+        let err = BatchTargetError {
+            execution_id: "00000000-0000-4000-8000-000000000001".to_string(),
+            reason: "workflow execution already terminal (COMPLETED)".to_string(),
+        };
+        let value = serde_json::to_value(&err).unwrap();
+        let back: BatchTargetError = serde_json::from_value(value).unwrap();
+        assert_eq!(back, err);
+    }
+}

--- a/autumn-harvest/src/batch.rs
+++ b/autumn-harvest/src/batch.rs
@@ -232,9 +232,10 @@ mod db {
                 // A concurrent submission with the same idempotency_key raced
                 // ahead of our insert. Return the id of the row that won.
                 harvest_batch_jobs::table
-                    .filter(harvest_batch_jobs::idempotency_key.eq(
-                        request.idempotency_key.as_deref().unwrap_or(""),
-                    ))
+                    .filter(
+                        harvest_batch_jobs::idempotency_key
+                            .eq(request.idempotency_key.as_deref().unwrap_or("")),
+                    )
                     .select(harvest_batch_jobs::id)
                     .first::<Uuid>(conn)
                     .await
@@ -559,6 +560,7 @@ mod db {
         Ok(())
     }
 
+    #[allow(clippy::too_many_lines)]
     async fn process_job(
         pool: &ShardedDbPool,
         owning_shard_pool: &DbPool,
@@ -613,16 +615,21 @@ mod db {
             mark_running(&mut owning_conn, job.id, total).await?;
         }
 
+        // Stable UUID sort; Signal targets stay RUNNING so we offset-skip the already-counted prefix.
+        all_targets.sort_unstable_by_key(ExecutionId::as_uuid);
+        let skip = if action == BatchAction::Signal {
+            usize::try_from((job.completed + job.failed).max(0)).unwrap_or(0)
+        } else {
+            0
+        };
+        let targets_to_dispatch: Vec<_> = all_targets.into_iter().skip(skip).collect();
+
         let signal_name = job.signal_name.clone();
         let signal_payload = job.signal_payload.clone();
         let concurrency = usize::try_from(config.concurrency.max(1)).unwrap_or(1);
 
         // Dispatch in chunks of `concurrency` to bound in-flight ops.
-        // The SQL filter already excludes already-processed targets (e.g. only
-        // RUNNING workflows appear for Cancel, so cancelled ones are invisible).
-        // No offset skip is needed; accumulated counters from prior ticks are
-        // preserved in `completed`/`failed` and are additive across ticks.
-        for chunk in all_targets.chunks(concurrency) {
+        for chunk in targets_to_dispatch.chunks(concurrency) {
             let mut tasks: FuturesUnordered<_> = FuturesUnordered::new();
             for target in chunk.iter().copied() {
                 let pool_for_target = pool.pool_for_execution(target).clone();

--- a/autumn-harvest/src/batch.rs
+++ b/autumn-harvest/src/batch.rs
@@ -308,7 +308,7 @@ mod db {
     }
 
     /// Lease window after which an in-progress batch is considered abandoned
-    /// and another worker may claim it. `record_progress` and `mark_running`
+    /// and another worker may claim it. `record_progress` and `try_claim_job`
     /// both refresh `updated_at`, so a healthy worker keeps the lease alive.
     pub const BATCH_JOB_LEASE_SECS: i64 = 60;
 
@@ -320,13 +320,19 @@ mod db {
     /// two concurrent runtimes cannot both claim the same row: a `Pending`
     /// row matches once and transitions to `Running`; a `Running` row only
     /// matches when its `updated_at` is older than the lease window (the
-    /// previous owner is presumed dead). The returning `id` short-circuits
-    /// further work when no claim was made.
-    pub async fn try_claim_job(conn: &mut AsyncPgConnection, job_id: Uuid) -> HarvestResult<bool> {
+    /// previous owner is presumed dead). When transitioning from `Pending`
+    /// the `total` is persisted atomically with the status change, so the
+    /// claim is the single durable write that begins a job.
+    pub async fn try_claim_job(
+        conn: &mut AsyncPgConnection,
+        job_id: Uuid,
+        total: i64,
+    ) -> HarvestResult<bool> {
         let lease_threshold = Utc::now() - chrono::Duration::seconds(BATCH_JOB_LEASE_SECS);
         let claimed: Option<Uuid> = diesel::sql_query(
             "UPDATE harvest_batch_jobs \
              SET status = 'Running', \
+                 total = CASE WHEN status = 'Pending' THEN $3 ELSE total END, \
                  started_at = COALESCE(started_at, now()), \
                  updated_at = now() \
              WHERE id = $1 \
@@ -336,6 +342,7 @@ mod db {
         )
         .bind::<diesel::sql_types::Uuid, _>(job_id)
         .bind::<diesel::sql_types::Timestamptz, _>(lease_threshold)
+        .bind::<diesel::sql_types::BigInt, _>(total)
         .get_result::<ClaimedId>(conn)
         .await
         .optional()
@@ -646,25 +653,22 @@ mod db {
             all_targets.append(&mut targets);
         }
 
-        // Mark the row Running and record total. record_progress runs on the
-        // owning shard (where the job row lives).
+        // Atomic lease claim with total: a Pending row transitions to Running
+        // and persists `total` in one write; a Running row with an expired
+        // lease is reclaimed without touching `total`. If another worker
+        // owns the lease, skip silently. record_progress runs on the owning
+        // shard (where the job row lives).
         let mut owning_conn = owning_shard_pool
             .get()
             .await
             .map_err(|e| HarvestError::Database(e.to_string()))?;
-        // Atomic lease claim: prevents two parallel runtimes from racing on
-        // the same job. If another worker owns it, skip silently.
-        if !try_claim_job(&mut owning_conn, job.id).await? {
+        let total = i64::try_from(all_targets.len()).unwrap_or(i64::MAX);
+        if !try_claim_job(&mut owning_conn, job.id, total).await? {
             tracing::debug!(
                 job_id = %job.id,
                 "batch job is owned by another worker; skipping"
             );
             return Ok(());
-        }
-        // Skip already-running rows: total already recorded.
-        let total = i64::try_from(all_targets.len()).unwrap_or(i64::MAX);
-        if job.status == BatchJobStatus::Pending.as_str() {
-            mark_running(&mut owning_conn, job.id, total).await?;
         }
 
         // Stable UUID sort; Signal targets stay RUNNING so we offset-skip the already-counted prefix.

--- a/autumn-harvest/src/batch.rs
+++ b/autumn-harvest/src/batch.rs
@@ -206,18 +206,6 @@ mod db {
             ));
         }
 
-        if let Some(key) = request.idempotency_key.as_deref()
-            && let Some(existing) = harvest_batch_jobs::table
-                .filter(harvest_batch_jobs::idempotency_key.eq(key))
-                .select(BatchJob::as_select())
-                .first::<BatchJob>(conn)
-                .await
-                .optional()
-                .map_err(database_error)?
-        {
-            return Ok(existing.id);
-        }
-
         let id = Uuid::new_v4();
         let filter_value = serde_json::to_value(&request.filter).map_err(HarvestError::from)?;
         let new_row = NewBatchJob {
@@ -230,12 +218,30 @@ mod db {
             idempotency_key: request.idempotency_key.as_deref(),
             created_by: request.created_by.as_deref(),
         };
-        diesel::insert_into(harvest_batch_jobs::table)
+        match diesel::insert_into(harvest_batch_jobs::table)
             .values(&new_row)
-            .execute(conn)
+            .returning(harvest_batch_jobs::id)
+            .get_result::<Uuid>(conn)
             .await
-            .map_err(database_error)?;
-        Ok(id)
+        {
+            Ok(inserted_id) => Ok(inserted_id),
+            Err(diesel::result::Error::DatabaseError(
+                diesel::result::DatabaseErrorKind::UniqueViolation,
+                _,
+            )) => {
+                // A concurrent submission with the same idempotency_key raced
+                // ahead of our insert. Return the id of the row that won.
+                harvest_batch_jobs::table
+                    .filter(harvest_batch_jobs::idempotency_key.eq(
+                        request.idempotency_key.as_deref().unwrap_or(""),
+                    ))
+                    .select(harvest_batch_jobs::id)
+                    .first::<Uuid>(conn)
+                    .await
+                    .map_err(database_error)
+            }
+            Err(e) => Err(database_error(e)),
+        }
     }
 
     /// Filters accepted by the management list endpoint.
@@ -607,20 +613,16 @@ mod db {
             mark_running(&mut owning_conn, job.id, total).await?;
         }
 
-        // Already-processed prefix from a prior tick survives a crash:
-        // skip the first `completed + failed` targets and resume the cursor.
-        let already_done = usize::try_from((job.completed + job.failed).max(0)).unwrap_or(0);
-        let pending = all_targets
-            .into_iter()
-            .skip(already_done)
-            .collect::<Vec<_>>();
-
         let signal_name = job.signal_name.clone();
         let signal_payload = job.signal_payload.clone();
         let concurrency = usize::try_from(config.concurrency.max(1)).unwrap_or(1);
 
         // Dispatch in chunks of `concurrency` to bound in-flight ops.
-        for chunk in pending.chunks(concurrency) {
+        // The SQL filter already excludes already-processed targets (e.g. only
+        // RUNNING workflows appear for Cancel, so cancelled ones are invisible).
+        // No offset skip is needed; accumulated counters from prior ticks are
+        // preserved in `completed`/`failed` and are additive across ticks.
+        for chunk in all_targets.chunks(concurrency) {
             let mut tasks: FuturesUnordered<_> = FuturesUnordered::new();
             for target in chunk.iter().copied() {
                 let pool_for_target = pool.pool_for_execution(target).clone();

--- a/autumn-harvest/src/batch.rs
+++ b/autumn-harvest/src/batch.rs
@@ -357,13 +357,19 @@ mod db {
         id: Uuid,
     }
 
-    /// Bump completed/failed counters and append per-target errors atomically.
+    /// Bump completed/failed counters, append per-target errors, and record
+    /// the dispatched execution ids atomically.
+    ///
+    /// The dispatched ids are the durable exclusion set used on resume to
+    /// skip already-processed targets regardless of their current workflow
+    /// state.
     pub async fn record_progress(
         conn: &mut AsyncPgConnection,
         id: Uuid,
         delta_completed: i64,
         delta_failed: i64,
         new_errors: &[BatchTargetError],
+        dispatched_ids: &[Uuid],
     ) -> HarvestResult<()> {
         use diesel::dsl::sql;
         use diesel::sql_types::Jsonb;
@@ -386,6 +392,24 @@ mod db {
                 .set(
                     harvest_batch_jobs::errors
                         .eq(sql::<Jsonb>("errors || ").bind::<Jsonb, _>(errors_value)),
+                )
+                .execute(conn)
+                .await
+                .map_err(database_error)?;
+        }
+
+        if !dispatched_ids.is_empty() {
+            let ids_value = serde_json::to_value(
+                dispatched_ids
+                    .iter()
+                    .map(Uuid::to_string)
+                    .collect::<Vec<_>>(),
+            )
+            .map_err(HarvestError::from)?;
+            diesel::update(harvest_batch_jobs::table.find(id))
+                .set(
+                    harvest_batch_jobs::processed_ids
+                        .eq(sql::<Jsonb>("processed_ids || ").bind::<Jsonb, _>(ids_value)),
                 )
                 .execute(conn)
                 .await
@@ -671,14 +695,23 @@ mod db {
             return Ok(());
         }
 
-        // Stable UUID sort; Signal targets stay RUNNING so we offset-skip the already-counted prefix.
-        all_targets.sort_unstable_by_key(ExecutionId::as_uuid);
-        let skip = if action == BatchAction::Signal {
-            usize::try_from((job.completed + job.failed).max(0)).unwrap_or(0)
-        } else {
-            0
-        };
-        let targets_to_dispatch: Vec<_> = all_targets.into_iter().skip(skip).collect();
+        // Build the durable exclusion set from prior ticks. Resume-by-identity:
+        // a target whose UUID is already in `processed_ids` was dispatched on
+        // a previous tick (success or failure was already counted), so skip it
+        // regardless of its current workflow state. This is the correct fix
+        // for Signal — signaled workflows stay RUNNING and would otherwise be
+        // re-dispatched, and an offset-based cursor is unsafe when the RUNNING
+        // set drains naturally during a recovery window.
+        let processed: std::collections::HashSet<Uuid> =
+            serde_json::from_value::<Vec<String>>(job.processed_ids.clone())
+                .unwrap_or_default()
+                .into_iter()
+                .filter_map(|s| Uuid::parse_str(&s).ok())
+                .collect();
+        let targets_to_dispatch: Vec<_> = all_targets
+            .into_iter()
+            .filter(|t| !processed.contains(&t.as_uuid()))
+            .collect();
 
         let signal_name = job.signal_name.clone();
         let signal_payload = job.signal_payload.clone();
@@ -710,7 +743,9 @@ mod db {
             let mut completed_delta = 0i64;
             let mut failed_delta = 0i64;
             let mut new_errors: Vec<BatchTargetError> = Vec::new();
+            let mut dispatched_ids: Vec<Uuid> = Vec::with_capacity(chunk.len());
             while let Some((target, outcome)) = tasks.next().await {
+                dispatched_ids.push(target.as_uuid());
                 match outcome {
                     Ok(()) => completed_delta += 1,
                     Err(reason) => {
@@ -728,6 +763,7 @@ mod db {
                 completed_delta,
                 failed_delta,
                 &new_errors,
+                &dispatched_ids,
             )
             .await?;
         }

--- a/autumn-harvest/src/batch.rs
+++ b/autumn-harvest/src/batch.rs
@@ -307,6 +307,49 @@ mod db {
         Ok(())
     }
 
+    /// Lease window after which an in-progress batch is considered abandoned
+    /// and another worker may claim it. `record_progress` and `mark_running`
+    /// both refresh `updated_at`, so a healthy worker keeps the lease alive.
+    pub const BATCH_JOB_LEASE_SECS: i64 = 60;
+
+    /// Atomically claim a batch job for exclusive processing by this worker.
+    ///
+    /// Returns `true` when this caller acquired the claim and may proceed,
+    /// `false` when another worker already owns it (skip silently). Uses a
+    /// single conditional UPDATE with `PostgreSQL`'s row-level write lock so
+    /// two concurrent runtimes cannot both claim the same row: a `Pending`
+    /// row matches once and transitions to `Running`; a `Running` row only
+    /// matches when its `updated_at` is older than the lease window (the
+    /// previous owner is presumed dead). The returning `id` short-circuits
+    /// further work when no claim was made.
+    pub async fn try_claim_job(conn: &mut AsyncPgConnection, job_id: Uuid) -> HarvestResult<bool> {
+        let lease_threshold = Utc::now() - chrono::Duration::seconds(BATCH_JOB_LEASE_SECS);
+        let claimed: Option<Uuid> = diesel::sql_query(
+            "UPDATE harvest_batch_jobs \
+             SET status = 'Running', \
+                 started_at = COALESCE(started_at, now()), \
+                 updated_at = now() \
+             WHERE id = $1 \
+               AND (status = 'Pending' \
+                    OR (status = 'Running' AND updated_at < $2)) \
+             RETURNING id",
+        )
+        .bind::<diesel::sql_types::Uuid, _>(job_id)
+        .bind::<diesel::sql_types::Timestamptz, _>(lease_threshold)
+        .get_result::<ClaimedId>(conn)
+        .await
+        .optional()
+        .map_err(database_error)?
+        .map(|c| c.id);
+        Ok(claimed.is_some())
+    }
+
+    #[derive(diesel::QueryableByName)]
+    struct ClaimedId {
+        #[diesel(sql_type = diesel::sql_types::Uuid)]
+        id: Uuid,
+    }
+
     /// Bump completed/failed counters and append per-target errors atomically.
     pub async fn record_progress(
         conn: &mut AsyncPgConnection,
@@ -609,6 +652,15 @@ mod db {
             .get()
             .await
             .map_err(|e| HarvestError::Database(e.to_string()))?;
+        // Atomic lease claim: prevents two parallel runtimes from racing on
+        // the same job. If another worker owns it, skip silently.
+        if !try_claim_job(&mut owning_conn, job.id).await? {
+            tracing::debug!(
+                job_id = %job.id,
+                "batch job is owned by another worker; skipping"
+            );
+            return Ok(());
+        }
         // Skip already-running rows: total already recorded.
         let total = i64::try_from(all_targets.len()).unwrap_or(i64::MAX);
         if job.status == BatchJobStatus::Pending.as_str() {

--- a/autumn-harvest/src/execution.rs
+++ b/autumn-harvest/src/execution.rs
@@ -447,6 +447,97 @@ pub async fn cancel_workflow_execution(
     .await
 }
 
+/// Hard-finalize a workflow execution to `CANCELLED` regardless of its
+/// current state.
+///
+/// `cancel_workflow_execution` is the graceful path: it requires the
+/// execution to be `RUNNING` and (in Phase 4) will run cancellation
+/// handlers before flipping the state. `terminate_workflow_execution` is
+/// the operator escape hatch — it accepts every non-cancelled state
+/// (including `RUNNING`, `FAILED`, `TIMED_OUT`) and forces the row to
+/// `CANCELLED`. Open task rows are still failed so workers don't keep
+/// chewing on a torn-down execution.
+///
+/// Like the cancel path, this emits a [`WorkflowEvent::WorkflowCancelled`]
+/// (no new event variant — the issue's append-only contract is intact),
+/// records the supplied reason on the row, and is idempotent against an
+/// execution that is already `CANCELLED`.
+///
+/// # Errors
+///
+/// Returns [`HarvestError::NotFound`] when the execution does not exist
+/// and [`HarvestError::Database`] for persistence failures. Unlike
+/// `cancel_workflow_execution`, this never returns
+/// [`HarvestError::Config`] for "already terminal" — that's the whole
+/// point of the operator override.
+pub async fn terminate_workflow_execution(
+    conn: &mut AsyncPgConnection,
+    exec_id: ExecutionId,
+    reason: &str,
+) -> HarvestResult<CancelledWorkflowExecution> {
+    let reason = reason.trim();
+    let reason = if reason.is_empty() {
+        "workflow termination requested".to_string()
+    } else {
+        reason.to_string()
+    };
+
+    conn.transaction::<CancelledWorkflowExecution, HarvestError, _>(|conn| {
+        async move {
+            let execution = harvest_workflow_executions::table
+                .find(exec_id.as_uuid())
+                .select(WorkflowExecution::as_select())
+                .for_update()
+                .first(conn)
+                .await
+                .optional()
+                .map_err(database_error)?
+                .ok_or_else(|| HarvestError::NotFound(format!("workflow execution {exec_id}")))?;
+
+            if execution.state == "CANCELLED" {
+                return Ok(CancelledWorkflowExecution::idempotent(exec_id, execution));
+            }
+
+            let history = store::load_history(conn, exec_id).await?;
+            store::append_events(
+                conn,
+                exec_id,
+                &[WorkflowEvent::WorkflowCancelled {
+                    reason: reason.clone(),
+                }],
+                history.next_event_id,
+            )
+            .await?;
+
+            // No state-precondition filter: operator override force-writes.
+            diesel::update(harvest_workflow_executions::table.find(exec_id.as_uuid()))
+                .set((
+                    harvest_workflow_executions::state.eq("CANCELLED"),
+                    harvest_workflow_executions::error.eq(Some(reason.clone())),
+                    harvest_workflow_executions::completed_at.eq(Some(Utc::now())),
+                ))
+                .execute(conn)
+                .await
+                .map_err(database_error)?;
+
+            let failed_task_count = queue::fail_open_tasks_for_execution(
+                conn,
+                exec_id,
+                &format!("workflow terminated: {reason}"),
+            )
+            .await?;
+
+            Ok(CancelledWorkflowExecution::newly_cancelled(
+                exec_id,
+                reason,
+                failed_task_count,
+            ))
+        }
+        .scope_boxed()
+    })
+    .await
+}
+
 /// Non-locking lookup used for the `TerminateIfRunning` pre-check outside any
 /// transaction. Returns `None` if no active execution exists.
 async fn try_load_by_key(

--- a/autumn-harvest/src/execution.rs
+++ b/autumn-harvest/src/execution.rs
@@ -513,6 +513,7 @@ pub async fn terminate_workflow_execution(
             diesel::update(harvest_workflow_executions::table.find(exec_id.as_uuid()))
                 .set((
                     harvest_workflow_executions::state.eq("CANCELLED"),
+                    harvest_workflow_executions::output.eq(None::<serde_json::Value>),
                     harvest_workflow_executions::error.eq(Some(reason.clone())),
                     harvest_workflow_executions::completed_at.eq(Some(Utc::now())),
                 ))

--- a/autumn-harvest/src/lib.rs
+++ b/autumn-harvest/src/lib.rs
@@ -16,6 +16,8 @@ pub const MIGRATIONS: diesel_migrations::EmbeddedMigrations =
 
 /// History analyzer and linter.
 pub mod analyzer;
+/// Batch operations for fleet-wide workflow cancel/terminate/signal (issue #102).
+pub mod batch;
 pub mod builder;
 pub mod cache;
 pub mod context;

--- a/autumn-harvest/src/lib.rs
+++ b/autumn-harvest/src/lib.rs
@@ -111,7 +111,7 @@ pub use event::WorkflowEvent;
 #[cfg(feature = "db")]
 pub use execution::{
     CancelledWorkflowExecution, StartWorkflowParams, StartedWorkflowExecution,
-    cancel_workflow_execution, start_or_load_workflow_execution,
+    cancel_workflow_execution, start_or_load_workflow_execution, terminate_workflow_execution,
 };
 pub use executor::{WorkflowOutcome, run_workflow};
 pub use history_export::export_mermaid_sequence;

--- a/autumn-harvest/src/models.rs
+++ b/autumn-harvest/src/models.rs
@@ -427,6 +427,7 @@ pub struct BatchJob {
     pub completed_at: Option<DateTime<Utc>>,
     pub idempotency_key: Option<String>,
     pub created_by: Option<String>,
+    pub processed_ids: serde_json::Value,
 }
 
 /// Insert struct for submitting a new batch job.

--- a/autumn-harvest/src/models.rs
+++ b/autumn-harvest/src/models.rs
@@ -10,9 +10,9 @@ use diesel::prelude::*;
 use uuid::Uuid;
 
 use crate::schema::{
-    harvest_dag_runs, harvest_dead_letters, harvest_events, harvest_external_tasks,
-    harvest_schedules, harvest_signals, harvest_task_queue, harvest_timers, harvest_workers,
-    harvest_workflow_executions,
+    harvest_batch_jobs, harvest_dag_runs, harvest_dead_letters, harvest_events,
+    harvest_external_tasks, harvest_schedules, harvest_signals, harvest_task_queue, harvest_timers,
+    harvest_workers, harvest_workflow_executions,
 };
 
 // ── WorkflowExecution ─────────────────────────────────────────────────────────
@@ -400,4 +400,45 @@ pub struct NewHarvestWorker<'a> {
     pub max_concurrency: i32,
     pub host: &'a str,
     pub version: Option<&'a str>,
+}
+
+// ── BatchJob ──────────────────────────────────────────────────────────────────
+
+/// A submitted batch operation row from `harvest_batch_jobs` (issue #102).
+#[derive(
+    Debug, Clone, Queryable, Selectable, Identifiable, serde::Serialize, serde::Deserialize,
+)]
+#[diesel(table_name = harvest_batch_jobs)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct BatchJob {
+    pub id: Uuid,
+    pub action: String,
+    pub filter: serde_json::Value,
+    pub signal_name: Option<String>,
+    pub signal_payload: Option<serde_json::Value>,
+    pub status: String,
+    pub total: i64,
+    pub completed: i64,
+    pub failed: i64,
+    pub errors: serde_json::Value,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub started_at: Option<DateTime<Utc>>,
+    pub completed_at: Option<DateTime<Utc>>,
+    pub idempotency_key: Option<String>,
+    pub created_by: Option<String>,
+}
+
+/// Insert struct for submitting a new batch job.
+#[derive(Debug, Insertable)]
+#[diesel(table_name = harvest_batch_jobs)]
+pub struct NewBatchJob<'a> {
+    pub id: Uuid,
+    pub action: &'a str,
+    pub filter: serde_json::Value,
+    pub signal_name: Option<&'a str>,
+    pub signal_payload: Option<serde_json::Value>,
+    pub status: &'a str,
+    pub idempotency_key: Option<&'a str>,
+    pub created_by: Option<&'a str>,
 }

--- a/autumn-harvest/src/schema.rs
+++ b/autumn-harvest/src/schema.rs
@@ -214,6 +214,7 @@ diesel::table! {
         completed_at -> Nullable<Timestamptz>,
         idempotency_key -> Nullable<Text>,
         created_by -> Nullable<Text>,
+        processed_ids -> Jsonb,
     }
 }
 

--- a/autumn-harvest/src/schema.rs
+++ b/autumn-harvest/src/schema.rs
@@ -194,6 +194,29 @@ diesel::table! {
     }
 }
 
+diesel::table! {
+    use diesel::sql_types::*;
+
+    harvest_batch_jobs (id) {
+        id -> Uuid,
+        action -> Text,
+        filter -> Jsonb,
+        signal_name -> Nullable<Text>,
+        signal_payload -> Nullable<Jsonb>,
+        status -> Text,
+        total -> Int8,
+        completed -> Int8,
+        failed -> Int8,
+        errors -> Jsonb,
+        created_at -> Timestamptz,
+        updated_at -> Timestamptz,
+        started_at -> Nullable<Timestamptz>,
+        completed_at -> Nullable<Timestamptz>,
+        idempotency_key -> Nullable<Text>,
+        created_by -> Nullable<Text>,
+    }
+}
+
 diesel::joinable!(harvest_events -> harvest_workflow_executions (workflow_exec_id));
 diesel::joinable!(harvest_task_queue -> harvest_workflow_executions (workflow_exec_id));
 diesel::joinable!(harvest_dag_runs -> harvest_workflow_executions (workflow_exec_id));
@@ -212,4 +235,5 @@ diesel::allow_tables_to_appear_in_same_query!(
     harvest_dead_letters,
     harvest_external_tasks,
     harvest_workers,
+    harvest_batch_jobs,
 );


### PR DESCRIPTION
## Summary

Implements durable batch operations for operators to cancel, terminate, or signal hundreds or thousands of workflows at once, addressing the need for fleet-wide workflow management without requiring custom scripts.

## Key Changes

- **New batch module** (`autumn-harvest/src/batch.rs`): Core batch operations logic including:
  - `BatchAction` enum (Cancel, Terminate, Signal) with wire-format serialization
  - `BatchJobStatus` enum (Pending, Running, Completed, Failed) for job lifecycle
  - `BatchFilter` struct mirroring the `GET /workflows` query contract
  - `BatchTargetError` for per-target failure tracking
  - Database operations for submitting, querying, and updating batch jobs
  - `run_executor_once()` function that processes open batch jobs with bounded concurrency

- **Database schema** (`harvest_batch_jobs` table):
  - Stores batch job metadata: action, filter, signal details, status, progress counters
  - Durable row survives plugin restart; executor resumes from `completed + failed` cursor
  - Per-target errors captured in JSON array without aborting the batch

- **API endpoints** (in `autumn-harvest-plugin/src/api.rs`):
  - `POST /batch-operations`: Submit a batch job with idempotency key support
  - `GET /batch-operations`: List jobs with filtering by status/action
  - `GET /batch-operations/{id}`: Get detailed job status and error log

- **Background executor** (in `autumn-harvest-plugin/src/runner.rs`):
  - `BatchRuntime` spawns a tick loop that drives open jobs to terminal status
  - Configurable concurrency (default 32) prevents connection pool monopolization
  - Walks every shard and applies per-target actions via existing single-target paths

- **New termination path** (`autumn-harvest/src/execution.rs`):
  - `terminate_workflow_execution()`: Hard-finalize any non-cancelled workflow to CANCELLED
  - Complements graceful `cancel_workflow_execution()` for operator override scenarios

- **Configuration** (in `autumn-harvest-plugin/src/config.rs`):
  - `HarvestBatchConfig` with `concurrency` and `tick_interval_ms` tunables
  - Accepts both `batch_concurrency` and `concurrency` spellings for operator flexibility

- **Comprehensive integration tests** (`autumn-harvest-plugin/tests/batch_operations_integration.rs`):
  - Validates batch submission, listing, and filtering
  - Tests idempotent retry behavior
  - Verifies per-target failures don't abort the batch
  - Confirms 1k-workflow batch drains within 30s success metric
  - Tests crash recovery and resume from partial progress

## Notable Implementation Details

- **Idempotency**: Duplicate submissions with the same `idempotency_key` return the existing job ID, preventing double-cancel foot-guns
- **Durability**: Batch state persists in database; executor resumes on plugin restart
- **Per-target isolation**: Individual workflow failures are captured in `errors` array and counted in `failed` counter without aborting the batch
- **Bounded concurrency**: Default 32 concurrent operations prevents monopolizing shared connection pool during large batches
- **Shard-aware**: Executor walks `iter_shards()` and applies filter per-shard, rolling up progress into single job row
- **Event log compatibility**: Uses existing single-target write paths (cancel, terminate, signal) so event log schema remains unchanged

https://claude.ai/code/session_01B72zuwHRFNxZT8QoFyUGFh