### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/autumn-harvest-redis/src/redis_queue.rs
+++ b/autumn-harvest-redis/src/redis_queue.rs
@@ -18,7 +18,7 @@
 //!   the stream directly. Instead the stable `task_id` is added to a per-queue
 //!   sorted set (`{prefix}:scheduled:{name}`) with score = unix milliseconds,
 //!   and the envelope payload is stored alongside in a hash
-//!   (`{prefix}:scheduled:{name}:payloads`). A periodic [`promote_due`] call
+//!   (`{prefix}:scheduled:{name}:payloads`). A periodic [`RedisTaskQueue::promote_due`] call
 //!   moves due entries onto the stream atomically via a small Lua script.
 //! - **Visibility timeout**: enforced by [`RedisTaskQueue::recover_pending`],
 //!   which calls XPENDING on each queue and XCLAIMs entries that have been

--- a/autumn-harvest/benches/replay_bench.rs
+++ b/autumn-harvest/benches/replay_bench.rs
@@ -5,7 +5,7 @@
 //! laptop-class machine for a workflow whose user code is in-memory only."
 //!
 //! Run with:
-//!   cargo bench -p autumn-harvest --features testing --no-default-features --bench replay_bench
+//!   cargo bench -p autumn-harvest --features testing --no-default-features --bench `replay_bench`
 
 use std::future::Future;
 use std::pin::Pin;
@@ -24,7 +24,7 @@ fn sequential_workflow<'a>(
     input: Value,
 ) -> Pin<Box<dyn Future<Output = Result<Value, String>> + Send + 'a>> {
     Box::pin(async move {
-        let n: usize = input.as_u64().unwrap_or(0) as usize;
+        let n: usize = input.as_u64().unwrap_or(0).try_into().unwrap_or(0);
         let mut last = Value::Null;
         for i in 0..n {
             let name = format!("activity_{i}");

--- a/autumn-harvest/src/replay.rs
+++ b/autumn-harvest/src/replay.rs
@@ -134,7 +134,7 @@ impl HistoryMatcher {
     /// `WorkflowCancelled`), or if there are buffered signals that were never
     /// delivered via `wait_for_signal`.
     ///
-    /// Used by [`WorkflowContext::history_has_unconsumed_events`] to avoid
+    /// Used by [`crate::context::WorkflowContext::history_has_unconsumed_events`] to avoid
     /// false non-determinism reports when replaying full histories that include
     /// a terminal event appended after workflow completion.
     ///

--- a/autumn-harvest/src/telemetry.rs
+++ b/autumn-harvest/src/telemetry.rs
@@ -110,9 +110,9 @@ pub struct TraceContextCarrier {
     /// The W3C `traceparent` header for the *parent* span.
     ///
     /// During replay this field is `None` — the replay span roots itself and
-    /// links to [`link_traceparent`] instead.
+    /// links to [`TraceContextCarrier::link_traceparent`] instead.
     ///
-    /// [`link_traceparent`]: TraceContextCarrier::link_traceparent
+    /// [`TraceContextCarrier::link_traceparent`]: TraceContextCarrier::link_traceparent
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub traceparent: Option<String>,
 
@@ -123,7 +123,7 @@ pub struct TraceContextCarrier {
     /// When `true`, the worker must emit the span with attribute
     /// `harvest.replay = true` and must NOT restore `traceparent` as the
     /// parent context. Instead, it should create a new root span and attach a
-    /// span *link* pointing at [`link_traceparent`].
+    /// span *link* pointing at [`TraceContextCarrier::link_traceparent`].
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub is_replay: bool,
 


### PR DESCRIPTION
📖 Chapter: The `replay`, `telemetry` and `redis_queue` modules
🔦 Insight: Fixed missing or unresolvable intra-doc links to ensure `cargo doc` produces clean, connected output. Also cleaned up `clippy` warnings (especially `doc_markdown` and potential 32-bit `usize` truncation in the benchmark).
🧪 Example: N/A - documentation fixes only.
🖼️ Preview: (clean `cargo doc` and `cargo clippy` run)

---
*PR created automatically by Jules for task [12109995581242347288](https://jules.google.com/task/12109995581242347288) started by @madmax983*