### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -542,7 +542,9 @@ struct LocalActivityRun {
 fn extract_run_local_activity(
     commands: Vec<WorkflowCommand>,
 ) -> (Vec<WorkflowEvent>, LocalActivityRun) {
-    let mut markers = Vec::new();
+    // ⚡ Bolt: Pre-allocate `markers` `Vec` using `with_capacity`.
+    // The number of markers is at most `commands.len().saturating_sub(1)` since one is `RunLocalActivity`.
+    let mut markers = Vec::with_capacity(commands.len().saturating_sub(1));
     let mut local_run = None;
     for cmd in commands {
         match cmd {

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -542,9 +542,8 @@ struct LocalActivityRun {
 fn extract_run_local_activity(
     commands: Vec<WorkflowCommand>,
 ) -> (Vec<WorkflowEvent>, LocalActivityRun) {
-    // ⚡ Bolt: Pre-allocate `markers` `Vec` using `with_capacity`.
-    // The number of markers is at most `commands.len().saturating_sub(1)` since one is `RunLocalActivity`.
-    let mut markers = Vec::with_capacity(commands.len().saturating_sub(1));
+    // Pre-allocate markers with capacity for the markers and the subsequent scheduled event.
+    let mut markers = Vec::with_capacity(commands.len());
     let mut local_run = None;
     for cmd in commands {
         match cmd {


### PR DESCRIPTION
💡 What: Pre-allocated `Vec::with_capacity` for the `markers` extraction logic in `extract_run_local_activity` instead of `Vec::new()`.
🎯 Why: Eliminated unneeded heap resizing operations while pushing elements to the list during command extraction.
📊 Impact: Reduces allocations within hot paths of worker extraction loops.
🔬 Measurement: Verified with `cargo test` and `cargo clippy`. No external dependencies or lifetime modifications were introduced.

---
*PR created automatically by Jules for task [9650951475556268289](https://jules.google.com/task/9650951475556268289) started by @madmax983*