### PR TITLE
[codex] Add advanced workflow examples

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -421,6 +421,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "billing-autumn-web"
+version = "0.2.0"
+dependencies = [
+ "autumn-harvest",
+ "autumn-harvest-plugin",
+ "autumn-web",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3939,6 +3952,19 @@ name = "stable_deref_trait"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+
+[[package]]
+name = "standalone-runner"
+version = "0.2.0"
+dependencies = [
+ "autumn-harvest",
+ "autumn-harvest-plugin",
+ "autumn-web",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+]
 
 [[package]]
 name = "static_assertions"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,9 @@ members = [
     "autumn-harvest-macros",
     "autumn-harvest-cli",
     "autumn-harvest-redis",
+    "examples/billing-autumn-web",
     "examples/quickstart",
+    "examples/standalone-runner",
 ]
 resolver = "3"
 

--- a/README.md
+++ b/README.md
@@ -22,6 +22,14 @@ the same shape with one fewer service to operate.
 
 Try it end-to-end: `cargo run -p quickstart` (see [`examples/quickstart/`](examples/quickstart/)).
 
+Need a real reference instead of the tiny hello-world path? See:
+
+- [`examples/billing-autumn-web/`](examples/billing-autumn-web/) for a full Autumn web billing
+  integration with app routes, workflow outbox publication, `HarvestPlugin`, saga compensation,
+  child workflows, version gates, signals, timers, deterministic side effects, and scheduled DAGs.
+- [`examples/standalone-runner/`](examples/standalone-runner/) for the out-of-the-box runner path:
+  no Autumn plugin, just `HarvestRunner` plus a manually mounted management API router.
+
 ```rust
 use autumn_harvest::prelude::*;
 

--- a/autumn-harvest-plugin/tests/examples_catalog.rs
+++ b/autumn-harvest-plugin/tests/examples_catalog.rs
@@ -1,0 +1,27 @@
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn advanced_examples_are_workspace_members_with_reference_docs() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("plugin crate should live below workspace root");
+    let workspace = fs::read_to_string(root.join("Cargo.toml")).expect("workspace manifest");
+
+    for member in ["examples/billing-autumn-web", "examples/standalone-runner"] {
+        assert!(
+            workspace.contains(member),
+            "{member} should be listed as a workspace member"
+        );
+
+        let readme = fs::read_to_string(root.join(member).join("README.md"))
+            .unwrap_or_else(|error| panic!("{member}/README.md should exist: {error}"));
+        assert!(
+            readme.contains("saga")
+                && readme.contains("child workflow")
+                && readme.contains("version")
+                && readme.contains("runner"),
+            "{member} README should explain the advanced surfaces it demonstrates"
+        );
+    }
+}

--- a/examples/billing-autumn-web/Cargo.toml
+++ b/examples/billing-autumn-web/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "billing-autumn-web"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish = false
+
+[dependencies]
+autumn-harvest = { path = "../../autumn-harvest", features = ["db", "testing"] }
+autumn-harvest-plugin = { path = "../../autumn-harvest-plugin" }
+autumn-web = "0.2"
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+
+[lints]
+workspace = true

--- a/examples/billing-autumn-web/README.md
+++ b/examples/billing-autumn-web/README.md
@@ -1,0 +1,90 @@
+# billing-autumn-web
+
+A full Autumn web integration for autumn-harvest. This is the reference example for the
+less tiny path: app routes, outbox workflow publication, `HarvestPlugin`, management API,
+worker, scheduler, saga compensation, child workflow composition, version gates, signals,
+timers, deterministic side effects, and a scheduled DAG.
+
+It models a subscription checkout. The web route accepts a billing request, writes a
+workflow-start row into the application outbox, and the Harvest plugin relays it into the
+durable workflow store. The workflow uses a saga for customer/payment/subscription rollback,
+spawns a child workflow to issue the invoice, fences the v2 tax path with `ctx.version`, waits
+for a `payment_captured` signal, and records payment capture before sending a receipt. The
+`monthly_billing_cycle` workflow shows continue-as-new for long-running billing periods.
+
+## Run
+
+```bash
+docker compose -f examples/billing-autumn-web/compose.yaml up -d
+
+AUTUMN_MANIFEST_DIR=examples/billing-autumn-web \
+AUTUMN_PROFILE=dev \
+cargo run -p billing-autumn-web
+```
+
+The app listens on `http://localhost:8081`.
+
+- App route: `POST /billing/checkout`
+- Plans route: `GET /billing/plans`
+- Harvest API: `GET /api/harvest/health`
+- Harvest UI: `GET /api/harvest/ui`
+
+## Start Checkout Through The App
+
+```bash
+curl -s -X POST http://localhost:8081/billing/checkout \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "tenant_id":"acme",
+    "customer_id":"cust_42",
+    "plan":"pro",
+    "seats":5,
+    "payment_method_id":"pm_card_demo"
+  }' | jq .
+```
+
+The outbox relay starts `billing_checkout` asynchronously. Find the execution in the UI or:
+
+```bash
+curl -s 'http://localhost:8081/api/harvest/workflows?workflow_name=billing_checkout&search_attr=tenant_id=acme' | jq .
+```
+
+Then deliver the gateway callback signal:
+
+```bash
+curl -s -X POST http://localhost:8081/api/harvest/workflows/<EXECUTION_ID>/signal/payment_captured \
+  -H 'Content-Type: application/json' \
+  -d '{"captured":true,"capture_id":"cap_demo_123"}' | jq .
+```
+
+## Useful Direct API Calls
+
+Start the same workflow without the application outbox:
+
+```bash
+curl -s -X POST http://localhost:8081/api/harvest/workflows/billing_checkout/start \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "workflow_id":"checkout-direct-1",
+    "input":{
+      "tenant_id":"acme",
+      "customer_id":"cust_42",
+      "plan":"pro",
+      "seats":5,
+      "payment_method_id":"pm_card_demo"
+    },
+    "search_attrs":{"tenant_id":"acme","customer_id":"cust_42","plan":"pro"}
+  }' | jq .
+```
+
+Run the reconciliation DAG:
+
+```bash
+curl -s -X POST http://localhost:8081/api/harvest/dags/billing_reconciliation/trigger \
+  -H 'Content-Type: application/json' \
+  -d '{"conf":{"date":"2026-05-01"}}' | jq .
+```
+
+The standalone runner example in `examples/standalone-runner` uses the same saga, child workflow,
+version, and runner vocabulary from the other side of the integration: no `HarvestPlugin`, just
+`HarvestRunner` and a manually mounted management router.

--- a/examples/billing-autumn-web/autumn.toml
+++ b/examples/billing-autumn-web/autumn.toml
@@ -1,0 +1,15 @@
+[server]
+port = 8081
+
+[database]
+url = "postgres://billing:billing@localhost:5433/billing"
+
+[harvest]
+mode = "embedded"
+worker_enabled = true
+scheduler_enabled = true
+
+[harvest.outbox]
+enabled = true
+batch_size = 32
+poll_interval_ms = 500

--- a/examples/billing-autumn-web/compose.yaml
+++ b/examples/billing-autumn-web/compose.yaml
@@ -1,0 +1,14 @@
+services:
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: billing
+      POSTGRES_PASSWORD: billing
+      POSTGRES_DB: billing
+    ports:
+      - "5433:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U billing"]
+      interval: 5s
+      timeout: 5s
+      retries: 10

