### PR TITLE
Add version gate support with mismatch detection

### DIFF
--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -733,6 +733,10 @@ impl WorkflowContext {
     ///
     /// Panics if the internal matcher or commands mutex is poisoned.
     pub fn version(&self, change_id: &str, min: u32, max: u32) -> u32 {
+        assert!(
+            min <= max,
+            "version gate '{change_id}': min version {min} must not exceed max version {max}"
+        );
         let version = self.match_history(|m| m.match_version(change_id, min, max));
 
         // During live execution (matcher returned max_version and is past
@@ -2045,6 +2049,16 @@ mod tests {
         } else {
             panic!("Expected NonDeterministic error");
         }
+    }
+
+    // ── Red-phase versioning tests ────────────────────────────────────────
+
+    /// min > max is a programmer error — must panic immediately with a clear message.
+    #[test]
+    #[should_panic(expected = "min version 5 must not exceed max version 2")]
+    fn version_panics_when_min_exceeds_max() {
+        let ctx = WorkflowContext::new_test();
+        ctx.version("my_gate", 5, 2);
     }
 
     #[test]

--- a/autumn-harvest/src/replay.rs
+++ b/autumn-harvest/src/replay.rs
@@ -229,6 +229,7 @@ impl HistoryMatcher {
     /// - [`HistoryMatch::TimedOut`] if a timeout is found
     /// - [`HistoryMatch::NoMatch`] if past end of history
     /// - [`HistoryMatch::Diverged`] if the event at cursor is not the expected activity
+    #[allow(clippy::too_many_lines)]
     pub fn match_activity(&mut self, activity_name: &str) -> HistoryMatch {
         if !self.prepare_match() {
             return HistoryMatch::NoMatch;
@@ -241,9 +242,18 @@ impl HistoryMatcher {
             ..
         } = &self.events[self.cursor]
         else {
+            // Include the marker name in the `actual` field so the replayer can
+            // classify a stale version-gate marker as `VersionMarkerMismatch`
+            // rather than the generic `ActivityScheduleMismatch`.
+            let actual = match &self.events[self.cursor] {
+                WorkflowEvent::MarkerRecorded { name, .. } => {
+                    format!("MarkerRecorded({name})")
+                }
+                other => other.type_name().to_string(),
+            };
             return HistoryMatch::Diverged {
                 expected: format!("ActivityScheduled({activity_name})"),
-                actual: self.events[self.cursor].type_name().to_string(),
+                actual,
             };
         };
         let activity_id = *activity_id;
@@ -381,10 +391,18 @@ impl HistoryMatcher {
                 }
                 Ok(*activity_id)
             }
-            other => Err(HistoryMatch::Diverged {
-                expected: format!("ActivityScheduled({activity_name})"),
-                actual: other.type_name().to_string(),
-            }),
+            other => {
+                let actual = match other {
+                    WorkflowEvent::MarkerRecorded { name, .. } => {
+                        format!("MarkerRecorded({name})")
+                    }
+                    e => e.type_name().to_string(),
+                };
+                Err(HistoryMatch::Diverged {
+                    expected: format!("ActivityScheduled({activity_name})"),
+                    actual,
+                })
+            }
         };
         let activity_id = match result {
             Ok(id) => id,

--- a/autumn-harvest/src/replay.rs
+++ b/autumn-harvest/src/replay.rs
@@ -98,6 +98,19 @@ impl HistoryMatcher {
         self.pending_signals.push_back((signal_name, payload));
     }
 
+    /// Format the `actual` field for a [`HistoryMatch::Diverged`] result.
+    ///
+    /// When the unexpected event is a `MarkerRecorded` its name is included so
+    /// the replayer's `classify_kind` can recognise `"MarkerRecorded(version:…)"`
+    /// and return [`crate::testing::NonDeterminismKind::VersionMarkerMismatch`]
+    /// instead of the generic command-level mismatch kind.
+    fn actual_event_name(event: &WorkflowEvent) -> String {
+        match event {
+            WorkflowEvent::MarkerRecorded { name, .. } => format!("MarkerRecorded({name})"),
+            other => other.type_name().to_string(),
+        }
+    }
+
     /// Prepares for matching by advancing past consumed events and draining early signals.
     /// Returns `true` if there are still events to replay.
     fn prepare_match(&mut self) -> bool {
@@ -242,18 +255,9 @@ impl HistoryMatcher {
             ..
         } = &self.events[self.cursor]
         else {
-            // Include the marker name in the `actual` field so the replayer can
-            // classify a stale version-gate marker as `VersionMarkerMismatch`
-            // rather than the generic `ActivityScheduleMismatch`.
-            let actual = match &self.events[self.cursor] {
-                WorkflowEvent::MarkerRecorded { name, .. } => {
-                    format!("MarkerRecorded({name})")
-                }
-                other => other.type_name().to_string(),
-            };
             return HistoryMatch::Diverged {
                 expected: format!("ActivityScheduled({activity_name})"),
-                actual,
+                actual: Self::actual_event_name(&self.events[self.cursor]),
             };
         };
         let activity_id = *activity_id;
@@ -391,18 +395,10 @@ impl HistoryMatcher {
                 }
                 Ok(*activity_id)
             }
-            other => {
-                let actual = match other {
-                    WorkflowEvent::MarkerRecorded { name, .. } => {
-                        format!("MarkerRecorded({name})")
-                    }
-                    e => e.type_name().to_string(),
-                };
-                Err(HistoryMatch::Diverged {
-                    expected: format!("ActivityScheduled({activity_name})"),
-                    actual,
-                })
-            }
+            other => Err(HistoryMatch::Diverged {
+                expected: format!("ActivityScheduled({activity_name})"),
+                actual: Self::actual_event_name(other),
+            }),
         };
         let activity_id = match result {
             Ok(id) => id,
@@ -516,7 +512,7 @@ impl HistoryMatcher {
         else {
             return HistoryMatch::Diverged {
                 expected: format!("ActivityAwaitingExternal({activity_name})"),
-                actual: self.events[self.cursor].type_name().to_string(),
+                actual: Self::actual_event_name(&self.events[self.cursor]),
             };
         };
 
@@ -627,7 +623,7 @@ impl HistoryMatcher {
         else {
             return HistoryMatch::Diverged {
                 expected: format!("TimerStarted({timer_id})"),
-                actual: self.events[self.cursor].type_name().to_string(),
+                actual: Self::actual_event_name(&self.events[self.cursor]),
             };
         };
 
@@ -738,7 +734,7 @@ impl HistoryMatcher {
                 other => {
                     return HistoryMatch::Diverged {
                         expected: format!("SignalReceived({signal_name})"),
-                        actual: other.type_name().to_string(),
+                        actual: Self::actual_event_name(other),
                     };
                 }
             }
@@ -762,7 +758,7 @@ impl HistoryMatcher {
         else {
             return HistoryMatch::Diverged {
                 expected: format!("WorkflowContinuedAsNew({input})"),
-                actual: self.events[self.cursor].type_name().to_string(),
+                actual: Self::actual_event_name(&self.events[self.cursor]),
             };
         };
 
@@ -798,7 +794,7 @@ impl HistoryMatcher {
         else {
             return HistoryMatch::Diverged {
                 expected: format!("ChildWorkflowStarted({workflow_name})"),
-                actual: self.events[self.cursor].type_name().to_string(),
+                actual: Self::actual_event_name(&self.events[self.cursor]),
             };
         };
         let child_id = *child_id;
@@ -878,7 +874,7 @@ impl HistoryMatcher {
             }
             other => HistoryMatch::Diverged {
                 expected: format!("MarkerRecorded({marker_name})"),
-                actual: other.type_name().to_string(),
+                actual: Self::actual_event_name(other),
             },
         }
     }
@@ -911,7 +907,7 @@ impl HistoryMatcher {
         else {
             return HistoryMatch::Diverged {
                 expected: format!("LocalActivityScheduled({activity_name})"),
-                actual: self.events[self.cursor].type_name().to_string(),
+                actual: Self::actual_event_name(&self.events[self.cursor]),
             };
         };
         let activity_id = *activity_id;
@@ -1016,7 +1012,7 @@ impl HistoryMatcher {
             }
             other => Err(HistoryMatch::Diverged {
                 expected: format!("LocalActivityScheduled({activity_name})"),
-                actual: other.type_name().to_string(),
+                actual: Self::actual_event_name(other),
             }),
         };
         let activity_id = match result {

--- a/autumn-harvest/src/testing.rs
+++ b/autumn-harvest/src/testing.rs
@@ -79,6 +79,10 @@ pub enum NonDeterminismKind {
     ContinueAsNewMismatch,
     /// The workflow returned before consuming all recorded history events.
     EarlyCompletion,
+    /// A version gate's `change_id` was renamed without migrating the history
+    /// so the old `version:…` marker was left unconsumed and was encountered
+    /// by the next command at that cursor position.
+    VersionMarkerMismatch,
     /// The divergence could not be classified into a known category.
     Unknown,
 }
@@ -95,6 +99,7 @@ impl std::fmt::Display for NonDeterminismKind {
             Self::ExternalActivityMismatch => write!(f, "ExternalActivityMismatch"),
             Self::ContinueAsNewMismatch => write!(f, "ContinueAsNewMismatch"),
             Self::EarlyCompletion => write!(f, "EarlyCompletion"),
+            Self::VersionMarkerMismatch => write!(f, "VersionMarkerMismatch"),
             Self::Unknown => write!(f, "Unknown"),
         }
     }
@@ -609,14 +614,28 @@ fn parse_nd_message(msg: &str) -> (NonDeterminismKind, String, String) {
             .strip_prefix("expected ")
             .unwrap_or(exp_part)
             .to_string();
-        let kind = classify_kind(kind_str);
-        return (kind, expected, actual.to_string());
+        let actual = actual.to_string();
+        let kind = classify_kind(kind_str, &actual);
+        return (kind, expected, actual);
     }
     // Fallback for unusual formats (e.g. "signal history contains unexpected failure")
     (NonDeterminismKind::Unknown, msg.to_string(), String::new())
 }
 
-fn classify_kind(kind_str: &str) -> NonDeterminismKind {
+/// Classify a non-determinism error into a [`NonDeterminismKind`].
+///
+/// `kind_str` is the prefix before `" mismatch:"` in the error message.
+/// `actual` is the event type / name that was actually found at the cursor.
+/// If `actual` names a `version:…` marker the cause is a renamed version gate,
+/// which is always classified as [`NonDeterminismKind::VersionMarkerMismatch`]
+/// regardless of which command kind triggered the mismatch.
+fn classify_kind(kind_str: &str, actual: &str) -> NonDeterminismKind {
+    // A version marker found where another event was expected means the version
+    // gate's change_id was renamed — classify specifically so error messages
+    // point at the version gate rather than the command that first noticed it.
+    if actual.starts_with("MarkerRecorded(version:") {
+        return NonDeterminismKind::VersionMarkerMismatch;
+    }
     match kind_str {
         "activity" => NonDeterminismKind::ActivityScheduleMismatch,
         "local activity" => NonDeterminismKind::LocalActivityScheduleMismatch,
@@ -766,34 +785,59 @@ mod tests {
     }
 
     #[test]
+    fn parse_nd_message_version_marker_mismatch() {
+        // The activity matcher sees a stale version-gate marker and produces this message.
+        let (kind, expected, actual) = parse_nd_message(
+            "activity mismatch: expected ActivityScheduled(step), got MarkerRecorded(version:gate_old)",
+        );
+        assert_eq!(kind, NonDeterminismKind::VersionMarkerMismatch);
+        assert_eq!(expected, "ActivityScheduled(step)");
+        assert_eq!(actual, "MarkerRecorded(version:gate_old)");
+    }
+
+    #[test]
     fn classify_kind_covers_all_prefixes() {
         assert_eq!(
-            classify_kind("activity"),
+            classify_kind("activity", "ActivityScheduled(other)"),
             NonDeterminismKind::ActivityScheduleMismatch
         );
         assert_eq!(
-            classify_kind("local activity"),
+            classify_kind("local activity", "LocalActivityScheduled(other)"),
             NonDeterminismKind::LocalActivityScheduleMismatch
         );
-        assert_eq!(classify_kind("timer"), NonDeterminismKind::TimerMismatch);
-        assert_eq!(classify_kind("signal"), NonDeterminismKind::SignalMismatch);
         assert_eq!(
-            classify_kind("child workflow"),
+            classify_kind("timer", "ActivityScheduled"),
+            NonDeterminismKind::TimerMismatch
+        );
+        assert_eq!(
+            classify_kind("signal", "ActivityScheduled"),
+            NonDeterminismKind::SignalMismatch
+        );
+        assert_eq!(
+            classify_kind("child workflow", "ActivityScheduled"),
             NonDeterminismKind::ChildWorkflowMismatch
         );
         assert_eq!(
-            classify_kind("side effect"),
+            classify_kind("side effect", "ActivityScheduled"),
             NonDeterminismKind::SideEffectMismatch
         );
         assert_eq!(
-            classify_kind("external activity"),
+            classify_kind("external activity", "ActivityScheduled"),
             NonDeterminismKind::ExternalActivityMismatch
         );
         assert_eq!(
-            classify_kind("continue-as-new"),
+            classify_kind("continue-as-new", ""),
             NonDeterminismKind::ContinueAsNewMismatch
         );
-        assert_eq!(classify_kind("something else"), NonDeterminismKind::Unknown);
+        assert_eq!(
+            classify_kind("something else", ""),
+            NonDeterminismKind::Unknown
+        );
+        // Version marker in actual always wins regardless of kind_str
+        assert_eq!(
+            classify_kind("activity", "MarkerRecorded(version:gate_old)"),
+            NonDeterminismKind::VersionMarkerMismatch
+        );
     }
 
     #[test]

--- a/autumn-harvest/tests/replayer_tests.rs
+++ b/autumn-harvest/tests/replayer_tests.rs
@@ -697,7 +697,7 @@ fn two_gate_workflow<'a>(
     })
 }
 
-/// History with two version markers: gate_alpha=2, gate_beta=4.
+/// History with two version markers: `gate_alpha=2`, `gate_beta=4`.
 fn two_gate_history() -> (ExecutionId, Vec<WorkflowEvent>) {
     let exec_id = ExecutionId::new();
     let events = vec![

--- a/autumn-harvest/tests/replayer_tests.rs
+++ b/autumn-harvest/tests/replayer_tests.rs
@@ -680,6 +680,191 @@ fn single_step_workflow<'a>(
     })
 }
 
+// ---------------------------------------------------------------------------
+// Acceptance criteria: multiple concurrent version changes in a single workflow
+// (spec AC#3: "Must support multiple concurrent version changes")
+// ---------------------------------------------------------------------------
+
+/// Workflow with two sequential version gates that BOTH have recorded markers.
+fn two_gate_workflow<'a>(
+    ctx: &'a WorkflowContext,
+    _input: Value,
+) -> Pin<Box<dyn Future<Output = Result<Value, String>> + Send + 'a>> {
+    Box::pin(async move {
+        let va = ctx.version("gate_alpha", 1, 3);
+        let vb = ctx.version("gate_beta", 1, 5);
+        Ok(serde_json::json!({"va": va, "vb": vb}))
+    })
+}
+
+/// History with two version markers: gate_alpha=2, gate_beta=4.
+fn two_gate_history() -> (ExecutionId, Vec<WorkflowEvent>) {
+    let exec_id = ExecutionId::new();
+    let events = vec![
+        WorkflowEvent::WorkflowStarted {
+            input: Value::Null,
+            timestamp: Utc::now(),
+        },
+        WorkflowEvent::MarkerRecorded {
+            name: "version:gate_alpha".into(),
+            details: serde_json::json!(2_u32),
+        },
+        WorkflowEvent::MarkerRecorded {
+            name: "version:gate_beta".into(),
+            details: serde_json::json!(4_u32),
+        },
+    ];
+    (exec_id, events)
+}
+
+/// Both version markers are consumed in order — no non-determinism.
+#[tokio::test]
+async fn replay_two_concurrent_version_gates_succeed() {
+    let (exec_id, events) = two_gate_history();
+    let report = WorkflowReplayer::new()
+        .register_fn("two_gate_workflow", two_gate_workflow)
+        .replay_from_snapshot(make_snapshot("two_gate_workflow", exec_id, events))
+        .await;
+
+    assert!(
+        matches!(report.status, ReplayStatus::ReplaySucceeded),
+        "two concurrent version gates must replay cleanly: {report}"
+    );
+}
+
+/// A version gate interleaved with an activity also replays correctly.
+fn interleaved_gate_workflow<'a>(
+    ctx: &'a WorkflowContext,
+    _input: Value,
+) -> Pin<Box<dyn Future<Output = Result<Value, String>> + Send + 'a>> {
+    Box::pin(async move {
+        let va = ctx.version("gate_alpha", 1, 3);
+        let r = ctx
+            .execute_activity_raw("step_one", Value::Null, "default")
+            .await
+            .map_err(|e| e.to_string())?;
+        let vb = ctx.version("gate_beta", 1, 5);
+        Ok(serde_json::json!({"va": va, "r": r, "vb": vb}))
+    })
+}
+
+fn interleaved_gate_history() -> (ExecutionId, Vec<WorkflowEvent>) {
+    let exec_id = ExecutionId::new();
+    let aid = ActivityExecId::new();
+    let events = vec![
+        WorkflowEvent::WorkflowStarted {
+            input: Value::Null,
+            timestamp: Utc::now(),
+        },
+        WorkflowEvent::MarkerRecorded {
+            name: "version:gate_alpha".into(),
+            details: serde_json::json!(2_u32),
+        },
+        WorkflowEvent::ActivityScheduled {
+            activity_id: aid,
+            name: "step_one".into(),
+            input: Value::Null,
+            queue: "default".into(),
+        },
+        WorkflowEvent::ActivityCompleted {
+            activity_id: aid,
+            output: serde_json::json!("done"),
+        },
+        WorkflowEvent::MarkerRecorded {
+            name: "version:gate_beta".into(),
+            details: serde_json::json!(4_u32),
+        },
+    ];
+    (exec_id, events)
+}
+
+#[tokio::test]
+async fn replay_interleaved_version_gate_and_activity_succeed() {
+    let (exec_id, events) = interleaved_gate_history();
+    let report = WorkflowReplayer::new()
+        .register_fn("interleaved_gate_workflow", interleaved_gate_workflow)
+        .replay_from_snapshot(make_snapshot("interleaved_gate_workflow", exec_id, events))
+        .await;
+
+    assert!(
+        matches!(report.status, ReplayStatus::ReplaySucceeded),
+        "interleaved version gate + activity must replay cleanly: {report}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Acceptance criteria: clear warnings for improper use
+// (spec AC#5: "Must provide clear compilation errors or runtime warnings if
+//  versioning is used improperly")
+// ---------------------------------------------------------------------------
+
+/// A workflow that was updated to use `version("gate_new", …)` where history
+/// still records `version("gate_old", …)`.  The unconsumed old marker causes
+/// the next command (an activity) to see a `MarkerRecorded(version:gate_old)`
+/// at the position where it expects `ActivityScheduled(step)`.
+/// The replayer must classify this as `VersionMarkerMismatch`, not a generic
+/// `ActivityScheduleMismatch`, so the error message clearly points to the
+/// version gate as the source of the problem.
+fn renamed_gate_workflow<'a>(
+    ctx: &'a WorkflowContext,
+    _input: Value,
+) -> Pin<Box<dyn Future<Output = Result<Value, String>> + Send + 'a>> {
+    Box::pin(async move {
+        // Code was updated: "gate_old" → "gate_new", but history still has gate_old
+        let _v = ctx.version("gate_new", 1, 2);
+        ctx.execute_activity_raw("step", Value::Null, "default")
+            .await
+            .map_err(|e| e.to_string())?;
+        Ok(Value::Null)
+    })
+}
+
+fn history_with_old_gate() -> (ExecutionId, Vec<WorkflowEvent>) {
+    let exec_id = ExecutionId::new();
+    let aid = ActivityExecId::new();
+    let events = vec![
+        WorkflowEvent::WorkflowStarted {
+            input: Value::Null,
+            timestamp: Utc::now(),
+        },
+        WorkflowEvent::MarkerRecorded {
+            name: "version:gate_old".into(),
+            details: serde_json::json!(1_u32),
+        },
+        WorkflowEvent::ActivityScheduled {
+            activity_id: aid,
+            name: "step".into(),
+            input: Value::Null,
+            queue: "default".into(),
+        },
+        WorkflowEvent::ActivityCompleted {
+            activity_id: aid,
+            output: serde_json::json!("done"),
+        },
+    ];
+    (exec_id, events)
+}
+
+#[tokio::test]
+async fn replay_renamed_version_gate_classified_as_version_marker_mismatch() {
+    let (exec_id, events) = history_with_old_gate();
+    let report = WorkflowReplayer::new()
+        .register_fn("renamed_gate_workflow", renamed_gate_workflow)
+        .replay_from_snapshot(make_snapshot("renamed_gate_workflow", exec_id, events))
+        .await;
+
+    match &report.status {
+        ReplayStatus::NonDeterminismDetected { kind, .. } => {
+            assert_eq!(
+                *kind,
+                NonDeterminismKind::VersionMarkerMismatch,
+                "a renamed version gate must produce VersionMarkerMismatch, got {kind:?}\nreport: {report}"
+            );
+        }
+        other => panic!("expected NonDeterminismDetected, got: {other:?}\nreport: {report}"),
+    }
+}
+
 /// Histories loaded from a completed execution include `WorkflowCompleted` as
 /// the last event. An unchanged workflow should still report `ReplaySucceeded`.
 #[tokio::test]


