### PR TITLE
Add workflow `stack` inspection endpoint and CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ cargo run -p autumn-harvest-cli -- workflow start approval_workflow --input-json
 cargo run -p autumn-harvest-cli -- workflow signal <execution-id> approved --payload-json '{"approved":true}'
 cargo run -p autumn-harvest-cli -- workflow query <execution-id> status
 cargo run -p autumn-harvest-cli -- workflow cancel <execution-id> --reason "operator request"
+cargo run -p autumn-harvest-cli -- workflow stack <execution-id>
 cargo run -p autumn-harvest-cli -- dag list
 cargo run -p autumn-harvest-cli -- dag trigger daily_pipeline --conf-json '{"date":"2026-04-21"}'
 cargo run -p autumn-harvest-cli -- dag pause daily_pipeline
@@ -298,6 +299,36 @@ cargo run -p autumn-harvest-cli -- workflow list \
     --workflow-name onboarding \
     --search-attr tenant=acme
 ```
+
+### Inspecting workflow stack (current wait-state)
+
+Use the stack endpoint to inspect what an execution is currently waiting on
+(pending activities, local activities, timers, buffered signals, child
+workflows) plus the latest durable event cursor:
+
+```bash
+# CLI
+cargo run -p autumn-harvest-cli -- workflow stack <execution-id>
+
+# HTTP
+curl -s http://localhost:3000/api/harvest/workflows/<execution-id>/stack | jq .
+```
+
+Route:
+
+```text
+GET /api/harvest/workflows/{execution_id}/stack
+```
+
+Forward-compatibility contract:
+
+- Unknown top-level fields are additive; clients should ignore what they do not
+  recognize.
+- Collection item objects may gain new optional fields over time.
+- Known fields retain their current meaning; optional fields may be `null` when
+  data is unavailable.
+- `last_event_id` is monotonic per execution and can be used as a lightweight
+  change cursor.
 
 ### Post-incident DLQ drain
 

--- a/autumn-harvest-cli/src/lib.rs
+++ b/autumn-harvest-cli/src/lib.rs
@@ -209,6 +209,11 @@ enum WorkflowCommand {
         /// Workflow execution ID.
         execution_id: String,
     },
+    /// Show what a workflow is currently waiting on.
+    Stack {
+        /// Workflow execution ID.
+        execution_id: String,
+    },
     /// Start a workflow execution.
     Start {
         /// Registered workflow name.
@@ -595,6 +600,10 @@ fn workflow_request(command: &WorkflowCommand) -> Result<ApiRequest, CliError> {
         )?)),
         WorkflowCommand::Get { execution_id } => Ok(ApiRequest::get(format!(
             "/workflows/{}",
+            path_segment(execution_id)
+        ))),
+        WorkflowCommand::Stack { execution_id } => Ok(ApiRequest::get(format!(
+            "/workflows/{}/stack",
             path_segment(execution_id)
         ))),
         WorkflowCommand::Start {

--- a/autumn-harvest-cli/tests/request_mapping.rs
+++ b/autumn-harvest-cli/tests/request_mapping.rs
@@ -67,6 +67,21 @@ fn workflow_list_and_query_use_get_requests() {
         "/workflows/00000000-0000-0000-0000-000000000001/query/status"
     );
     assert_eq!(query_request.body, None);
+
+    let stack = Cli::try_parse_from([
+        "harvest",
+        "workflow",
+        "stack",
+        "00000000-0000-0000-0000-000000000001",
+    ])
+    .expect("workflow stack args should parse");
+    let stack_request = stack.api_request().expect("stack request should build");
+    assert_eq!(stack_request.method, ApiMethod::Get);
+    assert_eq!(
+        stack_request.path,
+        "/workflows/00000000-0000-0000-0000-000000000001/stack"
+    );
+    assert_eq!(stack_request.body, None);
 }
 
 #[test]

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -36,8 +36,8 @@ use autumn_harvest::scheduler::{
     DagCatalog, RegisteredDag, SchedulerMonitor, SchedulerSnapshot, trigger_dag,
 };
 use autumn_harvest::schema::{
-    harvest_dag_runs, harvest_events, harvest_schedules, harvest_signals, harvest_task_queue,
-    harvest_timers, harvest_workflow_executions,
+    harvest_dag_runs, harvest_events, harvest_external_tasks, harvest_schedules, harvest_signals,
+    harvest_task_queue, harvest_timers, harvest_workflow_executions,
 };
 use autumn_harvest::shard::ShardRouter;
 use autumn_harvest::signal;
@@ -913,6 +913,32 @@ async fn get_workflow_stack(
                 .map(|(h, d)| h + d),
         })
         .collect::<Vec<_>>();
+    let external_pending = harvest_external_tasks::table
+        .filter(harvest_external_tasks::workflow_exec_id.eq(exec_uuid))
+        .filter(harvest_external_tasks::state.eq("PENDING"))
+        .select(autumn_harvest::models::ExternalTask::as_select())
+        .load::<autumn_harvest::models::ExternalTask>(&mut conn)
+        .await
+        .map_err(database_error)?
+        .into_iter()
+        .map(|task| PendingActivity {
+            activity_exec_id: task.activity_id.to_string(),
+            activity_name: task.name,
+            queue: task.queue,
+            scheduled_at: task.created_at,
+            attempt: 1,
+            max_attempts: 1,
+            task_status: "PENDING".to_string(),
+            claimed_by_worker_id: None,
+            last_heartbeat_at: None,
+            next_retry_at: None,
+            schedule_to_start_deadline: None,
+            start_to_close_deadline: Some(task.schedule_to_close_at),
+            heartbeat_deadline: None,
+        })
+        .collect::<Vec<_>>();
+    let mut pending_activities = pending_activities;
+    pending_activities.extend(external_pending);
     let pending_local_activities = harvest_events::table
         .filter(harvest_events::workflow_exec_id.eq(exec_uuid))
         .filter(harvest_events::event_type.eq_any([
@@ -960,7 +986,7 @@ async fn get_workflow_stack(
                             },
                         );
                     }
-                    ("LocalActivityCompleted" | "LocalActivityFailed", Some(activity_exec_id)) => {
+                    ("LocalActivityCompleted", Some(activity_exec_id)) => {
                         acc.remove(&activity_exec_id);
                     }
                     _ => {}
@@ -1016,12 +1042,19 @@ async fn get_workflow_stack(
             },
         )
         .collect::<Vec<_>>();
-    let pending_signals = buffered_signals
-        .iter()
-        .map(|entry| PendingSignal {
-            signal_name: entry.signal_name.clone(),
-            waiters: entry.buffered,
-            oldest_waiter_since: entry.oldest_received_at,
+    let pending_signals = harvest_task_queue::table
+        .filter(harvest_task_queue::workflow_exec_id.eq(Some(exec_uuid)))
+        .filter(harvest_task_queue::task_type.eq("workflow"))
+        .filter(harvest_task_queue::state.eq_any(["PENDING", "CLAIMED", "RUNNING"]))
+        .select(harvest_task_queue::scheduled_at)
+        .load::<chrono::DateTime<chrono::Utc>>(&mut conn)
+        .await
+        .map_err(database_error)?
+        .into_iter()
+        .map(|oldest_waiter_since| PendingSignal {
+            signal_name: "*".to_string(),
+            waiters: 1,
+            oldest_waiter_since,
         })
         .collect::<Vec<_>>();
     let pending_child_workflows = harvest_workflow_executions::table

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -35,7 +35,10 @@ use autumn_harvest::retention::{RetentionConfig, RetentionMonitor, RetentionStat
 use autumn_harvest::scheduler::{
     DagCatalog, RegisteredDag, SchedulerMonitor, SchedulerSnapshot, trigger_dag,
 };
-use autumn_harvest::schema::{harvest_dag_runs, harvest_schedules, harvest_workflow_executions};
+use autumn_harvest::schema::{
+    harvest_dag_runs, harvest_events, harvest_schedules, harvest_signals, harvest_task_queue,
+    harvest_timers, harvest_workflow_executions,
+};
 use autumn_harvest::shard::ShardRouter;
 use autumn_harvest::signal;
 use autumn_harvest::store;
@@ -251,6 +254,82 @@ struct WorkflowDetailsResponse {
 }
 
 #[derive(Debug, Serialize)]
+struct WorkflowStackResponse {
+    exec_id: String,
+    workflow_id: String,
+    workflow_name: String,
+    state: String,
+    is_terminal: bool,
+    pending_activities: Vec<PendingActivity>,
+    pending_local_activities: Vec<PendingLocalActivity>,
+    pending_timers: Vec<PendingTimer>,
+    pending_signals: Vec<PendingSignal>,
+    buffered_signals: Vec<BufferedSignal>,
+    pending_child_workflows: Vec<PendingChildWorkflow>,
+    last_event_id: i64,
+}
+
+#[derive(Debug, Serialize)]
+struct PendingActivity {
+    activity_exec_id: String,
+    activity_name: String,
+    queue: String,
+    scheduled_at: chrono::DateTime<chrono::Utc>,
+    attempt: i32,
+    max_attempts: i32,
+    task_status: String,
+    claimed_by_worker_id: Option<String>,
+    last_heartbeat_at: Option<chrono::DateTime<chrono::Utc>>,
+    next_retry_at: Option<chrono::DateTime<chrono::Utc>>,
+    schedule_to_start_deadline: Option<chrono::DateTime<chrono::Utc>>,
+    start_to_close_deadline: Option<chrono::DateTime<chrono::Utc>>,
+    heartbeat_deadline: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+#[derive(Debug, Serialize)]
+struct PendingLocalActivity {
+    activity_exec_id: String,
+    activity_name: String,
+    scheduled_at: chrono::DateTime<chrono::Utc>,
+    attempt: i32,
+    max_attempts: i32,
+    task_status: String,
+    last_heartbeat_at: Option<chrono::DateTime<chrono::Utc>>,
+    next_retry_at: Option<chrono::DateTime<chrono::Utc>>,
+    start_to_close_deadline: Option<chrono::DateTime<chrono::Utc>>,
+    heartbeat_deadline: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+#[derive(Debug, Serialize)]
+struct PendingTimer {
+    timer_id: String,
+    name: Option<String>,
+    fires_at: chrono::DateTime<chrono::Utc>,
+    created_at: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Debug, Serialize)]
+struct PendingSignal {
+    signal_name: String,
+    waiters: i64,
+    oldest_waiter_since: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Debug, Serialize)]
+struct BufferedSignal {
+    signal_name: String,
+    buffered: i64,
+    oldest_received_at: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(Debug, Serialize)]
+struct PendingChildWorkflow {
+    child_exec_id: String,
+    child_workflow_name: String,
+    state: String,
+}
+
+#[derive(Debug, Serialize)]
 struct StartWorkflowResponse {
     execution_id: String,
     workflow_name: String,
@@ -416,6 +495,7 @@ pub fn harvest_api_router(api_state: HarvestApiState) -> Router<AppState> {
     Router::new()
         .route("/workflows", get(list_workflows))
         .route("/workflows/{id}", get(get_workflow))
+        .route("/workflows/{id}/stack", get(get_workflow_stack))
         .route("/workflows/{workflow_name}/start", post(start_workflow))
         .route("/workflows/{id}/cancel", post(cancel_workflow))
         .route(
@@ -744,6 +824,175 @@ async fn get_workflow(
     Ok(Json(WorkflowDetailsResponse {
         execution,
         history: events,
+    }))
+}
+
+async fn get_workflow_stack(
+    Extension(api_state): Extension<HarvestApiState>,
+    Path(id): Path<String>,
+) -> Result<Json<WorkflowStackResponse>, AutumnError> {
+    let exec_id = parse_execution_id(&id)?;
+    let exec_uuid = exec_id.as_uuid();
+    let mut conn = db_conn_for_execution(&api_state, exec_id).await?;
+    let execution = load_execution(&mut conn, exec_id)
+        .await
+        .map_err(map_error)?;
+    let is_terminal = matches!(
+        execution.state.as_str(),
+        "COMPLETED" | "FAILED" | "CANCELLED" | "TERMINATED"
+    );
+    let last_event_id = harvest_events::table
+        .filter(harvest_events::workflow_exec_id.eq(exec_uuid))
+        .select(diesel::dsl::max(harvest_events::event_id))
+        .first::<Option<i32>>(&mut conn)
+        .await
+        .map_err(database_error)?
+        .map_or(0_i64, i64::from);
+    if is_terminal {
+        return Ok(Json(WorkflowStackResponse {
+            exec_id: exec_id.to_string(),
+            workflow_id: execution.workflow_id,
+            workflow_name: execution.workflow_name,
+            state: execution.state,
+            is_terminal,
+            pending_activities: Vec::new(),
+            pending_local_activities: Vec::new(),
+            pending_timers: Vec::new(),
+            pending_signals: Vec::new(),
+            buffered_signals: Vec::new(),
+            pending_child_workflows: Vec::new(),
+            last_event_id,
+        }));
+    }
+
+    let tasks = harvest_task_queue::table
+        .filter(harvest_task_queue::workflow_exec_id.eq(Some(exec_uuid)))
+        .filter(harvest_task_queue::state.eq_any(["PENDING", "CLAIMED", "RUNNING", "BACKOFF"]))
+        .select(autumn_harvest::models::TaskQueueItem::as_select())
+        .load::<autumn_harvest::models::TaskQueueItem>(&mut conn)
+        .await
+        .map_err(database_error)?;
+    let (activity_tasks, local_tasks): (Vec<_>, Vec<_>) = tasks
+        .into_iter()
+        .partition(|task| task.task_type != "LOCAL_ACTIVITY");
+    let pending_activities = activity_tasks
+        .into_iter()
+        .map(|t| PendingActivity {
+            activity_exec_id: t.id.to_string(),
+            activity_name: t.activity_name.unwrap_or_default(),
+            queue: t.queue_name,
+            scheduled_at: t.scheduled_at,
+            attempt: t.attempt,
+            max_attempts: t.max_attempts,
+            task_status: t.state,
+            claimed_by_worker_id: t.worker_id,
+            last_heartbeat_at: t.last_heartbeat_at,
+            next_retry_at: None,
+            schedule_to_start_deadline: t.schedule_to_start.map(|d| t.scheduled_at + d),
+            start_to_close_deadline: t.started_at.zip(t.start_to_close).map(|(s, d)| s + d),
+            heartbeat_deadline: t
+                .last_heartbeat_at
+                .zip(t.heartbeat_timeout)
+                .map(|(h, d)| h + d),
+        })
+        .collect::<Vec<_>>();
+    let pending_local_activities = local_tasks
+        .into_iter()
+        .map(|t| PendingLocalActivity {
+            activity_exec_id: t.id.to_string(),
+            activity_name: t.activity_name.unwrap_or_default(),
+            scheduled_at: t.scheduled_at,
+            attempt: t.attempt,
+            max_attempts: t.max_attempts,
+            task_status: t.state,
+            last_heartbeat_at: t.last_heartbeat_at,
+            next_retry_at: None,
+            start_to_close_deadline: t.started_at.zip(t.start_to_close).map(|(s, d)| s + d),
+            heartbeat_deadline: t
+                .last_heartbeat_at
+                .zip(t.heartbeat_timeout)
+                .map(|(h, d)| h + d),
+        })
+        .collect::<Vec<_>>();
+    let pending_timers = harvest_timers::table
+        .filter(harvest_timers::workflow_exec_id.eq(exec_uuid))
+        .filter(harvest_timers::fired.eq(false))
+        .select((harvest_timers::timer_id, harvest_timers::fires_at))
+        .load::<(String, chrono::DateTime<chrono::Utc>)>(&mut conn)
+        .await
+        .map_err(database_error)?
+        .into_iter()
+        .map(|(timer_id, fires_at)| PendingTimer {
+            timer_id,
+            name: None,
+            created_at: fires_at,
+            fires_at,
+        })
+        .collect::<Vec<_>>();
+    let buffered_signals = harvest_signals::table
+        .filter(harvest_signals::workflow_exec_id.eq(exec_uuid))
+        .filter(harvest_signals::consumed.eq(false))
+        .select((harvest_signals::signal_name, harvest_signals::received_at))
+        .load::<(String, chrono::DateTime<chrono::Utc>)>(&mut conn)
+        .await
+        .map_err(database_error)?
+        .into_iter()
+        .fold(
+            std::collections::BTreeMap::<String, (i64, chrono::DateTime<chrono::Utc>)>::new(),
+            |mut acc, (name, ts)| {
+                acc.entry(name)
+                    .and_modify(|entry| {
+                        entry.0 += 1;
+                        if ts < entry.1 {
+                            entry.1 = ts;
+                        }
+                    })
+                    .or_insert((1, ts));
+                acc
+            },
+        )
+        .into_iter()
+        .map(
+            |(signal_name, (buffered, oldest_received_at))| BufferedSignal {
+                signal_name,
+                buffered,
+                oldest_received_at,
+            },
+        )
+        .collect::<Vec<_>>();
+    let pending_child_workflows = harvest_workflow_executions::table
+        .filter(harvest_workflow_executions::parent_id.eq(Some(exec_uuid)))
+        .filter(harvest_workflow_executions::state.ne_all(["COMPLETED", "FAILED", "CANCELLED"]))
+        .select((
+            harvest_workflow_executions::id,
+            harvest_workflow_executions::workflow_name,
+            harvest_workflow_executions::state,
+        ))
+        .load::<(uuid::Uuid, String, String)>(&mut conn)
+        .await
+        .map_err(database_error)?
+        .into_iter()
+        .map(
+            |(child_exec_id, child_workflow_name, state)| PendingChildWorkflow {
+                child_exec_id: child_exec_id.to_string(),
+                child_workflow_name,
+                state,
+            },
+        )
+        .collect::<Vec<_>>();
+    Ok(Json(WorkflowStackResponse {
+        exec_id: exec_id.to_string(),
+        workflow_id: execution.workflow_id,
+        workflow_name: execution.workflow_name,
+        state: execution.state,
+        is_terminal,
+        pending_activities,
+        pending_local_activities,
+        pending_timers,
+        pending_signals: Vec::new(),
+        buffered_signals,
+        pending_child_workflows,
+        last_event_id,
     }))
 }
 

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -329,6 +329,13 @@ struct PendingChildWorkflow {
     state: String,
 }
 
+fn is_terminal_state(state: &str) -> bool {
+    matches!(
+        state,
+        "COMPLETED" | "FAILED" | "CANCELLED" | "TIMED_OUT" | "CONTINUED_AS_NEW"
+    )
+}
+
 #[derive(Debug, Serialize)]
 struct StartWorkflowResponse {
     execution_id: String,
@@ -722,6 +729,21 @@ pub async fn run_batch_executor_once(
         .map_err(map_error)
 }
 
+#[cfg(test)]
+mod stack_state_tests {
+    use super::is_terminal_state;
+
+    #[test]
+    fn terminal_state_classifier_includes_timeout_and_continue_as_new() {
+        assert!(is_terminal_state("COMPLETED"));
+        assert!(is_terminal_state("FAILED"));
+        assert!(is_terminal_state("CANCELLED"));
+        assert!(is_terminal_state("TIMED_OUT"));
+        assert!(is_terminal_state("CONTINUED_AS_NEW"));
+        assert!(!is_terminal_state("RUNNING"));
+    }
+}
+
 async fn list_workflows(
     Extension(api_state): Extension<HarvestApiState>,
     Query(pairs): Query<Vec<(String, String)>>,
@@ -837,10 +859,7 @@ async fn get_workflow_stack(
     let execution = load_execution(&mut conn, exec_id)
         .await
         .map_err(map_error)?;
-    let is_terminal = matches!(
-        execution.state.as_str(),
-        "COMPLETED" | "FAILED" | "CANCELLED" | "TERMINATED"
-    );
+    let is_terminal = is_terminal_state(&execution.state);
     let last_event_id = harvest_events::table
         .filter(harvest_events::workflow_exec_id.eq(exec_uuid))
         .select(diesel::dsl::max(harvest_events::event_id))
@@ -872,10 +891,7 @@ async fn get_workflow_stack(
         .load::<autumn_harvest::models::TaskQueueItem>(&mut conn)
         .await
         .map_err(database_error)?;
-    let (activity_tasks, local_tasks): (Vec<_>, Vec<_>) = tasks
-        .into_iter()
-        .partition(|task| task.task_type != "LOCAL_ACTIVITY");
-    let pending_activities = activity_tasks
+    let pending_activities = tasks
         .into_iter()
         .map(|t| PendingActivity {
             activity_exec_id: t.id.to_string(),
@@ -896,23 +912,60 @@ async fn get_workflow_stack(
                 .map(|(h, d)| h + d),
         })
         .collect::<Vec<_>>();
-    let pending_local_activities = local_tasks
+    let pending_local_activities = harvest_events::table
+        .filter(harvest_events::workflow_exec_id.eq(exec_uuid))
+        .filter(
+            harvest_events::event_type.eq_any(["LocalActivityScheduled", "LocalActivityCompleted"]),
+        )
+        .order(harvest_events::event_id.asc())
+        .select((
+            harvest_events::event_type,
+            harvest_events::event_data,
+            harvest_events::timestamp,
+        ))
+        .load::<(String, serde_json::Value, chrono::DateTime<chrono::Utc>)>(&mut conn)
+        .await
+        .map_err(database_error)?
         .into_iter()
-        .map(|t| PendingLocalActivity {
-            activity_exec_id: t.id.to_string(),
-            activity_name: t.activity_name.unwrap_or_default(),
-            scheduled_at: t.scheduled_at,
-            attempt: t.attempt,
-            max_attempts: t.max_attempts,
-            task_status: t.state,
-            last_heartbeat_at: t.last_heartbeat_at,
-            next_retry_at: None,
-            start_to_close_deadline: t.started_at.zip(t.start_to_close).map(|(s, d)| s + d),
-            heartbeat_deadline: t
-                .last_heartbeat_at
-                .zip(t.heartbeat_timeout)
-                .map(|(h, d)| h + d),
-        })
+        .fold(
+            std::collections::BTreeMap::<String, PendingLocalActivity>::new(),
+            |mut acc, (event_type, event_data, ts)| {
+                let activity_id = event_data
+                    .get("activity_id")
+                    .and_then(serde_json::Value::as_str)
+                    .map(ToOwned::to_owned);
+                match (event_type.as_str(), activity_id) {
+                    ("LocalActivityScheduled", Some(activity_exec_id)) => {
+                        let activity_name = event_data
+                            .get("name")
+                            .and_then(serde_json::Value::as_str)
+                            .unwrap_or("")
+                            .to_string();
+                        acc.insert(
+                            activity_exec_id.clone(),
+                            PendingLocalActivity {
+                                activity_exec_id,
+                                activity_name,
+                                scheduled_at: ts,
+                                attempt: 1,
+                                max_attempts: 1,
+                                task_status: "PENDING".to_string(),
+                                last_heartbeat_at: None,
+                                next_retry_at: None,
+                                start_to_close_deadline: None,
+                                heartbeat_deadline: None,
+                            },
+                        );
+                    }
+                    ("LocalActivityCompleted", Some(activity_exec_id)) => {
+                        acc.remove(&activity_exec_id);
+                    }
+                    _ => {}
+                }
+                acc
+            },
+        )
+        .into_values()
         .collect::<Vec<_>>();
     let pending_timers = harvest_timers::table
         .filter(harvest_timers::workflow_exec_id.eq(exec_uuid))
@@ -962,7 +1015,13 @@ async fn get_workflow_stack(
         .collect::<Vec<_>>();
     let pending_child_workflows = harvest_workflow_executions::table
         .filter(harvest_workflow_executions::parent_id.eq(Some(exec_uuid)))
-        .filter(harvest_workflow_executions::state.ne_all(["COMPLETED", "FAILED", "CANCELLED"]))
+        .filter(harvest_workflow_executions::state.ne_all([
+            "COMPLETED",
+            "FAILED",
+            "CANCELLED",
+            "TIMED_OUT",
+            "CONTINUED_AS_NEW",
+        ]))
         .select((
             harvest_workflow_executions::id,
             harvest_workflow_executions::workflow_name,

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -305,7 +305,7 @@ struct PendingTimer {
     timer_id: String,
     name: Option<String>,
     fires_at: chrono::DateTime<chrono::Utc>,
-    created_at: chrono::DateTime<chrono::Utc>,
+    created_at: Option<chrono::DateTime<chrono::Utc>>,
 }
 
 #[derive(Debug, Serialize)]
@@ -1007,7 +1007,7 @@ async fn get_workflow_stack(
         .map(|(timer_id, fires_at)| PendingTimer {
             timer_id,
             name: None,
-            created_at: fires_at,
+            created_at: None,
             fires_at,
         })
         .collect::<Vec<_>>();

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -886,6 +886,7 @@ async fn get_workflow_stack(
 
     let tasks = harvest_task_queue::table
         .filter(harvest_task_queue::workflow_exec_id.eq(Some(exec_uuid)))
+        .filter(harvest_task_queue::task_type.eq("activity"))
         .filter(harvest_task_queue::state.eq_any(["PENDING", "CLAIMED", "RUNNING", "BACKOFF"]))
         .select(autumn_harvest::models::TaskQueueItem::as_select())
         .load::<autumn_harvest::models::TaskQueueItem>(&mut conn)
@@ -914,9 +915,11 @@ async fn get_workflow_stack(
         .collect::<Vec<_>>();
     let pending_local_activities = harvest_events::table
         .filter(harvest_events::workflow_exec_id.eq(exec_uuid))
-        .filter(
-            harvest_events::event_type.eq_any(["LocalActivityScheduled", "LocalActivityCompleted"]),
-        )
+        .filter(harvest_events::event_type.eq_any([
+            "LocalActivityScheduled",
+            "LocalActivityCompleted",
+            "LocalActivityFailed",
+        ]))
         .order(harvest_events::event_id.asc())
         .select((
             harvest_events::event_type,
@@ -957,7 +960,7 @@ async fn get_workflow_stack(
                             },
                         );
                     }
-                    ("LocalActivityCompleted", Some(activity_exec_id)) => {
+                    ("LocalActivityCompleted" | "LocalActivityFailed", Some(activity_exec_id)) => {
                         acc.remove(&activity_exec_id);
                     }
                     _ => {}
@@ -1013,6 +1016,14 @@ async fn get_workflow_stack(
             },
         )
         .collect::<Vec<_>>();
+    let pending_signals = buffered_signals
+        .iter()
+        .map(|entry| PendingSignal {
+            signal_name: entry.signal_name.clone(),
+            waiters: entry.buffered,
+            oldest_waiter_since: entry.oldest_received_at,
+        })
+        .collect::<Vec<_>>();
     let pending_child_workflows = harvest_workflow_executions::table
         .filter(harvest_workflow_executions::parent_id.eq(Some(exec_uuid)))
         .filter(harvest_workflow_executions::state.ne_all([
@@ -1048,7 +1059,7 @@ async fn get_workflow_stack(
         pending_activities,
         pending_local_activities,
         pending_timers,
-        pending_signals: Vec::new(),
+        pending_signals,
         buffered_signals,
         pending_child_workflows,
         last_event_id,

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -1042,21 +1042,11 @@ async fn get_workflow_stack(
             },
         )
         .collect::<Vec<_>>();
-    let pending_signals = harvest_task_queue::table
-        .filter(harvest_task_queue::workflow_exec_id.eq(Some(exec_uuid)))
-        .filter(harvest_task_queue::task_type.eq("workflow"))
-        .filter(harvest_task_queue::state.eq_any(["PENDING", "CLAIMED", "RUNNING"]))
-        .select(harvest_task_queue::scheduled_at)
-        .load::<chrono::DateTime<chrono::Utc>>(&mut conn)
-        .await
-        .map_err(database_error)?
-        .into_iter()
-        .map(|oldest_waiter_since| PendingSignal {
-            signal_name: "*".to_string(),
-            waiters: 1,
-            oldest_waiter_since,
-        })
-        .collect::<Vec<_>>();
+    // Signal waiters are not directly materialized in a dedicated table today.
+    // Avoid inferring waiters from generic workflow-task rows because parked
+    // workflow tasks represent several suspension causes (timers, activities,
+    // children, etc.) and would over-report signal waits.
+    let pending_signals = Vec::new();
     let pending_child_workflows = harvest_workflow_executions::table
         .filter(harvest_workflow_executions::parent_id.eq(Some(exec_uuid)))
         .filter(harvest_workflow_executions::state.ne_all([

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -849,6 +849,7 @@ async fn get_workflow(
     }))
 }
 
+#[allow(clippy::too_many_lines)]
 async fn get_workflow_stack(
     Extension(api_state): Extension<HarvestApiState>,
     Path(id): Path<String>,

--- a/autumn-harvest-plugin/tests/api_scheduler_integration.rs
+++ b/autumn-harvest-plugin/tests/api_scheduler_integration.rs
@@ -1183,6 +1183,47 @@ async fn harvest_api_duplicate_start_reuses_existing_execution() {
 }
 
 #[tokio::test]
+async fn harvest_api_stack_endpoint_returns_shape() {
+    let (database_url, _container) = setup_test_database_url().await;
+    let pool = build_test_pool(&database_url);
+    let registry = approval_registry();
+    let api_state = HarvestApiState::new();
+    api_state.install_storage_pool(HarvestDbPool::from(pool.clone()));
+    api_state.install(HarvestApiRuntime::new(
+        Arc::clone(&registry),
+        Arc::new(HashMap::new()),
+        Arc::new(Vec::new()),
+        Some("test-worker".to_string()),
+        vec!["default".to_string()],
+        SchedulerMonitor::offline(),
+        HarvestRetentionRuntime::disabled(autumn_harvest::RetentionConfig::default()),
+        ShardRouter::single(),
+    ));
+    let app = harvest_api_router(api_state).with_state(test_app_state(pool));
+
+    let (start_status, start_json) = post_json(
+        &app,
+        "/workflows/approval_workflow/start",
+        json!({"workflow_id":"stack-shape","input":{"request_id":"stack"}}),
+    )
+    .await;
+    assert_eq!(start_status, StatusCode::CREATED);
+    let exec_id = start_json["execution_id"].as_str().unwrap();
+
+    let (status, payload) = get_json(&app, format!("/workflows/{exec_id}/stack")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(payload["exec_id"], exec_id);
+    assert_eq!(payload["workflow_name"], "approval_workflow");
+    assert!(payload["pending_activities"].is_array());
+    assert!(payload["pending_local_activities"].is_array());
+    assert!(payload["pending_timers"].is_array());
+    assert!(payload["pending_signals"].is_array());
+    assert!(payload["buffered_signals"].is_array());
+    assert!(payload["pending_child_workflows"].is_array());
+    assert!(payload["last_event_id"].is_number());
+}
+
+#[tokio::test]
 async fn harvest_api_cancels_workflows_and_rejects_late_signals() {
     let (database_url, _container) = setup_test_database_url().await;
     let pool = build_test_pool(&database_url);


### PR DESCRIPTION
### Motivation

- Provide operators a way to inspect what a workflow execution is currently waiting on (pending activities, local activities, timers, signals, child workflows) plus a lightweight durable event cursor.
- Expose the same information via the management HTTP API and the `harvest` CLI for debugging and triage workflows in-flight.

### Description

- Added a new HTTP route `GET /api/harvest/workflows/{execution_id}/stack` and implemented `get_workflow_stack` which returns a `WorkflowStackResponse` containing pending activities, local activities, timers, buffered signals, pending child workflows, and `last_event_id`.
- Introduced multiple response structs (`WorkflowStackResponse`, `PendingActivity`, `PendingLocalActivity`, `PendingTimer`, `PendingSignal`, `BufferedSignal`, `PendingChildWorkflow`) and queried the DB tables (`harvest_events`, `harvest_task_queue`, `harvest_timers`, `harvest_signals`, `harvest_workflow_executions`) to build the response; terminal executions return an empty stack quickly.
- Wire up the `harvest` CLI with a new `workflow stack <execution-id>` subcommand and map it to `GET /workflows/{id}/stack` so the CLI can call the new API route.
- Documented the new CLI and HTTP usage in `README.md` and added a shape/behaviour description with example `curl` and `cargo run -p autumn-harvest-cli` commands.

### Testing

- Added a unit test in `autumn-harvest-cli/tests/request_mapping.rs` that verifies the `workflow stack` CLI maps to a `GET` request to `/workflows/{id}/stack`, and the test passed.
- Added an integration test `harvest_api_stack_endpoint_returns_shape` in `autumn-harvest-plugin/tests/api_scheduler_integration.rs` that starts a workflow and asserts the stack payload shape and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f79095ff20832a80f0c94e20b2ad65)