--- a/examples/billing-autumn-web/src/activities.rs
+++ b/examples/billing-autumn-web/src/activities.rs
@@ -1,0 +1,173 @@
+use std::time::Duration;
+
+use autumn_harvest::prelude::*;
+use serde_json::{Value, json};
+
+use crate::domain::{CheckoutRequest, InvoiceRequest, InvoiceResult};
+
+pub fn activities() -> Vec<ActivityInfo> {
+    activities![
+        validate_checkout,
+        create_customer_profile,
+        delete_customer_profile,
+        authorize_payment,
+        void_payment_authorization,
+        create_subscription_record,
+        cancel_subscription_record,
+        create_invoice,
+        send_invoice,
+        void_invoice,
+        record_payment_capture,
+        send_receipt,
+        charge_subscription,
+        export_billing_events,
+        reconcile_gateway,
+        notify_finance,
+    ]
+}
+
+#[activity(
+    start_to_close = "10s",
+    retry = RetryPolicy::exponential(3, Duration::from_millis(100)),
+    queue = "billing"
+)]
+pub async fn validate_checkout(
+    _ctx: &ActivityContext,
+    request: CheckoutRequest,
+) -> HarvestResult<CheckoutRequest> {
+    let request = request.normalized();
+    if request.seats == 0 {
+        return Err(HarvestError::WorkflowFailed {
+            name: "validate_checkout".to_owned(),
+            reason: "seats must be greater than zero".to_owned(),
+        });
+    }
+    Ok(request)
+}
+
+#[activity(start_to_close = "30s", retry = RetryPolicy::fixed(3, Duration::from_secs(1)), queue = "billing")]
+pub async fn create_customer_profile(_ctx: &ActivityContext, input: Value) -> HarvestResult<Value> {
+    Ok(json!({
+        "customer_profile_id": format!(
+            "cus_{}_{}",
+            input["tenant_id"].as_str().unwrap_or("tenant"),
+            input["customer_id"].as_str().unwrap_or("customer")
+        )
+    }))
+}
+
+#[activity(start_to_close = "30s", queue = "billing")]
+pub async fn delete_customer_profile(_ctx: &ActivityContext, input: Value) -> HarvestResult<Value> {
+    tracing::info!(profile = ?input, "deleted customer profile during billing saga rollback");
+    Ok(json!({ "deleted": true }))
+}
+
+#[activity(
+    start_to_close = "30s",
+    heartbeat_timeout = "10s",
+    retry = RetryPolicy::exponential(5, Duration::from_secs(1)),
+    queue = "payments",
+    max_concurrent = 8,
+    concurrency_key = "stripe"
+)]
+pub async fn authorize_payment(_ctx: &ActivityContext, input: Value) -> HarvestResult<Value> {
+    Ok(json!({
+        "authorization_id": "auth_demo",
+        "amount_cents": input["amount_cents"],
+    }))
+}
+
+#[activity(
+    start_to_close = "30s",
+    queue = "payments",
+    max_concurrent = 8,
+    concurrency_key = "stripe"
+)]
+pub async fn void_payment_authorization(
+    _ctx: &ActivityContext,
+    input: Value,
+) -> HarvestResult<Value> {
+    tracing::info!(authorization = ?input, "voided payment authorization");
+    Ok(json!({ "voided": true }))
+}
+
+#[activity(start_to_close = "30s", queue = "billing")]
+pub async fn create_subscription_record(
+    _ctx: &ActivityContext,
+    input: Value,
+) -> HarvestResult<Value> {
+    Ok(json!({
+        "subscription_id": input["subscription_id"],
+        "state": "pending_capture",
+    }))
+}
+
+#[activity(start_to_close = "30s", queue = "billing")]
+pub async fn cancel_subscription_record(
+    _ctx: &ActivityContext,
+    input: Value,
+) -> HarvestResult<Value> {
+    tracing::info!(subscription = ?input, "cancelled subscription record");
+    Ok(json!({ "cancelled": true }))
+}
+
+#[activity(start_to_close = "30s", queue = "invoices")]
+pub async fn create_invoice(
+    _ctx: &ActivityContext,
+    input: InvoiceRequest,
+) -> HarvestResult<InvoiceResult> {
+    let tax_cents = if input.tax_enabled {
+        input.subtotal_cents / 10
+    } else {
+        0
+    };
+    Ok(InvoiceResult {
+        invoice_id: format!("inv_{}_{}", input.tenant_id, input.subscription_id),
+        total_cents: input.subtotal_cents + tax_cents,
+    })
+}
+
+#[activity(start_to_close = "30s", retry = RetryPolicy::fixed(3, Duration::from_secs(1)), queue = "invoices")]
+pub async fn send_invoice(_ctx: &ActivityContext, invoice: InvoiceResult) -> HarvestResult<Value> {
+    tracing::info!(invoice_id = %invoice.invoice_id, "sent invoice");
+    Ok(json!({ "sent": true }))
+}
+
+#[activity(start_to_close = "30s", queue = "invoices")]
+pub async fn void_invoice(_ctx: &ActivityContext, invoice: Value) -> HarvestResult<Value> {
+    tracing::info!(invoice = ?invoice, "voided invoice during billing saga rollback");
+    Ok(json!({ "voided": true }))
+}
+
+#[activity(start_to_close = "30s", queue = "payments")]
+pub async fn record_payment_capture(_ctx: &ActivityContext, input: Value) -> HarvestResult<Value> {
+    tracing::info!(capture = ?input, "recorded payment capture");
+    Ok(json!({ "posted": true }))
+}
+
+#[activity(start_to_close = "30s", queue = "billing")]
+pub async fn send_receipt(_ctx: &ActivityContext, input: Value) -> HarvestResult<Value> {
+    tracing::info!(receipt = ?input, "sent receipt");
+    Ok(json!({ "sent": true }))
+}
+
+#[activity(start_to_close = "1m", queue = "payments")]
+pub async fn charge_subscription(_ctx: &ActivityContext, input: Value) -> HarvestResult<Value> {
+    tracing::info!(charge = ?input, "charged subscription billing cycle");
+    Ok(json!({ "charged": true }))
+}
+
+#[activity(start_to_close = "2m", queue = "ops")]
+pub async fn export_billing_events(_ctx: &ActivityContext, input: Value) -> HarvestResult<Value> {
+    Ok(json!({ "exported": input }))
+}
+
+#[activity(start_to_close = "2m", queue = "ops")]
+pub async fn reconcile_gateway(_ctx: &ActivityContext, input: Value) -> HarvestResult<Value> {
+    Ok(json!({ "reconciled": input }))
+}
+
+#[activity(start_to_close = "30s", queue = "ops")]
+pub async fn notify_finance(_ctx: &ActivityContext, input: Value) -> HarvestResult<Value> {
+    Ok(json!({ "notified": input }))
+}

