### PR TITLE
👺 Havoc: Prevent unbounded memory allocation OOM in `task_duration`

### DIFF
--- a/autumn-harvest/src/lib.rs
+++ b/autumn-harvest/src/lib.rs
@@ -195,6 +195,9 @@ pub fn task_duration(s: &str) -> Option<std::time::Duration> {
 
     for ch in s.chars() {
         if ch.is_ascii_digit() {
+            if current_num.len() > 20 {
+                return None;
+            }
             current_num.push(ch);
         } else if ch.is_ascii_alphabetic() {
             let num: u64 = current_num.parse().ok()?;
@@ -262,5 +265,15 @@ mod tests {
         assert_eq!(task_duration("18446744073709551615h"), None); // u64::MAX
         assert_eq!(task_duration("18446744073709551615m"), None); // u64::MAX
         assert_eq!(task_duration("18446744073709551614s 2s"), None); // Add overflow
+    }
+
+    #[test]
+    fn havoc_task_duration_oom_prevention() {
+        // Attack: Create a 200MB string of just '1's.
+        // If unbounded, current_num will grow until it triggers an OOM killer
+        // or consumes excessive memory.
+        let massive_input = "1".repeat(200_000_000);
+        let result = task_duration(&massive_input);
+        assert_eq!(result, None);
     }
 }

--- a/autumn-harvest/src/lib.rs
+++ b/autumn-harvest/src/lib.rs
@@ -269,10 +269,9 @@ mod tests {
 
     #[test]
     fn havoc_task_duration_oom_prevention() {
-        // Attack: Create a 200MB string of just '1's.
-        // If unbounded, current_num will grow until it triggers an OOM killer
-        // or consumes excessive memory.
-        let massive_input = "1".repeat(200_000_000);
+        // Attack: Provide an excessively long string of digits.
+        // The implementation rejects it early instead of boundedly growing `current_num`.
+        let massive_input = "1".repeat(100);
         let result = task_duration(&massive_input);
         assert_eq!(result, None);
     }

--- a/autumn-harvest/src/lib.rs
+++ b/autumn-harvest/src/lib.rs
@@ -195,6 +195,9 @@ pub fn task_duration(s: &str) -> Option<std::time::Duration> {
 
     for ch in s.chars() {
         if ch.is_ascii_digit() {
+            if current_num == "0" {
+                current_num.clear();
+            }
             if current_num.len() > 20 {
                 return None;
             }
@@ -274,5 +277,14 @@ mod tests {
         let massive_input = "1".repeat(100);
         let result = task_duration(&massive_input);
         assert_eq!(result, None);
+    }
+
+    #[test]
+    fn task_duration_allows_zero_padded_values() {
+        let zero_padded = format!("{}1s", "0".repeat(50));
+        assert_eq!(task_duration(&zero_padded), Some(Duration::from_secs(1)));
+        // 0s is rejected globally by task_duration, so we test None
+        assert_eq!(task_duration("000000000000s"), None);
+        assert_eq!(task_duration("0000010m"), Some(Duration::from_secs(600)));
     }
 }

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,14 @@
+1. **Understand Comment**:
+   - The user (via CodeRabbit AI review, possibly) says the `havoc_task_duration_oom_prevention` test allocates 200MB and might cause OOMs or severe slowdown in CI, and makes the test suite flaky.
+   - The user suggests replacing the 200MB test input with a bounded-size regression case, since the guard triggers after ~22 digits. A much smaller crafted input (e.g., 100 digits) would exercise the same code path.
+
+2. **Fix the Test**:
+   - Open `autumn-harvest/src/lib.rs`.
+   - Update `havoc_task_duration_oom_prevention` to use a string of ~100 characters instead of 200,000,000.
+
+3. **Verify the Fix**:
+   - Run `cargo test -p autumn-harvest havoc_task_duration_oom_prevention` to make sure it passes.
+
+4. **Reply to Comment and Submit**:
+   - Use `reply_to_pr_comments` to let the user know the change was made.
+   - Use `submit` to push the changes using the original branch name `havoc-task-duration-oom`.

--- a/plan.md
+++ b/plan.md
@@ -1,14 +1,64 @@
-1. **Understand Comment**:
-   - The user (via CodeRabbit AI review, possibly) says the `havoc_task_duration_oom_prevention` test allocates 200MB and might cause OOMs or severe slowdown in CI, and makes the test suite flaky.
-   - The user suggests replacing the 200MB test input with a bounded-size regression case, since the guard triggers after ~22 digits. A much smaller crafted input (e.g., 100 digits) would exercise the same code path.
+Wait, `assert_eq!(task_duration("000000000000s"), Some(Duration::from_secs(0)));` failed!
+Why? Let's trace it.
+`task_duration` is:
+```rust
+    for ch in s.chars() {
+        if ch.is_ascii_digit() {
+            if current_num == "0" {
+                current_num.clear();
+            }
+            if current_num.len() > 20 {
+                return None;
+            }
+            current_num.push(ch);
+        } else if ch.is_ascii_alphabetic() {
+            let num: u64 = current_num.parse().ok()?;
+```
+If `s` is "000000000000s", what happens?
+1st char '0': `current_num` is "". Appends '0', `current_num`="0".
+2nd char '0': `current_num` == "0". Clears it. `current_num` is "". Appends '0', `current_num`="0".
+...
+Last char '0': Appends '0', `current_num`="0".
+Next char 's': Calls `current_num.parse().ok()?`. "0".parse() is `0`.
+Wait, why did it return `None`?
 
-2. **Fix the Test**:
-   - Open `autumn-harvest/src/lib.rs`.
-   - Update `havoc_task_duration_oom_prevention` to use a string of ~100 characters instead of 200,000,000.
+Ah! Wait, `0000010m`.
+1st '0': "0"
+2nd '0': clears, "0"
+...
+5th '0': clears, "0"
+Next '1': clears? No, `current_num` is "0", `ch` is '1'.
+It clears! `current_num` becomes "". Appends '1'. `current_num`="1".
+Next '0': `current_num` is "1", does not clear. Appends '0'. `current_num`="10".
+So `"0000010m"` parses correctly? Let me check which assertion failed!
 
-3. **Verify the Fix**:
-   - Run `cargo test -p autumn-harvest havoc_task_duration_oom_prevention` to make sure it passes.
-
-4. **Reply to Comment and Submit**:
-   - Use `reply_to_pr_comments` to let the user know the change was made.
-   - Use `submit` to push the changes using the original branch name `havoc-task-duration-oom`.
+`left: None, right: Some(0ns)`
+This corresponds to `assert_eq!(task_duration("000000000000s"), Some(Duration::from_secs(0)));`.
+Wait!
+"0".repeat(50) + "1s" -> `task_duration` returned `Some(Duration::from_secs(1))`. So the FIRST assertion passed!
+Wait, why did `task_duration("000000000000s")` fail?
+Ah! `current_num.parse().ok()?` succeeds. `total_secs = 0`.
+At the end:
+```rust
+    if !current_num.is_empty() || total_secs == 0 {
+        return None;
+    }
+```
+Oh! `total_secs == 0` returns `None`!
+Wait, `task_duration` ALWAYS returns `None` for `0` duration!
+Let's look at `autumn-harvest/src/lib.rs`.
+```rust
+    if !current_num.is_empty() || total_secs == 0 {
+        return None;
+    }
+```
+Yes! It rejects 0!
+So `assert_eq!(task_duration("000000000000s"), Some(Duration::from_secs(0)));` was WRONG to expect `Some(0)`!
+Wait, the original code had:
+```rust
+    if !current_num.is_empty() || total_secs == 0 {
+        return None;
+    }
+```
+So `task_duration("0s")` returns `None`!
+My test expects `Some(0)`.


### PR DESCRIPTION
🧨 **The Trigger:** Passing a massive string consisting solely of digits (e.g., `200MB` of `'1'`s) to `autumn_harvest::task_duration` bypassed the alphabet checks and endlessly appended to a `String` buffer without limit.
📉 **The Stack Trace:** OOM killer terminates the process due to unbounded heap allocation during `current_num.push(ch);`.
🧪 **Reproduction:** Call `autumn_harvest::task_duration(&"1".repeat(200_000_000))`.
😈 **Comment:** You assumed the buffer would never be larger than RAM. You were wrong.

---
*PR created automatically by Jules for task [2073544323656179099](https://jules.google.com/task/2073544323656179099) started by @madmax983*