### PR TITLE
⚒️ Forge: Refactor long functions in test_generator and critical_path

### DIFF
--- a/autumn-harvest/src/critical_path.rs
+++ b/autumn-harvest/src/critical_path.rs
@@ -67,7 +67,7 @@ impl CriticalPathAnalyzer {
             };
         }
 
-        let (distances, predecessors) = self.calculate_distances_and_predecessors(tasks, &levels);
+        let (distances, predecessors) = self.calculate_distances_and_predecessors(tasks, levels);
         let end_node = Self::find_critical_sink_node(tasks, &distances);
 
         let mut path_indices = Vec::new();

--- a/autumn-harvest/src/critical_path.rs
+++ b/autumn-harvest/src/critical_path.rs
@@ -67,6 +67,36 @@ impl CriticalPathAnalyzer {
             };
         }
 
+        let (distances, predecessors) = self.calculate_distances_and_predecessors(tasks, &levels);
+        let end_node = Self::find_critical_sink_node(tasks, &distances);
+
+        let mut path_indices = Vec::new();
+        let mut current = end_node;
+
+        while let Some(node) = current {
+            path_indices.push(node);
+            current = predecessors[node];
+        }
+
+        path_indices.reverse();
+
+        let path_names = path_indices
+            .iter()
+            .map(|&i| tasks[i].activity_name.clone())
+            .collect();
+
+        CriticalPathResult {
+            total_duration: end_node.map_or(Duration::ZERO, |n| distances[n]),
+            path_indices,
+            path_names,
+        }
+    }
+
+    fn calculate_distances_and_predecessors(
+        &self,
+        tasks: &[crate::dag::DagTask],
+        levels: &[Vec<usize>],
+    ) -> (Vec<Duration>, Vec<Option<usize>>) {
         let mut distances = vec![Duration::ZERO; tasks.len()];
         let mut predecessors = vec![None; tasks.len()];
 
@@ -99,7 +129,13 @@ impl CriticalPathAnalyzer {
                 predecessors[task_index] = best_pred;
             }
         }
+        (distances, predecessors)
+    }
 
+    fn find_critical_sink_node(
+        tasks: &[crate::dag::DagTask],
+        distances: &[Duration],
+    ) -> Option<usize> {
         // Identify sink nodes (nodes with no downstreams)
         let mut is_sink = vec![true; tasks.len()];
         for task in tasks {
@@ -118,27 +154,7 @@ impl CriticalPathAnalyzer {
                 end_node = Some(i);
             }
         }
-
-        let mut path_indices = Vec::new();
-        let mut current = end_node;
-
-        while let Some(node) = current {
-            path_indices.push(node);
-            current = predecessors[node];
-        }
-
-        path_indices.reverse();
-
-        let path_names = path_indices
-            .iter()
-            .map(|&i| tasks[i].activity_name.clone())
-            .collect();
-
-        CriticalPathResult {
-            total_duration: max_dist,
-            path_indices,
-            path_names,
-        }
+        end_node
     }
 }
 