--- a/examples/billing-autumn-web/src/dags.rs
+++ b/examples/billing-autumn-web/src/dags.rs
@@ -1,0 +1,27 @@
+use std::time::Duration;
+
+use autumn_harvest::prelude::*;
+
+use crate::activities::{export_billing_events, notify_finance, reconcile_gateway};
+
+pub fn dags() -> Vec<DagInfo> {
+    dags![billing_reconciliation]
+}
+
+#[dag(
+    schedule = "0 6 * * *",
+    catchup = false,
+    max_active_runs = 1,
+    default_queue = "ops"
+)]
+pub fn billing_reconciliation(dag: &mut DagBuilder) {
+    let export = dag.activity(export_billing_events);
+    let reconcile = dag
+        .activity(reconcile_gateway)
+        .upstream(&export)
+        .retry(RetryPolicy::fixed(3, Duration::from_secs(30)));
+    let _notify = dag
+        .activity(notify_finance)
+        .upstream(&reconcile)
+        .trigger_rule(TriggerRule::AllDone);
+}

--- a/examples/billing-autumn-web/src/domain.rs
+++ b/examples/billing-autumn-web/src/domain.rs
@@ -1,0 +1,120 @@
+use autumn_harvest_plugin::prelude::WorkflowStartRequest;
+use serde::{Deserialize, Serialize};
+use serde_json::json;
+
+pub const CHECKOUT_QUEUE: &str = "billing";
+pub const PAYMENT_QUEUE: &str = "payments";
+pub const INVOICE_QUEUE: &str = "invoices";
+pub const OPS_QUEUE: &str = "ops";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CheckoutRequest {
+    pub tenant_id: String,
+    pub customer_id: String,
+    pub plan: String,
+    pub seats: u32,
+    pub payment_method_id: String,
+}
+
+impl CheckoutRequest {
+    pub fn normalized(mut self) -> Self {
+        self.tenant_id = self.tenant_id.trim().to_ascii_lowercase();
+        self.customer_id = self.customer_id.trim().to_owned();
+        self.plan = self.plan.trim().to_ascii_lowercase();
+        self.payment_method_id = self.payment_method_id.trim().to_owned();
+        self
+    }
+
+    pub fn unit_price_cents(&self) -> u64 {
+        match self.plan.as_str() {
+            "enterprise" => 5_000,
+            "pro" => 2_900,
+            _ => 1_200,
+        }
+    }
+
+    pub fn subtotal_cents(&self) -> u64 {
+        self.unit_price_cents() * u64::from(self.seats)
+    }
+
+    pub fn requires_manual_review(&self) -> bool {
+        self.subtotal_cents() >= 250_000
+    }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct CheckoutStartResponse {
+    pub workflow_id: String,
+    pub outbox: &'static str,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct PlanQuote {
+    plan: &'static str,
+    monthly_cents_per_seat: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct InvoiceRequest {
+    pub tenant_id: String,
+    pub customer_id: String,
+    pub subscription_id: String,
+    pub subtotal_cents: u64,
+    pub tax_enabled: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct InvoiceResult {
+    pub invoice_id: String,
+    pub total_cents: u64,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct BillingOutcome {
+    pub subscription_id: String,
+    pub invoice_id: String,
+    pub capture_id: String,
+    pub status: String,
+}
+
+pub fn plan_quotes() -> Vec<PlanQuote> {
+    vec![
+        PlanQuote {
+            plan: "starter",
+            monthly_cents_per_seat: 1_200,
+        },
+        PlanQuote {
+            plan: "pro",
+            monthly_cents_per_seat: 2_900,
+        },
+        PlanQuote {
+            plan: "enterprise",
+            monthly_cents_per_seat: 5_000,
+        },
+    ]
+}
+
+pub fn checkout_start_request(request: CheckoutRequest) -> WorkflowStartRequest {
+    let request = request.normalized();
+    WorkflowStartRequest {
+        workflow_name: "billing_checkout".to_owned(),
+        workflow_id: checkout_workflow_id(&request),
+        queue_name: CHECKOUT_QUEUE.to_owned(),
+        input: json!(request),
+        memo: Some(json!({
+            "kind": "subscription_checkout",
+        })),
+        search_attrs: Some(json!({
+            "tenant_id": request.tenant_id,
+            "customer_id": request.customer_id,
+            "plan": request.plan,
+        })),
+    }
+}
+
+fn checkout_workflow_id(request: &CheckoutRequest) -> String {
+    format!(
+        "billing-checkout:{}:{}:{}",
+        request.tenant_id, request.customer_id, request.plan
+    )
+}

--- a/examples/billing-autumn-web/src/main.rs
+++ b/examples/billing-autumn-web/src/main.rs
@@ -1,0 +1,36 @@
+#![allow(clippy::missing_errors_doc, clippy::unused_async)]
+
+mod activities;
+mod dags;
+mod domain;
+mod routes;
+mod workflows;
+
+#[cfg(test)]
+mod tests;
+
+use autumn_harvest::prelude::WorkerConfig;
+use autumn_harvest_plugin::prelude::HarvestPlugin;
+
+use crate::domain::{CHECKOUT_QUEUE, INVOICE_QUEUE, OPS_QUEUE, PAYMENT_QUEUE};
+
+#[autumn_web::main]
+async fn main() {
+    autumn_web::app()
+        .routes(routes::routes())
+        .plugin(
+            HarvestPlugin::new()
+                .workflows(workflows::workflows())
+                .activities(activities::activities())
+                .dags(dags::dags())
+                .worker(WorkerConfig::default().with_queues([
+                    CHECKOUT_QUEUE,
+                    PAYMENT_QUEUE,
+                    INVOICE_QUEUE,
+                    OPS_QUEUE,
+                ]))
+                .api("/api/harvest"),
+        )
+        .run()
+        .await;
+}

--- a/examples/billing-autumn-web/src/routes.rs
+++ b/examples/billing-autumn-web/src/routes.rs
@@ -1,0 +1,40 @@
+use autumn_harvest_plugin::prelude::enqueue_workflow_start_outbox;
+use autumn_web::prelude::*;
+use autumn_web::reexports::axum::extract::State;
+
+use crate::domain::{
+    CheckoutRequest, CheckoutStartResponse, PlanQuote, checkout_start_request, plan_quotes,
+};
+
+pub fn routes() -> Vec<autumn_web::Route> {
+    routes![list_plans, start_checkout]
+}
+
+#[get("/billing/plans")]
+pub async fn list_plans() -> Json<Vec<PlanQuote>> {
+    Json(plan_quotes())
+}
+
+#[post("/billing/checkout")]
+pub async fn start_checkout(
+    State(state): State<autumn_web::AppState>,
+    Json(request): Json<CheckoutRequest>,
+) -> AutumnResult<Json<CheckoutStartResponse>> {
+    let start = checkout_start_request(request);
+    let pool = state.pool().cloned().ok_or_else(|| {
+        AutumnError::service_unavailable_msg("billing checkout requires an application database")
+    })?;
+    let mut conn = pool
+        .get()
+        .await
+        .map_err(|error| AutumnError::service_unavailable_msg(error.to_string()))?;
+
+    enqueue_workflow_start_outbox(&mut conn, &start)
+        .await
+        .map_err(|error| AutumnError::service_unavailable_msg(error.to_string()))?;
+
+    Ok(Json(CheckoutStartResponse {
+        workflow_id: start.workflow_id,
+        outbox: "queued",
+    }))
+}

--- a/examples/billing-autumn-web/src/tests.rs
+++ b/examples/billing-autumn-web/src/tests.rs
@@ -1,0 +1,242 @@
+use autumn_harvest::{WorkflowEvent, WorkflowSimulator};
+use serde_json::json;
+
+use crate::domain::{
+    BillingOutcome, CHECKOUT_QUEUE, CheckoutRequest, InvoiceRequest, InvoiceResult, PAYMENT_QUEUE,
+    checkout_start_request,
+};
+use crate::{activities, dags, routes, workflows};
+
+fn checkout() -> CheckoutRequest {
+    CheckoutRequest {
+        tenant_id: "ACME".to_owned(),
+        customer_id: "cust_42".to_owned(),
+        plan: "Pro".to_owned(),
+        seats: 5,
+        payment_method_id: "pm_card_demo".to_owned(),
+    }
+}
+
+#[test]
+fn checkout_start_request_carries_outbox_metadata() {
+    let request = checkout_start_request(checkout());
+
+    assert_eq!(request.workflow_name, "billing_checkout");
+    assert_eq!(request.queue_name, CHECKOUT_QUEUE);
+    assert_eq!(request.workflow_id, "billing-checkout:acme:cust_42:pro");
+    assert_eq!(
+        request
+            .search_attrs
+            .as_ref()
+            .and_then(|v| v["tenant_id"].as_str()),
+        Some("acme")
+    );
+}
+
+#[test]
+fn app_routes_and_harvest_registrations_are_present() {
+    let routes = routes::routes();
+    assert_eq!(routes.len(), 2);
+    assert_eq!(routes[0].path, "/billing/plans");
+    assert_eq!(routes[1].path, "/billing/checkout");
+
+    let workflows = workflows::workflows();
+    assert_eq!(workflows.len(), 3);
+    assert!(
+        workflows
+            .iter()
+            .any(|workflow| workflow.name == "billing_checkout")
+    );
+
+    let authorize = activities::__autumn_activity_info_authorize_payment();
+    assert_eq!(authorize.default_queue, Some(PAYMENT_QUEUE));
+    assert_eq!(authorize.max_concurrent, Some(8));
+    assert_eq!(authorize.concurrency_key, Some("stripe"));
+
+    let dag = dags::__autumn_dag_info_billing_reconciliation();
+    let definition = dag.build_definition().expect("billing DAG should compile");
+    assert_eq!(definition.tasks().len(), 3);
+}
+
+#[tokio::test]
+async fn billing_checkout_happy_path_uses_saga_child_signal_version_and_timer() {
+    let result =
+        WorkflowSimulator::new(workflows::__autumn_workflow_info_billing_checkout().handler)
+            .mock_activity("validate_checkout", Ok)
+            .mock_activity("create_customer_profile", |_| {
+                Ok(json!({ "customer_profile_id": "cus_demo" }))
+            })
+            .mock_activity("authorize_payment", |_| {
+                Ok(json!({ "authorization_id": "auth_demo", "amount_cents": 14_500 }))
+            })
+            .mock_activity("create_subscription_record", |input| {
+                Ok(json!({
+                    "subscription_id": input["subscription_id"],
+                    "state": "pending_capture",
+                }))
+            })
+            .mock_child_workflow("issue_initial_invoice", |_| {
+                Ok(json!({
+                    "invoice_id": "inv_demo",
+                    "total_cents": 15_950,
+                }))
+            })
+            .mock_activity("record_payment_capture", |_| Ok(json!({ "posted": true })))
+            .mock_activity("send_receipt", |_| Ok(json!({ "sent": true })))
+            .send_signal(
+                "payment_captured",
+                json!({
+                    "captured": true,
+                    "capture_id": "cap_demo",
+                }),
+            )
+            .run(json!(checkout()))
+            .await;
+
+    let output: BillingOutcome = serde_json::from_value(
+        result
+            .final_output
+            .expect("billing checkout should complete"),
+    )
+    .expect("billing output should deserialize");
+    assert_eq!(output.invoice_id, "inv_demo");
+    assert_eq!(output.capture_id, "cap_demo");
+    assert_eq!(output.status, "completed");
+
+    assert!(result.history.iter().any(|event| matches!(
+        event,
+        WorkflowEvent::MarkerRecorded { name, details }
+            if name == "version:billing_checkout_v2_tax" && details == &json!(2)
+    )));
+    assert!(result.history.iter().any(|event| matches!(
+        event,
+        WorkflowEvent::MarkerRecorded { name, .. }
+            if name == "side_effect:subscription-id"
+    )));
+    assert!(result.history.iter().any(|event| matches!(
+        event,
+        WorkflowEvent::ChildWorkflowStarted { workflow_name, .. }
+            if workflow_name == "issue_initial_invoice"
+    )));
+    assert!(result.history.iter().any(|event| matches!(
+        event,
+        WorkflowEvent::SignalReceived { signal_name, .. }
+            if signal_name == "payment_captured"
+    )));
+    assert!(result.history.iter().any(|event| matches!(
+        event,
+        WorkflowEvent::TimerStarted { timer_id, .. }
+            if timer_id.as_str() == "receipt-settlement-window"
+    )));
+}
+
+#[tokio::test]
+async fn billing_checkout_compensates_when_invoice_child_fails() {
+    let result =
+        WorkflowSimulator::new(workflows::__autumn_workflow_info_billing_checkout().handler)
+            .mock_activity("validate_checkout", Ok)
+            .mock_activity("create_customer_profile", |_| {
+                Ok(json!({ "customer_profile_id": "cus_demo" }))
+            })
+            .mock_activity("authorize_payment", |_| {
+                Ok(json!({ "authorization_id": "auth_demo", "amount_cents": 14_500 }))
+            })
+            .mock_activity("create_subscription_record", |input| {
+                Ok(json!({
+                    "subscription_id": input["subscription_id"],
+                    "state": "pending_capture",
+                }))
+            })
+            .mock_child_workflow("issue_initial_invoice", |_| {
+                Err("invoice service unavailable".to_owned())
+            })
+            .mock_activity("cancel_subscription_record", |_| {
+                Ok(json!({ "cancelled": true }))
+            })
+            .mock_activity("void_payment_authorization", |_| {
+                Ok(json!({ "voided": true }))
+            })
+            .mock_activity("delete_customer_profile", |_| {
+                Ok(json!({ "deleted": true }))
+            })
+            .run(json!(checkout()))
+            .await;
+
+    let error = result
+        .final_output
+        .expect_err("billing checkout should fail when child workflow fails");
+    assert!(error.contains("child-workflow:issue_initial_invoice"));
+
+    let scheduled: Vec<&str> = result
+        .history
+        .iter()
+        .filter_map(|event| match event {
+            WorkflowEvent::ActivityScheduled { name, .. } => Some(name.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert!(scheduled.contains(&"cancel_subscription_record"));
+    assert!(scheduled.contains(&"void_payment_authorization"));
+    assert!(scheduled.contains(&"delete_customer_profile"));
+}
+
+#[tokio::test]
+async fn monthly_billing_cycle_continues_as_new_to_bound_history() {
+    let result =
+        WorkflowSimulator::new(workflows::__autumn_workflow_info_monthly_billing_cycle().handler)
+            .mock_activity("charge_subscription", |_| Ok(json!({ "charged": true })))
+            .run(json!({
+                "subscription_id": "sub_demo",
+                "cycle": 1,
+                "stop_after": 3,
+            }))
+            .await;
+
+    assert_eq!(
+        result
+            .final_output
+            .expect("continue-as-new should surface next input"),
+        json!({
+            "subscription_id": "sub_demo",
+            "cycle": 2,
+            "stop_after": 3,
+        })
+    );
+    assert!(
+        result
+            .history
+            .iter()
+            .any(|event| matches!(event, WorkflowEvent::WorkflowContinuedAsNew { .. }))
+    );
+}
+
+#[tokio::test]
+async fn issue_initial_invoice_applies_versioned_tax_flag() {
+    let result =
+        WorkflowSimulator::new(workflows::__autumn_workflow_info_issue_initial_invoice().handler)
+            .mock_activity("create_invoice", |input| {
+                let request: InvoiceRequest =
+                    serde_json::from_value(input).expect("invoice input should deserialize");
+                Ok(json!(InvoiceResult {
+                    invoice_id: "inv_taxed".to_owned(),
+                    total_cents: request.subtotal_cents + (request.subtotal_cents / 10),
+                }))
+            })
+            .mock_activity("send_invoice", |_| Ok(json!({ "sent": true })))
+            .run(json!(InvoiceRequest {
+                tenant_id: "acme".to_owned(),
+                customer_id: "cust_42".to_owned(),
+                subscription_id: "sub_demo".to_owned(),
+                subtotal_cents: 14_500,
+                tax_enabled: true,
+            }))
+            .await;
+
+    assert_eq!(
+        result.final_output.expect("invoice child should complete"),
+        json!(InvoiceResult {
+            invoice_id: "inv_taxed".to_owned(),
+            total_cents: 15_950,
+        })
+    );
+}

--- a/examples/billing-autumn-web/src/workflows.rs
+++ b/examples/billing-autumn-web/src/workflows.rs
@@ -1,0 +1,244 @@
+use std::sync::{Arc, Mutex};
+
+use autumn_harvest::prelude::*;
+use serde_json::{Value, json};
+
+use crate::domain::{
+    BillingOutcome, CHECKOUT_QUEUE, CheckoutRequest, INVOICE_QUEUE, InvoiceRequest, InvoiceResult,
+    OPS_QUEUE, PAYMENT_QUEUE,
+};
+
+pub fn workflows() -> Vec<WorkflowInfo> {
+    workflows![
+        billing_checkout,
+        issue_initial_invoice,
+        monthly_billing_cycle,
+    ]
+}
+
+#[workflow]
+#[allow(clippy::too_many_lines)]
+pub async fn billing_checkout(
+    ctx: &WorkflowContext,
+    request: CheckoutRequest,
+) -> HarvestResult<BillingOutcome> {
+    let status = Arc::new(Mutex::new(String::from("validating")));
+    let query_status = Arc::clone(&status);
+    ctx.register_query("status", move || {
+        json!({
+            "status": query_status.lock().expect("status query lock poisoned").as_str(),
+        })
+    });
+
+    let validated = ctx
+        .execute_activity_raw("validate_checkout", json!(request), CHECKOUT_QUEUE)
+        .await?;
+    let checkout: CheckoutRequest = serde_json::from_value(validated)?;
+    let tax_version = ctx.version("billing_checkout_v2_tax", 1, 2);
+    let subscription_uuid = ctx.random_uuid("subscription-id")?;
+    let subscription_id = format!("sub_{}", subscription_uuid.simple());
+
+    *status.lock().expect("status lock poisoned") = String::from("reserving");
+    let mut saga = Saga::new(ctx);
+
+    let customer_profile = saga
+        .step(
+            || async {
+                ctx.execute_activity_raw(
+                    "create_customer_profile",
+                    json!({
+                        "tenant_id": checkout.tenant_id,
+                        "customer_id": checkout.customer_id,
+                    }),
+                    CHECKOUT_QUEUE,
+                )
+                .await
+            },
+            |profile| async move {
+                ctx.execute_activity_raw("delete_customer_profile", profile, CHECKOUT_QUEUE)
+                    .await
+                    .map(|_| ())
+            },
+        )
+        .await?;
+
+    let authorization = saga
+        .step(
+            || async {
+                ctx.execute_activity_raw(
+                    "authorize_payment",
+                    json!({
+                        "customer_profile": customer_profile,
+                        "payment_method_id": checkout.payment_method_id,
+                        "amount_cents": checkout.subtotal_cents(),
+                    }),
+                    PAYMENT_QUEUE,
+                )
+                .await
+            },
+            |auth| async move {
+                ctx.execute_activity_raw("void_payment_authorization", auth, PAYMENT_QUEUE)
+                    .await
+                    .map(|_| ())
+            },
+        )
+        .await?;
+
+    let subscription_record = saga
+        .step(
+            || async {
+                ctx.execute_activity_raw(
+                    "create_subscription_record",
+                    json!({
+                        "subscription_id": subscription_id,
+                        "tenant_id": checkout.tenant_id,
+                        "customer_id": checkout.customer_id,
+                        "plan": checkout.plan,
+                        "seats": checkout.seats,
+                    }),
+                    CHECKOUT_QUEUE,
+                )
+                .await
+            },
+            |record| async move {
+                ctx.execute_activity_raw("cancel_subscription_record", record, CHECKOUT_QUEUE)
+                    .await
+                    .map(|_| ())
+            },
+        )
+        .await?;
+
+    if checkout.requires_manual_review() {
+        ctx.execute_activity_external(
+            "approve_high_value_subscription",
+            json!({
+                "subscription": subscription_record,
+                "authorization": authorization,
+            }),
+            OPS_QUEUE,
+            24 * 60 * 60,
+        )
+        .await?;
+    }
+
+    let invoice_input = InvoiceRequest {
+        tenant_id: checkout.tenant_id.clone(),
+        customer_id: checkout.customer_id.clone(),
+        subscription_id: subscription_id.clone(),
+        subtotal_cents: checkout.subtotal_cents(),
+        tax_enabled: tax_version >= 2,
+    };
+    let invoice = saga
+        .step(
+            || async {
+                ctx.spawn_child_workflow_raw("issue_initial_invoice", json!(invoice_input))
+                    .await
+            },
+            |invoice| async move {
+                ctx.execute_activity_raw("void_invoice", invoice, INVOICE_QUEUE)
+                    .await
+                    .map(|_| ())
+            },
+        )
+        .await?;
+    let invoice: InvoiceResult = serde_json::from_value(invoice)?;
+
+    *status.lock().expect("status lock poisoned") = String::from("awaiting_payment_capture");
+    let capture = ctx.wait_for_signal("payment_captured").await?;
+    let captured = capture
+        .get("captured")
+        .and_then(Value::as_bool)
+        .unwrap_or_default();
+    if !captured {
+        saga.compensate_all().await?;
+        return Err(HarvestError::WorkflowFailed {
+            name: "billing_checkout".to_owned(),
+            reason: "payment capture was rejected".to_owned(),
+        });
+    }
+    let capture_id = capture
+        .get("capture_id")
+        .and_then(Value::as_str)
+        .unwrap_or("capture-missing")
+        .to_owned();
+
+    ctx.execute_activity_raw(
+        "record_payment_capture",
+        json!({
+            "subscription_id": subscription_id,
+            "invoice_id": invoice.invoice_id,
+            "capture_id": capture_id,
+        }),
+        PAYMENT_QUEUE,
+    )
+    .await?;
+    ctx.timer("receipt-settlement-window", 1).await?;
+    ctx.execute_activity_raw(
+        "send_receipt",
+        json!({
+            "tenant_id": checkout.tenant_id,
+            "customer_id": checkout.customer_id,
+            "invoice_id": invoice.invoice_id,
+        }),
+        CHECKOUT_QUEUE,
+    )
+    .await?;
+
+    *status.lock().expect("status lock poisoned") = String::from("completed");
+    Ok(BillingOutcome {
+        subscription_id,
+        invoice_id: invoice.invoice_id,
+        capture_id,
+        status: "completed".to_owned(),
+    })
+}
+
+#[workflow]
+pub async fn issue_initial_invoice(
+    ctx: &WorkflowContext,
+    request: InvoiceRequest,
+) -> HarvestResult<InvoiceResult> {
+    let invoice = ctx
+        .execute_activity_raw("create_invoice", json!(request), INVOICE_QUEUE)
+        .await?;
+    let invoice: InvoiceResult = serde_json::from_value(invoice)?;
+    ctx.execute_activity_raw("send_invoice", json!(invoice), INVOICE_QUEUE)
+        .await?;
+    Ok(invoice)
+}
+
+#[workflow]
+pub async fn monthly_billing_cycle(ctx: &WorkflowContext, input: Value) -> HarvestResult<Value> {
+    let cycle = input.get("cycle").and_then(Value::as_u64).unwrap_or(1);
+    let stop_after = input
+        .get("stop_after")
+        .and_then(Value::as_u64)
+        .unwrap_or(12);
+    ctx.register_query("cycle", move || json!({ "cycle": cycle }));
+
+    if cycle > stop_after {
+        return Ok(json!({
+            "status": "complete",
+            "cycle": cycle,
+        }));
+    }
+
+    ctx.execute_activity_raw(
+        "charge_subscription",
+        json!({
+            "subscription_id": input.get("subscription_id").cloned().unwrap_or(Value::Null),
+            "cycle": cycle,
+        }),
+        PAYMENT_QUEUE,
+    )
+    .await?;
+    ctx.timer(&format!("next-cycle-{cycle}"), 86_400).await?;
+    ctx.continue_as_new(json!({
+        "subscription_id": input.get("subscription_id").cloned().unwrap_or(Value::Null),
+        "cycle": cycle + 1,
+        "stop_after": stop_after,
+    }))
+    .await?;
+
+    unreachable!("continue_as_new does not return during live execution")
+}

--- a/examples/standalone-runner/Cargo.toml
+++ b/examples/standalone-runner/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "standalone-runner"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+publish = false
+
+[dependencies]
+autumn-harvest = { path = "../../autumn-harvest", features = ["db", "testing"] }
+autumn-harvest-plugin = { path = "../../autumn-harvest-plugin" }
+autumn-web = "0.2"
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+
+[lints]
+workspace = true

--- a/examples/standalone-runner/README.md
+++ b/examples/standalone-runner/README.md
@@ -1,0 +1,41 @@
+# standalone-runner
+
+This example shows the out-of-the-box non-`HarvestPlugin` runner path. It does not call
+`autumn_web::app()` and does not install `HarvestPlugin`. Instead it builds Harvest directly,
+starts `HarvestRunner`, installs the runner's API runtime into `HarvestApiState`, and mounts the
+management router on a raw Axum server.
+
+The workflow is intentionally smaller than the billing Autumn app, but it still uses the same
+reference ideas: a saga reserves inventory with rollback, a child workflow buys the shipping
+label, and a version gate selects the v2 shipping payload. The point is runner ownership, not web
+framework ceremony.
+
+## Run
+
+```bash
+docker compose -f examples/standalone-runner/compose.yaml up -d
+
+$env:DATABASE_URL = "postgres://runner:runner@localhost:5434/runner"
+$env:AUTUMN_PROFILE = "dev"
+cargo run -p standalone-runner
+```
+
+The raw Axum process listens on `http://localhost:8082`.
+
+- Runner health route: `GET /`
+- Harvest API: `GET /api/harvest/health`
+- Start workflow: `POST /api/harvest/workflows/standalone_order/start`
+
+```bash
+curl -s -X POST http://localhost:8082/api/harvest/workflows/standalone_order/start \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "workflow_id":"order-1001",
+    "input":{"order_id":"order-1001","sku":"sku-book","quantity":2}
+  }' | jq .
+```
+
+Use `examples/billing-autumn-web` when you want the full Autumn web integration with app routes,
+outbox publication, saga rollback, child workflow orchestration, version fencing, scheduled DAGs,
+signals, timers, and the plugin-managed runner. Use this one when you want to see the runner
+wired manually.

--- a/examples/standalone-runner/compose.yaml
+++ b/examples/standalone-runner/compose.yaml
@@ -1,0 +1,14 @@
+services:
+  postgres:
+    image: postgres:16
+    environment:
+      POSTGRES_USER: runner
+      POSTGRES_PASSWORD: runner
+      POSTGRES_DB: runner
+    ports:
+      - "5434:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U runner"]
+      interval: 5s
+      timeout: 5s
+      retries: 10

--- a/examples/standalone-runner/src/activities.rs
+++ b/examples/standalone-runner/src/activities.rs
@@ -1,0 +1,36 @@
+use std::time::Duration;
+
+use autumn_harvest::prelude::*;
+use serde_json::{Value, json};
+
+use crate::domain::StandaloneOrder;
+
+pub fn activities() -> Vec<ActivityInfo> {
+    activities![reserve_inventory, release_inventory, buy_shipping_label,]
+}
+
+#[activity(start_to_close = "30s", retry = RetryPolicy::fixed(3, Duration::from_secs(1)), queue = "standalone")]
+pub async fn reserve_inventory(
+    _ctx: &ActivityContext,
+    order: StandaloneOrder,
+) -> HarvestResult<Value> {
+    Ok(json!({
+        "reservation_id": format!("res_{}", order.order_id),
+        "sku": order.sku,
+        "quantity": order.quantity,
+    }))
+}
+
+#[activity(start_to_close = "30s", queue = "standalone")]
+pub async fn release_inventory(_ctx: &ActivityContext, reservation: Value) -> HarvestResult<Value> {
+    tracing::info!(reservation = ?reservation, "released inventory reservation");
+    Ok(json!({ "released": true }))
+}
+
+#[activity(start_to_close = "30s", retry = RetryPolicy::exponential(3, Duration::from_secs(1)), queue = "standalone")]
+pub async fn buy_shipping_label(_ctx: &ActivityContext, input: Value) -> HarvestResult<Value> {
+    Ok(json!({
+        "label_id": format!("lbl_{}", input["order_id"].as_str().unwrap_or("order")),
+        "carrier": input["carrier"],
+    }))
+}

--- a/examples/standalone-runner/src/domain.rs
+++ b/examples/standalone-runner/src/domain.rs
@@ -1,0 +1,10 @@
+use serde::{Deserialize, Serialize};
+
+pub const RUNNER_QUEUE: &str = "standalone";
+
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct StandaloneOrder {
+    pub order_id: String,
+    pub sku: String,
+    pub quantity: u32,
+}

--- a/examples/standalone-runner/src/main.rs
+++ b/examples/standalone-runner/src/main.rs
@@ -1,0 +1,15 @@
+#![allow(clippy::missing_errors_doc, clippy::unused_async)]
+
+mod activities;
+mod domain;
+mod runtime;
+mod server;
+mod workflows;
+
+#[cfg(test)]
+mod tests;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    server::run().await
+}

--- a/examples/standalone-runner/src/runtime.rs
+++ b/examples/standalone-runner/src/runtime.rs
@@ -1,0 +1,28 @@
+use autumn_harvest::prelude::*;
+use autumn_harvest_plugin::prelude::*;
+
+use crate::domain::RUNNER_QUEUE;
+use crate::{activities, workflows};
+
+pub fn standalone_runtime_config(database_url: String) -> HarvestRuntimeConfig {
+    HarvestRuntimeConfig {
+        mode: HarvestMode::External,
+        worker_enabled: true,
+        scheduler_enabled: true,
+        database: HarvestDatabaseConfig {
+            url: Some(database_url),
+        },
+        outbox: HarvestOutboxConfig {
+            enabled: false,
+            ..HarvestOutboxConfig::default()
+        },
+        batch: autumn_harvest_plugin::config::HarvestBatchConfig::default(),
+    }
+}
+
+pub fn standalone_builder() -> HarvestBuilder {
+    HarvestBuilder::default()
+        .workflows(workflows::workflows())
+        .activities(activities::activities())
+        .worker(WorkerConfig::default().with_queues([RUNNER_QUEUE]))
+}

--- a/examples/standalone-runner/src/server.rs
+++ b/examples/standalone-runner/src/server.rs
@@ -1,0 +1,56 @@
+use std::net::SocketAddr;
+
+use autumn_harvest_plugin::prelude::*;
+use autumn_web::config::DatabaseConfig;
+use autumn_web::reexports::axum::{self, Json, routing::get};
+use serde_json::json;
+
+use crate::runtime::{standalone_builder, standalone_runtime_config};
+
+pub async fn run() -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let database_url = std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://runner:runner@localhost:5434/runner".to_owned());
+    if std::env::var("AUTUMN_PROFILE").as_deref() == Ok("dev") {
+        autumn_web::migrate::run_pending(&database_url, autumn_harvest::MIGRATIONS)?;
+    }
+
+    let pool = autumn_web::db::create_pool(&DatabaseConfig {
+        url: Some(database_url.clone()),
+        ..DatabaseConfig::default()
+    })?
+    .ok_or("DATABASE_URL must create a Postgres pool")?;
+
+    let config = standalone_runtime_config(database_url);
+    let built = standalone_builder().try_build()?;
+    let runner = HarvestRunner::start(built, &config, HarvestRunnerResources::new(pool.clone()))
+        .map_err(|error| format!("failed to start Harvest runner: {error}"))?;
+
+    let api_state = HarvestApiState::new();
+    api_state.install_storage_pool(runner.storage_pool());
+    api_state.install(runner.api_runtime());
+
+    let web_state = autumn_web::AppState::for_test().with_pool(pool);
+    let app = axum::Router::new()
+        .route(
+            "/",
+            get(|| async { Json(json!({ "service": "standalone-runner" })) }),
+        )
+        .nest("/api/harvest", harvest_api_router(api_state))
+        .with_state(web_state);
+
+    let address = SocketAddr::from(([127, 0, 0, 1], 8082));
+    tracing::info!(%address, "standalone Harvest runner listening");
+    let listener = tokio::net::TcpListener::bind(address).await?;
+    axum::serve(listener, app)
+        .with_graceful_shutdown(shutdown_signal())
+        .await?;
+
+    runner.stop().await;
+    Ok(())
+}
+
+async fn shutdown_signal() {
+    if let Err(error) = tokio::signal::ctrl_c().await {
+        tracing::warn!(%error, "failed to listen for shutdown signal");
+    }
+}

--- a/examples/standalone-runner/src/tests.rs
+++ b/examples/standalone-runner/src/tests.rs
@@ -1,0 +1,79 @@
+use autumn_harvest::{WorkflowEvent, WorkflowSimulator};
+use autumn_harvest_plugin::prelude::HarvestMode;
+use serde_json::json;
+
+use crate::domain::{RUNNER_QUEUE, StandaloneOrder};
+use crate::runtime::{standalone_builder, standalone_runtime_config};
+use crate::workflows;
+
+#[test]
+fn runtime_config_uses_external_runner_mode_without_outbox() {
+    let config = standalone_runtime_config("postgres://runner:runner@localhost/runner".to_owned());
+
+    assert_eq!(config.mode, HarvestMode::External);
+    assert!(config.worker_enabled);
+    assert!(config.scheduler_enabled);
+    assert!(!config.outbox.enabled);
+}
+
+#[test]
+fn builder_registers_runner_owned_workflows_and_activities() {
+    let built = standalone_builder()
+        .try_build()
+        .expect("standalone runner registrations should build");
+
+    assert_eq!(built.workflow_count(), 2);
+    assert_eq!(built.activity_count(), 3);
+    assert_eq!(built.worker_config().queues, vec![RUNNER_QUEUE.to_owned()]);
+}
+
+#[tokio::test]
+async fn standalone_order_uses_version_gate_saga_and_child_workflow() {
+    let result =
+        WorkflowSimulator::new(workflows::__autumn_workflow_info_standalone_order().handler)
+            .mock_activity("reserve_inventory", |input| {
+                let order: StandaloneOrder =
+                    serde_json::from_value(input).expect("order should deserialize");
+                Ok(json!({
+                    "reservation_id": format!("res_{}", order.order_id),
+                    "sku": order.sku,
+                    "quantity": order.quantity,
+                }))
+            })
+            .mock_child_workflow("standalone_shipping", |input| {
+                Ok(json!({
+                    "label_id": format!("lbl_{}", input["order_id"].as_str().unwrap_or("order")),
+                    "carrier": input["carrier"],
+                }))
+            })
+            .run(json!(StandaloneOrder {
+                order_id: "order-1001".to_owned(),
+                sku: "sku-book".to_owned(),
+                quantity: 2,
+            }))
+            .await;
+
+    assert_eq!(
+        result
+            .final_output
+            .expect("standalone order should complete"),
+        json!({
+            "order_id": "order-1001",
+            "shipment": {
+                "label_id": "lbl_order-1001",
+                "carrier": "ground",
+            },
+            "version": 2,
+        })
+    );
+    assert!(result.history.iter().any(|event| matches!(
+        event,
+        WorkflowEvent::MarkerRecorded { name, details }
+            if name == "version:standalone_order_shipping_v2" && details == &json!(2)
+    )));
+    assert!(result.history.iter().any(|event| matches!(
+        event,
+        WorkflowEvent::ChildWorkflowStarted { workflow_name, .. }
+            if workflow_name == "standalone_shipping"
+    )));
+}

--- a/examples/standalone-runner/src/workflows.rs
+++ b/examples/standalone-runner/src/workflows.rs
@@ -1,0 +1,53 @@
+use autumn_harvest::prelude::*;
+use serde_json::{Value, json};
+
+use crate::domain::{RUNNER_QUEUE, StandaloneOrder};
+
+pub fn workflows() -> Vec<WorkflowInfo> {
+    workflows![standalone_order, standalone_shipping]
+}
+
+#[workflow]
+pub async fn standalone_order(
+    ctx: &WorkflowContext,
+    order: StandaloneOrder,
+) -> HarvestResult<Value> {
+    let version = ctx.version("standalone_order_shipping_v2", 1, 2);
+    let mut saga = Saga::new(ctx);
+    let reservation = saga
+        .step(
+            || async {
+                ctx.execute_activity_raw("reserve_inventory", json!(order), RUNNER_QUEUE)
+                    .await
+            },
+            |reservation| async move {
+                ctx.execute_activity_raw("release_inventory", reservation, RUNNER_QUEUE)
+                    .await
+                    .map(|_| ())
+            },
+        )
+        .await?;
+
+    let shipment = ctx
+        .spawn_child_workflow_raw(
+            "standalone_shipping",
+            json!({
+                "order_id": order.order_id,
+                "reservation": reservation,
+                "carrier": if version >= 2 { "ground" } else { "postal" },
+            }),
+        )
+        .await?;
+
+    Ok(json!({
+        "order_id": order.order_id,
+        "shipment": shipment,
+        "version": version,
+    }))
+}
+
+#[workflow]
+pub async fn standalone_shipping(ctx: &WorkflowContext, input: Value) -> HarvestResult<Value> {
+    ctx.execute_activity_raw("buy_shipping_label", input, RUNNER_QUEUE)
+        .await
+}


### PR DESCRIPTION
## Summary
- Add `examples/billing-autumn-web`, a full Autumn web billing reference that demonstrates app routes, workflow outbox publication, `HarvestPlugin`, saga compensation, child workflows, version gates, signals, timers, deterministic side effects, continue-as-new, activity concurrency caps, and a scheduled DAG.
- Add `examples/standalone-runner`, a raw Axum + `HarvestRunner` reference for running Harvest without `HarvestPlugin`.
- Wire both examples into the workspace, update the top-level README, and add a catalog regression test so these reference examples stay registered and documented.

## Validation
- `cargo test -p billing-autumn-web`
- `cargo test -p standalone-runner`
- `cargo test -p autumn-harvest-plugin --test examples_catalog`
- `cargo clippy -p billing-autumn-web -p standalone-runner --all-targets -- -D warnings`
- `cargo check --workspace`
- `rg -n "TODO|FIXME|Stub:" examples/billing-autumn-web examples/standalone-runner autumn-harvest-plugin/tests/examples_catalog.rs README.md Cargo.toml` returned no matches.