### PR TITLE
Expose workflow children management surface

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -153,7 +153,7 @@ Current implementation scope: `ExecutionId`/`ShardId` encoding, `ShardRouter`, `
 | `prelude.rs` | 1 | Core glob re-export surface including macros |
 | `schema.rs` | 1 | Diesel `table!` macros -- 9 tables |
 | `models.rs` | 1 | `Queryable`/`Selectable` read structs and `Insertable` `New*` write structs for all 9 tables |
-| `store.rs` | 2 | Event store: `append_events`, `load_history`, `events_to_rows` with sequential event IDs |
+| `store.rs` | 2 | Event store and read helpers: `append_events`, `load_history`, `events_to_rows` with sequential event IDs, `load_workflow_children` for parent -> child operator queries |
 | `replay.rs` | 2 | Deterministic replay engine: `HistoryMatcher` walks event history, detects non-determinism |
 | `executor.rs` | 2 | Workflow executor: `run_workflow` drives replay + live execution, handles suspension |
 | `queue.rs` | 2 | Postgres task queue: `enqueue`, `claim` (FOR UPDATE SKIP LOCKED), `complete`, `fail` |

--- a/README.md
+++ b/README.md
@@ -311,7 +311,7 @@ combined result.
 
 | CLI flag | Query param | Behavior |
 |---|---|---|
-| `--status Failed` (repeatable, also accepts comma-separated values) | `?status=Failed&status=Running` | OR filter on child status. Allowed values: `Running`, `Failed`, `Completed`, `Cancelled`, `Terminated`, `TimedOut`. |
+| `--status Failed` (repeatable, also accepts comma-separated values) | `?status=Failed&status=Running` | OR filter on child status. Allowed values: `Running`, `Failed`, `Completed`, `Cancelled`, `Terminated`, `TimedOut`, `ContinuedAsNew`. |
 | `--workflow-name billing_child` | `?workflow_name=billing_child` | Exact match on the child workflow name. |
 | `--limit 100` | `?limit=100` | Page size. Defaults to 50 and is capped at 500. |
 | `--cursor <cursor>` | `?cursor=<cursor>` | Continue from the previous page's `next_cursor`. |

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ cargo run -p autumn-harvest-cli -- workflow signal <execution-id> approved --pay
 cargo run -p autumn-harvest-cli -- workflow query <execution-id> status
 cargo run -p autumn-harvest-cli -- workflow cancel <execution-id> --reason "operator request"
 cargo run -p autumn-harvest-cli -- workflow stack <execution-id>
+cargo run -p autumn-harvest-cli -- workflow children <execution-id> --status Failed
 cargo run -p autumn-harvest-cli -- workflow reset <execution-id> --to-event 42 --reason "bad deploy recovery" --operator-id mark
 cargo run -p autumn-harvest-cli -- dag list
 cargo run -p autumn-harvest-cli -- dag trigger daily_pipeline --conf-json '{"date":"2026-04-21"}'
@@ -300,6 +301,27 @@ cargo run -p autumn-harvest-cli -- workflow list \
     --workflow-name onboarding \
     --search-attr tenant=acme
 ```
+
+### Listing child workflows
+
+`workflow children` and `GET /workflows/{execution_id}/children` expose the
+parent -> child relationship recorded on workflow execution rows. The API fans
+out across all configured shards, merges by `started_at DESC`, and paginates the
+combined result.
+
+| CLI flag | Query param | Behavior |
+|---|---|---|
+| `--status Failed` (repeatable, also accepts comma-separated values) | `?status=Failed&status=Running` | OR filter on child status. Allowed values: `Running`, `Failed`, `Completed`, `Cancelled`, `Terminated`, `TimedOut`. |
+| `--workflow-name billing_child` | `?workflow_name=billing_child` | Exact match on the child workflow name. |
+| `--limit 100` | `?limit=100` | Page size. Defaults to 50 and is capped at 500. |
+| `--cursor <cursor>` | `?cursor=<cursor>` | Continue from the previous page's `next_cursor`. |
+| `--depth 1` | `?depth=1` | Include recursive descendants through the given zero-based depth. Direct children are depth `0`; values above `5` return `400 Bad Request`. |
+| `--json` | n/a | Print the raw JSON payload. Without `--json`, the CLI renders a table. |
+
+Each child entry includes `exec_id`, `workflow_name`, `status`, `started_at`,
+`completed_at`, `error_summary`, `shard_id`, and `depth`. `GET
+/workflows/{execution_id}` also includes top-level `parent_id` alongside the
+existing execution/history payload.
 
 ### Inspecting workflow stack (current wait-state)
 

--- a/autumn-harvest-cli/src/lib.rs
+++ b/autumn-harvest-cli/src/lib.rs
@@ -232,6 +232,30 @@ enum WorkflowCommand {
         /// Workflow execution ID.
         execution_id: String,
     },
+    /// List child workflow executions for a parent execution.
+    Children {
+        /// Parent workflow execution ID.
+        execution_id: String,
+        /// Filter by child workflow status. Repeat the flag or pass a
+        /// comma-separated list to match any of several statuses.
+        #[arg(long, value_delimiter = ',')]
+        status: Vec<String>,
+        /// Filter by registered child workflow name (exact match).
+        #[arg(long)]
+        workflow_name: Option<String>,
+        /// Maximum number of rows to return.
+        #[arg(long, value_parser = clap::value_parser!(i64).range(1..=500))]
+        limit: Option<i64>,
+        /// Opaque pagination cursor returned by the previous response.
+        #[arg(long)]
+        cursor: Option<String>,
+        /// Recursive descent depth; 0 returns direct children only.
+        #[arg(long, value_parser = clap::value_parser!(u8).range(0..=5))]
+        depth: Option<u8>,
+        /// Print the raw JSON API payload instead of a human table.
+        #[arg(long)]
+        json: bool,
+    },
     /// Start a workflow execution.
     Start {
         /// Registered workflow name.
@@ -561,9 +585,8 @@ pub async fn run_cli(cli: Cli) -> Result<(), CliError> {
         return tui::run_tui(&cli).await;
     }
 
-    let output = cli.output;
     let response = execute(&cli).await?;
-    let rendered = format_output(&response, output)?;
+    let rendered = render_response(&cli, &response)?;
     println!("{rendered}");
     Ok(())
 }
@@ -622,6 +645,107 @@ pub fn format_output(value: &Value, output: OutputFormat) -> Result<String, CliE
     }
 }
 
