### PR TITLE
🎸 Bard: [documentation update]

### DIFF
--- a/autumn-harvest/benches/metrics_noop.rs
+++ b/autumn-harvest/benches/metrics_noop.rs
@@ -30,7 +30,7 @@ fn bench_noop_workflow_completed(c: &mut Criterion) {
     let rec = NoOpMetrics;
     c.bench_function("noop/workflow_completed", |b| {
         b.iter(|| {
-            rec.record_workflow_completed("onboarding", "default", 1.0, WorkflowStatus::Completed)
+            rec.record_workflow_completed("onboarding", "default", 1.0, WorkflowStatus::Completed);
         });
     });
 }
@@ -39,7 +39,7 @@ fn bench_noop_activity_completed(c: &mut Criterion) {
     let rec = NoOpMetrics;
     c.bench_function("noop/activity_completed", |b| {
         b.iter(|| {
-            rec.record_activity_completed("send_email", "default", 0.5, ActivityStatus::Completed)
+            rec.record_activity_completed("send_email", "default", 0.5, ActivityStatus::Completed);
         });
     });
 }

--- a/autumn-harvest/src/replay.rs
+++ b/autumn-harvest/src/replay.rs
@@ -144,7 +144,7 @@ impl HistoryMatcher {
     /// `WorkflowCancelled`), or if there are buffered signals that were never
     /// delivered via `wait_for_signal`.
     ///
-    /// Used by [`WorkflowContext::history_has_unconsumed_events`] to avoid
+    /// Used by [`crate::context::WorkflowContext::history_has_unconsumed_events`] to avoid
     /// false non-determinism reports when replaying full histories that include
     /// a terminal event appended after workflow completion.
     ///

--- a/autumn-harvest/src/telemetry.rs
+++ b/autumn-harvest/src/telemetry.rs
@@ -153,7 +153,7 @@ pub struct TraceContextCarrier {
     /// When `true`, the worker must emit the span with attribute
     /// `harvest.replay = true` and must NOT restore `traceparent` as the
     /// parent context. Instead, it should create a new root span and attach a
-    /// span *link* pointing at [`link_traceparent`].
+    /// span *link* pointing at [`TraceContextCarrier::link_traceparent`].
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub is_replay: bool,
 


### PR DESCRIPTION
📖 Chapter: The `telemetry` and `replay` modules.
🔦 Insight: Clarified broken rustdoc links and ensured that `cargo doc` can resolve links to `history_has_unconsumed_events` and `link_traceparent` properly. Also added semicolons in `metrics_noop.rs` benchmark file to eliminate implicit returns clippy warnings.
🧪 Example: Resolved links `crate::context::WorkflowContext::history_has_unconsumed_events` and `TraceContextCarrier::link_traceparent`.
🖼️ Preview: No visual change, but terminal `cargo doc --no-deps` is now warning-free!

---
*PR created automatically by Jules for task [8067304442624007943](https://jules.google.com/task/8067304442624007943) started by @madmax983*