### PR TITLE
Add quickstart example with workflow, activity, and durable timer

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,16 @@ jobs:
         if: runner.os == 'Linux'
         run: cargo test -p autumn-harvest-plugin --test api_scheduler_integration -- --test-threads=1
 
+  quickstart:
+    name: Quickstart example builds
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+      - name: Build quickstart
+        run: cargo build -p quickstart
+
   msrv:
     name: MSRV (1.88.0)
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2919,6 +2919,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
+name = "quickstart"
+version = "0.2.0"
+dependencies = [
+ "autumn-harvest",
+ "autumn-harvest-plugin",
+ "autumn-web",
+ "serde_json",
+ "tracing",
+]
+
+[[package]]
 name = "quinn"
 version = "0.11.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "autumn-harvest-macros",
     "autumn-harvest-cli",
     "autumn-harvest-redis",
+    "examples/quickstart",
 ]
 resolver = "3"
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ the same shape with one fewer service to operate.
 
 ## Quick example
 
+Try it end-to-end: `cargo run -p quickstart` (see [`examples/quickstart/`](examples/quickstart/)).
+
 ```rust
 use autumn_harvest::prelude::*;
 

--- a/examples/quickstart/Cargo.toml
+++ b/examples/quickstart/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "quickstart"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish = false
+
+[dependencies]
+autumn-harvest = { path = "../../autumn-harvest", features = ["db"] }
+autumn-harvest-plugin = { path = "../../autumn-harvest-plugin" }
+autumn-web = "0.2"
+serde_json = { workspace = true }
+tracing = { workspace = true }

--- a/examples/quickstart/README.md
+++ b/examples/quickstart/README.md
@@ -1,0 +1,70 @@
+# quickstart
+
+A minimal runnable example for [autumn-harvest](../../README.md): one `#[workflow]`, one `#[activity]`, one durable timer.
+From `git clone` on a machine with Docker to a running durable workflow in under 5 minutes.
+
+## Prerequisites
+
+- Stable Rust toolchain (`rustup default stable`)
+- Docker (for Postgres via `compose.yaml`)
+
+## Step 1 — Start Postgres
+
+```bash
+docker compose -f examples/quickstart/compose.yaml up -d
+```
+
+Wait a few seconds for Postgres to become healthy (`docker compose -f examples/quickstart/compose.yaml ps`).
+
+## Step 2 — Start the app
+
+Run from the workspace root. `AUTUMN_PROFILE=dev` enables automatic migration application on startup.
+
+```bash
+AUTUMN_MANIFEST_DIR=examples/quickstart AUTUMN_PROFILE=dev cargo run -p quickstart
+```
+
+The app starts on **http://localhost:8080**.  
+The management API is at **http://localhost:8080/api/harvest**.  
+The workflow dashboard is at **http://localhost:8080/api/harvest/ui**.
+
+## Step 3 — Trigger a workflow execution
+
+```bash
+curl -s -X POST http://localhost:8080/api/harvest/workflows/greeting/start \
+  -H 'Content-Type: application/json' \
+  -d '{"workflow_id":"demo-1","input":"World"}' | jq .
+```
+
+The `greeting` workflow will:
+
+1. Run the `send_greeting` activity — logs `welcome to World!`
+2. **Pause for 30 seconds** on a durable timer
+3. Run `send_greeting` again — logs `farewell to World!`
+4. Complete with the final greeting string
+
+## Step 4 — Observe in the dashboard
+
+Open **http://localhost:8080/api/harvest/ui** in your browser to watch the execution progress through each step in real time.
+
+## The durability promise: Kill it and restart
+
+The 30-second timer exists so you can observe the engine's durability guarantee directly:
+
+```bash
+# While the workflow is paused on the timer (between steps 1 and 3 above),
+# press Ctrl+C to stop the process, then immediately restart it:
+AUTUMN_MANIFEST_DIR=examples/quickstart AUTUMN_PROFILE=dev cargo run -p quickstart
+
+# The engine replays the welcome step from Postgres event history and resumes
+# waiting on the remaining timer — without re-executing the activity.
+# After the timer elapses, the farewell step runs and the workflow completes.
+```
+
+Check the dashboard to confirm the workflow reaches the `COMPLETED` state after the restart, with the full event history intact.
+
+## Step 5 — Tear down
+
+```bash
+docker compose -f examples/quickstart/compose.yaml down -v
+```

--- a/examples/quickstart/autumn.toml
+++ b/examples/quickstart/autumn.toml
@@ -1,0 +1,2 @@
+[database]
+url = "postgres://quickstart:quickstart@localhost:5432/quickstart"

--- a/examples/quickstart/compose.yaml
+++ b/examples/quickstart/compose.yaml
@@ -1,0 +1,19 @@
+services:
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: quickstart
+      POSTGRES_PASSWORD: quickstart
+      POSTGRES_DB: quickstart
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U quickstart"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres_data:

--- a/examples/quickstart/src/main.rs
+++ b/examples/quickstart/src/main.rs
@@ -1,8 +1,62 @@
+//! autumn-harvest quickstart: one workflow, one activity, durable timer.
+//!
+//! Run against a local Postgres (see compose.yaml) with:
+//!
+//!   AUTUMN_MANIFEST_DIR=examples/quickstart AUTUMN_PROFILE=dev cargo run -p quickstart
+
+use std::time::Duration;
+
 use autumn_harvest::prelude::*;
 use autumn_harvest_plugin::HarvestPlugin;
 
