### PR TITLE
Implement Update primitive for synchronous workflow requests (issue #140)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,6 +53,7 @@ Two crates in the workspace. `autumn-harvest` is the public library. `autumn-har
 - **Phase 2** (complete): event store, replay engine, workflow context, activity context, task queue (SKIP LOCKED), LISTEN/NOTIFY, worker runtime, heartbeating, timeout enforcement, workflow versioning (ctx.version), LRU workflow cache, dead letter queue, separate worker pool with shared ceiling, testcontainers integration tests
 - **Phase 3** (implemented): DAG scheduler/runtime, `DagBuilder`, `#[dag]` macro, trigger rules, signals/queries, management HTTP API, Autumn adapter crate with `HarvestExt` lifecycle integration
 - **Phase 3.5** (implemented): Local activities (`#[activity(local = true)]`, `ctx.execute_local_activity_raw`, `WorkflowCommand::RunLocalActivity`, three new `WorkflowEvent` variants, builder cap validation) — see issue #98
+- **Phase 3.6** (implemented): Update primitive (`UpdateAdmitted`, `UpdateCompleted`, `UpdateFailed` event variants, `UpdateId` type, `UpdateRegistry`, `WorkflowContext::register_update_handler`, `validate_update`, `execute_admitted_update`, `HistoryMatcher::match_update`, `drain_admitted_updates`) — see issue #140
 - **Phase 4** (next): production hardening -- cancellation/saga semantics, sharding, sticky cross-worker routing, observability, metrics, dashboard (autumn-harvest-ui)
 
 ---
@@ -145,7 +146,7 @@ Current implementation scope: `ExecutionId`/`ShardId` encoding, `ShardRouter`, `
 | `types.rs` | 1 | Newtypes: `WorkflowId` (String), `ExecutionId` (Uuid v4), `ActivityExecId` (Uuid v4), `TimerId` (String), `WorkerId` (String) |
 | `error.rs` | 1 | `HarvestError` (thiserror), `HarvestResult<T>`, `TimeoutType` enum |
 | `policy.rs` | 1 | `RetryPolicy`, `TriggerRule`, `Schedule`, `TaskStatus`, `compute_retry_delay` |
-| `event.rs` | 1 | `WorkflowEvent` enum (17 variants, adjacently-tagged serde), `type_name()` |
+| `event.rs` | 1 | `WorkflowEvent` enum (28 variants, adjacently-tagged serde), `type_name()`. Variants added in issue #140: `UpdateAdmitted`, `UpdateCompleted`, `UpdateFailed` |
 | `context.rs` | 1+2 | `WorkflowContext` (replay, suspension, version gate, timers), `ActivityContext` (heartbeat channel, cancellation) |
 | `info.rs` | 1 | `WorkflowInfo`, `ActivityInfo`, `WorkflowHandlerFn`, `ActivityHandlerFn` type aliases |
 | `builder.rs` | 1 | `HarvestBuilder` (fluent), `WorkerConfig` (queues, concurrency, timeouts) |
@@ -164,6 +165,7 @@ Current implementation scope: `ExecutionId`/`ShardId` encoding, `ShardRouter`, `
 | `cache.rs` | 2 | LRU workflow state cache: bounded capacity, access-order eviction |
 | `dlq.rs` | 2 | Dead letter queue: `DeadLetterEntry` builder, move-to-DLQ on retry exhaustion |
 | `pool.rs` | 2 | Separate DB pool config: web pool + worker pool with shared ceiling, minimum guarantees |
+| `update.rs` | 3.6 | Update primitive: `UpdateRegistry` (type-erased validators + async handlers), `BoxUpdateHandler`, `BoxUpdateValidator`. `WorkflowContext` methods: `register_update_handler`, `register_update_handler_no_validator`, `validate_update`, `execute_admitted_update`. `HistoryMatcher` methods: `match_update(update_id)`, `drain_admitted_updates()`. Error variants: `HarvestError::UpdateRejected`, `HarvestError::UpdateHandlerNotFound` |
 | `telemetry.rs` | 4 | OpenTelemetry surface: `TraceContextCarrier`, `TraceContextPropagator`, `MetricsRecorder`, `TelemetryConfig` — no-op by default, opt-in via `HarvestBuilder::telemetry`. Implements all 8 ADR-0001 span kinds (issue #136); see `docs/adr/0001-otel-trace-contract.md` for the full attribute schema and propagation rules. Metric catalogue (ADR-0001 §7): `harvest.workflow.started` (counter, `worker.rs`), `harvest.workflow.duration` (histogram, `worker.rs`), `harvest.activity.duration` (histogram, `worker.rs`), `harvest.timer.started` (counter, `worker.rs`), `harvest.queue.depth` (gauge, `worker.rs` sampler), `harvest.dlq.entries` (gauge, `worker.rs` sampler), `harvest.schedule.runs` (counter, `scheduler.rs`), `harvest.schedule.skipped` (counter, `scheduler.rs`), `harvest.retention.deleted` (counter, `retention.rs`). Cardinality rule: `execution.id` is span-only; `MetricsRecorder` API enforces this by construction. |
 | `metrics_rs_adapter.rs` | 4 | `metrics-rs` feature flag adapter: `MetricsRsRecorder` bridges `MetricsRecorder` → `metrics` crate global registry. See `docs/telemetry.md` for recipe. |
 | `migrations/` | 1 | SQL -- run with `diesel migration run` |

--- a/autumn-harvest-cli/src/lib.rs
+++ b/autumn-harvest-cli/src/lib.rs
@@ -274,6 +274,34 @@ enum WorkflowCommand {
         /// Registered query name.
         query_name: String,
     },
+    /// Send a synchronous update request to a running workflow.
+    Update {
+        /// Workflow execution ID.
+        execution_id: String,
+        /// Registered update handler name.
+        update_name: String,
+        /// Inline JSON input for the update handler.
+        #[arg(long, conflicts_with = "input_file")]
+        input_json: Option<String>,
+        /// File containing JSON input. Use `-` for stdin.
+        #[arg(long, value_name = "PATH", conflicts_with = "input_json")]
+        input_file: Option<PathBuf>,
+        /// How long to wait for the result.
+        /// `admitted` — return immediately after durable admission (202).
+        /// `completed` — block until the handler returns (default).
+        #[arg(long, value_name = "MODE", default_value = "completed")]
+        wait: String,
+        /// Timeout in seconds when `--wait completed` (default: 30).
+        #[arg(long, value_name = "SECS")]
+        timeout_secs: Option<u64>,
+    },
+    /// Look up the durable result of a previously admitted update.
+    UpdateResult {
+        /// Workflow execution ID.
+        execution_id: String,
+        /// Update ID returned by a prior `harvest workflow update` call.
+        update_id: String,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -657,6 +685,45 @@ fn workflow_request(command: &WorkflowCommand) -> Result<ApiRequest, CliError> {
             "/workflows/{}/query/{}",
             path_segment(execution_id),
             path_segment(query_name)
+        ))),
+        WorkflowCommand::Update {
+            execution_id,
+            update_name,
+            input_json,
+            input_file,
+            wait,
+            timeout_secs,
+        } => {
+            let input =
+                parse_json_source(input_json.as_deref(), input_file.as_deref(), "update input")?
+                    .unwrap_or(serde_json::Value::Null);
+            let path = timeout_secs.map_or_else(
+                || {
+                    format!(
+                        "/workflows/{}/update/{}?wait={}",
+                        path_segment(execution_id),
+                        path_segment(update_name),
+                        wait,
+                    )
+                },
+                |secs| {
+                    format!(
+                        "/workflows/{}/update/{}?wait={}&timeout_secs={secs}",
+                        path_segment(execution_id),
+                        path_segment(update_name),
+                        wait,
+                    )
+                },
+            );
+            Ok(ApiRequest::post(path, Some(json!({ "input": input }))))
+        }
+        WorkflowCommand::UpdateResult {
+            execution_id,
+            update_id,
+        } => Ok(ApiRequest::get(format!(
+            "/workflows/{}/update/{}/result",
+            path_segment(execution_id),
+            path_segment(update_id),
         ))),
     }
 }

--- a/autumn-harvest-cli/tests/request_mapping.rs
+++ b/autumn-harvest-cli/tests/request_mapping.rs
@@ -331,6 +331,78 @@ fn dlq_bulk_replay_with_all_filters_maps_correctly() {
 }
 
 #[test]
+fn workflow_update_maps_to_post_with_wait_query() {
+    let cli = Cli::try_parse_from([
+        "harvest",
+        "workflow",
+        "update",
+        "00000000-0000-0000-0000-000000000001",
+        "approve",
+        "--input-json",
+        r#"{"approved":true}"#,
+    ])
+    .expect("workflow update args should parse");
+    let request = cli.api_request().expect("update request should build");
+
+    assert_eq!(request.method, ApiMethod::Post);
+    assert_eq!(
+        request.path,
+        "/workflows/00000000-0000-0000-0000-000000000001/update/approve?wait=completed"
+    );
+    assert_eq!(request.body, Some(json!({ "input": { "approved": true } })));
+}
+
+#[test]
+fn workflow_update_admitted_mode_sets_wait_query_param() {
+    let cli = Cli::try_parse_from([
+        "harvest",
+        "workflow",
+        "update",
+        "00000000-0000-0000-0000-000000000001",
+        "approve",
+        "--wait",
+        "admitted",
+        "--timeout-secs",
+        "10",
+    ])
+    .expect("workflow update admitted args should parse");
+    let request = cli.api_request().expect("update admitted request should build");
+
+    assert_eq!(request.method, ApiMethod::Post);
+    // wait=admitted is in path; timeout_secs is included too
+    assert!(
+        request.path.contains("wait=admitted"),
+        "path must include wait=admitted: {}",
+        request.path
+    );
+    assert!(
+        request.path.contains("timeout_secs=10"),
+        "path must include timeout_secs=10: {}",
+        request.path
+    );
+}
+
+#[test]
+fn workflow_update_result_maps_to_get() {
+    let cli = Cli::try_parse_from([
+        "harvest",
+        "workflow",
+        "update-result",
+        "00000000-0000-0000-0000-000000000001",
+        "aaaaaaaa-bbbb-cccc-dddd-000000000002",
+    ])
+    .expect("workflow update-result args should parse");
+    let request = cli.api_request().expect("update-result request should build");
+
+    assert_eq!(request.method, ApiMethod::Get);
+    assert_eq!(
+        request.path,
+        "/workflows/00000000-0000-0000-0000-000000000001/update/aaaaaaaa-bbbb-cccc-dddd-000000000002/result"
+    );
+    assert_eq!(request.body, None);
+}
+
+#[test]
 fn retention_commands_match_management_routes() {
     let status = Cli::try_parse_from(["harvest", "retention", "status"])
         .expect("retention status args should parse");

--- a/autumn-harvest-cli/tests/request_mapping.rs
+++ b/autumn-harvest-cli/tests/request_mapping.rs
@@ -366,7 +366,9 @@ fn workflow_update_admitted_mode_sets_wait_query_param() {
         "10",
     ])
     .expect("workflow update admitted args should parse");
-    let request = cli.api_request().expect("update admitted request should build");
+    let request = cli
+        .api_request()
+        .expect("update admitted request should build");
 
     assert_eq!(request.method, ApiMethod::Post);
     // wait=admitted is in path; timeout_secs is included too
@@ -392,7 +394,9 @@ fn workflow_update_result_maps_to_get() {
         "aaaaaaaa-bbbb-cccc-dddd-000000000002",
     ])
     .expect("workflow update-result args should parse");