### PR DESCRIPTION
## Summary
This PR adds comprehensive support for workflow versioning through version gates, including detection and clear classification of version-related non-determinism errors. The implementation allows workflows to safely evolve by recording version markers in history and replaying them deterministically.

## Key Changes

- **New `NonDeterminismKind::VersionMarkerMismatch` variant**: Specifically classifies errors when a version gate's `change_id` is renamed without migrating history, making error messages point clearly to the version gate rather than the command that first noticed the mismatch.

- **Enhanced error classification in `classify_kind()`**: Now accepts the actual event found at the cursor position and detects when a stale `version:…` marker is encountered, automatically classifying it as `VersionMarkerMismatch` regardless of which command type triggered the mismatch.

- **Improved `HistoryMatcher::match_activity()` error reporting**: When an activity schedule fails to match, the error now includes the full marker name (e.g., `MarkerRecorded(version:gate_old)`) instead of just the event type, enabling proper classification of version gate mismatches.

- **Version gate validation**: Added assertion in `WorkflowContext::version()` to panic immediately if `min > max`, catching programmer errors at the point of definition with a clear message.

- **Comprehensive test coverage**: Added three new test scenarios:
  - `replay_two_concurrent_version_gates_succeed`: Validates multiple sequential version gates with recorded markers
  - `replay_interleaved_version_gate_and_activity_succeed`: Ensures version gates work correctly when interleaved with activities
  - `replay_renamed_version_gate_classified_as_version_marker_mismatch`: Verifies that renamed version gates produce the correct error classification

## Implementation Details

The version marker mismatch detection works by examining the actual event type found during history matching. When a `MarkerRecorded(version:…)` event is encountered where another command type was expected, it's immediately classified as a version gate issue rather than a command-specific mismatch. This provides users with actionable error messages that point to the root cause (a renamed version gate) rather than the symptom (a mismatched activity or other command).

https://claude.ai/code/session_01NvZu8n3iJcenRyE9x4MiTQ