--- a/autumn-harvest/src/test_generator.rs
+++ b/autumn-harvest/src/test_generator.rs
@@ -50,50 +50,14 @@ impl TestHarnessGenerator {
     ///
     /// # Errors
     /// Returns `std::fmt::Error` if string formatting fails.
-    #[allow(clippy::too_many_lines)]
     pub fn generate(&self, history: &[WorkflowEvent]) -> Result<String, std::fmt::Error> {
+        let ExtractedHistory {
+            mocks,
+            workflow_input,
+            final_result,
+        } = Self::extract_history_mocks(history);
+
         let mut out = String::new();
-        let mut activity_names: HashMap<ActivityExecId, String> = HashMap::new();
-        let mut mocks = Vec::new();
-        let mut workflow_input = serde_json::Value::Null;
-        let mut final_result: Option<Result<serde_json::Value, String>> = None;
-
-        for event in history {
-            match event {
-                WorkflowEvent::WorkflowStarted { input, .. } => {
-                    workflow_input = input.clone();
-                }
-                WorkflowEvent::ActivityScheduled {
-                    activity_id, name, ..
-                } => {
-                    activity_names.insert(*activity_id, name.clone());
-                }
-                WorkflowEvent::ActivityCompleted {
-                    activity_id,
-                    output,
-                } => {
-                    if let Some(name) = activity_names.get(activity_id) {
-                        mocks.push((name.clone(), Ok(output.clone())));
-                    }
-                }
-                WorkflowEvent::ActivityFailed {
-                    activity_id, error, ..
-                } => {
-                    if let Some(name) = activity_names.get(activity_id) {
-                        // For simplicity, we just capture the failure outcome for the mock.
-                        mocks.push((name.clone(), Err(error.clone())));
-                    }
-                }
-                WorkflowEvent::WorkflowCompleted { output } => {
-                    final_result = Some(Ok(output.clone()));
-                }
-                WorkflowEvent::WorkflowFailed { error } => {
-                    final_result = Some(Err(error.clone()));
-                }
-                _ => {}
-            }
-        }
-
         writeln!(out, "#[tokio::test]")?;
         writeln!(out, "async fn {}() {{", self.test_name)?;
         writeln!(out, "    use autumn_harvest::simulator::WorkflowSimulator;")?;
@@ -158,6 +122,61 @@ impl TestHarnessGenerator {
 
         Ok(out)
     }
+
+    fn extract_history_mocks(history: &[WorkflowEvent]) -> ExtractedHistory {
+        let mut activity_names: HashMap<ActivityExecId, String> = HashMap::new();
+        let mut mocks = Vec::new();
+        let mut workflow_input = serde_json::Value::Null;
+        let mut final_result: Option<Result<serde_json::Value, String>> = None;
+
+        for event in history {
+            match event {
+                WorkflowEvent::WorkflowStarted { input, .. } => {
+                    workflow_input = input.clone();
+                }
+                WorkflowEvent::ActivityScheduled {
+                    activity_id, name, ..
+                } => {
+                    activity_names.insert(*activity_id, name.clone());
+                }
+                WorkflowEvent::ActivityCompleted {
+                    activity_id,
+                    output,
+                } => {
+                    if let Some(name) = activity_names.get(activity_id) {
+                        mocks.push((name.clone(), Ok(output.clone())));
+                    }
+                }
+                WorkflowEvent::ActivityFailed {
+                    activity_id, error, ..
+                } => {
+                    if let Some(name) = activity_names.get(activity_id) {
+                        // For simplicity, we just capture the failure outcome for the mock.
+                        mocks.push((name.clone(), Err(error.clone())));
+                    }
+                }
+                WorkflowEvent::WorkflowCompleted { output } => {
+                    final_result = Some(Ok(output.clone()));
+                }
+                WorkflowEvent::WorkflowFailed { error } => {
+                    final_result = Some(Err(error.clone()));
+                }
+                _ => {}
+            }
+        }
+
+        ExtractedHistory {
+            mocks,
+            workflow_input,
+            final_result,
+        }
+    }
+}
+
+struct ExtractedHistory {
+    mocks: Vec<(String, Result<serde_json::Value, String>)>,
+    workflow_input: serde_json::Value,
+    final_result: Option<Result<serde_json::Value, String>>,
 }
 
 #[cfg(test)]


### PR DESCRIPTION
🚮 Smell: `generate` in `test_generator.rs` and `analyze` in `critical_path.rs` were long, complex "God Functions" taking up over 80-100 lines each.
✨ Solution: Extracted the event parsing loop in `generate` into a helper function `extract_history_mocks`. Extracted distance and predecessor calculation and sink node finding in `analyze` into `calculate_distances_and_predecessors` and `find_critical_sink_node` respectively.
🧼 Benefit: Reduces cognitive load, flattens the structure, and adheres to idiomatic Rust function length principles.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [16368851870886948722](https://jules.google.com/task/16368851870886948722) started by @madmax983*