-    let request = cli.api_request().expect("update-result request should build");
+    let request = cli
+        .api_request()
+        .expect("update-result request should build");
 
     assert_eq!(request.method, ApiMethod::Get);
     assert_eq!(

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -40,12 +40,15 @@ use autumn_harvest::shard::ShardRouter;
 use autumn_harvest::signal;
 use autumn_harvest::store;
 use autumn_harvest::telemetry::{ATTR_EXECUTION_ID, ATTR_QUEUE, ATTR_SHARD_ID, ATTR_WORKFLOW_ID};
-use autumn_harvest::types::{ExecutionId, ExternalActivityToken, ShardId, WorkflowIdReusePolicy};
+use autumn_harvest::types::{
+    ExecutionId, ExternalActivityToken, ShardId, UpdateId, WorkflowIdReusePolicy,
+};
 use autumn_harvest::worker::{DbPool, HandlerRegistry};
 use autumn_harvest::workers::{
     FleetHealth, WorkerFilters, WorkerRow, fleet_health, get_worker, list_workers,
     parse_worker_filters,
 };
+use autumn_harvest::{HistoryMatch, HistoryMatcher, WorkflowEvent};
 use autumn_harvest::{
     StartWorkflowParams, cancel_workflow_execution, start_or_load_workflow_execution,
 };
@@ -420,6 +423,12 @@ pub fn harvest_api_router(api_state: HarvestApiState) -> Router<AppState> {
             post(signal_workflow),
         )
         .route("/workflows/{id}/query/{query_name}", get(query_workflow))
+        // Update primitive (issue #140): synchronous request/response into a running workflow.
+        .route("/workflows/{id}/update/{update_name}", post(admit_update))
+        .route(
+            "/workflows/{id}/update/{update_id}/result",
+            get(get_update_result),
+        )
         .route("/dags", get(list_dags))
         .route("/dags/{dag_name}/runs", get(list_dag_runs))
         .route("/dags/{dag_name}/trigger", post(trigger_dag_run))
@@ -1745,7 +1754,9 @@ fn parse_uuid(raw: &str, label: &str) -> Result<uuid::Uuid, AutumnError> {
 
 pub(crate) fn map_error(error: HarvestError) -> AutumnError {
     match error {
-        HarvestError::NotFound(message) => AutumnError::not_found_msg(message),
+        HarvestError::NotFound(message) | HarvestError::UpdateHandlerNotFound(message) => {
+            AutumnError::not_found_msg(message)
+        }
         HarvestError::Config(message)
         | HarvestError::NonDeterministic(message)
         | HarvestError::Cancelled(message)
@@ -1753,6 +1764,9 @@ pub(crate) fn map_error(error: HarvestError) -> AutumnError {
             name: _,
             reason: message,
         } => AutumnError::bad_request_msg(message),
+        HarvestError::UpdateRejected { reason } => {
+            AutumnError::bad_request_msg(reason).with_status(axum::http::StatusCode::CONFLICT)
+        }
         HarvestError::AlreadyExists {
             existing_exec_id,
             existing_state,
@@ -1994,6 +2008,266 @@ async fn workers_health(
 /// Parse worker query-string parameters, mapping errors to `400 Bad Request`.
 fn parse_worker_filters_api(pairs: &[(String, String)]) -> Result<WorkerFilters, AutumnError> {
     parse_worker_filters(pairs).map_err(AutumnError::bad_request_msg)
+}
+
+// ---------------------------------------------------------------------------
+// Update primitive (issue #140)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct AdmitUpdateRequest {
+    #[serde(default)]
+    input: Value,
+}
+
+#[derive(Debug, Deserialize)]
+struct AdmitUpdateQuery {
+    /// Controls how long to wait for a result.
+    /// `"admitted"` — return 202 as soon as the event is durably written.
+    /// `"completed"` (default) — block until the handler returns or the timeout fires.
+    wait: Option<String>,
+    /// Wall-clock timeout in seconds for `wait=completed` mode. Default: 30.
+    timeout_secs: Option<u64>,
+}
+
+#[derive(Debug, Serialize)]
+struct UpdateAdmittedResponse {
+    update_id: String,
+}
+
+#[derive(Debug, Serialize)]
+struct UpdateCompletedResponse {
+    update_id: String,
+    output: Value,
+}
+
+#[derive(Debug, Serialize)]
+struct UpdateFailedResponse {
+    update_id: String,
+    error: String,
+}
+
+/// `POST /workflows/{id}/update/{update_name}`
+///
+/// Durably appends an `UpdateAdmitted` event for the named handler, wakes the
+/// workflow worker, then either returns immediately (`?wait=admitted`) or polls
+/// for the terminal `UpdateCompleted`/`UpdateFailed` event (`?wait=completed`,
+/// the default) until the configurable timeout fires.
+async fn admit_update(
+    Extension(api_state): Extension<HarvestApiState>,
+    Path((id, update_name)): Path<(String, String)>,
+    Query(query): Query<AdmitUpdateQuery>,
+    Json(request): Json<AdmitUpdateRequest>,
+) -> axum::response::Response {
+    use axum::response::IntoResponse as _;
+
+    let exec_id = match parse_execution_id(&id) {
+        Ok(id) => id,
+        Err(e) => return e.into_response(),
+    };
+    let mut conn = match db_conn_for_execution(&api_state, exec_id).await {
+        Ok(c) => c,
+        Err(e) => return e.into_response(),
+    };
+
+    // Reject if the workflow is not RUNNING.
+    let execution = match load_execution(&mut conn, exec_id).await {
+        Ok(e) => e,
+        Err(e) => return map_error(e).into_response(),
+    };
+    if execution.state != "RUNNING" {
+        return (
+            axum::http::StatusCode::CONFLICT,
+            Json(serde_json::json!({
+                "error": format!(
+                    "workflow {} is not RUNNING (state: {})",
+                    exec_id, execution.state
+                )
+            })),
+        )
+            .into_response();
+    }
+
+    let update_id = UpdateId::new();
+
+    // Load history to determine the next sequential event_id.
+    let history = match store::load_history(&mut conn, exec_id).await {
+        Ok(h) => h,
+        Err(e) => return map_error(e).into_response(),
+    };
+    let next_event_id = history.next_event_id;
+
+    // Durably append the UpdateAdmitted event.
+    let admitted_event = WorkflowEvent::UpdateAdmitted {
+        update_id,
+        name: update_name.clone(),
+        input: request.input.clone(),
+        timestamp: chrono::Utc::now(),
+    };
+    if let Err(e) = store::append_events(&mut conn, exec_id, &[admitted_event], next_event_id).await
+    {
+        return map_error(e).into_response();
+    }
+
+    // Wake the workflow worker so it picks up the new admitted update.
+    if let Err(e) = queue::wake_workflow_task(&mut conn, exec_id).await {
+        return map_error(e).into_response();
+    }
+
+    // Return immediately if the caller only wanted durable admission.
+    let wait_mode = query.wait.as_deref().unwrap_or("completed");
+    if wait_mode == "admitted" {
+        return (
+            axum::http::StatusCode::ACCEPTED,
+            Json(UpdateAdmittedResponse {
+                update_id: update_id.to_string(),
+            }),
+        )
+            .into_response();
+    }
+
+    let timeout_secs = query.timeout_secs.unwrap_or(30);
+    let pool = match api_state.storage_pool() {
+        Ok(p) => p,
+        Err(e) => return map_error(e).into_response(),
+    };
+    poll_update_result(&pool, exec_id, update_id, timeout_secs).await
+}
+
+/// Poll history until `update_id` resolves to `UpdateCompleted`/`UpdateFailed`
+/// or the wall-clock `timeout_secs` elapses (→ 504 Gateway Timeout).
+async fn poll_update_result(
+    pool: &HarvestDbPool,
+    exec_id: ExecutionId,
+    update_id: UpdateId,
+    timeout_secs: u64,
+) -> axum::response::Response {
+    use axum::response::IntoResponse as _;
+
+    let poll_interval = Duration::from_millis(300);
+
+    let poll_result = tokio::time::timeout(Duration::from_secs(timeout_secs), async {
+        loop {
+            let mut c = pool
+                .pool_for_execution(exec_id)
+                .get()
+                .await
+                .map_err(|e| HarvestError::Database(e.to_string()))?;
+            let h = store::load_history(&mut c, exec_id).await?;
+            match HistoryMatcher::new(h.events).match_update(update_id) {
+                HistoryMatch::Matched { output } => {
+                    return Ok::<_, HarvestError>((true, output, String::new()));
+                }
+                HistoryMatch::Failed { error, .. } => {
+                    return Ok((false, Value::Null, error));
+                }
+                _ => {
+                    tokio::time::sleep(poll_interval).await;
+                }
+            }
+        }
+    })
+    .await;
+
+    match poll_result {
+        Ok(Ok((true, output, _))) => (
+            axum::http::StatusCode::OK,
+            Json(UpdateCompletedResponse {
+                update_id: update_id.to_string(),
+                output,
+            }),
+        )
+            .into_response(),
+        Ok(Ok((false, _, error))) => (
+            axum::http::StatusCode::CONFLICT,
+            Json(UpdateFailedResponse {
+                update_id: update_id.to_string(),
+                error,
+            }),
+        )
+            .into_response(),
+        Ok(Err(e)) => map_error(e).into_response(),
+        Err(_timeout) => (
+            axum::http::StatusCode::GATEWAY_TIMEOUT,
+            Json(serde_json::json!({
+                "update_id": update_id.to_string(),
+                "message": format!("update did not complete within {timeout_secs}s"),
+            })),
+        )
+            .into_response(),
+    }
+}
+
+/// `GET /workflows/{id}/update/{update_id}/result`
+///
+/// Look up the durable result of a previously admitted update by its
+/// `update_id`. Returns:
+/// - `200 OK` with `output` if the handler completed successfully.
+/// - `409 Conflict` with `error` if the handler failed or the update was rejected.
+/// - `202 Accepted` if the update is still in-flight.
+/// - `404 Not Found` if no `UpdateAdmitted` event exists for the given ID.
+async fn get_update_result(
+    Extension(api_state): Extension<HarvestApiState>,
+    Path((id, update_id_str)): Path<(String, String)>,
+) -> axum::response::Response {
+    use axum::response::IntoResponse as _;
+
+    let exec_id = match parse_execution_id(&id) {
+        Ok(id) => id,
+        Err(e) => return e.into_response(),
+    };
+    let update_id: UpdateId = match update_id_str.parse() {
+        Ok(id) => id,
+        Err(_) => {
+            return AutumnError::bad_request_msg(format!("invalid update id '{update_id_str}'"))
+                .into_response();
+        }
+    };
+
+    let mut conn = match db_conn_for_execution(&api_state, exec_id).await {
+        Ok(c) => c,
+        Err(e) => return e.into_response(),
+    };
+
+    let history = match store::load_history(&mut conn, exec_id).await {
+        Ok(h) => h,
+        Err(e) => return map_error(e).into_response(),
+    };
+
+    // Confirm the update was ever admitted.
+    let admitted = history.events.iter().any(
+        |ev| matches!(ev, WorkflowEvent::UpdateAdmitted { update_id: id, .. } if *id == update_id),
+    );
+    if !admitted {
+        return AutumnError::not_found_msg(format!("update {update_id_str}")).into_response();
+    }
+
+    let matcher = HistoryMatcher::new(history.events);
+    match matcher.match_update(update_id) {
+        HistoryMatch::Matched { output } => (
+            axum::http::StatusCode::OK,
+            Json(UpdateCompletedResponse {
+                update_id: update_id.to_string(),
+                output,
+            }),
+        )
+            .into_response(),
+        HistoryMatch::Failed { error, .. } => (
+            axum::http::StatusCode::CONFLICT,
+            Json(UpdateFailedResponse {
+                update_id: update_id.to_string(),
+                error,
+            }),
+        )
+            .into_response(),
+        _ => (
+            axum::http::StatusCode::ACCEPTED,
+            Json(UpdateAdmittedResponse {
+                update_id: update_id.to_string(),
+            }),
+        )
+            .into_response(),
+    }
 }
 
 #[cfg(test)]

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -2070,29 +2070,13 @@ async fn admit_update(
         Err(e) => return e.into_response(),
     };
 
-    // Reject if the workflow is not RUNNING.
-    let execution = match load_execution(&mut conn, exec_id).await {
-        Ok(e) => e,
-        Err(e) => return map_error(e).into_response(),
-    };
-    if execution.state != "RUNNING" {
-        return (
-            axum::http::StatusCode::CONFLICT,
-            Json(serde_json::json!({
-                "error": format!(
-                    "workflow {} is not RUNNING (state: {})",
-                    exec_id, execution.state
-                )
-            })),
-        )
-            .into_response();
-    }
-
     let update_id = UpdateId::new();
 
-    // Durably append the UpdateAdmitted event using the serialised helper so
-    // concurrent appenders (workflow executor, other API calls) cannot race to
-    // claim the same event_id.
+    // Durably append the UpdateAdmitted event inside a FOR UPDATE transaction
+    // that also verifies the execution is still RUNNING.  Doing the state check
+    // and the insert under the same row-level lock prevents a TOCTOU race where
+    // the workflow could complete between a separate state read and the insert.
+    // UpdateRejected is returned if the execution is no longer RUNNING.
     if let Err(e) = store::admit_update_event(
         &mut conn,
         exec_id,
@@ -2144,22 +2128,24 @@ async fn poll_update_result(
 
     let poll_result = tokio::time::timeout(Duration::from_secs(timeout_secs), async {
         loop {
-            let mut c = pool
-                .pool_for_execution(exec_id)
-                .get()
-                .await
-                .map_err(|e| HarvestError::Database(e.to_string()))?;
-            let h = store::load_history(&mut c, exec_id).await?;
-            match HistoryMatcher::new(h.events).match_update(update_id) {
-                HistoryMatch::Matched { output } => {
-                    return Ok::<_, HarvestError>((true, output, String::new()));
+            let result = {
+                // Scope the connection so it is returned to the pool before sleeping.
+                let mut c = pool
+                    .pool_for_execution(exec_id)
+                    .get()
+                    .await
+                    .map_err(|e| HarvestError::Database(e.to_string()))?;
+                let h = store::load_history(&mut c, exec_id).await?;
+                // c is dropped here, releasing the connection back to the pool.
+                match HistoryMatcher::new(h.events).match_update(update_id) {
+                    HistoryMatch::Matched { output } => Some(Ok((true, output, String::new()))),
+                    HistoryMatch::Failed { error, .. } => Some(Ok((false, Value::Null, error))),
+                    _ => None,
                 }
-                HistoryMatch::Failed { error, .. } => {
-                    return Ok((false, Value::Null, error));
-                }
-                _ => {
-                    tokio::time::sleep(poll_interval).await;
-                }
+            };
+            match result {
+                Some(v) => return v,
+                None => tokio::time::sleep(poll_interval).await,
             }
         }
     })

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -2090,21 +2090,17 @@ async fn admit_update(
 
     let update_id = UpdateId::new();
 
-    // Load history to determine the next sequential event_id.
-    let history = match store::load_history(&mut conn, exec_id).await {
-        Ok(h) => h,
-        Err(e) => return map_error(e).into_response(),
-    };
-    let next_event_id = history.next_event_id;
-
-    // Durably append the UpdateAdmitted event.
-    let admitted_event = WorkflowEvent::UpdateAdmitted {
+    // Durably append the UpdateAdmitted event using the serialised helper so
+    // concurrent appenders (workflow executor, other API calls) cannot race to
+    // claim the same event_id.
+    if let Err(e) = store::admit_update_event(
+        &mut conn,
+        exec_id,
         update_id,
-        name: update_name.clone(),
-        input: request.input.clone(),
-        timestamp: chrono::Utc::now(),
-    };
-    if let Err(e) = store::append_events(&mut conn, exec_id, &[admitted_event], next_event_id).await
+        update_name.clone(),
+        request.input,
+    )
+    .await
     {
         return map_error(e).into_response();
     }

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -20,7 +20,8 @@ use crate::error::{HarvestError, HarvestResult};
 use crate::event::WorkflowEvent;
 use crate::query::QueryRegistry;
 use crate::replay::{HistoryMatch, HistoryMatcher};
-use crate::types::{ActivityExecId, ExecutionId, ExternalActivityToken, TimerId};
+use crate::types::{ActivityExecId, ExecutionId, ExternalActivityToken, TimerId, UpdateId};
+use crate::update::{BoxUpdateHandler, BoxUpdateValidator, UpdateRegistry};
 
 /// Runtime map of typed shared state registered on the harvest builder.
 pub type SharedStateMap = HashMap<TypeId, Box<dyn Any + Send + Sync>>;
@@ -308,6 +309,9 @@ pub struct WorkflowContext {
     state: SharedState,
     /// In-memory query handlers (not persisted to history).
     query_registry: Mutex<QueryRegistry>,
+    /// In-memory update handlers and their validators (not persisted to history).
+    /// Registration is idempotent — the first registration wins on each replay.
+    update_registry: Mutex<UpdateRegistry>,
     /// Cancellation reason captured from a `WorkflowCancelled` event in history,
     /// if any. When set, `is_cancelled()` returns true and `check_cancellation()`
     /// yields [`HarvestError::Cancelled`]. Cooperative: the workflow function is
@@ -386,6 +390,7 @@ impl WorkflowContext {
             activity_seq: Mutex::new(0),
             state,
             query_registry: Mutex::new(QueryRegistry::new()),
+            update_registry: Mutex::new(UpdateRegistry::new()),
             cancellation_reason,
             strict_replay: false,
         }
@@ -447,6 +452,7 @@ impl WorkflowContext {
             activity_seq: Mutex::new(0),
             state: empty_shared_state(),
             query_registry: Mutex::new(QueryRegistry::new()),
+            update_registry: Mutex::new(UpdateRegistry::new()),
             cancellation_reason: None,
             strict_replay: false,
         }
@@ -1412,6 +1418,143 @@ impl WorkflowContext {
             || Err(HarvestError::NotFound(format!("query handler '{name}'"))),
             |h| Ok(h()),
         )
+    }
+
+    // ── Update handlers ───────────────────────────────────────────────
+
+    /// Register a typed update handler with an optional validator.
+    ///
+    /// The `validator` runs synchronously before the update is admitted to
+    /// history. A rejected update writes **no event** and the caller receives
+    /// the rejection reason. The `handler` is an async closure that mutates
+    /// workflow state and returns a typed result.
+    ///
+    /// Registration is **idempotent** — calling this with the same `name`
+    /// multiple times (e.g., on every replay cycle at the top of the workflow
+    /// function) is a no-op after the first call.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal update registry mutex is poisoned.
+    pub fn register_update_handler<V, H, F>(&self, name: &str, validator: V, handler: H)
+    where
+        V: Fn(&Value) -> Result<(), String> + Send + Sync + 'static,
+        H: Fn(Value) -> F + Send + Sync + 'static,
+        F: std::future::Future<Output = Result<Value, String>> + Send + 'static,
+    {
+        let boxed_validator: BoxUpdateValidator = Arc::new(validator);
+        let boxed_handler: BoxUpdateHandler = Arc::new(move |input| Box::pin(handler(input)));
+        self.update_registry
+            .lock()
+            .expect("update_registry lock poisoned")
+            .register(name, Some(boxed_validator), boxed_handler);
+    }
+
+    /// Register an update handler with no validator (always admitted).
+    ///
+    /// Equivalent to [`register_update_handler`](Self::register_update_handler)
+    /// with a validator that always returns `Ok(())`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal update registry mutex is poisoned.
+    pub fn register_update_handler_no_validator<H, F>(&self, name: &str, handler: H)
+    where
+        H: Fn(Value) -> F + Send + Sync + 'static,
+        F: std::future::Future<Output = Result<Value, String>> + Send + 'static,
+    {
+        let boxed_handler: BoxUpdateHandler = Arc::new(move |input| Box::pin(handler(input)));
+        self.update_registry
+            .lock()
+            .expect("update_registry lock poisoned")
+            .register(name, None, boxed_handler);
+    }
+
+    /// Validate an incoming update without admitting it.
+    ///
+    /// - Returns `Ok(())` if the handler exists and the validator accepts.
+    /// - Returns [`HarvestError::UpdateHandlerNotFound`] if no handler is registered.
+    /// - Returns [`HarvestError::UpdateRejected`] if the validator rejects.
+    ///
+    /// **No event is appended** — the caller is responsible for appending
+    /// `UpdateAdmitted` only when this returns `Ok(())`.
+    ///
+    /// # Errors
+    ///
+    /// - Returns [`HarvestError::UpdateHandlerNotFound`] if no handler is registered under `name`.
+    /// - Returns [`HarvestError::UpdateRejected`] if the validator rejects `input`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal update registry mutex is poisoned.
+    pub fn validate_update(&self, name: &str, input: &Value) -> HarvestResult<()> {
+        self.update_registry
+            .lock()
+            .expect("update_registry lock poisoned")
+            .validate(name, input)
+            .map_err(|reason| {
+                if reason.ends_with("not found") {
+                    HarvestError::UpdateHandlerNotFound(name.to_string())
+                } else {
+                    HarvestError::UpdateRejected { reason }
+                }
+            })
+    }
+
+    /// Execute an already-admitted update by `update_id`.
+    ///
+    /// Call this **after** the `UpdateAdmitted` event has been durably appended
+    /// to `harvest_events`. The method:
+    ///
+    /// - In **replay mode**: returns the recorded `UpdateCompleted` output or
+    ///   `UpdateFailed` error without re-running the handler.
+    /// - In **live mode** (no completion in history): runs the registered
+    ///   handler and returns its result. The caller is responsible for
+    ///   appending `UpdateCompleted` or `UpdateFailed` to history.
+    ///
+    /// Returns `Err(String)` matching the handler error on failure.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err("update handler 'name' not found")` if no handler is
+    /// registered under `name`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal update registry or matcher mutex is poisoned.
+    pub async fn execute_admitted_update(
+        &self,
+        update_id: UpdateId,
+        name: &str,
+        input: Value,
+    ) -> Result<Value, String> {
+        // Check history first (replay path).
+        let history_match = self.match_history(|m| m.match_update(update_id));
+
+        match history_match {
+            HistoryMatch::Matched { output } => return Ok(output),
+            HistoryMatch::Failed { error, .. } => return Err(error),
+            HistoryMatch::NoMatch => {} // live path — run the handler
+            other => {
+                return Err(format!(
+                    "unexpected history match for update '{name}': {other:?}"
+                ));
+            }
+        }
+
+        // Live path: invoke the registered handler.
+        let future = {
+            let registry = self
+                .update_registry
+                .lock()
+                .expect("update_registry lock poisoned");
+            registry.invoke(name, input)
+        };
+
+        match future {
+            Some(fut) => fut.await,
+            None => Err(format!("update handler '{name}' not found")),
+        }
     }
 
     // ── Command drain ─────────────────────────────────────────────────

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -1488,17 +1488,18 @@ impl WorkflowContext {
     ///
     /// Panics if the internal update registry mutex is poisoned.
     pub fn validate_update(&self, name: &str, input: &Value) -> HarvestResult<()> {
-        self.update_registry
+        let registry = self
+            .update_registry
             .lock()
-            .expect("update_registry lock poisoned")
+            .expect("update_registry lock poisoned");
+        // Check existence structurally so validator errors are never confused
+        // with a missing handler, regardless of the error message text.
+        if !registry.contains(name) {
+            return Err(HarvestError::UpdateHandlerNotFound(name.to_string()));
+        }
+        registry
             .validate(name, input)
-            .map_err(|reason| {
-                if reason.ends_with("not found") {
-                    HarvestError::UpdateHandlerNotFound(name.to_string())
-                } else {
-                    HarvestError::UpdateRejected { reason }
-                }
-            })
+            .map_err(|reason| HarvestError::UpdateRejected { reason })
     }
 
     /// Execute an already-admitted update by `update_id`.

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -188,6 +188,18 @@ pub enum WorkflowCommand {
         /// The worker sends the final result (success or exhausted retries) here.
         result_tx: oneshot::Sender<Result<Value, String>>,
     },
+    /// Record a terminal result for an admitted update.
+    ///
+    /// Pushed by [`WorkflowContext::execute_admitted_update`] in live mode so
+    /// the worker can durably append `UpdateCompleted` or `UpdateFailed` to the
+    /// event history before persisting any other side effects from the same
+    /// execution cycle.
+    RecordUpdateResult {
+        /// The update whose result is being recorded.
+        update_id: crate::types::UpdateId,
+        /// `Ok(value)` on success; `Err(reason)` when the handler returned an error.
+        result: Result<Value, String>,
+    },
 }
 
 // Manual Debug because oneshot::Sender is not Debug.
@@ -266,6 +278,14 @@ impl std::fmt::Debug for WorkflowCommand {
                 .field("name", name)
                 .field("start_to_close_secs", start_to_close_secs)
                 .finish_non_exhaustive(),
+            Self::RecordUpdateResult { update_id, result } => f
+                .debug_struct("RecordUpdateResult")
+                .field("update_id", update_id)
+                .field(
+                    "result",
+                    &result.as_ref().map(|_| "<output>").map_err(String::as_str),
+                )
+                .finish(),
         }
     }
 }
@@ -1552,10 +1572,19 @@ impl WorkflowContext {
             registry.invoke(name, input)
         };
 
-        match future {
+        let result = match future {
             Some(fut) => fut.await,
             None => Err(format!("update handler '{name}' not found")),
-        }
+        };
+
+        // Durably record the terminal result so the worker can append
+        // UpdateCompleted/UpdateFailed before persisting other side effects.
+        self.push_command(WorkflowCommand::RecordUpdateResult {
+            update_id,
+            result: result.clone(),
+        });
+
+        result
     }
 
     // ── Command drain ─────────────────────────────────────────────────

--- a/autumn-harvest/src/error.rs
+++ b/autumn-harvest/src/error.rs
@@ -141,6 +141,23 @@ pub enum HarvestError {
         /// The state of the conflicting prior run (e.g. `"RUNNING"`, `"COMPLETED"`).
         existing_state: String,
     },
+
+    /// An update request was rejected by the handler's validator before being
+    /// admitted to the workflow's event history.
+    ///
+    /// No event is written to `harvest_events`. The caller receives the reason
+    /// string and should surface it as a `409 Conflict` or `400 Bad Request`.
+    #[error("update rejected: {reason}")]
+    UpdateRejected {
+        /// Human-readable rejection reason returned by the validator.
+        reason: String,
+    },
+
+    /// No update handler is registered under the given name.
+    ///
+    /// Surfaces as `404 Not Found` at the management API layer.
+    #[error("update handler not found: {0}")]
+    UpdateHandlerNotFound(String),
 }
 
 /// Standard result type for internal harvest engine operations.

--- a/autumn-harvest/src/event.rs
+++ b/autumn-harvest/src/event.rs
@@ -12,7 +12,9 @@ use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 
 use crate::error::TimeoutType;
-use crate::types::{ActivityExecId, ExecutionId, ExternalActivityToken, TimerId, WorkerId};
+use crate::types::{
+    ActivityExecId, ExecutionId, ExternalActivityToken, TimerId, UpdateId, WorkerId,
+};
 
 /// All possible events in a workflow's history.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -241,6 +243,38 @@ pub enum WorkflowEvent {
         /// Token of the activity whose deadline was extended.
         token: ExternalActivityToken,
     },
+
+    // ── Updates (issue #140) ──────────────────────────────────────────────
+    /// An update request passed its validator and was durably admitted into
+    /// the workflow's event history. The `update_id` correlates with the
+    /// paired `UpdateCompleted` or `UpdateFailed` event.
+    ///
+    /// Validator failures leave **no trace** in history — only admitted updates
+    /// produce this event.
+    UpdateAdmitted {
+        /// Unique ID for this update invocation. Stable across worker restarts.
+        update_id: UpdateId,
+        /// The name of the registered update handler.
+        name: String,
+        /// JSON payload delivered with the update request.
+        input: serde_json::Value,
+        /// Time when the update was admitted.
+        timestamp: DateTime<Utc>,
+    },
+    /// The update handler ran to completion and returned a value.
+    UpdateCompleted {
+        /// Unique ID matching the corresponding `UpdateAdmitted`.
+        update_id: UpdateId,
+        /// The JSON result returned by the update handler.
+        output: serde_json::Value,
+    },
+    /// The update handler returned an error.
+    UpdateFailed {
+        /// Unique ID matching the corresponding `UpdateAdmitted`.
+        update_id: UpdateId,
+        /// String representation of the handler error.
+        error: String,
+    },
 }
 
 impl WorkflowEvent {
@@ -274,6 +308,9 @@ impl WorkflowEvent {
             Self::ActivityCompletedExternally { .. } => "ActivityCompletedExternally",
             Self::ActivityFailedExternally { .. } => "ActivityFailedExternally",
             Self::ActivityExternalDeadlineExtended { .. } => "ActivityExternalDeadlineExtended",
+            Self::UpdateAdmitted { .. } => "UpdateAdmitted",
+            Self::UpdateCompleted { .. } => "UpdateCompleted",
+            Self::UpdateFailed { .. } => "UpdateFailed",
         }
     }
 
@@ -484,10 +521,24 @@ mod tests {
                 error: "transient".into(),
                 attempt: 1,
             },
+            WorkflowEvent::UpdateAdmitted {
+                update_id: crate::types::UpdateId::new(),
+                name: "approve".into(),
+                input: serde_json::Value::Null,
+                timestamp: Utc::now(),
+            },
+            WorkflowEvent::UpdateCompleted {
+                update_id: crate::types::UpdateId::new(),
+                output: serde_json::Value::Null,
+            },
+            WorkflowEvent::UpdateFailed {
+                update_id: crate::types::UpdateId::new(),
+                error: "x".into(),
+            },
         ];
 
-        assert_eq!(events.len(), 25);
+        assert_eq!(events.len(), 28);
         let names: HashSet<_> = events.iter().map(WorkflowEvent::type_name).collect();
-        assert_eq!(names.len(), 25, "duplicate type names detected");
+        assert_eq!(names.len(), 28, "duplicate type names detected");
     }
 }

--- a/autumn-harvest/src/executor.rs
+++ b/autumn-harvest/src/executor.rs
@@ -90,7 +90,7 @@ pub async fn run_workflow(
     handler: WorkflowHandlerFn,
     input: Value,
 ) -> WorkflowOutcome {
-    let (outcome, _span) =
+    let (outcome, _pending, _span) =
         run_workflow_with_state(exec_id, history, handler, input, empty_shared_state(), None).await;
     outcome
 }
@@ -161,11 +161,18 @@ pub async fn run_workflow_strict(
 
 /// Run a workflow function through replay and live execution with shared state.
 ///
-/// Returns the outcome paired with a [`tracing::Span`] handle for the
-/// `harvest.workflow.execute` span.  The caller should hold the handle alive
-/// while persisting producer-side side-effects (activity schedules, child
-/// workflow starts) so that those producer spans can be correctly parented to
-/// this executor cycle.  Dropping the handle closes the span.
+/// Returns a triple of `(outcome, pending_commands, span_handle)`:
+/// - `outcome`: the workflow's terminal or suspended state.
+/// - `pending_commands`: commands emitted during a `Completed` or `Failed` run
+///   that the worker must persist before recording the terminal event. This is
+///   non-empty only when the workflow invoked `execute_admitted_update` in live
+///   mode — the `RecordUpdateResult` commands must be appended to history before
+///   `WorkflowCompleted`/`WorkflowFailed`. For `Suspended` outcomes the commands
+///   are already carried inside the variant; this Vec will be empty.
+/// - `span_handle`: the open `harvest.workflow.execute` span. The caller should
+///   hold it alive while persisting producer-side side-effects (activity
+///   schedules, child workflow starts) so those producer spans are nested inside
+///   the executor cycle. Dropping the handle closes the span.
 pub async fn run_workflow_with_state(
     exec_id: ExecutionId,
     history: Vec<WorkflowEvent>,
@@ -173,7 +180,7 @@ pub async fn run_workflow_with_state(
     input: Value,
     state: SharedState,
     span_meta: Option<&WorkflowExecuteSpanMeta>,
-) -> (WorkflowOutcome, tracing::Span) {
+) -> (WorkflowOutcome, Vec<WorkflowCommand>, tracing::Span) {
     let ctx = WorkflowContext::for_replay_with_state(exec_id, history, state);
 
     // ADR-0001 §2.1: emit harvest.workflow.execute for every executor cycle.
@@ -210,19 +217,24 @@ pub async fn run_workflow_with_state(
     // the instrumented future has already completed.
     let span_handle = span.clone();
 
-    let outcome = async {
+    let (outcome, pending) = async {
         // Run the handler with a timeout. If it completes, we get the result.
         // If it blocks on a oneshot (suspended), the timeout fires and we drain
         // the accumulated commands.
         let timeout_result = tokio::time::timeout(SUSPENSION_TIMEOUT, handler(&ctx, input)).await;
 
         match timeout_result {
-            // Handler completed within the timeout window.
-            Ok(Ok(output)) => WorkflowOutcome::Completed { output },
-            Ok(Err(error)) => WorkflowOutcome::Failed { error },
+            // Handler completed within the timeout window.  Drain any commands
+            // emitted during live execution (e.g. RecordUpdateResult from
+            // execute_admitted_update) so the worker can persist them before the
+            // terminal WorkflowCompleted/WorkflowFailed event.
+            Ok(Ok(output)) => (WorkflowOutcome::Completed { output }, ctx.drain_commands()),
+            Ok(Err(error)) => (WorkflowOutcome::Failed { error }, ctx.drain_commands()),
 
             // Timeout elapsed -- the handler is suspended on a oneshot channel.
-            // Drain the commands it emitted before suspending.
+            // Drain the commands it emitted before suspending. RecordUpdateResult
+            // commands emitted in this cycle are included in the commands list and
+            // will be handled by the worker alongside the suspension side-effects.
             Err(_elapsed) => {
                 let mut commands = ctx.drain_commands();
                 // ContinueAsNew is terminal: when the workflow body parks on
@@ -236,16 +248,16 @@ pub async fn run_workflow_with_state(
                     .rposition(|cmd| matches!(cmd, WorkflowCommand::ContinueAsNew { .. }))
                     && let WorkflowCommand::ContinueAsNew { input } = commands.swap_remove(idx)
                 {
-                    return WorkflowOutcome::ContinuedAsNew { input };
+                    return (WorkflowOutcome::ContinuedAsNew { input }, vec![]);
                 }
-                WorkflowOutcome::Suspended { commands }
+                (WorkflowOutcome::Suspended { commands }, vec![])
             }
         }
     }
     .instrument(span)
     .await;
 
-    (outcome, span_handle)
+    (outcome, pending, span_handle)
 }
 
 // ---------------------------------------------------------------------------

--- a/autumn-harvest/src/history_export.rs
+++ b/autumn-harvest/src/history_export.rs
@@ -77,6 +77,11 @@ impl MermaidExporter {
                 | WorkflowEvent::LocalActivityFailed { .. } => {
                     self.handle_local_activity_event(event)?;
                 }
+                WorkflowEvent::UpdateAdmitted { .. }
+                | WorkflowEvent::UpdateCompleted { .. }
+                | WorkflowEvent::UpdateFailed { .. } => {
+                    self.handle_update_event(event)?;
+                }
             }
         }
         Ok(())
@@ -331,6 +336,34 @@ impl MermaidExporter {
                 writeln!(
                     self.out,
                     "    Note right of WF: Deadline Extended (token: {token})"
+                )?;
+            }
+            _ => unreachable!(),
+        }
+        Ok(())
+    }
+
+    fn handle_update_event(&mut self, event: &WorkflowEvent) -> Result<(), std::fmt::Error> {
+        match event {
+            WorkflowEvent::UpdateAdmitted {
+                update_id, name, ..
+            } => {
+                writeln!(
+                    self.out,
+                    "    Note over WF: Update Admitted: {name} (id: {update_id})"
+                )?;
+            }
+            WorkflowEvent::UpdateCompleted { update_id, .. } => {
+                writeln!(
+                    self.out,
+                    "    Note over WF: Update Completed (id: {update_id})"
+                )?;
+            }
+            WorkflowEvent::UpdateFailed { update_id, error } => {
+                let safe_error = error.replace('\n', " ").replace('"', "'");
+                writeln!(
+                    self.out,
+                    "    Note over WF: Update Failed (id: {update_id}): {safe_error}"
                 )?;
             }
             _ => unreachable!(),

--- a/autumn-harvest/src/lib.rs
+++ b/autumn-harvest/src/lib.rs
@@ -66,6 +66,7 @@ pub mod test_generator;
 #[cfg(any(test, feature = "testing"))]
 pub mod testing;
 pub mod types;
+pub mod update;
 
 #[cfg(feature = "db")]
 #[doc(hidden)]
@@ -159,9 +160,10 @@ pub use testing::{
     HistorySnapshot, NonDeterminismKind, ReplayReport, ReplayStatus, WorkflowReplayer,
 };
 pub use types::{
-    ActivityExecId, ExecutionId, ExternalActivityToken, ShardId, TimerId, WorkerId, WorkflowId,
-    WorkflowIdReusePolicy,
+    ActivityExecId, ExecutionId, ExternalActivityToken, ShardId, TimerId, UpdateId, WorkerId,
+    WorkflowId, WorkflowIdReusePolicy,
 };
+pub use update::UpdateRegistry;
 
 #[cfg(feature = "db")]
 pub use store::EventHistory;

--- a/autumn-harvest/src/replay.rs
+++ b/autumn-harvest/src/replay.rs
@@ -14,7 +14,7 @@ use std::collections::{HashSet, VecDeque};
 
 use crate::error::TimeoutType;
 use crate::event::WorkflowEvent;
-use crate::types::{ActivityExecId, ExecutionId, ExternalActivityToken};
+use crate::types::{ActivityExecId, ExecutionId, ExternalActivityToken, UpdateId};
 
 /// Result of matching a workflow command against the event history.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -108,6 +108,20 @@ impl HistoryMatcher {
         self.pending_signals.push_back((signal_name, payload));
     }
 
+    /// Returns `true` for the three update event variants.
+    ///
+    /// Update events are transparent to the main workflow replay sequence —
+    /// they are skipped during activity/timer/signal/child-workflow matching
+    /// and are consumed by the `match_update` / `drain_admitted_updates` APIs.
+    const fn is_update_event(event: &WorkflowEvent) -> bool {
+        matches!(
+            event,
+            WorkflowEvent::UpdateAdmitted { .. }
+                | WorkflowEvent::UpdateCompleted { .. }
+                | WorkflowEvent::UpdateFailed { .. }
+        )
+    }
+
     /// Format the `actual` field for a [`HistoryMatch::Diverged`] result.
     ///
     /// When the unexpected event is a `MarkerRecorded` its name is included so
@@ -190,8 +204,7 @@ impl HistoryMatcher {
         }
     }
 
-    /// Drain any `SignalReceived` events at the current cursor into
-    /// `pending_signals`.
+    /// Drain any `SignalReceived` and update events at the current cursor.
     ///
     /// Signals can be ingested into history at any point (when the worker
     /// picks up a task), so they may appear before an `ActivityScheduled`,
@@ -199,20 +212,30 @@ impl HistoryMatcher {
     /// workflow code only calls `wait_for_signal` later.  This helper
     /// buffers those early signals so the normal matcher methods do not
     /// mis-report them as non-determinism.
+    ///
+    /// Update events (`UpdateAdmitted`, `UpdateCompleted`, `UpdateFailed`) are
+    /// also transparent to the main workflow replay sequence and are consumed
+    /// here so they don't cause spurious `Diverged` results in `prepare_match`.
     fn drain_early_signals(&mut self) {
         while self.cursor < self.events.len() {
-            if let WorkflowEvent::SignalReceived {
-                signal_name,
-                payload,
-            } = &self.events[self.cursor]
-            {
-                let signal_name = signal_name.clone();
-                let payload = payload.clone();
-                self.stash_signal(self.cursor, signal_name, payload);
-                self.cursor += 1;
-                self.advance_to_next_unconsumed_event();
-            } else {
-                break;
+            match &self.events[self.cursor] {
+                WorkflowEvent::SignalReceived {
+                    signal_name,
+                    payload,
+                } => {
+                    let signal_name = signal_name.clone();
+                    let payload = payload.clone();
+                    self.stash_signal(self.cursor, signal_name, payload);
+                    self.cursor += 1;
+                    self.advance_to_next_unconsumed_event();
+                }
+                ev if Self::is_update_event(ev) => {
+                    // Consume the update event so it doesn't block the cursor.
+                    self.consumed_signal_events.insert(self.cursor);
+                    self.cursor += 1;
+                    self.advance_to_next_unconsumed_event();
+                }
+                _ => break,
             }
         }
     }
@@ -361,6 +384,10 @@ impl HistoryMatcher {
                     self.stash_signal(scan_cursor, signal_name, payload);
                     scan_cursor += 1;
                 }
+                // Update events are transparent to the activity scan.
+                ev if Self::is_update_event(ev) => {
+                    scan_cursor += 1;
+                }
                 // Any other event type is unexpected mid-activity
                 _ => break,
             }
@@ -487,6 +514,9 @@ impl HistoryMatcher {
                     self.stash_signal(scan_cursor, signal_name, payload);
                     scan_cursor += 1;
                 }
+                ev if Self::is_update_event(ev) => {
+                    scan_cursor += 1;
+                }
                 _ => break,
             }
         }
@@ -609,6 +639,10 @@ impl HistoryMatcher {
                 } if *id == activity_id => {
                     scan_cursor += 1;
                 }
+                // Update events are transparent to the external activity scan.
+                ev if Self::is_update_event(ev) => {
+                    scan_cursor += 1;
+                }
                 _ => break,
             }
         }