+fn render_response(cli: &Cli, value: &Value) -> Result<String, CliError> {
+    if workflow_children_wants_table(cli) {
+        return Ok(format_workflow_children_table(value));
+    }
+
+    let output = if workflow_children_wants_raw_json(cli) {
+        OutputFormat::Json
+    } else {
+        cli.output
+    };
+    format_output(value, output)
+}
+
+fn workflow_children_wants_table(cli: &Cli) -> bool {
+    matches!(
+        &cli.command,
+        Commands::Workflow {
+            command: WorkflowCommand::Children { json: false, .. }
+        } if cli.output == OutputFormat::PrettyJson
+    )
+}
+
+const fn workflow_children_wants_raw_json(cli: &Cli) -> bool {
+    matches!(
+        &cli.command,
+        Commands::Workflow {
+            command: WorkflowCommand::Children { json: true, .. }
+        }
+    )
+}
+
+fn format_workflow_children_table(value: &Value) -> String {
+    let Some(items) = value.get("items").and_then(Value::as_array) else {
+        return "No child workflows found.".to_string();
+    };
+    if items.is_empty() {
+        return "No child workflows found.".to_string();
+    }
+
+    let mut rows = Vec::with_capacity(items.len() + 1);
+    rows.push(vec![
+        "DEPTH".to_string(),
+        "EXEC ID".to_string(),
+        "WORKFLOW".to_string(),
+        "STATUS".to_string(),
+        "STARTED".to_string(),
+        "COMPLETED".to_string(),
+        "SHARD".to_string(),
+        "ERROR".to_string(),
+    ]);
+    for item in items {
+        rows.push(vec![
+            cell_number(item.get("depth")),
+            cell_str(item.get("exec_id")),
+            cell_str(item.get("workflow_name")),
+            cell_str(item.get("status")),
+            cell_str(item.get("started_at")),
+            cell_optional_str(item.get("completed_at")),
+            cell_number(item.get("shard_id")),
+            cell_optional_str(item.get("error_summary")),
+        ]);
+    }
+
+    let widths = (0..rows[0].len())
+        .map(|col| rows.iter().map(|row| row[col].len()).max().unwrap_or(0))
+        .collect::<Vec<_>>();
+    let mut rendered = rows
+        .iter()
+        .map(|row| {
+            row.iter()
+                .enumerate()
+                .map(|(col, cell)| format!("{cell:<width$}", width = widths[col]))
+                .collect::<Vec<_>>()
+                .join("  ")
+                .trim_end()
+                .to_string()
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    if let Some(cursor) = value.get("next_cursor").and_then(Value::as_str) {
+        rendered.push_str("\nnext_cursor: ");
+        rendered.push_str(cursor);
+    }
+    rendered
+}
+
+fn cell_str(value: Option<&Value>) -> String {
+    value.and_then(Value::as_str).unwrap_or("").to_string()
+}
+
+fn cell_optional_str(value: Option<&Value>) -> String {
+    value.and_then(Value::as_str).unwrap_or("-").to_string()
+}
+
+fn cell_number(value: Option<&Value>) -> String {
+    value
+        .and_then(Value::as_i64)
+        .map_or_else(String::new, |number| number.to_string())
+}
+
 #[allow(clippy::too_many_lines)]
 fn workflow_request(command: &WorkflowCommand) -> Result<ApiRequest, CliError> {
     match command {
@@ -643,6 +767,22 @@ fn workflow_request(command: &WorkflowCommand) -> Result<ApiRequest, CliError> {
         WorkflowCommand::Stack { execution_id } => Ok(ApiRequest::get(format!(
             "/workflows/{}/stack",
             path_segment(execution_id)
+        ))),
+        WorkflowCommand::Children {
+            execution_id,
+            status,
+            workflow_name,
+            limit,
+            cursor,
+            depth,
+            json: _,
+        } => Ok(ApiRequest::get(build_workflow_children_path(
+            execution_id,
+            status,
+            workflow_name.as_deref(),
+            *limit,
+            cursor.as_deref(),
+            *depth,
         ))),
         WorkflowCommand::Start {
             workflow_name,
@@ -1076,6 +1216,43 @@ fn build_workflow_list_path(
     Ok(format!("/workflows?{encoded}"))
 }
 
+fn build_workflow_children_path(
+    execution_id: &str,
+    statuses: &[String],
+    workflow_name: Option<&str>,
+    limit: Option<i64>,
+    cursor: Option<&str>,
+    depth: Option<u8>,
+) -> String {
+    let mut params: Vec<(&'static str, String)> = Vec::new();
+    for status in statuses {
+        params.push(("status", status.clone()));
+    }
+    if let Some(name) = workflow_name {
+        params.push(("workflow_name", name.to_string()));
+    }
+    if let Some(value) = limit {
+        params.push(("limit", value.to_string()));
+    }
+    if let Some(value) = cursor {
+        params.push(("cursor", value.to_string()));
+    }
+    if let Some(value) = depth {
+        params.push(("depth", value.to_string()));
+    }
+
+    let base = format!("/workflows/{}/children", path_segment(execution_id));
+    if params.is_empty() {
+        return base;
+    }
+    let encoded = params
+        .iter()
+        .map(|(key, value)| format!("{key}={}", query_encode(value)))
+        .collect::<Vec<_>>()
+        .join("&");
+    format!("{base}?{encoded}")
+}
+
 fn query_encode(input: &str) -> String {
     // RFC 3986 query-component encoding. We intentionally leave `:` unencoded
     // so the management API sees `search_attr=key:value` as a stable shape.
@@ -1182,5 +1359,52 @@ mod reuse_policy_tests {
         let body = req.body.as_ref().unwrap();
         assert_eq!(body["workflow_id"], "wf-123");
         assert_eq!(body["reuse_policy"], "reject_duplicate");
+    }
+
+    #[test]
+    fn children_default_output_renders_human_table() {
+        let cli = parse(&[
+            "workflow",
+            "children",
+            "00000000-0000-0000-0000-000000000001",
+        ]);
+        let payload = json!({
+            "items": [{
+                "exec_id": "00000000-0000-0000-0000-000000000002",
+                "workflow_name": "billing_child",
+                "status": "Failed",
+                "started_at": "2026-05-04T12:00:00Z",
+                "completed_at": null,
+                "error_summary": "charge card failed",
+                "shard_id": 1,
+                "depth": 0
+            }],
+            "next_cursor": null
+        });
+
+        let rendered = render_response(&cli, &payload).expect("table output should render");
+
+        assert!(rendered.contains("EXEC ID"));
+        assert!(rendered.contains("billing_child"));
+        assert!(rendered.contains("charge card failed"));
+        assert!(!rendered.trim_start().starts_with('{'));
+    }
+
+    #[test]
+    fn children_json_flag_renders_raw_payload() {
+        let cli = parse(&[
+            "workflow",
+            "children",
+            "00000000-0000-0000-0000-000000000001",
+            "--json",
+        ]);
+        let payload = json!({
+            "items": [],
+            "next_cursor": null
+        });
+
+        let rendered = render_response(&cli, &payload).expect("json output should render");
+
+        assert_eq!(rendered, r#"{"items":[],"next_cursor":null}"#);
     }
 }

--- a/autumn-harvest-cli/tests/request_mapping.rs
+++ b/autumn-harvest-cli/tests/request_mapping.rs
@@ -129,6 +129,40 @@ fn workflow_list_supports_repeated_and_comma_states() {
 }
 
 #[test]
+fn workflow_children_maps_to_management_api_request() {
+    let cli = Cli::try_parse_from([
+        "harvest",
+        "workflow",
+        "children",
+        "00000000-0000-0000-0000-000000000001",
+        "--status",
+        "Failed",
+        "--status",
+        "Running",
+        "--workflow-name",
+        "billing_child",
+        "--limit",
+        "25",
+        "--cursor",
+        "2026-05-04T12:00:00Z|00000000-0000-0000-0000-000000000099",
+        "--depth",
+        "2",
+        "--json",
+    ])
+    .expect("workflow children args should parse");
+    let request = cli.api_request().expect("children request should build");
+
+    assert_eq!(request.method, ApiMethod::Get);
+    assert_eq!(
+        request.path,
+        "/workflows/00000000-0000-0000-0000-000000000001/children\
+         ?status=Failed&status=Running&workflow_name=billing_child&limit=25\
+         &cursor=2026-05-04T12:00:00Z%7C00000000-0000-0000-0000-000000000099&depth=2"
+    );
+    assert_eq!(request.body, None);
+}
+
+#[test]
 fn workflow_list_rejects_search_attr_without_equals() {
     let list = Cli::try_parse_from(["harvest", "workflow", "list", "--search-attr", "tenant"])
         .expect("malformed search-attr args should still parse at clap level");

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -253,6 +253,7 @@ impl HarvestApiState {
 
 #[derive(Debug, Serialize)]
 struct WorkflowDetailsResponse {
+    parent_id: Option<uuid::Uuid>,
     execution: WorkflowExecution,
     history: Vec<Value>,
 }
@@ -526,6 +527,9 @@ pub(crate) const KNOWN_WORKFLOW_STATES: &[&str] = &[
 
 const DEFAULT_WORKFLOW_LIMIT: i64 = 50;
 const MAX_WORKFLOW_LIMIT: i64 = 200;
+const DEFAULT_WORKFLOW_CHILDREN_LIMIT: usize = 50;
+const MAX_WORKFLOW_CHILDREN_LIMIT: usize = 500;
+const MAX_WORKFLOW_CHILDREN_DEPTH: u8 = 5;
 
 #[derive(Debug, Default, Clone)]
 pub(crate) struct WorkflowFilters {
@@ -542,6 +546,51 @@ impl WorkflowFilters {
     }
 }
 
+#[derive(Debug, Clone)]
+struct WorkflowChildrenFilters {
+    limit: usize,
+    statuses: Vec<String>,
+    workflow_name: Option<String>,
+    cursor: Option<WorkflowChildrenCursor>,
+    max_depth: u8,
+}
+
+impl Default for WorkflowChildrenFilters {
+    fn default() -> Self {
+        Self {
+            limit: DEFAULT_WORKFLOW_CHILDREN_LIMIT,
+            statuses: Vec::new(),
+            workflow_name: None,
+            cursor: None,
+            max_depth: 0,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+struct WorkflowChildrenCursor {
+    started_at: chrono::DateTime<chrono::Utc>,
+    exec_id: uuid::Uuid,
+}
+
+#[derive(Debug, Serialize)]
+struct WorkflowChildrenResponse {
+    items: Vec<WorkflowChildResponse>,
+    next_cursor: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct WorkflowChildResponse {
+    exec_id: String,
+    workflow_name: String,
+    status: String,
+    started_at: chrono::DateTime<chrono::Utc>,
+    completed_at: Option<chrono::DateTime<chrono::Utc>>,
+    error_summary: Option<String>,
+    shard_id: i32,
+    depth: u8,
+}
+
 #[derive(Debug, Deserialize)]
 struct DeadLetterListQuery {
     limit: Option<i64>,
@@ -551,6 +600,7 @@ pub fn harvest_api_router(api_state: HarvestApiState) -> Router<AppState> {
     Router::new()
         .route("/workflows", get(list_workflows))
         .route("/workflows/{id}", get(get_workflow))
+        .route("/workflows/{id}/children", get(list_workflow_children))
         .route("/workflows/{id}/stack", get(get_workflow_stack))
         .route("/workflows/{workflow_name}/start", post(start_workflow))
         .route("/workflows/{id}/cancel", post(cancel_workflow))
@@ -895,9 +945,242 @@ async fn get_workflow(
         .map_err(map_error)?;
 
     Ok(Json(WorkflowDetailsResponse {
+        parent_id: execution.parent_id,
         execution,
         history: events,
     }))
+}
+
+async fn list_workflow_children(
+    Extension(api_state): Extension<HarvestApiState>,
+    Path(id): Path<String>,
+    Query(pairs): Query<Vec<(String, String)>>,
+) -> Result<Json<WorkflowChildrenResponse>, AutumnError> {
+    let exec_id = parse_execution_id(&id)?;
+    let filters = parse_workflow_children_filters(&pairs)?;
+
+    {
+        let mut conn = db_conn_for_execution(&api_state, exec_id).await?;
+        load_execution(&mut conn, exec_id)
+            .await
+            .map_err(map_error)?;
+    }
+
+    let mut rows =
+        load_workflow_children_tree_from_shards(&api_state, exec_id, filters.max_depth).await?;
+    rows.retain(|row| workflow_child_matches_filters(row, &filters));
+    sort_workflow_child_rows(&mut rows);
+    if let Some(cursor) = &filters.cursor {
+        rows.retain(|row| workflow_child_is_after_cursor(row, cursor));
+    }
+
+    let next_cursor = if rows.len() > filters.limit {
+        let cursor = encode_workflow_children_cursor(&rows[filters.limit - 1]);
+        rows.truncate(filters.limit);
+        Some(cursor)
+    } else {
+        None
+    };
+
+    Ok(Json(WorkflowChildrenResponse {
+        items: rows.into_iter().map(WorkflowChildResponse::from).collect(),
+        next_cursor,
+    }))
+}
+
+async fn load_workflow_children_tree_from_shards(
+    api_state: &HarvestApiState,
+    parent_id: ExecutionId,
+    max_depth: u8,
+) -> Result<Vec<store::WorkflowChildRow>, AutumnError> {
+    let pool = api_state.storage_pool().map_err(map_error)?;
+    let mut rows = Vec::new();
+    let mut frontier = vec![parent_id];
+    let query_filters = store::WorkflowChildFilters::default();
+
+    for depth in 0..=max_depth {
+        if frontier.is_empty() {
+            break;
+        }
+
+        let mut level_rows = Vec::new();
+        for parent in &frontier {
+            for (_shard, shard_pool) in pool.iter_shards() {
+                let mut conn = acquire_conn(shard_pool).await?;
+                let mut shard_rows =
+                    store::load_workflow_children(&mut conn, *parent, &query_filters, depth)
+                        .await
+                        .map_err(map_error)?;
+                level_rows.append(&mut shard_rows);
+            }
+        }
+
+        frontier = level_rows.iter().map(|row| row.exec_id).collect();
+        rows.append(&mut level_rows);
+    }
+
+    Ok(rows)
+}
+
+fn parse_workflow_children_filters(
+    pairs: &[(String, String)],
+) -> Result<WorkflowChildrenFilters, AutumnError> {
+    let mut filters = WorkflowChildrenFilters::default();
+
+    for (key, value) in pairs {
+        match key.as_str() {
+            "status" => {
+                for raw in value.split(',') {
+                    let trimmed = raw.trim();
+                    if trimmed.is_empty() {
+                        continue;
+                    }
+                    let status = parse_workflow_child_status(trimmed)?;
+                    if !filters.statuses.contains(&status) {
+                        filters.statuses.push(status);
+                    }
+                }
+            }
+            "workflow_name" => {
+                let trimmed = value.trim();
+                if !trimmed.is_empty() {
+                    filters.workflow_name = Some(trimmed.to_string());
+                }
+            }
+            "limit" => {
+                let parsed = value.parse::<usize>().map_err(|_| {
+                    AutumnError::bad_request_msg(format!("invalid limit '{value}'"))
+                })?;
+                filters.limit = parsed.clamp(1, MAX_WORKFLOW_CHILDREN_LIMIT);
+            }
+            "cursor" => {
+                filters.cursor = Some(parse_workflow_children_cursor(value)?);
+            }
+            "depth" => {
+                let parsed = value.parse::<u8>().map_err(|_| {
+                    AutumnError::bad_request_msg(format!("invalid depth '{value}'"))
+                })?;
+                if parsed > MAX_WORKFLOW_CHILDREN_DEPTH {
+                    return Err(AutumnError::bad_request_msg(format!(
+                        "depth {parsed} exceeds maximum {MAX_WORKFLOW_CHILDREN_DEPTH}"
+                    )));
+                }
+                filters.max_depth = parsed;
+            }
+            _ => {}
+        }
+    }
+
+    Ok(filters)
+}
+
+fn parse_workflow_child_status(raw: &str) -> Result<String, AutumnError> {
+    let normalized = raw
+        .chars()
+        .filter(|ch| *ch != '_' && *ch != '-')
+        .flat_map(char::to_lowercase)
+        .collect::<String>();
+    let status = match normalized.as_str() {
+        "running" => "RUNNING",
+        "failed" => "FAILED",
+        "completed" => "COMPLETED",
+        "cancelled" | "canceled" => "CANCELLED",
+        "terminated" => "TERMINATED",
+        "timedout" => "TIMED_OUT",
+        _ => {
+            return Err(AutumnError::bad_request_msg(format!(
+                "unknown workflow child status '{raw}'; expected one of Running, Failed, Completed, Cancelled, Terminated, TimedOut"
+            )));
+        }
+    };
+    Ok(status.to_string())
+}
+
+fn parse_workflow_children_cursor(raw: &str) -> Result<WorkflowChildrenCursor, AutumnError> {
+    let (started_at, exec_id) = raw.split_once('|').ok_or_else(|| {
+        AutumnError::bad_request_msg("invalid cursor; expected '<started_at>|<exec_id>'")
+    })?;
+    let started_at = chrono::DateTime::parse_from_rfc3339(started_at)
+        .map_err(|_| AutumnError::bad_request_msg("invalid cursor timestamp"))?
+        .with_timezone(&chrono::Utc);
+    let exec_id = exec_id
+        .parse::<uuid::Uuid>()
+        .map_err(|_| AutumnError::bad_request_msg("invalid cursor execution id"))?;
+
+    Ok(WorkflowChildrenCursor {
+        started_at,
+        exec_id,
+    })
+}
+
+fn workflow_child_matches_filters(
+    row: &store::WorkflowChildRow,
+    filters: &WorkflowChildrenFilters,
+) -> bool {
+    if !filters.statuses.is_empty() && !filters.statuses.contains(&row.status) {
+        return false;
+    }
+    if let Some(name) = &filters.workflow_name
+        && row.workflow_name != *name
+    {
+        return false;
+    }
+    true
+}
+
+fn sort_workflow_child_rows(rows: &mut [store::WorkflowChildRow]) {
+    rows.sort_by(|left, right| {
+        right
+            .started_at
+            .cmp(&left.started_at)
+            .then_with(|| right.exec_id.as_uuid().cmp(&left.exec_id.as_uuid()))
+    });
+}
+
+fn workflow_child_is_after_cursor(
+    row: &store::WorkflowChildRow,
+    cursor: &WorkflowChildrenCursor,
+) -> bool {
+    row.started_at < cursor.started_at
+        || (row.started_at == cursor.started_at && row.exec_id.as_uuid() < cursor.exec_id)
+}
+
+fn encode_workflow_children_cursor(row: &store::WorkflowChildRow) -> String {
+    format!(
+        "{}|{}",
+        row.started_at
+            .to_rfc3339_opts(chrono::SecondsFormat::Micros, true),
+        row.exec_id
+    )
+}
+
+fn workflow_child_status_label(status: &str) -> String {
+    match status {
+        "RUNNING" => "Running",
+        "FAILED" => "Failed",
+        "COMPLETED" => "Completed",
+        "CANCELLED" => "Cancelled",
+        "TERMINATED" => "Terminated",
+        "TIMED_OUT" => "TimedOut",
+        "CONTINUED_AS_NEW" => "ContinuedAsNew",
+        other => other,
+    }
+    .to_string()
+}
+
+impl From<store::WorkflowChildRow> for WorkflowChildResponse {
+    fn from(row: store::WorkflowChildRow) -> Self {
+        Self {
+            exec_id: row.exec_id.to_string(),
+            workflow_name: row.workflow_name,
+            status: workflow_child_status_label(&row.status),
+            started_at: row.started_at,
+            completed_at: row.completed_at,
+            error_summary: row.error_summary,
+            shard_id: row.shard_id,
+            depth: row.depth,
+        }
+    }
 }
 
 #[allow(clippy::too_many_lines)]
@@ -2845,6 +3128,44 @@ mod tests {
             .expect("unknown keys should be skipped");
         assert!(filters.states.is_empty());
         assert!(filters.workflow_name.is_none());
+    }
+
+    #[test]
+    fn parse_workflow_children_filters_accepts_statuses_limit_and_depth() {
+        let filters = parse_workflow_children_filters(&pairs(&[
+            ("status", "Failed,Running"),
+            ("status", "TimedOut"),
+            ("workflow_name", "billing_child"),
+            ("limit", "9001"),
+            ("depth", "2"),
+        ]))
+        .expect("children filters should parse");
+
+        assert_eq!(
+            filters.statuses,
+            vec![
+                "FAILED".to_string(),
+                "RUNNING".to_string(),
+                "TIMED_OUT".to_string(),
+            ]
+        );
+        assert_eq!(filters.workflow_name.as_deref(), Some("billing_child"));
+        assert_eq!(filters.limit, MAX_WORKFLOW_CHILDREN_LIMIT);
+        assert_eq!(filters.max_depth, 2);
+    }
+
+    #[test]
+    fn parse_workflow_children_filters_rejects_depth_above_cap() {
+        let err = parse_workflow_children_filters(&pairs(&[("depth", "6")]))
+            .expect_err("depth above cap must error");
+        assert!(err.to_string().contains("exceeds maximum"));
+    }
+
+    #[test]
+    fn parse_workflow_children_filters_rejects_unknown_status() {
+        let err = parse_workflow_children_filters(&pairs(&[("status", "Zombie")]))
+            .expect_err("unknown child status must error");
+        assert!(err.to_string().contains("unknown workflow child status"));
     }
 
     #[test]

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -966,13 +966,8 @@ async fn list_workflow_children(
             .map_err(map_error)?;
     }
 
-    let mut rows =
-        load_workflow_children_tree_from_shards(&api_state, exec_id, filters.max_depth).await?;
-    rows.retain(|row| workflow_child_matches_filters(row, &filters));
+    let mut rows = load_workflow_children_page_from_shards(&api_state, exec_id, &filters).await?;
     sort_workflow_child_rows(&mut rows);
-    if let Some(cursor) = &filters.cursor {
-        rows.retain(|row| workflow_child_is_after_cursor(row, cursor));
-    }
 
     let next_cursor = if rows.len() > filters.limit {
         let cursor = encode_workflow_children_cursor(&rows[filters.limit - 1]);
@@ -988,38 +983,53 @@ async fn list_workflow_children(
     }))
 }
 
-async fn load_workflow_children_tree_from_shards(
+async fn load_workflow_children_page_from_shards(
     api_state: &HarvestApiState,
     parent_id: ExecutionId,
-    max_depth: u8,
+    filters: &WorkflowChildrenFilters,
 ) -> Result<Vec<store::WorkflowChildRow>, AutumnError> {
     let pool = api_state.storage_pool().map_err(map_error)?;
     let mut rows = Vec::new();
-    let mut frontier = vec![parent_id];
-    let query_filters = store::WorkflowChildFilters::default();
+    let query_filters = workflow_children_store_filters(filters);
 
-    for depth in 0..=max_depth {
-        if frontier.is_empty() {
-            break;
-        }
-
-        let mut level_rows = Vec::new();
-        for parent in &frontier {
-            for (_shard, shard_pool) in pool.iter_shards() {
-                let mut conn = acquire_conn(shard_pool).await?;
-                let mut shard_rows =
-                    store::load_workflow_children(&mut conn, *parent, &query_filters, depth)
-                        .await
-                        .map_err(map_error)?;
-                level_rows.append(&mut shard_rows);
-            }
-        }
-
-        frontier = level_rows.iter().map(|row| row.exec_id).collect();
-        rows.append(&mut level_rows);
+    for (_shard, shard_pool) in pool.iter_shards() {
+        let mut conn = acquire_conn(shard_pool).await?;
+        let mut shard_rows = if filters.max_depth == 0 {
+            store::load_workflow_children(&mut conn, parent_id, &query_filters, 0)
+                .await
+                .map_err(map_error)?
+        } else {
+            store::load_workflow_child_descendants(
+                &mut conn,
+                parent_id,
+                &query_filters,
+                filters.max_depth,
+            )
+            .await
+            .map_err(map_error)?
+        };
+        rows.append(&mut shard_rows);
     }
 
     Ok(rows)
+}
+
+fn workflow_children_store_filters(
+    filters: &WorkflowChildrenFilters,
+) -> store::WorkflowChildFilters {
+    let query_limit = filters.limit.saturating_add(1);
+    store::WorkflowChildFilters {
+        statuses: filters.statuses.clone(),
+        workflow_name: filters.workflow_name.clone(),
+        cursor: filters
+            .cursor
+            .as_ref()
+            .map(|cursor| store::WorkflowChildCursor {
+                started_at: cursor.started_at,
+                exec_id: cursor.exec_id,
+            }),
+        limit: Some(i64::try_from(query_limit).unwrap_or(i64::MAX)),
+    }
 }
 
 fn parse_workflow_children_filters(
@@ -1114,21 +1124,6 @@ fn parse_workflow_children_cursor(raw: &str) -> Result<WorkflowChildrenCursor, A
     })
 }
 
-fn workflow_child_matches_filters(
-    row: &store::WorkflowChildRow,
-    filters: &WorkflowChildrenFilters,
-) -> bool {
-    if !filters.statuses.is_empty() && !filters.statuses.contains(&row.status) {
-        return false;
-    }
-    if let Some(name) = &filters.workflow_name
-        && row.workflow_name != *name
-    {
-        return false;
-    }
-    true
-}
-
 fn sort_workflow_child_rows(rows: &mut [store::WorkflowChildRow]) {
     rows.sort_by(|left, right| {
         right
@@ -1136,14 +1131,6 @@ fn sort_workflow_child_rows(rows: &mut [store::WorkflowChildRow]) {
             .cmp(&left.started_at)
             .then_with(|| right.exec_id.as_uuid().cmp(&left.exec_id.as_uuid()))
     });
-}
-
-fn workflow_child_is_after_cursor(
-    row: &store::WorkflowChildRow,
-    cursor: &WorkflowChildrenCursor,
-) -> bool {
-    row.started_at < cursor.started_at
-        || (row.started_at == cursor.started_at && row.exec_id.as_uuid() < cursor.exec_id)
 }
 
 fn encode_workflow_children_cursor(row: &store::WorkflowChildRow) -> String {

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -1,5 +1,6 @@
 //! Axum management routes for Harvest workflows and DAGs.
 
+use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
@@ -988,27 +989,67 @@ async fn load_workflow_children_page_from_shards(
     parent_id: ExecutionId,
     filters: &WorkflowChildrenFilters,
 ) -> Result<Vec<store::WorkflowChildRow>, AutumnError> {
+    if filters.max_depth > 0 {
+        return load_workflow_children_tree_from_shards(api_state, parent_id, filters).await;
+    }
+
     let pool = api_state.storage_pool().map_err(map_error)?;
     let mut rows = Vec::new();
     let query_filters = workflow_children_store_filters(filters);
 
     for (_shard, shard_pool) in pool.iter_shards() {
         let mut conn = acquire_conn(shard_pool).await?;
-        let mut shard_rows = if filters.max_depth == 0 {
-            store::load_workflow_children(&mut conn, parent_id, &query_filters, 0)
-                .await
-                .map_err(map_error)?
-        } else {
-            store::load_workflow_child_descendants(
-                &mut conn,
-                parent_id,
-                &query_filters,
-                filters.max_depth,
-            )
+        let mut shard_rows = store::load_workflow_children(&mut conn, parent_id, &query_filters, 0)
             .await
-            .map_err(map_error)?
-        };
+            .map_err(map_error)?;
         rows.append(&mut shard_rows);
+    }
+
+    Ok(rows)
+}
+
+async fn load_workflow_children_tree_from_shards(
+    api_state: &HarvestApiState,
+    parent_id: ExecutionId,
+    filters: &WorkflowChildrenFilters,
+) -> Result<Vec<store::WorkflowChildRow>, AutumnError> {
+    let pool = api_state.storage_pool().map_err(map_error)?;
+    let mut rows = Vec::new();
+    let mut frontier = vec![parent_id];
+    let mut seen = HashSet::new();
+    // Result filters cannot constrain traversal: a nonmatching child can have
+    // matching descendants, and either row may live on any shard.
+    let traversal_filters = store::WorkflowChildFilters::default();
+
+    for depth in 0..=filters.max_depth {
+        if frontier.is_empty() {
+            break;
+        }
+
+        let mut next_frontier = Vec::new();
+        for parent in &frontier {
+            for (_shard, shard_pool) in pool.iter_shards() {
+                let mut conn = acquire_conn(shard_pool).await?;
+                let shard_rows =
+                    store::load_workflow_children(&mut conn, *parent, &traversal_filters, depth)
+                        .await
+                        .map_err(map_error)?;
+                for row in shard_rows {
+                    if !seen.insert(row.exec_id.as_uuid()) {
+                        continue;
+                    }
+
+                    next_frontier.push(row.exec_id);
+                    if workflow_child_matches_filters(&row, filters)
+                        && workflow_child_is_after_cursor(&row, filters.cursor.as_ref())
+                    {
+                        rows.push(row);
+                    }
+                }
+            }
+        }
+
+        frontier = next_frontier;
     }
 
     Ok(rows)
@@ -1122,6 +1163,33 @@ fn parse_workflow_children_cursor(raw: &str) -> Result<WorkflowChildrenCursor, A
         started_at,
         exec_id,
     })
+}
+
+fn workflow_child_matches_filters(
+    row: &store::WorkflowChildRow,
+    filters: &WorkflowChildrenFilters,
+) -> bool {
+    if !filters.statuses.is_empty() && !filters.statuses.contains(&row.status) {
+        return false;
+    }
+    if let Some(name) = &filters.workflow_name
+        && row.workflow_name != *name
+    {
+        return false;
+    }
+    true
+}
+
+fn workflow_child_is_after_cursor(
+    row: &store::WorkflowChildRow,
+    cursor: Option<&WorkflowChildrenCursor>,
+) -> bool {
+    let Some(cursor) = cursor else {
+        return true;
+    };
+
+    row.started_at < cursor.started_at
+        || (row.started_at == cursor.started_at && row.exec_id.as_uuid() < cursor.exec_id)
 }
 
 fn sort_workflow_child_rows(rows: &mut [store::WorkflowChildRow]) {

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -1087,9 +1087,10 @@ fn parse_workflow_child_status(raw: &str) -> Result<String, AutumnError> {
         "cancelled" | "canceled" => "CANCELLED",
         "terminated" => "TERMINATED",
         "timedout" => "TIMED_OUT",
+        "continuedasnew" => "CONTINUED_AS_NEW",
         _ => {
             return Err(AutumnError::bad_request_msg(format!(
-                "unknown workflow child status '{raw}'; expected one of Running, Failed, Completed, Cancelled, Terminated, TimedOut"
+                "unknown workflow child status '{raw}'; expected one of Running, Failed, Completed, Cancelled, Terminated, TimedOut, ContinuedAsNew"
             )));
         }
     };
@@ -3152,6 +3153,14 @@ mod tests {
         assert_eq!(filters.workflow_name.as_deref(), Some("billing_child"));
         assert_eq!(filters.limit, MAX_WORKFLOW_CHILDREN_LIMIT);
         assert_eq!(filters.max_depth, 2);
+    }
+
+    #[test]
+    fn parse_workflow_children_filters_accepts_continued_as_new() {
+        let filters = parse_workflow_children_filters(&pairs(&[("status", "ContinuedAsNew")]))
+            .expect("ContinuedAsNew is a valid workflow execution state");
+
+        assert_eq!(filters.statuses, vec!["CONTINUED_AS_NEW".to_string()]);
     }
 
     #[test]

--- a/autumn-harvest-plugin/tests/api_scheduler_integration.rs
+++ b/autumn-harvest-plugin/tests/api_scheduler_integration.rs
@@ -1311,6 +1311,59 @@ async fn harvest_api_lists_direct_workflow_children_with_filters() {
 }
 
 #[tokio::test]
+async fn harvest_api_filters_workflow_children_by_continued_as_new_status() {
+    let (database_url, _container) = setup_test_database_url().await;
+    let pool = build_test_pool(&database_url);
+    let api_state = HarvestApiState::new();
+    api_state.install_storage_pool(HarvestDbPool::from(pool));
+    let app = harvest_api_router(api_state).with_state(test_app_state_without_database());
+
+    let parent = insert_workflow_on_url(
+        &database_url,
+        ShardId::new(0),
+        "fanout_parent",
+        "parent-continued-as-new",
+    )
+    .await;
+    let continued_child = insert_child_workflow_on_url(ChildWorkflowFixture {
+        database_url: &database_url,
+        shard: ShardId::new(0),
+        parent_id: parent,
+        workflow_name: "billing_child",
+        workflow_id: "continued-child",
+        state: "CONTINUED_AS_NEW",
+        error: None,
+        started_offset_secs: 10,
+    })
+    .await;
+    insert_child_workflow_on_url(ChildWorkflowFixture {
+        database_url: &database_url,
+        shard: ShardId::new(0),
+        parent_id: parent,
+        workflow_name: "billing_child",
+        workflow_id: "failed-child",
+        state: "FAILED",
+        error: Some("not the requested state"),
+        started_offset_secs: 5,
+    })
+    .await;
+
+    let (status, body) = get_json(
+        &app,
+        format!("/workflows/{parent}/children?status=ContinuedAsNew"),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    let items = body["items"]
+        .as_array()
+        .expect("children response must have an items array");
+
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0]["exec_id"], continued_child.to_string());
+    assert_eq!(items[0]["status"], "ContinuedAsNew");
+}
+
+#[tokio::test]
 async fn harvest_api_lists_workflow_children_across_shards_and_paginates() {
     let ((shard0_url, shard1_url), _container) = setup_sharded_test_database_urls().await;
     let api_state = HarvestApiState::new();

--- a/autumn-harvest-plugin/tests/api_scheduler_integration.rs
+++ b/autumn-harvest-plugin/tests/api_scheduler_integration.rs
@@ -1542,6 +1542,62 @@ async fn harvest_api_lists_workflow_children_across_shards_and_paginates() {
 }
 
 #[tokio::test]
+async fn harvest_api_recursive_children_traverse_across_shards() {
+    let ((shard0_url, shard1_url), _container) = setup_sharded_test_database_urls().await;
+    let api_state = HarvestApiState::new();
+    api_state.install_storage_pool(build_two_shard_pool(&shard0_url, &shard1_url));
+    let app = harvest_api_router(api_state).with_state(test_app_state_without_database());
+
+    let parent = insert_workflow_on_url(
+        &shard0_url,
+        ShardId::new(0),
+        "fanout_parent",
+        "cross-shard-recursive-parent",
+    )
+    .await;
+    let child = insert_child_workflow_on_url(ChildWorkflowFixture {
+        database_url: &shard1_url,
+        shard: ShardId::new(1),
+        parent_id: parent,
+        workflow_name: "middle_child",
+        workflow_id: "cross-shard-recursive-child",
+        state: "RUNNING",
+        error: None,
+        started_offset_secs: 10,
+    })
+    .await;
+    let grandchild = insert_child_workflow_on_url(ChildWorkflowFixture {
+        database_url: &shard0_url,
+        shard: ShardId::new(0),
+        parent_id: child,
+        workflow_name: "leaf_child",
+        workflow_id: "cross-shard-recursive-grandchild",
+        state: "FAILED",
+        error: Some("leaf failed across shards"),
+        started_offset_secs: 5,
+    })
+    .await;
+
+    let (status, body) = get_json(&app, format!("/workflows/{parent}/children?depth=1")).await;
+    assert_eq!(status, StatusCode::OK);
+    let items = body["items"]
+        .as_array()
+        .expect("children response must have an items array");
+
+    assert_eq!(items.len(), 2);
+    assert!(items.iter().any(|row| row["exec_id"] == child.to_string()
+        && row["depth"] == 0
+        && row["shard_id"] == 1));
+    assert!(
+        items
+            .iter()
+            .any(|row| row["exec_id"] == grandchild.to_string()
+                && row["depth"] == 1
+                && row["shard_id"] == 0)
+    );
+}
+
+#[tokio::test]
 async fn harvest_api_children_distinguishes_empty_parent_from_missing_parent() {
     let (database_url, _container) = setup_test_database_url().await;
     let pool = build_test_pool(&database_url);

--- a/autumn-harvest-plugin/tests/api_scheduler_integration.rs
+++ b/autumn-harvest-plugin/tests/api_scheduler_integration.rs
@@ -64,6 +64,10 @@ const INIT_SQL: &str = concat!(
     ),
     "\n",
     include_str!("../../autumn-harvest/migrations/20260430000001_harvest_external_tasks/up.sql"),
+    "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260504000000_harvest_workflow_parent_children/up.sql"
+    ),
 );
 type HarvestApiApp = axum::Router;
 
@@ -71,6 +75,12 @@ type HarvestApiApp = axum::Router;
 struct CountByName {
     #[diesel(sql_type = diesel::sql_types::BigInt)]
     count: i64,
+}
+
+#[derive(diesel::QueryableByName)]
+struct ExistsByName {
+    #[diesel(sql_type = diesel::sql_types::Bool)]
+    exists: bool,
 }
 
 async fn setup_test_database_url() -> (String, ContainerAsync<Postgres>) {
@@ -207,6 +217,14 @@ async fn get_json(app: &HarvestApiApp, uri: impl Into<String>) -> (StatusCode, V
     let status = response.status();
     let json = read_json_response(response).await;
     (status, json)
+}
+
+async fn get_response(app: &HarvestApiApp, uri: impl Into<String>) -> axum::response::Response {
+    let uri = uri.into();
+    app.clone()
+        .oneshot(Request::builder().uri(&uri).body(Body::empty()).unwrap())
+        .await
+        .expect("GET request failed")
 }
 
 async fn post_json(
@@ -358,6 +376,71 @@ async fn insert_workflow_on_url(
     )
     .await
     .expect("workflow insert should succeed");
+    exec_id
+}
+
+struct ChildWorkflowFixture<'a> {
+    database_url: &'a str,
+    shard: ShardId,
+    parent_id: ExecutionId,
+    workflow_name: &'a str,
+    workflow_id: &'a str,
+    state: &'a str,
+    error: Option<&'a str>,
+    started_offset_secs: i64,
+}
+
+async fn insert_child_workflow_on_url(fixture: ChildWorkflowFixture<'_>) -> ExecutionId {
+    let ChildWorkflowFixture {
+        database_url,
+        shard,
+        parent_id,
+        workflow_name,
+        workflow_id,
+        state,
+        error,
+        started_offset_secs,
+    } = fixture;
+    let exec_id = ExecutionId::new_for_shard(shard);
+    let mut conn = <AsyncPgConnection as AsyncConnection>::establish(database_url)
+        .await
+        .expect("failed to connect fresh Postgres client for child workflow insert");
+    start_or_load_workflow_execution(
+        &mut conn,
+        StartWorkflowParams {
+            workflow_name,
+            workflow_id,
+            exec_id,
+            input: json!({ "workflow_id": workflow_id, "shard": shard.as_i32() }),
+            parent_id: Some(parent_id.as_uuid()),
+            queue_name: "default",
+            execution_timeout: None,
+            memo: None,
+            search_attrs: None,
+            reuse_policy: autumn_harvest::WorkflowIdReusePolicy::default(),
+            trace_context: None,
+        },
+    )
+    .await
+    .expect("child workflow insert should succeed");
+
+    let started_at = chrono::Utc::now() - chrono::Duration::seconds(started_offset_secs);
+    let completed_at = if state == "RUNNING" {
+        None
+    } else {
+        Some(started_at + chrono::Duration::seconds(5))
+    };
+    diesel::update(harvest_workflow_executions::table.find(exec_id.as_uuid()))
+        .set((
+            harvest_workflow_executions::state.eq(state),
+            harvest_workflow_executions::error.eq(error.map(ToOwned::to_owned)),
+            harvest_workflow_executions::started_at.eq(started_at),
+            harvest_workflow_executions::completed_at.eq(completed_at),
+        ))
+        .execute(&mut conn)
+        .await
+        .expect("failed to update child workflow fixture state");
+
     exec_id
 }
 
@@ -1121,6 +1204,285 @@ async fn harvest_api_uses_installed_storage_pool_when_app_state_has_no_database(
     );
 
     shutdown_test_worker(&worker, worker_task).await;
+}
+
+#[tokio::test]
+async fn harvest_api_workflow_details_include_parent_id_at_top_level() {
+    let (database_url, _container) = setup_test_database_url().await;
+    let pool = build_test_pool(&database_url);
+    let api_state = HarvestApiState::new();
+    api_state.install_storage_pool(HarvestDbPool::from(pool));
+    let app = harvest_api_router(api_state).with_state(test_app_state_without_database());
+
+    let parent = insert_workflow_on_url(
+        &database_url,
+        ShardId::new(0),
+        "fanout_parent",
+        "parent-details",
+    )
+    .await;
+    let child = insert_child_workflow_on_url(ChildWorkflowFixture {
+        database_url: &database_url,
+        shard: ShardId::new(0),
+        parent_id: parent,
+        workflow_name: "billing_child",
+        workflow_id: "child-details",
+        state: "RUNNING",
+        error: None,
+        started_offset_secs: 0,
+    })
+    .await;
+
+    let (status, details_json) = get_json(&app, format!("/workflows/{child}")).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(details_json["parent_id"], parent.to_string());
+}
+
+#[tokio::test]
+async fn harvest_api_lists_direct_workflow_children_with_filters() {
+    let (database_url, _container) = setup_test_database_url().await;
+    let pool = build_test_pool(&database_url);
+    let api_state = HarvestApiState::new();
+    api_state.install_storage_pool(HarvestDbPool::from(pool));
+    let app = harvest_api_router(api_state).with_state(test_app_state_without_database());
+
+    let parent = insert_workflow_on_url(
+        &database_url,
+        ShardId::new(0),
+        "fanout_parent",
+        "parent-children",
+    )
+    .await;
+    let failed_child = insert_child_workflow_on_url(ChildWorkflowFixture {
+        database_url: &database_url,
+        shard: ShardId::new(0),
+        parent_id: parent,
+        workflow_name: "billing_child",
+        workflow_id: "failed-child",
+        state: "FAILED",
+        error: Some("charge card failed\nstack trace omitted"),
+        started_offset_secs: 10,
+    })
+    .await;
+    insert_child_workflow_on_url(ChildWorkflowFixture {
+        database_url: &database_url,
+        shard: ShardId::new(0),
+        parent_id: parent,
+        workflow_name: "billing_child",
+        workflow_id: "running-child",
+        state: "RUNNING",
+        error: None,
+        started_offset_secs: 20,
+    })
+    .await;
+    insert_child_workflow_on_url(ChildWorkflowFixture {
+        database_url: &database_url,
+        shard: ShardId::new(0),
+        parent_id: parent,
+        workflow_name: "email_child",
+        workflow_id: "failed-other-name",
+        state: "FAILED",
+        error: Some("smtp failed"),
+        started_offset_secs: 30,
+    })
+    .await;
+
+    let response = get_response(
+        &app,
+        format!("/workflows/{parent}/children?status=Failed&workflow_name=billing_child"),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = read_json_response(response).await;
+    let items = body["items"]
+        .as_array()
+        .expect("children response must have an items array");
+
+    assert_eq!(items.len(), 1);
+    assert_eq!(items[0]["exec_id"], failed_child.to_string());
+    assert_eq!(items[0]["workflow_name"], "billing_child");
+    assert_eq!(items[0]["status"], "Failed");
+    assert_eq!(items[0]["error_summary"], "charge card failed");
+    assert_eq!(items[0]["shard_id"], 0);
+    assert_eq!(items[0]["depth"], 0);
+    assert!(items[0]["started_at"].is_string());
+    assert!(items[0]["completed_at"].is_string());
+    assert!(body["next_cursor"].is_null());
+}
+
+#[tokio::test]
+async fn harvest_api_lists_workflow_children_across_shards_and_paginates() {
+    let ((shard0_url, shard1_url), _container) = setup_sharded_test_database_urls().await;
+    let api_state = HarvestApiState::new();
+    api_state.install_storage_pool(build_two_shard_pool(&shard0_url, &shard1_url));
+    let app = harvest_api_router(api_state).with_state(test_app_state_without_database());
+
+    let mut shard0_conn = <AsyncPgConnection as AsyncConnection>::establish(&shard0_url)
+        .await
+        .expect("failed to connect to shard 0");
+    let index_exists: ExistsByName = diesel::sql_query(
+        "SELECT EXISTS (
+            SELECT 1 FROM pg_indexes
+            WHERE schemaname = 'public' AND indexname = 'idx_harvest_we_parent_id'
+         ) AS exists",
+    )
+    .get_result(&mut shard0_conn)
+    .await
+    .expect("failed to inspect parent_id index");
+    assert!(
+        index_exists.exists,
+        "parent_id lookup must have a per-shard index"
+    );
+
+    let parent = insert_workflow_on_url(
+        &shard0_url,
+        ShardId::new(0),
+        "fanout_parent",
+        "parent-cross-shard",
+    )
+    .await;
+    let newest_child = insert_child_workflow_on_url(ChildWorkflowFixture {
+        database_url: &shard1_url,
+        shard: ShardId::new(1),
+        parent_id: parent,
+        workflow_name: "billing_child",
+        workflow_id: "newest-cross-shard-child",
+        state: "FAILED",
+        error: Some("newest failed"),
+        started_offset_secs: 5,
+    })
+    .await;
+    let older_child = insert_child_workflow_on_url(ChildWorkflowFixture {
+        database_url: &shard0_url,
+        shard: ShardId::new(0),
+        parent_id: parent,
+        workflow_name: "billing_child",
+        workflow_id: "older-cross-shard-child",
+        state: "FAILED",
+        error: Some("older failed"),
+        started_offset_secs: 20,
+    })
+    .await;
+
+    let (first_status, first_page) =
+        get_json(&app, format!("/workflows/{parent}/children?limit=1")).await;
+    assert_eq!(first_status, StatusCode::OK);
+    let first_items = first_page["items"]
+        .as_array()
+        .expect("children response must have an items array");
+    assert_eq!(first_items.len(), 1);
+    assert_eq!(first_items[0]["exec_id"], newest_child.to_string());
+    assert_eq!(first_items[0]["shard_id"], 1);
+    let cursor = first_page["next_cursor"]
+        .as_str()
+        .expect("limited page should return a cursor");
+    let encoded_cursor = cursor.replace('|', "%7C");
+
+    let (second_status, second_page) = get_json(
+        &app,
+        format!("/workflows/{parent}/children?limit=1&cursor={encoded_cursor}"),
+    )
+    .await;
+    assert_eq!(second_status, StatusCode::OK);
+    let second_items = second_page["items"]
+        .as_array()
+        .expect("children response must have an items array");
+    assert_eq!(second_items.len(), 1);
+    assert_eq!(second_items[0]["exec_id"], older_child.to_string());
+    assert_eq!(second_items[0]["shard_id"], 0);
+    assert!(second_page["next_cursor"].is_null());
+}
+
+#[tokio::test]
+async fn harvest_api_children_distinguishes_empty_parent_from_missing_parent() {
+    let (database_url, _container) = setup_test_database_url().await;
+    let pool = build_test_pool(&database_url);
+    let api_state = HarvestApiState::new();
+    api_state.install_storage_pool(HarvestDbPool::from(pool));
+    let app = harvest_api_router(api_state).with_state(test_app_state_without_database());
+
+    let parent = insert_workflow_on_url(
+        &database_url,
+        ShardId::new(0),
+        "fanout_parent",
+        "parent-without-children",
+    )
+    .await;
+
+    let (empty_status, empty_body) = get_json(&app, format!("/workflows/{parent}/children")).await;
+    assert_eq!(empty_status, StatusCode::OK);
+    assert_eq!(
+        empty_body["items"]
+            .as_array()
+            .expect("children response must have an items array")
+            .len(),
+        0
+    );
+    assert!(empty_body["next_cursor"].is_null());
+
+    let missing_parent = ExecutionId::new_for_shard(ShardId::new(0));
+    let missing_response =
+        get_response(&app, format!("/workflows/{missing_parent}/children")).await;
+    assert_eq!(missing_response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn harvest_api_children_supports_recursive_depth_with_cap() {
+    let (database_url, _container) = setup_test_database_url().await;
+    let pool = build_test_pool(&database_url);
+    let api_state = HarvestApiState::new();
+    api_state.install_storage_pool(HarvestDbPool::from(pool));
+    let app = harvest_api_router(api_state).with_state(test_app_state_without_database());
+
+    let parent = insert_workflow_on_url(
+        &database_url,
+        ShardId::new(0),
+        "fanout_parent",
+        "recursive-parent",
+    )
+    .await;
+    let child = insert_child_workflow_on_url(ChildWorkflowFixture {
+        database_url: &database_url,
+        shard: ShardId::new(0),
+        parent_id: parent,
+        workflow_name: "middle_child",
+        workflow_id: "recursive-child",
+        state: "RUNNING",
+        error: None,
+        started_offset_secs: 10,
+    })
+    .await;
+    let grandchild = insert_child_workflow_on_url(ChildWorkflowFixture {
+        database_url: &database_url,
+        shard: ShardId::new(0),
+        parent_id: child,
+        workflow_name: "leaf_child",
+        workflow_id: "recursive-grandchild",
+        state: "FAILED",
+        error: Some("leaf failed"),
+        started_offset_secs: 5,
+    })
+    .await;
+
+    let (status, body) = get_json(&app, format!("/workflows/{parent}/children?depth=1")).await;
+    assert_eq!(status, StatusCode::OK);
+    let items = body["items"]
+        .as_array()
+        .expect("children response must have an items array");
+    assert_eq!(items.len(), 2);
+    assert!(items.iter().any(|row| row["exec_id"] == child.to_string()
+        && row["depth"] == 0
+        && row["workflow_name"] == "middle_child"));
+    assert!(
+        items
+            .iter()
+            .any(|row| row["exec_id"] == grandchild.to_string()
+                && row["depth"] == 1
+                && row["workflow_name"] == "leaf_child")
+    );
+
+    let too_deep = get_response(&app, format!("/workflows/{parent}/children?depth=6")).await;
+    assert_eq!(too_deep.status(), StatusCode::BAD_REQUEST);
 }
 
 #[tokio::test]

--- a/autumn-harvest-plugin/tests/api_scheduler_integration.rs
+++ b/autumn-harvest-plugin/tests/api_scheduler_integration.rs
@@ -18,6 +18,7 @@ use autumn_harvest::schema::{
     harvest_workflow_executions,
 };
 use autumn_harvest::shard::{ShardRouter, ShardedDbPool};
+use autumn_harvest::store;
 use autumn_harvest::types::{ExecutionId, ShardId};
 use autumn_harvest::worker::{DbPool, HandlerRegistry, Worker, WorkerRuntimeConfig};
 use autumn_harvest::{
@@ -1364,6 +1365,100 @@ async fn harvest_api_filters_workflow_children_by_continued_as_new_status() {
 }
 
 #[tokio::test]
+async fn load_workflow_children_applies_limit_and_cursor_before_returning_rows() {
+    let (database_url, _container) = setup_test_database_url().await;
+    let parent = insert_workflow_on_url(
+        &database_url,
+        ShardId::new(0),
+        "fanout_parent",
+        "store-page-parent",
+    )
+    .await;
+    let newest_child = insert_child_workflow_on_url(ChildWorkflowFixture {
+        database_url: &database_url,
+        shard: ShardId::new(0),
+        parent_id: parent,
+        workflow_name: "billing_child",
+        workflow_id: "store-page-newest",
+        state: "FAILED",
+        error: None,
+        started_offset_secs: 5,
+    })
+    .await;
+    let middle_child = insert_child_workflow_on_url(ChildWorkflowFixture {
+        database_url: &database_url,
+        shard: ShardId::new(0),
+        parent_id: parent,
+        workflow_name: "billing_child",
+        workflow_id: "store-page-middle",
+        state: "FAILED",
+        error: None,
+        started_offset_secs: 10,
+    })
+    .await;
+    let oldest_child = insert_child_workflow_on_url(ChildWorkflowFixture {
+        database_url: &database_url,
+        shard: ShardId::new(0),
+        parent_id: parent,
+        workflow_name: "billing_child",
+        workflow_id: "store-page-oldest",
+        state: "FAILED",
+        error: None,
+        started_offset_secs: 15,
+    })
+    .await;
+
+    let mut conn = <AsyncPgConnection as AsyncConnection>::establish(&database_url)
+        .await
+        .expect("failed to connect for store page query");
+    let first_page = store::load_workflow_children(
+        &mut conn,
+        parent,
+        &store::WorkflowChildFilters {
+            statuses: Vec::new(),
+            workflow_name: None,
+            cursor: None,
+            limit: Some(2),
+        },
+        0,
+    )
+    .await
+    .expect("first child page should load");
+    assert_eq!(
+        first_page.iter().map(|row| row.exec_id).collect::<Vec<_>>(),
+        vec![newest_child, middle_child]
+    );
+
+    let cursor_row = first_page
+        .last()
+        .expect("first page should include a cursor row");
+    let second_page = store::load_workflow_children(
+        &mut conn,
+        parent,
+        &store::WorkflowChildFilters {
+            statuses: Vec::new(),
+            workflow_name: None,
+            cursor: Some(store::WorkflowChildCursor {
+                started_at: cursor_row.started_at,
+                exec_id: cursor_row.exec_id.as_uuid(),
+            }),
+            limit: Some(2),
+        },
+        0,
+    )
+    .await
+    .expect("second child page should load");
+
+    assert_eq!(
+        second_page
+            .iter()
+            .map(|row| row.exec_id)
+            .collect::<Vec<_>>(),
+        vec![oldest_child]
+    );
+}
+
+#[tokio::test]
 async fn harvest_api_lists_workflow_children_across_shards_and_paginates() {
     let ((shard0_url, shard1_url), _container) = setup_sharded_test_database_urls().await;
     let api_state = HarvestApiState::new();
@@ -1533,6 +1628,19 @@ async fn harvest_api_children_supports_recursive_depth_with_cap() {
                 && row["depth"] == 1
                 && row["workflow_name"] == "leaf_child")
     );
+
+    let (filtered_status, filtered_body) = get_json(
+        &app,
+        format!("/workflows/{parent}/children?depth=1&status=Failed"),
+    )
+    .await;
+    assert_eq!(filtered_status, StatusCode::OK);
+    let filtered_items = filtered_body["items"]
+        .as_array()
+        .expect("filtered children response must have an items array");
+    assert_eq!(filtered_items.len(), 1);
+    assert_eq!(filtered_items[0]["exec_id"], grandchild.to_string());
+    assert_eq!(filtered_items[0]["depth"], 1);
 
     let too_deep = get_response(&app, format!("/workflows/{parent}/children?depth=6")).await;
     assert_eq!(too_deep.status(), StatusCode::BAD_REQUEST);

--- a/autumn-harvest-plugin/tests/security.rs
+++ b/autumn-harvest-plugin/tests/security.rs
@@ -206,6 +206,18 @@ async fn eris_require_auth_blocks_get_workflow() {
 }
 
 #[tokio::test]
+async fn eris_require_auth_blocks_workflow_children() {
+    let app = authenticated_app();
+    let res = app
+        .oneshot(get(
+            "/workflows/00000000-0000-0000-0000-000000000001/children",
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+}
+
+#[tokio::test]
 async fn eris_require_auth_blocks_start_workflow() {
     let app = authenticated_app();
     let res = app

--- a/autumn-harvest/migrations/20260504000000_harvest_workflow_parent_children/down.sql
+++ b/autumn-harvest/migrations/20260504000000_harvest_workflow_parent_children/down.sql
@@ -1,0 +1,5 @@
+DROP INDEX IF EXISTS idx_harvest_we_parent_id;
+
+ALTER TABLE harvest_workflow_executions
+    ADD CONSTRAINT harvest_workflow_executions_parent_id_fkey
+    FOREIGN KEY (parent_id) REFERENCES harvest_workflow_executions(id) NOT VALID;

--- a/autumn-harvest/migrations/20260504000000_harvest_workflow_parent_children/up.sql
+++ b/autumn-harvest/migrations/20260504000000_harvest_workflow_parent_children/up.sql
@@ -1,0 +1,13 @@
+-- Expose parent -> children traversal efficiently across shard-local workflow tables.
+--
+-- Multi-shard deployments may store a child workflow on a different database
+-- than its parent, so parent_id cannot be enforced with a shard-local foreign
+-- key. Keep it as an operator-visible relationship and index the nullable FK
+-- value for per-shard lookup fan-out.
+
+ALTER TABLE harvest_workflow_executions
+    DROP CONSTRAINT IF EXISTS harvest_workflow_executions_parent_id_fkey;
+
+CREATE INDEX IF NOT EXISTS idx_harvest_we_parent_id
+    ON harvest_workflow_executions (parent_id)
+    WHERE parent_id IS NOT NULL;

--- a/autumn-harvest/src/store.rs
+++ b/autumn-harvest/src/store.rs
@@ -4,10 +4,12 @@
 //! The `UNIQUE(workflow_exec_id, event_id)` constraint guarantees
 //! that two workers can't append conflicting events to the same workflow.
 
+use diesel::BoolExpressionMethods;
 use diesel::ExpressionMethods;
 use diesel::OptionalExtension;
 use diesel::QueryDsl;
 use diesel::SelectableHelper;
+use diesel::sql_types::{Array, BigInt, Bool, Integer, Nullable, Text};
 use diesel_async::AsyncConnection;
 use diesel_async::AsyncPgConnection;
 use diesel_async::RunQueryDsl;
@@ -35,6 +37,15 @@ pub struct EventHistory {
 pub struct WorkflowChildFilters {
     pub statuses: Vec<String>,
     pub workflow_name: Option<String>,
+    pub cursor: Option<WorkflowChildCursor>,
+    pub limit: Option<i64>,
+}
+
+/// Cursor anchor for paged child workflow queries.
+#[derive(Debug, Clone)]
+pub struct WorkflowChildCursor {
+    pub started_at: chrono::DateTime<chrono::Utc>,
+    pub exec_id: uuid::Uuid,
 }
 
 /// Operator-facing child workflow row used by management API read models.
@@ -59,6 +70,26 @@ type WorkflowChildProjection = (
     Option<String>,
     i32,
 );
+
+#[derive(Debug, diesel::QueryableByName)]
+struct WorkflowChildQueryRow {
+    #[diesel(sql_type = diesel::sql_types::Uuid)]
+    id: uuid::Uuid,
+    #[diesel(sql_type = Text)]
+    workflow_name: String,
+    #[diesel(sql_type = Text)]
+    state: String,
+    #[diesel(sql_type = diesel::sql_types::Timestamptz)]
+    started_at: chrono::DateTime<chrono::Utc>,
+    #[diesel(sql_type = Nullable<diesel::sql_types::Timestamptz>)]
+    completed_at: Option<chrono::DateTime<chrono::Utc>>,
+    #[diesel(sql_type = Nullable<Text>)]
+    error: Option<String>,
+    #[diesel(sql_type = Integer)]
+    shard_id: i32,
+    #[diesel(sql_type = Integer)]
+    depth: i32,
+}
 
 /// Convert in-memory events to insertable rows with sequential event IDs
 /// starting from 0.
@@ -357,6 +388,18 @@ pub async fn load_workflow_children(
     if let Some(name) = &filters.workflow_name {
         query = query.filter(harvest_workflow_executions::workflow_name.eq(name.clone()));
     }
+    if let Some(cursor) = &filters.cursor {
+        query = query.filter(
+            harvest_workflow_executions::started_at
+                .lt(cursor.started_at)
+                .or(harvest_workflow_executions::started_at
+                    .eq(cursor.started_at)
+                    .and(harvest_workflow_executions::id.lt(cursor.exec_id))),
+        );
+    }
+    if let Some(limit) = filters.limit {
+        query = query.limit(limit);
+    }
 
     query
         .select((
@@ -375,20 +418,147 @@ pub async fn load_workflow_children(
             rows.into_iter()
                 .map(
                     |(id, workflow_name, state, started_at, completed_at, error, shard_id)| {
-                        WorkflowChildRow {
-                            exec_id: ExecutionId::from_uuid(id),
+                        workflow_child_row_from_parts(
+                            id,
                             workflow_name,
-                            status: state,
+                            state,
                             started_at,
                             completed_at,
-                            error_summary: summarize_error(error),
+                            error,
                             shard_id,
                             depth,
-                        }
+                        )
                     },
                 )
                 .collect()
         })
+}
+
+/// Load descendants of `parent_id` from one shard, applying result filters and
+/// pagination in SQL before rows are returned to the API layer.
+///
+/// # Errors
+///
+/// Returns [`crate::error::HarvestError::Database`] on query failure.
+pub async fn load_workflow_child_descendants(
+    conn: &mut AsyncPgConnection,
+    parent_id: ExecutionId,
+    filters: &WorkflowChildFilters,
+    max_depth: u8,
+) -> HarvestResult<Vec<WorkflowChildRow>> {
+    let no_status_filter = filters.statuses.is_empty();
+    let no_name_filter = filters.workflow_name.is_none();
+    let no_cursor = filters.cursor.is_none();
+    let workflow_name = filters.workflow_name.clone().unwrap_or_default();
+    let cursor_started_at = filters
+        .cursor
+        .as_ref()
+        .map_or_else(chrono::Utc::now, |cursor| cursor.started_at);
+    let cursor_exec_id = filters
+        .cursor
+        .as_ref()
+        .map_or_else(uuid::Uuid::nil, |cursor| cursor.exec_id);
+    let limit = filters.limit.unwrap_or(i64::MAX);
+
+    diesel::sql_query(
+        "WITH RECURSIVE descendants AS (
+            SELECT
+                id,
+                workflow_name,
+                state,
+                started_at,
+                completed_at,
+                error,
+                shard_id,
+                0::int AS depth
+            FROM harvest_workflow_executions
+            WHERE parent_id = $1
+            UNION ALL
+            SELECT
+                child.id,
+                child.workflow_name,
+                child.state,
+                child.started_at,
+                child.completed_at,
+                child.error,
+                child.shard_id,
+                descendants.depth + 1
+            FROM harvest_workflow_executions child
+            JOIN descendants ON child.parent_id = descendants.id
+            WHERE descendants.depth < $2
+        )
+        SELECT
+            id,
+            workflow_name,
+            state,
+            started_at,
+            completed_at,
+            error,
+            shard_id,
+            depth
+        FROM descendants
+        WHERE ($3 OR state = ANY($4))
+          AND ($5 OR workflow_name = $6)
+          AND ($7 OR started_at < $8 OR (started_at = $8 AND id < $9))
+        ORDER BY started_at DESC, id DESC
+        LIMIT $10",
+    )
+    .bind::<diesel::sql_types::Uuid, _>(parent_id.as_uuid())
+    .bind::<Integer, _>(i32::from(max_depth))
+    .bind::<Bool, _>(no_status_filter)
+    .bind::<Array<Text>, _>(filters.statuses.clone())
+    .bind::<Bool, _>(no_name_filter)
+    .bind::<Text, _>(workflow_name)
+    .bind::<Bool, _>(no_cursor)
+    .bind::<diesel::sql_types::Timestamptz, _>(cursor_started_at)
+    .bind::<diesel::sql_types::Uuid, _>(cursor_exec_id)
+    .bind::<BigInt, _>(limit)
+    .load::<WorkflowChildQueryRow>(conn)
+    .await
+    .map_err(crate::error::database_error)?
+    .into_iter()
+    .map(|row| {
+        let depth = u8::try_from(row.depth).map_err(|_| {
+            crate::error::HarvestError::Database(format!(
+                "workflow child depth {} does not fit in u8",
+                row.depth
+            ))
+        })?;
+        Ok(workflow_child_row_from_parts(
+            row.id,
+            row.workflow_name,
+            row.state,
+            row.started_at,
+            row.completed_at,
+            row.error,
+            row.shard_id,
+            depth,
+        ))
+    })
+    .collect()
+}
+
+#[allow(clippy::too_many_arguments)]
+fn workflow_child_row_from_parts(
+    id: uuid::Uuid,
+    workflow_name: String,
+    state: String,
+    started_at: chrono::DateTime<chrono::Utc>,
+    completed_at: Option<chrono::DateTime<chrono::Utc>>,
+    error: Option<String>,
+    shard_id: i32,
+    depth: u8,
+) -> WorkflowChildRow {
+    WorkflowChildRow {
+        exec_id: ExecutionId::from_uuid(id),
+        workflow_name,
+        status: state,
+        started_at,
+        completed_at,
+        error_summary: summarize_error(error),
+        shard_id,
+        depth,
+    }
 }
 
 fn summarize_error(error: Option<String>) -> Option<String> {

--- a/autumn-harvest/src/store.rs
+++ b/autumn-harvest/src/store.rs
@@ -15,8 +15,8 @@ use scoped_futures::ScopedFutureExt as _;
 
 use crate::error::HarvestResult;
 use crate::event::WorkflowEvent;
-use crate::models::NewHarvestEvent;
-use crate::schema::harvest_events;
+use crate::models::{NewHarvestEvent, WorkflowExecution};
+use crate::schema::{harvest_events, harvest_workflow_executions};
 use crate::types::ExecutionId;
 
 /// Loaded event history for a single workflow execution.
@@ -28,6 +28,26 @@ pub struct EventHistory {
     pub exec_id: ExecutionId,
     pub events: Vec<WorkflowEvent>,
     pub next_event_id: i32,
+}
+
+/// Filters for loading child workflow execution rows under one parent.
+#[derive(Debug, Clone, Default)]
+pub struct WorkflowChildFilters {
+    pub statuses: Vec<String>,
+    pub workflow_name: Option<String>,
+}
+
+/// Operator-facing child workflow row used by management API read models.
+#[derive(Debug, Clone)]
+pub struct WorkflowChildRow {
+    pub exec_id: ExecutionId,
+    pub workflow_name: String,
+    pub status: String,
+    pub started_at: chrono::DateTime<chrono::Utc>,
+    pub completed_at: Option<chrono::DateTime<chrono::Utc>>,
+    pub error_summary: Option<String>,
+    pub shard_id: i32,
+    pub depth: u8,
 }
 
 /// Convert in-memory events to insertable rows with sequential event IDs
@@ -297,6 +317,72 @@ pub async fn load_history_with_codecs(
         events,
         next_event_id,
     })
+}
+
+/// Load the direct children of `parent_id` from one shard.
+///
+/// Callers that need cross-shard discovery should call this once per shard and
+/// merge the rows after applying any global ordering/pagination.
+///
+/// # Errors
+///
+/// Returns [`crate::error::HarvestError::Database`] on query failure.
+pub async fn load_workflow_children(
+    conn: &mut AsyncPgConnection,
+    parent_id: ExecutionId,
+    filters: &WorkflowChildFilters,
+    depth: u8,
+) -> HarvestResult<Vec<WorkflowChildRow>> {
+    let mut query = harvest_workflow_executions::table
+        .into_boxed()
+        .filter(harvest_workflow_executions::parent_id.eq(Some(parent_id.as_uuid())))
+        .order((
+            harvest_workflow_executions::started_at.desc(),
+            harvest_workflow_executions::id.desc(),
+        ));
+
+    if !filters.statuses.is_empty() {
+        query = query.filter(harvest_workflow_executions::state.eq_any(filters.statuses.clone()));
+    }
+    if let Some(name) = &filters.workflow_name {
+        query = query.filter(harvest_workflow_executions::workflow_name.eq(name.clone()));
+    }
+
+    query
+        .select(WorkflowExecution::as_select())
+        .load::<WorkflowExecution>(conn)
+        .await
+        .map_err(crate::error::database_error)
+        .map(|rows| {
+            rows.into_iter()
+                .map(|row| WorkflowChildRow {
+                    exec_id: ExecutionId::from_uuid(row.id),
+                    workflow_name: row.workflow_name,
+                    status: row.state,
+                    started_at: row.started_at,
+                    completed_at: row.completed_at,
+                    error_summary: summarize_error(row.error),
+                    shard_id: row.shard_id,
+                    depth,
+                })
+                .collect()
+        })
+}
+
+fn summarize_error(error: Option<String>) -> Option<String> {
+    const MAX_ERROR_SUMMARY_CHARS: usize = 240;
+
+    let first_line = error?.lines().next().unwrap_or_default().trim().to_string();
+    if first_line.is_empty() {
+        return None;
+    }
+
+    let mut chars = first_line.chars();
+    let summary = chars
+        .by_ref()
+        .take(MAX_ERROR_SUMMARY_CHARS)
+        .collect::<String>();
+    Some(summary)
 }
 
 #[cfg(test)]

--- a/autumn-harvest/src/store.rs
+++ b/autumn-harvest/src/store.rs
@@ -9,7 +9,6 @@ use diesel::ExpressionMethods;
 use diesel::OptionalExtension;
 use diesel::QueryDsl;
 use diesel::SelectableHelper;
-use diesel::sql_types::{Array, BigInt, Bool, Integer, Nullable, Text};
 use diesel_async::AsyncConnection;
 use diesel_async::AsyncPgConnection;
 use diesel_async::RunQueryDsl;
@@ -70,26 +69,6 @@ type WorkflowChildProjection = (
     Option<String>,
     i32,
 );
-
-#[derive(Debug, diesel::QueryableByName)]
-struct WorkflowChildQueryRow {
-    #[diesel(sql_type = diesel::sql_types::Uuid)]
-    id: uuid::Uuid,
-    #[diesel(sql_type = Text)]
-    workflow_name: String,
-    #[diesel(sql_type = Text)]
-    state: String,
-    #[diesel(sql_type = diesel::sql_types::Timestamptz)]
-    started_at: chrono::DateTime<chrono::Utc>,
-    #[diesel(sql_type = Nullable<diesel::sql_types::Timestamptz>)]
-    completed_at: Option<chrono::DateTime<chrono::Utc>>,
-    #[diesel(sql_type = Nullable<Text>)]
-    error: Option<String>,
-    #[diesel(sql_type = Integer)]
-    shard_id: i32,
-    #[diesel(sql_type = Integer)]
-    depth: i32,
-}
 
 /// Convert in-memory events to insertable rows with sequential event IDs
 /// starting from 0.
@@ -432,110 +411,6 @@ pub async fn load_workflow_children(
                 )
                 .collect()
         })
-}
-
-/// Load descendants of `parent_id` from one shard, applying result filters and
-/// pagination in SQL before rows are returned to the API layer.
-///
-/// # Errors
-///
-/// Returns [`crate::error::HarvestError::Database`] on query failure.
-pub async fn load_workflow_child_descendants(
-    conn: &mut AsyncPgConnection,
-    parent_id: ExecutionId,
-    filters: &WorkflowChildFilters,
-    max_depth: u8,
-) -> HarvestResult<Vec<WorkflowChildRow>> {
-    let no_status_filter = filters.statuses.is_empty();
-    let no_name_filter = filters.workflow_name.is_none();
-    let no_cursor = filters.cursor.is_none();
-    let workflow_name = filters.workflow_name.clone().unwrap_or_default();
-    let cursor_started_at = filters
-        .cursor
-        .as_ref()
-        .map_or_else(chrono::Utc::now, |cursor| cursor.started_at);
-    let cursor_exec_id = filters
-        .cursor
-        .as_ref()
-        .map_or_else(uuid::Uuid::nil, |cursor| cursor.exec_id);
-    let limit = filters.limit.unwrap_or(i64::MAX);
-
-    diesel::sql_query(
-        "WITH RECURSIVE descendants AS (
-            SELECT
-                id,
-                workflow_name,
-                state,
-                started_at,
-                completed_at,
-                error,
-                shard_id,
-                0::int AS depth
-            FROM harvest_workflow_executions
-            WHERE parent_id = $1
-            UNION ALL
-            SELECT
-                child.id,
-                child.workflow_name,
-                child.state,
-                child.started_at,
-                child.completed_at,
-                child.error,
-                child.shard_id,
-                descendants.depth + 1
-            FROM harvest_workflow_executions child
-            JOIN descendants ON child.parent_id = descendants.id
-            WHERE descendants.depth < $2
-        )
-        SELECT
-            id,
-            workflow_name,
-            state,
-            started_at,
-            completed_at,
-            error,
-            shard_id,
-            depth
-        FROM descendants
-        WHERE ($3 OR state = ANY($4))
-          AND ($5 OR workflow_name = $6)
-          AND ($7 OR started_at < $8 OR (started_at = $8 AND id < $9))
-        ORDER BY started_at DESC, id DESC
-        LIMIT $10",
-    )
-    .bind::<diesel::sql_types::Uuid, _>(parent_id.as_uuid())
-    .bind::<Integer, _>(i32::from(max_depth))
-    .bind::<Bool, _>(no_status_filter)
-    .bind::<Array<Text>, _>(filters.statuses.clone())
-    .bind::<Bool, _>(no_name_filter)
-    .bind::<Text, _>(workflow_name)
-    .bind::<Bool, _>(no_cursor)
-    .bind::<diesel::sql_types::Timestamptz, _>(cursor_started_at)
-    .bind::<diesel::sql_types::Uuid, _>(cursor_exec_id)
-    .bind::<BigInt, _>(limit)
-    .load::<WorkflowChildQueryRow>(conn)
-    .await
-    .map_err(crate::error::database_error)?
-    .into_iter()
-    .map(|row| {
-        let depth = u8::try_from(row.depth).map_err(|_| {
-            crate::error::HarvestError::Database(format!(
-                "workflow child depth {} does not fit in u8",
-                row.depth
-            ))
-        })?;
-        Ok(workflow_child_row_from_parts(
-            row.id,
-            row.workflow_name,
-            row.state,
-            row.started_at,
-            row.completed_at,
-            row.error,
-            row.shard_id,
-            depth,
-        ))
-    })
-    .collect()
 }
 
 #[allow(clippy::too_many_arguments)]

--- a/autumn-harvest/src/store.rs
+++ b/autumn-harvest/src/store.rs
@@ -15,7 +15,7 @@ use scoped_futures::ScopedFutureExt as _;
 
 use crate::error::HarvestResult;
 use crate::event::WorkflowEvent;
-use crate::models::{NewHarvestEvent, WorkflowExecution};
+use crate::models::NewHarvestEvent;
 use crate::schema::{harvest_events, harvest_workflow_executions};
 use crate::types::ExecutionId;
 
@@ -49,6 +49,16 @@ pub struct WorkflowChildRow {
     pub shard_id: i32,
     pub depth: u8,
 }
+
+type WorkflowChildProjection = (
+    uuid::Uuid,
+    String,
+    String,
+    chrono::DateTime<chrono::Utc>,
+    Option<chrono::DateTime<chrono::Utc>>,
+    Option<String>,
+    i32,
+);
 
 /// Convert in-memory events to insertable rows with sequential event IDs
 /// starting from 0.
@@ -349,22 +359,34 @@ pub async fn load_workflow_children(
     }
 
     query
-        .select(WorkflowExecution::as_select())
-        .load::<WorkflowExecution>(conn)
+        .select((
+            harvest_workflow_executions::id,
+            harvest_workflow_executions::workflow_name,
+            harvest_workflow_executions::state,
+            harvest_workflow_executions::started_at,
+            harvest_workflow_executions::completed_at,
+            harvest_workflow_executions::error,
+            harvest_workflow_executions::shard_id,
+        ))
+        .load::<WorkflowChildProjection>(conn)
         .await
         .map_err(crate::error::database_error)
         .map(|rows| {
             rows.into_iter()
-                .map(|row| WorkflowChildRow {
-                    exec_id: ExecutionId::from_uuid(row.id),
-                    workflow_name: row.workflow_name,
-                    status: row.state,
-                    started_at: row.started_at,
-                    completed_at: row.completed_at,
-                    error_summary: summarize_error(row.error),
-                    shard_id: row.shard_id,
-                    depth,
-                })
+                .map(
+                    |(id, workflow_name, state, started_at, completed_at, error, shard_id)| {
+                        WorkflowChildRow {
+                            exec_id: ExecutionId::from_uuid(id),
+                            workflow_name,
+                            status: state,
+                            started_at,
+                            completed_at,
+                            error_summary: summarize_error(error),
+                            shard_id,
+                            depth,
+                        }
+                    },
+                )
                 .collect()
         })
 }
@@ -372,17 +394,12 @@ pub async fn load_workflow_children(
 fn summarize_error(error: Option<String>) -> Option<String> {
     const MAX_ERROR_SUMMARY_CHARS: usize = 240;
 
-    let first_line = error?.lines().next().unwrap_or_default().trim().to_string();
+    let first_line = error?.lines().next()?.trim().to_string();
     if first_line.is_empty() {
         return None;
     }
 
-    let mut chars = first_line.chars();
-    let summary = chars
-        .by_ref()
-        .take(MAX_ERROR_SUMMARY_CHARS)
-        .collect::<String>();
-    Some(summary)
+    Some(first_line.chars().take(MAX_ERROR_SUMMARY_CHARS).collect())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Add `GET /workflows/{exec_id}/children` with shard fan-out, filtering, cursor pagination, recursive depth support, and parent existence semantics.
- Add `parent_id` to workflow detail responses and `workflow children` CLI output with table/default and raw `--json` modes.
- Add a parent-id lookup migration and document the new management surface.

## Test Plan
- `cargo fmt --all`
- `cargo check --all-targets --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test -p autumn-harvest-cli children_`
- `cargo test -p autumn-harvest-plugin parse_workflow_children_filters`
- `cargo test -p autumn-harvest-plugin --test security eris_require_auth_blocks_workflow_children`
- `cargo test -p autumn-harvest-plugin --test api_scheduler_integration children`
- `cargo test -p autumn-harvest-plugin --test api_scheduler_integration harvest_api_workflow_details_include_parent_id_at_top_level`

## Notes
- Full workspace `cargo test --workspace --all-features` was run and reached the existing UI performance test `ui_workers_perf_1k_workers_4_shards_under_500ms`, which failed outside this change at ~2.0s vs a 500ms budget; rerunning that single test reproduced the same failure.