-// RED: greeting and send_greeting are not defined yet.
-// This crate will not compile until the workflow and activity bodies are added.
+/// Greets `name` with a welcome activity, pauses for 30 seconds on a durable
+/// timer, then delivers a farewell activity.
+///
+/// The 30-second pause is intentional: kill the process and restart while the
+/// timer is counting down. The engine replays the welcome step from Postgres
+/// history and resumes exactly at the timer — without re-running the activity.
+#[workflow]
+async fn greeting(ctx: &WorkflowContext, name: String) -> HarvestResult<String> {
+    let welcome = ctx
+        .execute_activity_raw(
+            "send_greeting",
+            serde_json::json!({ "name": name, "kind": "welcome" }),
+            "default",
+        )
+        .await?;
+
+    // Durable 30-second pause — the workflow suspends here.
+    // Restart the process mid-timer; the engine resumes without re-executing
+    // the welcome activity above.
+    ctx.timer("greeting-pause", 30).await?;
+
+    let farewell = ctx
+        .execute_activity_raw(
+            "send_greeting",
+            serde_json::json!({ "name": name, "kind": "farewell" }),
+            "default",
+        )
+        .await?;
+
+    Ok(format!(
+        "{} — {}",
+        welcome["message"].as_str().unwrap_or("(welcome)"),
+        farewell["message"].as_str().unwrap_or("(farewell)"),
+    ))
+}
+
+/// Logs a greeting step and returns a confirmation message.
+#[activity(start_to_close = "30s", retry = RetryPolicy::exponential(3, Duration::from_secs(1)))]
+async fn send_greeting(
+    _ctx: &ActivityContext,
+    input: serde_json::Value,
+) -> HarvestResult<serde_json::Value> {
+    let name = input["name"].as_str().unwrap_or("world");
+    let kind = input["kind"].as_str().unwrap_or("greeting");
+    let message = format!("{kind} to {name}!");
+    tracing::info!(name, kind, message, "greeting sent");
+    Ok(serde_json::json!({ "message": message }))
+}
 
 #[autumn_web::main]
 async fn main() {
@@ -16,4 +70,19 @@ async fn main() {
         )
         .run()
         .await;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn quickstart_components_compile_and_register() {
+        let wf = __autumn_workflow_info_greeting();
+        let act = __autumn_activity_info_send_greeting();
+        assert_eq!(wf.name, "greeting");
+        assert_eq!(act.name, "send_greeting");
+        // The default worker listens on "default", matching execute_activity_raw's queue arg.
+        assert!(WorkerConfig::default().queues.contains(&"default".to_string()));
+    }
 }

--- a/examples/quickstart/src/main.rs
+++ b/examples/quickstart/src/main.rs
@@ -1,0 +1,19 @@
+use autumn_harvest::prelude::*;
+use autumn_harvest_plugin::HarvestPlugin;
+
+// RED: greeting and send_greeting are not defined yet.
+// This crate will not compile until the workflow and activity bodies are added.
+
+#[autumn_web::main]
+async fn main() {
+    autumn_web::app()
+        .plugin(
+            HarvestPlugin::new()
+                .workflows(workflows![greeting])
+                .activities(activities![send_greeting])
+                .worker(WorkerConfig::default())
+                .api("/api/harvest"),
+        )
+        .run()
+        .await;
+}

--- a/examples/quickstart/src/main.rs
+++ b/examples/quickstart/src/main.rs
@@ -83,6 +83,10 @@ mod tests {
         assert_eq!(wf.name, "greeting");
         assert_eq!(act.name, "send_greeting");
         // The default worker listens on "default", matching execute_activity_raw's queue arg.
-        assert!(WorkerConfig::default().queues.contains(&"default".to_string()));
+        assert!(
+            WorkerConfig::default()
+                .queues
+                .contains(&"default".to_string())
+        );
     }
 }


### PR DESCRIPTION
## Summary

This PR adds a complete, runnable quickstart example demonstrating autumn-harvest's core durability features. The example includes a minimal workflow with an activity and durable timer, along with comprehensive documentation and Docker setup for local development.

## Key Changes

- **New quickstart example package** (`examples/quickstart/`) with:
  - `main.rs`: A simple `greeting` workflow that executes an activity, pauses on a 30-second durable timer, then executes another activity
  - `send_greeting` activity that logs greeting messages with configurable retry policy
  - Comprehensive README with step-by-step instructions from setup through observing durability guarantees
  - `compose.yaml` for local Postgres database
  - `autumn.toml` with database configuration
  - Unit test verifying workflow and activity registration

- **Documentation**: README guides users through:
  - Prerequisites and setup
  - Starting Postgres via Docker Compose
  - Running the application
  - Triggering a workflow execution via HTTP
  - Observing execution in the dashboard
  - **Durability demonstration**: Kill-and-restart instructions showing the engine replays history and resumes without re-executing activities

- **CI integration**: Added GitHub Actions job to build the quickstart example

- **Root README update**: Added reference to the quickstart example with quick-start instructions

## Notable Implementation Details

- The 30-second timer is intentionally long to allow users to observe the durability guarantee by killing and restarting the process mid-execution
- Uses `execute_activity_raw` with JSON payloads to demonstrate flexible activity invocation
- Includes retry policy configuration (`exponential(3, 1s)`) on the activity
- Demonstrates both workflow and activity macros with proper context usage
- Self-contained with all necessary configuration and documentation for a complete end-to-end experience

https://claude.ai/code/session_01Nni8B2KsyzqtzG2V99Yrk7