@@ -688,6 +722,12 @@ impl HistoryMatcher {
                 continue;
             }
 
+            // Update events are transparent to the timer scan.
+            if Self::is_update_event(&self.events[scan_cursor]) {
+                scan_cursor += 1;
+                continue;
+            }
+
             break;
         }
 
@@ -739,6 +779,10 @@ impl HistoryMatcher {
                     let recorded_name = recorded_name.clone();
                     let payload = payload.clone();
                     self.stash_signal(scan_cursor, recorded_name, payload);
+                    scan_cursor += 1;
+                }
+                ev if Self::is_update_event(ev) => {
+                    // Update events are transparent to signal scanning.
                     scan_cursor += 1;
                 }
                 other => {
@@ -975,6 +1019,9 @@ impl HistoryMatcher {
                     self.stash_signal(scan_cursor, signal_name, payload);
                     scan_cursor += 1;
                 }
+                ev if Self::is_update_event(ev) => {
+                    scan_cursor += 1;
+                }
                 _ => break,
             }
         }
@@ -1073,6 +1120,9 @@ impl HistoryMatcher {
                     self.stash_signal(scan_cursor, signal_name, payload);
                     scan_cursor += 1;
                 }
+                ev if Self::is_update_event(ev) => {
+                    scan_cursor += 1;
+                }
                 _ => break,
             }
         }
@@ -1116,6 +1166,87 @@ impl HistoryMatcher {
             // this version gate. Don't advance cursor.
             _ => min_version,
         }
+    }
+
+    // ── Update primitive (issue #140) ─────────────────────────────────────
+
+    /// Look up the recorded result for a specific update by `update_id`.
+    ///
+    /// Unlike the cursor-based activity/timer/signal matching methods, this
+    /// performs a full-history scan keyed by `update_id`. It does **not**
+    /// advance the cursor — update events are managed independently of the
+    /// main workflow replay sequence.
+    ///
+    /// Returns:
+    /// - [`HistoryMatch::Matched`] if `UpdateCompleted` with the given ID is found.
+    /// - [`HistoryMatch::Failed`] if `UpdateFailed` with the given ID is found.
+    /// - [`HistoryMatch::NoMatch`] if only `UpdateAdmitted` exists (in-flight) or
+    ///   if the ID is entirely unknown.
+    #[must_use]
+    pub fn match_update(&self, update_id: UpdateId) -> HistoryMatch {
+        for event in &self.events {
+            match event {
+                WorkflowEvent::UpdateCompleted {
+                    update_id: id,
+                    output,
+                } if *id == update_id => {
+                    return HistoryMatch::Matched {
+                        output: output.clone(),
+                    };
+                }
+                WorkflowEvent::UpdateFailed {
+                    update_id: id,
+                    error,
+                } if *id == update_id => {
+                    return HistoryMatch::Failed {
+                        error: error.clone(),
+                        attempt: 1,
+                    };
+                }
+                _ => {}
+            }
+        }
+        HistoryMatch::NoMatch
+    }
+
+    /// Return all `UpdateAdmitted` events that do not have a paired
+    /// `UpdateCompleted` or `UpdateFailed` event in history.
+    ///
+    /// The worker calls this on restart to discover in-flight updates that
+    /// must be re-dispatched to their registered handlers.
+    ///
+    /// Returns a `Vec` of `(update_id, handler_name, input)` tuples.
+    #[must_use]
+    pub fn drain_admitted_updates(&self) -> Vec<(UpdateId, String, Value)> {
+        // Collect IDs of completed/failed updates.
+        let mut resolved: std::collections::HashSet<UpdateId> = std::collections::HashSet::new();
+        for event in &self.events {
+            match event {
+                WorkflowEvent::UpdateCompleted { update_id, .. }
+                | WorkflowEvent::UpdateFailed { update_id, .. } => {
+                    resolved.insert(*update_id);
+                }
+                _ => {}
+            }
+        }
+
+        // Return admitted updates that are not yet resolved.
+        self.events
+            .iter()
+            .filter_map(|event| {
+                if let WorkflowEvent::UpdateAdmitted {
+                    update_id,
+                    name,
+                    input,
+                    ..
+                } = event
+                    && !resolved.contains(update_id)
+                {
+                    return Some((*update_id, name.clone(), input.clone()));
+                }
+                None
+            })
+            .collect()
     }
 }
 

--- a/autumn-harvest/src/simulator.rs
+++ b/autumn-harvest/src/simulator.rs
@@ -109,7 +109,7 @@ impl WorkflowSimulator {
         }];
 
         loop {
-            let (outcome, _span) = run_workflow_with_state(
+            let (outcome, _pending, _span) = run_workflow_with_state(
                 exec_id,
                 history.clone(),
                 self.handler,

--- a/autumn-harvest/src/store.rs
+++ b/autumn-harvest/src/store.rs
@@ -156,14 +156,18 @@ pub async fn append_single_event(
 
 /// Durably admit an update into a workflow's event history.
 ///
-/// Wraps [`append_single_event`] in a transaction that acquires a row-level
-/// lock on the workflow execution row, ensuring concurrent admission calls
-/// (e.g. management API + timeout scanner) cannot race to claim the same
-/// `event_id`.
+/// Opens a transaction, acquires a row-level `FOR UPDATE` lock on the
+/// execution row, verifies the execution is still `RUNNING`, reads
+/// `MAX(event_id)`, and then appends the `UpdateAdmitted` event.  Doing
+/// the state check and the insert inside the same lock ensures that a
+/// concurrent state transition (e.g. `RUNNING → COMPLETED` from the worker)
+/// is fully visible before admission proceeds.
 ///
 /// # Errors
 ///
 /// Returns [`crate::error::HarvestError::NotFound`] if `exec_id` does not exist.
+/// Returns [`crate::error::HarvestError::UpdateRejected`] if the execution is
+/// not in the `RUNNING` state.
 /// Returns [`crate::error::HarvestError::Database`] on query or insert failure.
 pub async fn admit_update_event(
     conn: &mut AsyncPgConnection,
@@ -172,15 +176,52 @@ pub async fn admit_update_event(
     name: String,
     input: serde_json::Value,
 ) -> HarvestResult<()> {
+    use crate::models::WorkflowExecution;
+    use crate::schema::harvest_workflow_executions;
+    use diesel::dsl::max;
+
     conn.transaction::<(), crate::error::HarvestError, _>(|conn| {
         async move {
+            // Acquire a row-level lock so concurrent appenders serialize their
+            // MAX(event_id) + INSERT pairs and the state check is consistent.
+            let execution: WorkflowExecution = harvest_workflow_executions::table
+                .find(exec_id.as_uuid())
+                .for_update()
+                .select(WorkflowExecution::as_select())
+                .first(conn)
+                .await
+                .optional()
+                .map_err(crate::error::database_error)?
+                .ok_or_else(|| {
+                    crate::error::HarvestError::NotFound(format!("workflow execution {exec_id}"))
+                })?;
+
+            // Reject the update if the execution is no longer running.
+            if execution.state != "RUNNING" {
+                return Err(crate::error::HarvestError::UpdateRejected {
+                    reason: format!(
+                        "workflow {exec_id} is not RUNNING (state: {})",
+                        execution.state
+                    ),
+                });
+            }
+
+            let max_id: Option<i32> = harvest_events::table
+                .filter(harvest_events::workflow_exec_id.eq(exec_id.as_uuid()))
+                .select(max(harvest_events::event_id))
+                .first(conn)
+                .await
+                .map_err(crate::error::database_error)?;
+
+            let next_id = max_id.map_or(0, |id| id.saturating_add(1));
             let event = WorkflowEvent::UpdateAdmitted {
                 update_id,
                 name,
                 input,
                 timestamp: chrono::Utc::now(),
             };
-            append_single_event(conn, exec_id, event).await
+            append_events(conn, exec_id, &[event], next_id).await?;
+            Ok(())
         }
         .scope_boxed()
     })

--- a/autumn-harvest/src/store.rs
+++ b/autumn-harvest/src/store.rs
@@ -8,8 +8,10 @@ use diesel::ExpressionMethods;
 use diesel::OptionalExtension;
 use diesel::QueryDsl;
 use diesel::SelectableHelper;
+use diesel_async::AsyncConnection;
 use diesel_async::AsyncPgConnection;
 use diesel_async::RunQueryDsl;
+use scoped_futures::ScopedFutureExt as _;
 
 use crate::error::HarvestResult;
 use crate::event::WorkflowEvent;
@@ -150,6 +152,39 @@ pub async fn append_single_event(
     let next_id = max_id.map_or(0, |id| id.saturating_add(1));
     append_events(conn, exec_id, &[event], next_id).await?;
     Ok(())
+}
+
+/// Durably admit an update into a workflow's event history.
+///
+/// Wraps [`append_single_event`] in a transaction that acquires a row-level
+/// lock on the workflow execution row, ensuring concurrent admission calls
+/// (e.g. management API + timeout scanner) cannot race to claim the same
+/// `event_id`.
+///
+/// # Errors
+///
+/// Returns [`crate::error::HarvestError::NotFound`] if `exec_id` does not exist.
+/// Returns [`crate::error::HarvestError::Database`] on query or insert failure.
+pub async fn admit_update_event(
+    conn: &mut AsyncPgConnection,
+    exec_id: ExecutionId,
+    update_id: crate::types::UpdateId,
+    name: String,
+    input: serde_json::Value,
+) -> HarvestResult<()> {
+    conn.transaction::<(), crate::error::HarvestError, _>(|conn| {
+        async move {
+            let event = WorkflowEvent::UpdateAdmitted {
+                update_id,
+                name,
+                input,
+                timestamp: chrono::Utc::now(),
+            };
+            append_single_event(conn, exec_id, event).await
+        }
+        .scope_boxed()
+    })
+    .await
 }
 
 /// Load the full event history for a workflow execution, ordered by `event_id`.

--- a/autumn-harvest/src/types.rs
+++ b/autumn-harvest/src/types.rs
@@ -342,6 +342,62 @@ impl FromStr for ActivityExecId {
     }
 }
 
+/// Unique identifier for a single workflow update invocation.
+///
+/// Generated when an update request is admitted (validator passed) and embedded
+/// in the `UpdateAdmitted`, `UpdateCompleted`, and `UpdateFailed` events so the
+/// result can be looked up by any worker after a restart.
+///
+/// ## Examples
+///
+/// ```rust
+/// use autumn_harvest::types::UpdateId;
+///
+/// let id = UpdateId::new();
+/// assert!(!id.as_uuid().is_nil());
+/// ```
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct UpdateId(Uuid);
+
+impl UpdateId {
+    /// Creates a new, random `UpdateId` using a v4 UUID.
+    #[must_use]
+    pub fn new() -> Self {
+        Self(Uuid::new_v4())
+    }
+
+    /// Returns the underlying `Uuid`.
+    #[must_use]
+    pub const fn as_uuid(&self) -> Uuid {
+        self.0
+    }
+
+    /// Wraps an existing `Uuid` as an `UpdateId`.
+    #[must_use]
+    pub const fn from_uuid(id: Uuid) -> Self {
+        Self(id)
+    }
+}
+
+impl Default for UpdateId {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl fmt::Display for UpdateId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl FromStr for UpdateId {
+    type Err = uuid::Error;
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Uuid::parse_str(s).map(Self)
+    }
+}
+
 /// Opaque single-use token that uniquely identifies a pending external activity.
 ///
 /// The token is embedded in the `ActivityAwaitingExternal` event when a workflow

--- a/autumn-harvest/src/update.rs
+++ b/autumn-harvest/src/update.rs
@@ -1,0 +1,95 @@
+//! Update handler registry for the workflow Update primitive (issue #140).
+//!
+//! An `UpdateRegistry` stores type-erased validators and async handlers keyed
+//! by name. Registration is idempotent — calling `register` twice for the same
+//! name is a no-op, making it safe to call at the top of every `#[workflow]`
+//! function on each replay cycle.
+
+use std::collections::HashMap;
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::Arc;
+
+use serde_json::Value;
+
+/// Pinned boxed async future returned by an update handler invocation.
+pub type UpdateHandlerFuture = Pin<Box<dyn Future<Output = Result<Value, String>> + Send>>;
+
+/// Type-erased async update handler: takes JSON input, returns JSON result or string error.
+pub type BoxUpdateHandler = Arc<dyn Fn(Value) -> UpdateHandlerFuture + Send + Sync>;
+
+/// Type-erased synchronous validator: takes JSON input, returns Ok or a rejection reason.
+pub type BoxUpdateValidator = Arc<dyn Fn(&Value) -> Result<(), String> + Send + Sync>;
+
+/// An entry in the update registry.
+struct UpdateEntry {
+    validator: Option<BoxUpdateValidator>,
+    handler: BoxUpdateHandler,
+}
+
+/// In-memory registry of update handlers and their optional validators.
+///
+/// Stored on [`WorkflowContext`](crate::context::WorkflowContext) behind a
+/// `Mutex`. Registration is idempotent — the first registration wins and
+/// subsequent calls with the same `name` are ignored.
+#[derive(Default)]
+pub struct UpdateRegistry {
+    entries: HashMap<String, UpdateEntry>,
+}
+
+impl UpdateRegistry {
+    /// Create an empty registry.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            entries: HashMap::new(),
+        }
+    }
+
+    /// Register a handler (and optional validator) under `name`.
+    ///
+    /// If `name` is already registered, this is a no-op (first registration wins).
+    pub fn register(
+        &mut self,
+        name: &str,
+        validator: Option<BoxUpdateValidator>,
+        handler: BoxUpdateHandler,
+    ) {
+        // Idempotent: first registration wins.
+        self.entries
+            .entry(name.to_string())
+            .or_insert(UpdateEntry { validator, handler });
+    }
+
+    /// Returns `true` if a handler is registered under `name`.
+    #[must_use]
+    pub fn contains(&self, name: &str) -> bool {
+        self.entries.contains_key(name)
+    }
+
+    /// Run the validator for `name` against `input`.
+    ///
+    /// # Errors
+    ///
+    /// - Returns `Err("update handler 'name' not found")` if `name` is unknown.
+    /// - Returns `Err(reason)` if the validator rejects.
+    pub fn validate(&self, name: &str, input: &Value) -> Result<(), String> {
+        let entry = self
+            .entries
+            .get(name)
+            .ok_or_else(|| format!("update handler '{name}' not found"))?;
+
+        if let Some(validator) = &entry.validator {
+            validator(input)?;
+        }
+        Ok(())
+    }
+
+    /// Invoke the handler for `name` with `input`.
+    ///
+    /// Returns `None` if `name` is not registered.
+    #[must_use]
+    pub fn invoke(&self, name: &str, input: Value) -> Option<UpdateHandlerFuture> {
+        self.entries.get(name).map(|e| (e.handler)(input))
+    }
+}

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -262,6 +262,7 @@ const fn workflow_command_name(command: &WorkflowCommand) -> &'static str {
         WorkflowCommand::Fail { .. } => "Fail",
         WorkflowCommand::ContinueAsNew { .. } => "ContinueAsNew",
         WorkflowCommand::RunLocalActivity { .. } => "RunLocalActivity",
+        WorkflowCommand::RecordUpdateResult { .. } => "RecordUpdateResult",
     }
 }
 
@@ -297,14 +298,18 @@ fn should_requeue_signal_wait(commands: &[WorkflowCommand]) -> bool {
     let has_wait = commands
         .iter()
         .any(|cmd| matches!(cmd, WorkflowCommand::WaitForSignal { .. }));
-    let only_wait_or_marker = commands.iter().all(|cmd| {
+    // RecordUpdateResult commands are bookkeeping already handled before this
+    // check; they don't affect the signal-wait decision.
+    let only_wait_or_bookkeeping = commands.iter().all(|cmd| {
         matches!(
             cmd,
-            WorkflowCommand::WaitForSignal { .. } | WorkflowCommand::RecordMarker { .. }
+            WorkflowCommand::WaitForSignal { .. }
+                | WorkflowCommand::RecordMarker { .. }
+                | WorkflowCommand::RecordUpdateResult { .. }
         )
     });
 
-    has_wait && only_wait_or_marker
+    has_wait && only_wait_or_bookkeeping
 }
 
 #[derive(Debug, Clone)]
@@ -400,9 +405,15 @@ fn extract_single_command<T>(
     commands: &[WorkflowCommand],
     extractor: impl Fn(&WorkflowCommand) -> Option<T>,
 ) -> Option<T> {
-    let mut iter = commands
-        .iter()
-        .filter(|cmd| !matches!(cmd, WorkflowCommand::RecordMarker { .. }));
+    // RecordUpdateResult and RecordMarker are bookkeeping commands that have
+    // already been (or are about to be) persisted; they do not count toward
+    // the suspension-type determination.
+    let mut iter = commands.iter().filter(|cmd| {
+        !matches!(
+            cmd,
+            WorkflowCommand::RecordMarker { .. } | WorkflowCommand::RecordUpdateResult { .. }
+        )
+    });
 
     let first_cmd = iter.next()?;
 
@@ -457,15 +468,21 @@ fn extract_single_started_timer(commands: &[WorkflowCommand]) -> Option<StartedT
     })
 }
 
-/// Extract all `StartChildWorkflow` commands when every non-marker command is
+/// Extract all `StartChildWorkflow` commands when every non-bookkeeping command is
 /// a child-workflow start.  Returns `Some(children)` (may have length > 1 for
-/// parallel spawns) or `None` if any non-marker command is of a different type.
+/// parallel spawns) or `None` if any non-bookkeeping command is of a different type.
+/// `RecordMarker` and `RecordUpdateResult` are considered bookkeeping and ignored.
 fn extract_all_started_child_workflows(
     commands: &[WorkflowCommand],
 ) -> Option<Vec<StartedChildWorkflowCommand>> {
     let non_markers: Vec<&WorkflowCommand> = commands
         .iter()
-        .filter(|c| !matches!(c, WorkflowCommand::RecordMarker { .. }))
+        .filter(|c| {
+            !matches!(
+                c,
+                WorkflowCommand::RecordMarker { .. } | WorkflowCommand::RecordUpdateResult { .. }
+            )
+        })
         .collect();
 
     if non_markers.is_empty() {
@@ -948,6 +965,44 @@ async fn persist_workflow_failure(
         .scope_boxed()
     })
     .await
+}
+
+/// Append `UpdateCompleted` or `UpdateFailed` events for each
+/// `RecordUpdateResult` command in `commands`, in order.
+///
+/// Used to durably record in-flight update results before the terminal workflow
+/// event (`WorkflowCompleted`, `WorkflowFailed`, or a suspension side-effect).
+/// `next_event_id` is advanced by the number of events written.
+async fn persist_update_result_commands(
+    conn: &mut AsyncPgConnection,
+    exec_id: ExecutionId,
+    commands: &[WorkflowCommand],
+    next_event_id: &mut i32,
+) -> HarvestResult<()> {
+    let events: Vec<WorkflowEvent> = commands
+        .iter()
+        .filter_map(|cmd| match cmd {
+            WorkflowCommand::RecordUpdateResult { update_id, result } => Some(match result {
+                Ok(output) => WorkflowEvent::UpdateCompleted {
+                    update_id: *update_id,
+                    output: output.clone(),
+                },
+                Err(error) => WorkflowEvent::UpdateFailed {
+                    update_id: *update_id,
+                    error: error.clone(),
+                },
+            }),
+            _ => None,
+        })
+        .collect();
+
+    if events.is_empty() {
+        return Ok(());
+    }
+
+    store::append_events(conn, exec_id, &events, *next_event_id).await?;
+    *next_event_id = next_event_id.saturating_add(i32::try_from(events.len()).unwrap_or(i32::MAX));
+    Ok(())
 }
 
 async fn persist_signal_wait_park(
@@ -1902,9 +1957,29 @@ async fn persist_scheduled_external_activity(
 async fn handle_suspended_workflow(
     conn: &mut AsyncPgConnection,
     registry: &HandlerRegistry,
-    context: SuspendedWorkflowContext<'_>,
+    mut context: SuspendedWorkflowContext<'_>,
     commands: &[WorkflowCommand],
 ) -> HarvestResult<()> {
+    // Persist UpdateCompleted/UpdateFailed events for any update handlers that
+    // ran in this execution cycle before the suspension side-effects.
+    // next_event_id is advanced so subsequent persist calls use correct IDs.
+    if let Err(e) = persist_update_result_commands(
+        conn,
+        context.persistence.exec_id,
+        commands,
+        &mut context.persistence.next_event_id,
+    )
+    .await
+    {
+        return fail_execution_on_error(
+            conn,
+            context.persistence.task,
+            context.persistence.worker_id,
+            Err(e),
+        )
+        .await;
+    }
+
     let sticky = context.persistence.sticky_hint();
 
     if should_requeue_signal_wait(commands) {
@@ -2438,7 +2513,7 @@ async fn process_workflow_task(
                 .and_then(|c| c.link_traceparent.clone().or_else(|| c.traceparent.clone())),
         };
 
-        let (run_outcome, execute_span) = run_workflow_with_state(
+        let (run_outcome, pending_cmds, execute_span) = run_workflow_with_state(
             prepared.exec_id,
             history_events.clone(),
             workflow.handler,
@@ -2470,11 +2545,11 @@ async fn process_workflow_task(
                 .await?;
                 history_events.extend(new_events);
             }
-            other => break (other, execute_span),
+            other => break (other, pending_cmds, execute_span),
         }
     };
 
-    let (outcome, execute_span) = loop_result;
+    let (outcome, pending_cmds, execute_span) = loop_result;
 
     let status = match &outcome {
         WorkflowOutcome::Completed { .. } => WorkflowStatus::Completed,
@@ -2488,6 +2563,16 @@ async fn process_workflow_task(
         started_at.elapsed().as_secs_f64(),
         status,
     );
+
+    // Append UpdateCompleted/UpdateFailed events for any update handlers that
+    // ran during this live execution cycle before the terminal event.  For
+    // Suspended outcomes these commands are inside the variant and are handled
+    // inside handle_suspended_workflow; pending_cmds is only non-empty for
+    // Completed/Failed outcomes.
+    if !pending_cmds.is_empty() {
+        persist_update_result_commands(conn, prepared.exec_id, &pending_cmds, &mut next_event_id)
+            .await?;
+    }
 
     persist_workflow_outcome(
         conn,

--- a/autumn-harvest/tests/update_tests.rs
+++ b/autumn-harvest/tests/update_tests.rs
@@ -3,7 +3,7 @@
 //! Covers: event serde, UpdateId, UpdateRegistry, WorkflowContext
 //! registration/validation/dispatch, and HistoryMatcher update replay.
 
-#![cfg(any(test, feature = "testing"))]
+#![cfg(feature = "testing")]
 
 use autumn_harvest::context::WorkflowContext;
 use autumn_harvest::event::WorkflowEvent;

--- a/autumn-harvest/tests/update_tests.rs
+++ b/autumn-harvest/tests/update_tests.rs
@@ -1,0 +1,587 @@
+//! Tests for the Update primitive (issue #140).
+//!
+//! Covers: event serde, UpdateId, UpdateRegistry, WorkflowContext
+//! registration/validation/dispatch, and HistoryMatcher update replay.
+
+#![cfg(any(test, feature = "testing"))]
+
+use autumn_harvest::context::WorkflowContext;
+use autumn_harvest::event::WorkflowEvent;
+use autumn_harvest::types::{ExecutionId, UpdateId};
+use chrono::Utc;
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+fn make_admitted_history(update_id: UpdateId, name: &str) -> Vec<WorkflowEvent> {
+    vec![
+        WorkflowEvent::WorkflowStarted {
+            input: serde_json::json!({}),
+            timestamp: Utc::now(),
+        },
+        WorkflowEvent::UpdateAdmitted {
+            update_id,
+            name: name.to_string(),
+            input: serde_json::json!({"amount": 100}),
+            timestamp: Utc::now(),
+        },
+    ]
+}
+
+fn make_completed_history(update_id: UpdateId, name: &str) -> Vec<WorkflowEvent> {
+    let mut events = make_admitted_history(update_id, name);
+    events.push(WorkflowEvent::UpdateCompleted {
+        update_id,
+        output: serde_json::json!({"approved": true}),
+    });
+    events
+}
+
+fn make_failed_history(update_id: UpdateId, name: &str) -> Vec<WorkflowEvent> {
+    let mut events = make_admitted_history(update_id, name);
+    events.push(WorkflowEvent::UpdateFailed {
+        update_id,
+        error: "insufficient funds".to_string(),
+    });
+    events
+}
+
+// ── Event serde round-trips ────────────────────────────────────────────────
+
+#[test]
+fn update_admitted_round_trips_serde() {
+    let id = UpdateId::new();
+    let event = WorkflowEvent::UpdateAdmitted {
+        update_id: id,
+        name: "approve".to_string(),
+        input: serde_json::json!({"amount": 50}),
+        timestamp: Utc::now(),
+    };
+    let json = serde_json::to_string(&event).expect("serialize");
+    let back: WorkflowEvent = serde_json::from_str(&json).expect("deserialize");
+    assert!(matches!(back, WorkflowEvent::UpdateAdmitted { .. }));
+    // Adjacently-tagged: {"type":"UpdateAdmitted","data":{...}}
+    assert!(json.contains("\"type\":\"UpdateAdmitted\""));
+}
+
+#[test]
+fn update_completed_round_trips_serde() {
+    let id = UpdateId::new();
+    let event = WorkflowEvent::UpdateCompleted {
+        update_id: id,
+        output: serde_json::json!({"ok": true}),
+    };
+    let json = serde_json::to_string(&event).expect("serialize");
+    let back: WorkflowEvent = serde_json::from_str(&json).expect("deserialize");
+    assert!(matches!(back, WorkflowEvent::UpdateCompleted { .. }));
+    assert!(json.contains("\"type\":\"UpdateCompleted\""));
+}
+
+#[test]
+fn update_failed_round_trips_serde() {
+    let id = UpdateId::new();
+    let event = WorkflowEvent::UpdateFailed {
+        update_id: id,
+        error: "bad input".to_string(),
+    };
+    let json = serde_json::to_string(&event).expect("serialize");
+    let back: WorkflowEvent = serde_json::from_str(&json).expect("deserialize");
+    assert!(
+        matches!(back, WorkflowEvent::UpdateFailed { error, .. } if error == "bad input"),
+        "error field should round-trip"
+    );
+}
+
+#[test]
+fn update_event_type_names_are_stable() {
+    let id = UpdateId::new();
+    assert_eq!(
+        WorkflowEvent::UpdateAdmitted {
+            update_id: id,
+            name: "x".to_string(),
+            input: serde_json::Value::Null,
+            timestamp: Utc::now(),
+        }
+        .type_name(),
+        "UpdateAdmitted"
+    );
+    assert_eq!(
+        WorkflowEvent::UpdateCompleted {
+            update_id: id,
+            output: serde_json::Value::Null,
+        }
+        .type_name(),
+        "UpdateCompleted"
+    );
+    assert_eq!(
+        WorkflowEvent::UpdateFailed {
+            update_id: id,
+            error: "x".to_string(),
+        }
+        .type_name(),
+        "UpdateFailed"
+    );
+}
+
+// ── UpdateId type ─────────────────────────────────────────────────────────
+
+#[test]
+fn update_id_new_is_unique() {
+    let a = UpdateId::new();
+    let b = UpdateId::new();
+    assert_ne!(a, b);
+}
+
+#[test]
+fn update_id_serde_round_trip() {
+    let id = UpdateId::new();
+    let json = serde_json::to_string(&id).expect("serialize");
+    let back: UpdateId = serde_json::from_str(&json).expect("deserialize");
+    assert_eq!(id, back);
+}
+
+#[test]
+fn update_id_display_is_uuid() {
+    let id = UpdateId::new();
+    let s = id.to_string();
+    // UUID format: 8-4-4-4-12 hex chars
+    assert_eq!(s.len(), 36);
+    assert_eq!(s.chars().filter(|&c| c == '-').count(), 4);
+}
+
+// ── register_update_handler ────────────────────────────────────────────────
+
+#[test]
+fn register_update_handler_is_idempotent() {
+    let ctx = WorkflowContext::new_test();
+    // Registering twice must not panic or error
+    ctx.register_update_handler(
+        "approve",
+        |_input: &serde_json::Value| -> Result<(), String> { Ok(()) },
+        |_input: serde_json::Value| async move {
+            Ok::<serde_json::Value, String>(serde_json::json!({"ok": true}))
+        },
+    );
+    ctx.register_update_handler(
+        "approve",
+        |_input: &serde_json::Value| -> Result<(), String> { Ok(()) },
+        |_input: serde_json::Value| async move {
+            Ok::<serde_json::Value, String>(serde_json::json!({"ok": true}))
+        },
+    );
+    // No panic = pass
+}
+
+#[test]
+fn register_update_handler_emits_no_commands() {
+    let ctx = WorkflowContext::new_test();
+    ctx.register_update_handler(
+        "approve",
+        |_input: &serde_json::Value| -> Result<(), String> { Ok(()) },
+        |_input: serde_json::Value| async move {
+            Ok::<serde_json::Value, String>(serde_json::json!({}))
+        },
+    );
+    let cmds = ctx.drain_commands();
+    assert!(cmds.is_empty(), "registration must not emit any commands");
+}
+
+// ── validate_update ────────────────────────────────────────────────────────
+
+#[test]
+fn validate_update_no_handler_returns_not_found() {
+    let ctx = WorkflowContext::new_test();
+    let result = ctx.validate_update("approve", &serde_json::json!({}));
+    assert!(
+        result.is_err(),
+        "should error when no handler is registered"
+    );
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.to_lowercase().contains("not found")
+            || err_msg.to_lowercase().contains("no handler")
+            || err_msg.to_lowercase().contains("approve"),
+        "error should mention the missing handler or 'not found', got: {err_msg}"
+    );
+}
+
+#[test]
+fn validate_update_passes_when_validator_accepts() {
+    let ctx = WorkflowContext::new_test();
+    ctx.register_update_handler(
+        "approve",
+        |input: &serde_json::Value| -> Result<(), String> {
+            if input["amount"].as_i64().unwrap_or(0) > 0 {
+                Ok(())
+            } else {
+                Err("amount must be positive".to_string())
+            }
+        },
+        |_input: serde_json::Value| async move {
+            Ok::<serde_json::Value, String>(serde_json::json!({}))
+        },
+    );
+    let result = ctx.validate_update("approve", &serde_json::json!({"amount": 100}));
+    assert!(result.is_ok(), "validator should accept positive amount");
+}
+
+#[test]
+fn validate_update_rejected_when_validator_rejects() {
+    let ctx = WorkflowContext::new_test();
+    ctx.register_update_handler(
+        "approve",
+        |input: &serde_json::Value| -> Result<(), String> {
+            if input["amount"].as_i64().unwrap_or(0) > 0 {
+                Ok(())
+            } else {
+                Err("amount must be positive".to_string())
+            }
+        },
+        |_input: serde_json::Value| async move {
+            Ok::<serde_json::Value, String>(serde_json::json!({}))
+        },
+    );
+    let result = ctx.validate_update("approve", &serde_json::json!({"amount": -1}));
+    assert!(result.is_err(), "validator should reject negative amount");
+    let err_msg = result.unwrap_err().to_string();
+    assert!(
+        err_msg.contains("amount must be positive"),
+        "error should contain validator message, got: {err_msg}"
+    );
+}
+
+#[test]
+fn validate_update_passes_when_no_validator_provided() {
+    let ctx = WorkflowContext::new_test();
+    ctx.register_update_handler_no_validator("approve", |_input: serde_json::Value| async move {
+        Ok::<serde_json::Value, String>(serde_json::json!({}))
+    });
+    let result = ctx.validate_update("approve", &serde_json::json!({"anything": true}));
+    assert!(result.is_ok(), "no validator should always accept");
+}
+
+// ── execute_admitted_update ────────────────────────────────────────────────
+
+#[tokio::test]
+async fn execute_admitted_update_runs_handler_in_live_mode() {
+    let ctx = WorkflowContext::new_test();
+    ctx.register_update_handler(
+        "approve",
+        |_: &serde_json::Value| Ok::<(), String>(()),
+        |input: serde_json::Value| async move {
+            let amount = input["amount"].as_i64().unwrap_or(0);
+            Ok::<serde_json::Value, String>(serde_json::json!({"approved": amount > 0}))
+        },
+    );
+    let update_id = UpdateId::new();
+    let result = ctx
+        .execute_admitted_update(update_id, "approve", serde_json::json!({"amount": 50}))
+        .await;
+    assert!(result.is_ok(), "handler should succeed");
+    let output = result.unwrap();
+    assert_eq!(output["approved"], serde_json::json!(true));
+}
+
+#[tokio::test]
+async fn execute_admitted_update_propagates_handler_error() {
+    let ctx = WorkflowContext::new_test();
+    ctx.register_update_handler(
+        "approve",
+        |_: &serde_json::Value| Ok::<(), String>(()),
+        |_input: serde_json::Value| async move {
+            Err::<serde_json::Value, String>("insufficient funds".to_string())
+        },
+    );
+    let update_id = UpdateId::new();
+    let result = ctx
+        .execute_admitted_update(update_id, "approve", serde_json::json!({}))
+        .await;
+    assert!(result.is_err(), "handler error should propagate");
+    assert_eq!(result.unwrap_err(), "insufficient funds");
+}
+
+#[tokio::test]
+async fn execute_admitted_update_replays_completed_result_without_rerunning() {
+    let update_id = UpdateId::new();
+    let exec_id = ExecutionId::new();
+    let history = make_completed_history(update_id, "approve");
+    let ctx = WorkflowContext::for_replay(exec_id, history);
+
+    let mut handler_ran = false;
+    ctx.register_update_handler(
+        "approve",
+        |_: &serde_json::Value| Ok::<(), String>(()),
+        |_input: serde_json::Value| async move {
+            // This should NOT run during replay
+            Ok::<serde_json::Value, String>(serde_json::json!({"handler_ran": true}))
+        },
+    );
+
+    let result = ctx
+        .execute_admitted_update(update_id, "approve", serde_json::json!({"amount": 100}))
+        .await;
+    assert!(result.is_ok());
+    // Should get the recorded output, not the handler's output
+    assert_eq!(result.unwrap()["approved"], serde_json::json!(true));
+    // handler_ran stays false because the closure is a different one; the key assertion
+    // is that the returned value matches the recorded history, not the live handler.
+    let _ = handler_ran; // suppress unused warning
+}
+
+#[tokio::test]
+async fn execute_admitted_update_replays_failed_result_without_rerunning() {
+    let update_id = UpdateId::new();
+    let exec_id = ExecutionId::new();
+    let history = make_failed_history(update_id, "approve");
+    let ctx = WorkflowContext::for_replay(exec_id, history);
+
+    ctx.register_update_handler(
+        "approve",
+        |_: &serde_json::Value| Ok::<(), String>(()),
+        |_input: serde_json::Value| async move {
+            Ok::<serde_json::Value, String>(serde_json::json!({"should_not_run": true}))
+        },
+    );
+
+    let result = ctx
+        .execute_admitted_update(update_id, "approve", serde_json::json!({}))
+        .await;
+    assert!(result.is_err(), "should replay recorded failure");
+    assert_eq!(result.unwrap_err(), "insufficient funds");
+}
+
+// ── HistoryMatcher::match_update ──────────────────────────────────────────
+
+#[test]
+fn history_matcher_finds_update_completed() {
+    use autumn_harvest::replay::{HistoryMatch, HistoryMatcher};
+
+    let update_id = UpdateId::new();
+    let events = vec![
+        WorkflowEvent::WorkflowStarted {
+            input: serde_json::Value::Null,
+            timestamp: Utc::now(),
+        },
+        WorkflowEvent::UpdateAdmitted {
+            update_id,
+            name: "approve".to_string(),
+            input: serde_json::json!({}),
+            timestamp: Utc::now(),
+        },
+        WorkflowEvent::UpdateCompleted {
+            update_id,
+            output: serde_json::json!({"result": 42}),
+        },
+    ];
+
+    let mut matcher = HistoryMatcher::new(events);
+    let result = matcher.match_update(update_id);
+    assert!(
+        matches!(result, HistoryMatch::Matched { .. }),
+        "should find UpdateCompleted"
+    );
+    if let HistoryMatch::Matched { output } = result {
+        assert_eq!(output["result"], 42);
+    }
+}
+
+#[test]
+fn history_matcher_finds_update_failed() {
+    use autumn_harvest::replay::{HistoryMatch, HistoryMatcher};
+
+    let update_id = UpdateId::new();
+    let events = vec![
+        WorkflowEvent::WorkflowStarted {
+            input: serde_json::Value::Null,
+            timestamp: Utc::now(),
+        },
+        WorkflowEvent::UpdateAdmitted {
+            update_id,
+            name: "approve".to_string(),
+            input: serde_json::json!({}),
+            timestamp: Utc::now(),
+        },
+        WorkflowEvent::UpdateFailed {
+            update_id,
+            error: "insufficient funds".to_string(),
+        },
+    ];
+
+    let mut matcher = HistoryMatcher::new(events);
+    let result = matcher.match_update(update_id);
+    assert!(
+        matches!(result, HistoryMatch::Failed { .. }),
+        "should find UpdateFailed"
+    );
+    if let HistoryMatch::Failed { error, .. } = result {
+        assert_eq!(error, "insufficient funds");
+    }
+}
+
+#[test]
+fn history_matcher_returns_no_match_for_admitted_without_completion() {
+    use autumn_harvest::replay::{HistoryMatch, HistoryMatcher};
+
+    let update_id = UpdateId::new();
+    let events = vec![
+        WorkflowEvent::WorkflowStarted {
+            input: serde_json::Value::Null,
+            timestamp: Utc::now(),
+        },
+        WorkflowEvent::UpdateAdmitted {
+            update_id,
+            name: "approve".to_string(),
+            input: serde_json::json!({}),
+            timestamp: Utc::now(),
+        },
+        // No UpdateCompleted or UpdateFailed
+    ];
+
+    let mut matcher = HistoryMatcher::new(events);
+    let result = matcher.match_update(update_id);
+    assert!(
+        matches!(result, HistoryMatch::NoMatch),
+        "admitted-without-completion should be NoMatch"
+    );
+}
+
+#[test]
+fn history_matcher_returns_no_match_for_unknown_update_id() {
+    use autumn_harvest::replay::{HistoryMatch, HistoryMatcher};
+
+    let known_id = UpdateId::new();
+    let unknown_id = UpdateId::new();
+    let events = vec![
+        WorkflowEvent::WorkflowStarted {
+            input: serde_json::Value::Null,
+            timestamp: Utc::now(),
+        },
+        WorkflowEvent::UpdateCompleted {
+            update_id: known_id,
+            output: serde_json::json!({}),
+        },
+    ];
+
+    let mut matcher = HistoryMatcher::new(events);
+    let result = matcher.match_update(unknown_id);
+    assert!(
+        matches!(result, HistoryMatch::NoMatch),
+        "should not find result for different update_id"
+    );
+}
+
+// ── Update events are transparent to activity replay ─────────────────────
+
+#[test]
+fn update_events_do_not_break_activity_replay() {
+    use autumn_harvest::replay::{HistoryMatch, HistoryMatcher};
+    use autumn_harvest::types::ActivityExecId;
+
+    let update_id = UpdateId::new();
+    let activity_id = ActivityExecId::new();
+    // History interleaves an update between an activity scheduled and completed
+    let events = vec![
+        WorkflowEvent::WorkflowStarted {
+            input: serde_json::Value::Null,
+            timestamp: Utc::now(),
+        },
+        WorkflowEvent::ActivityScheduled {
+            activity_id,
+            name: "send_email".to_string(),
+            input: serde_json::json!({}),
+            queue: "default".to_string(),
+        },
+        // An update was admitted and completed while the activity was running
+        WorkflowEvent::UpdateAdmitted {
+            update_id,
+            name: "query_status".to_string(),
+            input: serde_json::json!({}),
+            timestamp: Utc::now(),
+        },
+        WorkflowEvent::UpdateCompleted {
+            update_id,
+            output: serde_json::json!({"status": "running"}),
+        },
+        WorkflowEvent::ActivityCompleted {
+            activity_id,
+            output: serde_json::json!("sent"),
+        },
+    ];
+
+    let mut matcher = HistoryMatcher::new(events);
+    // Skip WorkflowStarted
+    matcher.advance();
+    let result = matcher.match_activity("send_email");
+    assert!(
+        matches!(result, HistoryMatch::Matched { .. }),
+        "activity replay should succeed even with interleaved update events, got: {result:?}"
+    );
+}
+
+// ── drain_admitted_updates ────────────────────────────────────────────────
+
+#[test]
+fn drain_admitted_updates_returns_pending_update() {
+    use autumn_harvest::replay::HistoryMatcher;
+
+    let update_id = UpdateId::new();
+    let events = vec![
+        WorkflowEvent::WorkflowStarted {
+            input: serde_json::Value::Null,
+            timestamp: Utc::now(),
+        },
+        WorkflowEvent::UpdateAdmitted {
+            update_id,
+            name: "approve".to_string(),
+            input: serde_json::json!({"amount": 10}),
+            timestamp: Utc::now(),
+        },
+        // No completion — this update is pending
+    ];
+
+    let matcher = HistoryMatcher::new(events);
+    let pending = matcher.drain_admitted_updates();
+    assert_eq!(pending.len(), 1);
+    assert_eq!(pending[0].0, update_id);
+    assert_eq!(pending[0].1, "approve");
+}
+
+#[test]
+fn drain_admitted_updates_excludes_already_completed() {
+    use autumn_harvest::replay::HistoryMatcher;
+
+    let pending_id = UpdateId::new();
+    let completed_id = UpdateId::new();
+    let events = vec![
+        WorkflowEvent::WorkflowStarted {
+            input: serde_json::Value::Null,
+            timestamp: Utc::now(),
+        },
+        WorkflowEvent::UpdateAdmitted {
+            update_id: completed_id,
+            name: "step_one".to_string(),
+            input: serde_json::json!({}),
+            timestamp: Utc::now(),
+        },
+        WorkflowEvent::UpdateCompleted {
+            update_id: completed_id,
+            output: serde_json::json!({}),
+        },
+        WorkflowEvent::UpdateAdmitted {
+            update_id: pending_id,
+            name: "step_two".to_string(),
+            input: serde_json::json!({}),
+            timestamp: Utc::now(),
+        },
+        // step_two has no completion — it is pending
+    ];
+
+    let matcher = HistoryMatcher::new(events);
+    let pending = matcher.drain_admitted_updates();
+    assert_eq!(
+        pending.len(),
+        1,
+        "only the unresolved update should be pending"
+    );
+    assert_eq!(pending[0].0, pending_id);
+    assert_eq!(pending[0].1, "step_two");
+}

--- a/autumn-harvest/tests/update_tests.rs
+++ b/autumn-harvest/tests/update_tests.rs
@@ -1,7 +1,7 @@
 //! Tests for the Update primitive (issue #140).
 //!
-//! Covers: event serde, UpdateId, UpdateRegistry, WorkflowContext
-//! registration/validation/dispatch, and HistoryMatcher update replay.
+//! Covers: event serde, `UpdateId`, `UpdateRegistry`, `WorkflowContext`
+//! registration/validation/dispatch, and `HistoryMatcher` update replay.
 
 #![cfg(feature = "testing")]
 
@@ -306,7 +306,7 @@ async fn execute_admitted_update_replays_completed_result_without_rerunning() {
     let history = make_completed_history(update_id, "approve");
     let ctx = WorkflowContext::for_replay(exec_id, history);
 
-    let mut handler_ran = false;
+    let handler_ran = false;
     ctx.register_update_handler(
         "approve",
         |_: &serde_json::Value| Ok::<(), String>(()),
@@ -373,7 +373,7 @@ fn history_matcher_finds_update_completed() {
         },
     ];
 
-    let mut matcher = HistoryMatcher::new(events);
+    let matcher = HistoryMatcher::new(events);
     let result = matcher.match_update(update_id);
     assert!(
         matches!(result, HistoryMatch::Matched { .. }),
@@ -406,7 +406,7 @@ fn history_matcher_finds_update_failed() {
         },
     ];
 
-    let mut matcher = HistoryMatcher::new(events);
+    let matcher = HistoryMatcher::new(events);
     let result = matcher.match_update(update_id);
     assert!(
         matches!(result, HistoryMatch::Failed { .. }),
@@ -436,7 +436,7 @@ fn history_matcher_returns_no_match_for_admitted_without_completion() {
         // No UpdateCompleted or UpdateFailed
     ];
 
-    let mut matcher = HistoryMatcher::new(events);
+    let matcher = HistoryMatcher::new(events);
     let result = matcher.match_update(update_id);
     assert!(
         matches!(result, HistoryMatch::NoMatch),
@@ -461,7 +461,7 @@ fn history_matcher_returns_no_match_for_unknown_update_id() {
         },
     ];
 
-    let mut matcher = HistoryMatcher::new(events);
+    let matcher = HistoryMatcher::new(events);
     let result = matcher.match_update(unknown_id);
     assert!(
         matches!(result, HistoryMatch::NoMatch),


### PR DESCRIPTION
## Summary

Implements the Update primitive, a new workflow feature that allows synchronous request/response communication with running workflows. This enables clients to send named update requests, have them validated and executed by the workflow, and receive typed results—all within a configurable timeout window.

## Key Changes

### Core Update Types & Events
- **`UpdateId`** type in `types.rs`: UUID-based identifier for update invocations, stable across worker restarts
- **Update events** in `event.rs`: Three new event variants:
  - `UpdateAdmitted`: Durably recorded when a validator accepts an update request
  - `UpdateCompleted`: Records the handler's successful result
  - `UpdateFailed`: Records the handler's error
- All events are adjacently-tagged JSON for stable serialization

### Update Handler Registry
- **`update.rs`** (new module): `UpdateRegistry` stores type-erased validators and async handlers keyed by name
  - Registration is idempotent—first registration wins, safe to call on every replay cycle
  - Validators run synchronously before admission; rejections write no event
  - Handlers are async closures that mutate workflow state and return typed results

### WorkflowContext Integration
- **`context.rs`**: New methods for update lifecycle:
  - `register_update_handler()`: Register handler with optional validator
  - `register_update_handler_no_validator()`: Register handler that always admits
  - `validate_update()`: Synchronously validate without admitting
  - `execute_admitted_update()`: Run handler in live mode or replay from history
  - `drain_admitted_updates()`: Retrieve pending updates for manual processing
- Updates are transparent to replay—history matcher skips them during activity/timer/signal matching

### History Replay
- **`replay.rs`**: Update events are transparent to the main workflow sequence
  - `is_update_event()` helper identifies the three update variants
  - `drain_early_signals()` now also consumes update events so they don't block the cursor
  - Activity, timer, signal, and external activity matchers skip over update events
  - `match_update()`: Finds `UpdateCompleted`/`UpdateFailed` for a given `UpdateId`
  - `drain_admitted_updates()`: Returns pending updates without completion events

### HTTP API
- **`autumn-harvest-plugin/src/api.rs`**:
  - `POST /workflows/{id}/update/{update_name}`: Admit and optionally wait for update result
    - Query params: `wait` (`admitted`|`completed`, default), `timeout_secs` (default 30)
    - Returns `202 Accepted` with `update_id` for `wait=admitted`
    - Returns `200 OK` with result or `409 Conflict` with error for `wait=completed`
  - `GET /workflows/{id}/update/{update_id}/result`: Poll for result of previously admitted update
  - Error mapping: `UpdateHandlerNotFound` → 404, `UpdateRejected` → 409 Conflict
  - Polling loop with 300ms interval until timeout or result found

### CLI Support
- **`autumn-harvest-cli/src/lib.rs`**: New `workflow update` and `workflow update-result` commands
  - `harvest workflow update <exec-id> <update-name> [--input-json|--input-file] [--wait MODE] [--timeout-secs N]`
  - `harvest workflow update-result <exec-id> <update-id>`
- Request mapping tests verify correct HTTP method, path, and query parameters

### Testing
- **`update_tests.rs`** (new, 587 lines): Comprehensive test suite covering:
  - Event serde round-trips and type name stability
  - `UpdateId` uniqueness, serde, and display format
  - Handler registration idempotency and command emission
  - Validation: missing handler, accepted input, rejected input, no validator
  - Live execution: handler success, error propagation
  - Replay: completed/failed results returned without rerunning handler
  - History matcher: finding completed/failed updates, no-match cases, interleaved events
  - Update events don't break activity replay
  -

https://claude.ai/code/session_01YJRLskKVoeSqqMmV5ah7zJ