### PR TITLE
Add activity idempotency key support for at-least-once semantics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4871,6 +4871,7 @@ dependencies = [
  "getrandom 0.4.2",
  "js-sys",
  "serde_core",
+ "sha1_smol",
  "wasm-bindgen",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1.1"
 thiserror = "2"
-uuid = { version = "1", features = ["v4", "serde"] }
+uuid = { version = "1", features = ["v4", "v5", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 tracing = "0.1"
 futures = "0.3"

--- a/README.md
+++ b/README.md
@@ -292,8 +292,8 @@ SendGrid, Twilio, S3 multipart, your own mutation endpoint) converts
 at-least-once into effectively-exactly-once by letting the provider
 deduplicate.
 
-Every activity receives a Harvest-provided key via `ctx.idempotency_key()`.
-The key is stable across:
+Every activity — **regular and local** — receives a Harvest-provided key via
+`ctx.idempotency_key()`.  The key is stable across:
 
 - worker restarts
 - duplicate task-queue dispatch of the same logical invocation
@@ -302,6 +302,15 @@ The key is stable across:
 
 Two distinct activity invocations — even calling the same activity name with
 the same input — always receive different keys.
+
+**Local activities** (`#[activity(local = true)]`) are fully supported.  The
+key is derived from the `ActivityExecId` recorded in the
+`LocalActivityScheduled` event, so it is identical across all inline retry
+attempts.  Local activities do not support heartbeating, but `idempotency_key()`
+works identically to regular activities.  If a future activity type were ever
+excluded, `idempotency_key()` would return a descriptive
+`HarvestError::Config` rather than silently producing an unstable or
+meaningless value.
 
 #### Billing / payment example
 

--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ async fn main() {
   up at the same state.
 - **Activities with retries.** Side effects live in `#[activity]` functions
   with configurable `start_to_close`, `heartbeat_timeout`, and `retry` policies.
+  Activities are **at-least-once**: a worker crash or timeout will trigger a
+  retry. Use `ctx.idempotency_key()` (see below) to make downstream calls safe
+  to retry without duplicate charges or duplicate emails.
 - **Per-activity concurrency caps.** Declare `max_concurrent = N` on an
   activity to enforce a cluster-wide cap without spinning up dedicated worker
   processes. Activities sharing a rate-limited dependency can share a budget
@@ -277,6 +280,90 @@ Or via the management API directly:
 
 ```bash
 GET /api/harvest/admin/concurrency
+```
+
+### Activity idempotency keys
+
+Harvest activities are **at-least-once**. A worker crash, a `start_to_close`
+timeout, or a duplicate task-queue dispatch will cause the activity to run
+again — potentially after the external system has already accepted the first
+request.  Passing a stable idempotency key to the downstream API (Stripe,
+SendGrid, Twilio, S3 multipart, your own mutation endpoint) converts
+at-least-once into effectively-exactly-once by letting the provider
+deduplicate.
+
+Every activity receives a Harvest-provided key via `ctx.idempotency_key()`.
+The key is stable across:
+
+- worker restarts
+- duplicate task-queue dispatch of the same logical invocation
+- deterministic replay
+- every retry attempt for the same logical invocation
+
+Two distinct activity invocations — even calling the same activity name with
+the same input — always receive different keys.
+
+#### Billing / payment example
+
+```rust
+#[activity(start_to_close = "30s", retry = RetryPolicy::exponential(3, Duration::from_secs(2)))]
+async fn charge_card(
+    ctx: &ActivityContext,
+    amount_cents: u64,
+    customer_id: String,
+) -> HarvestResult<String> {
+    // idempotency_key() is always Ok in production; only None in bare unit-test
+    // contexts built without with_idempotency_key().
+    let idem_key = ctx.idempotency_key()?.as_str().to_owned();
+
+    let charge_id = stripe_client
+        .charges()
+        .create(CreateCharge {
+            amount: amount_cents as i64,
+            customer: customer_id,
+            idempotency_key: Some(idem_key), // ← same on every retry attempt
+            ..Default::default()
+        })
+        .await
+        .map_err(|e| e.to_string())?;
+
+    Ok(charge_id)
+}
+```
+
+If the worker crashes after Stripe accepts the charge but before Harvest
+records `ActivityCompleted`, the retry carries the same key and Stripe returns
+the already-created charge — no duplicate payment.
+
+#### Subkeys for multiple side effects
+
+When one activity must produce several distinct outbound calls, derive named
+subkeys from the base key:
+
+```rust
+#[activity(start_to_close = "60s")]
+async fn provision_account(ctx: &ActivityContext, user_id: i64) -> HarvestResult<()> {
+    let key = ctx.idempotency_key()?;
+
+    // Each call gets a distinct, stable key derived from the same parent.
+    create_db_user(&user_id, key.subkey("db").as_str()).await?;
+    send_welcome_email(&user_id, key.subkey("email").as_str()).await?;
+    create_billing_profile(&user_id, key.subkey("billing").as_str()).await?;
+
+    Ok(())
+}
+```
+
+#### Attempt-scoped keys (opt-in)
+
+The default key is **retry-stable** — the same value across all attempts for
+the same logical invocation. If a downstream API requires a fresh key on each
+attempt (uncommon), derive an attempt-scoped subkey:
+
+```rust
+let idem_key = ctx
+    .idempotency_key()?
+    .subkey(&format!("attempt-{}", ctx.attempt().unwrap_or(1)));
 ```
 
 ### Filtering the workflow list

--- a/autumn-harvest/Cargo.toml
+++ b/autumn-harvest/Cargo.toml
@@ -56,6 +56,10 @@ name = "metrics_noop"
 harness = false
 
 [[test]]
+name = "idempotency_tests"
+required-features = ["testing"]
+
+[[test]]
 name = "replayer_tests"
 required-features = ["testing"]
 

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -20,7 +20,9 @@ use crate::error::{HarvestError, HarvestResult};
 use crate::event::WorkflowEvent;
 use crate::query::QueryRegistry;
 use crate::replay::{HistoryMatch, HistoryMatcher};
-use crate::types::{ActivityExecId, ExecutionId, ExternalActivityToken, IdempotencyKey, TimerId, UpdateId};
+use crate::types::{
+    ActivityExecId, ExecutionId, ExternalActivityToken, IdempotencyKey, TimerId, UpdateId,
+};
 use crate::update::{BoxUpdateHandler, BoxUpdateValidator, UpdateRegistry};
 
 /// Runtime map of typed shared state registered on the harvest builder.

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -197,6 +197,14 @@ pub enum WorkflowCommand {
         /// (worker crashed after appending it but before recording a terminal
         /// event). The worker must **not** append a second scheduled event.
         already_scheduled: bool,
+        /// Number of `LocalActivityFailed` events already recorded in history.
+        /// The worker starts its retry loop from `failed_attempts + 1`.
+        /// When `failed_attempts >= max_attempts`, the worker returns `last_error`
+        /// immediately without executing the handler.
+        failed_attempts: u32,
+        /// Error from the last recorded `LocalActivityFailed`, used when
+        /// `failed_attempts >= max_attempts` to return the correct error.
+        last_error: Option<String>,
     },
     /// Record a terminal result for an admitted update.
     ///
@@ -911,6 +919,7 @@ impl WorkflowContext {
     /// # Panics
     ///
     /// Panics if the internal matcher or commands mutex is poisoned.
+    #[allow(clippy::too_many_lines)]
     pub async fn execute_local_activity_raw(
         &self,
         name: &str,
@@ -949,11 +958,38 @@ impl WorkflowContext {
                 )
             }
 
-            // Worker crashed after appending `LocalActivityScheduled` but before
+            // Worker crashed after appending `LocalActivityScheduled` (and
+            // possibly one or more `LocalActivityFailed` events) but before
             // recording a terminal event. Re-run with the original `activity_id`
-            // so the idempotency key is stable. Signal the worker not to append a
-            // second scheduled event.
-            HistoryMatch::LocalActivityInProgress { activity_id } => {
+            // so the idempotency key is stable across the crash.
+            HistoryMatch::LocalActivityInProgress {
+                activity_id,
+                failed_attempts,
+                last_error,
+            } => {
+                if self.strict_replay {
+                    return Err(HarvestError::NonDeterministic(format!(
+                        "local activity '{name}' scheduled but terminal not in history"
+                    )));
+                }
+
+                // If the recorded failure count already covers all retry
+                // attempts, return the last error immediately — no handler
+                // execution is needed and no command should be pushed.
+                let max_attempts = retry_policy.as_ref().map_or(1, |p| p.max_attempts);
+                if failed_attempts >= max_attempts {
+                    let error = last_error.unwrap_or_else(|| {
+                        format!("local activity '{name}' failed after {failed_attempts} attempts")
+                    });
+                    return Err(HarvestError::ActivityFailed {
+                        name: name.to_string(),
+                        attempt: failed_attempts,
+                        source: error.into(),
+                    });
+                }
+
+                // Some retry attempts remain — push the command so the worker
+                // re-runs the handler starting from the next unrecorded attempt.
                 let (tx, rx) = oneshot::channel();
                 self.push_command(WorkflowCommand::RunLocalActivity {
                     activity_id,
@@ -963,12 +999,14 @@ impl WorkflowContext {
                     retry_policy,
                     result_tx: tx,
                     already_scheduled: true,
+                    failed_attempts,
+                    last_error,
                 });
                 match rx.await {
                     Ok(Ok(output)) => Ok(output),
                     Ok(Err(error)) => Err(HarvestError::ActivityFailed {
                         name: name.to_string(),
-                        attempt: 1,
+                        attempt: failed_attempts.max(1),
                         source: error.into(),
                     }),
                     Err(_) => Err(HarvestError::Cancelled(format!(
@@ -996,6 +1034,8 @@ impl WorkflowContext {
                     retry_policy,
                     result_tx: tx,
                     already_scheduled: false,
+                    failed_attempts: 0,
+                    last_error: None,
                 });
 
                 match rx.await {

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -20,7 +20,7 @@ use crate::error::{HarvestError, HarvestResult};
 use crate::event::WorkflowEvent;
 use crate::query::QueryRegistry;
 use crate::replay::{HistoryMatch, HistoryMatcher};
-use crate::types::{ActivityExecId, ExecutionId, ExternalActivityToken, TimerId, UpdateId};
+use crate::types::{ActivityExecId, ExecutionId, ExternalActivityToken, IdempotencyKey, TimerId, UpdateId};
 use crate::update::{BoxUpdateHandler, BoxUpdateValidator, UpdateRegistry};
 
 /// Runtime map of typed shared state registered on the harvest builder.
@@ -1659,6 +1659,15 @@ pub struct ActivityContext {
     /// W3C tracecontext carrier captured at enqueue, surfaced so activity
     /// handlers can propagate the trace to downstream services.
     trace_context: Option<crate::telemetry::TraceContextCarrier>,
+    /// Stable idempotency key for this logical activity invocation.
+    ///
+    /// Derived from the `ActivityExecId` recorded in the `ActivityScheduled`
+    /// or `LocalActivityScheduled` event — identical across all retry attempts
+    /// for the same logical invocation.
+    idempotency_key: Option<IdempotencyKey>,
+    /// Which attempt of the logical activity invocation this context represents.
+    /// `1` for the first attempt. Stable retries share a key but differ here.
+    attempt: Option<u32>,
 }
 
 impl ActivityContext {
@@ -1683,6 +1692,8 @@ impl ActivityContext {
             #[cfg(feature = "db")]
             cancellation_check: None,
             trace_context: None,
+            idempotency_key: None,
+            attempt: None,
         }
     }
 
@@ -1712,6 +1723,8 @@ impl ActivityContext {
                 last_checked_at: Mutex::new(None),
             }),
             trace_context: None,
+            idempotency_key: None,
+            attempt: None,
         }
     }
 
@@ -1729,6 +1742,8 @@ impl ActivityContext {
             #[cfg(feature = "db")]
             cancellation_check: None,
             trace_context: None,
+            idempotency_key: None,
+            attempt: None,
         }
     }
 
@@ -1750,6 +1765,67 @@ impl ActivityContext {
     #[must_use]
     pub const fn trace_context(&self) -> Option<&crate::telemetry::TraceContextCarrier> {
         self.trace_context.as_ref()
+    }
+
+    /// Attach a stable idempotency key to this context.
+    ///
+    /// The engine calls this automatically for both regular and local
+    /// activities. You only need it when constructing a context manually in
+    /// tests.
+    #[must_use]
+    pub fn with_idempotency_key(mut self, key: IdempotencyKey) -> Self {
+        self.idempotency_key = Some(key);
+        self
+    }
+
+    /// Set the attempt number for this activity invocation.
+    ///
+    /// `1` means the first attempt. The engine sets this automatically; you
+    /// only need it when constructing a context manually in tests.
+    #[must_use]
+    pub fn with_attempt(mut self, attempt: u32) -> Self {
+        self.attempt = Some(attempt);
+        self
+    }
+
+    /// The stable idempotency key for this logical activity invocation.
+    ///
+    /// Identical across all retry attempts for the same logical invocation
+    /// (worker restarts, duplicate dispatch, and deterministic replay all
+    /// produce the same key).  Safe to use directly as an `Idempotency-Key`
+    /// HTTP request header.
+    ///
+    /// Use [`IdempotencyKey::subkey`] to derive a named child key when one
+    /// activity must produce multiple distinct side effects.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HarvestError::Config`] if no idempotency key was attached to
+    /// this context.  In production this never happens; in tests use
+    /// [`Self::with_idempotency_key`] or [`Self::new_test`] which always
+    /// provides a key.
+    pub fn idempotency_key(&self) -> Result<&IdempotencyKey, HarvestError> {
+        self.idempotency_key.as_ref().ok_or_else(|| {
+            HarvestError::Config(
+                "idempotency key not available on this context; \
+                 use ActivityContext::new_test() or ActivityContext::with_idempotency_key()"
+                    .into(),
+            )
+        })
+    }
+
+    /// Which attempt of the logical activity invocation this context
+    /// represents.  `Some(1)` for the first attempt, `Some(2)` for the first
+    /// retry, and so on.  `None` if the engine did not set an attempt (e.g.
+    /// contexts built with the bare `new` constructor).
+    ///
+    /// The default idempotency key is **retry-stable** (same value for all
+    /// attempts).  Call `ctx.idempotency_key()?.subkey(&format!("attempt-{}",
+    /// ctx.attempt().unwrap_or(1)))` to opt into an attempt-scoped subkey if
+    /// your downstream API requires distinct keys per attempt.
+    #[must_use]
+    pub fn attempt(&self) -> Option<u32> {
+        self.attempt
     }
 
     /// Access typed shared state.
@@ -1944,6 +2020,21 @@ impl ActivityContext {
     #[cfg(any(test, feature = "testing"))]
     #[must_use]
     pub fn new_test() -> Self {
+        let id = ActivityExecId::new();
+        Self::new(
+            empty_shared_state(),
+            None,
+            tokio_util::sync::CancellationToken::new(),
+        )
+        .with_idempotency_key(IdempotencyKey::from_activity_exec_id(id))
+        .with_attempt(1)
+    }
+
+    /// Like [`new_test`](Self::new_test) but intentionally omits the
+    /// idempotency key.  Used only in tests that verify the error path.
+    #[cfg(any(test, feature = "testing"))]
+    #[must_use]
+    pub fn new_for_idempotency_test_no_key() -> Self {
         Self::new(
             empty_shared_state(),
             None,

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -193,6 +193,10 @@ pub enum WorkflowCommand {
         retry_policy: Option<crate::policy::RetryPolicy>,
         /// The worker sends the final result (success or exhausted retries) here.
         result_tx: oneshot::Sender<Result<Value, String>>,
+        /// `true` when the `LocalActivityScheduled` event is already in history
+        /// (worker crashed after appending it but before recording a terminal
+        /// event). The worker must **not** append a second scheduled event.
+        already_scheduled: bool,
     },
     /// Record a terminal result for an admitted update.
     ///
@@ -698,7 +702,8 @@ impl WorkflowContext {
             HistoryMatch::Failed { .. }
             | HistoryMatch::TimedOut { .. }
             | HistoryMatch::AwaitingExternalCompletion { .. }
-            | HistoryMatch::ChildInProgress { .. } => {
+            | HistoryMatch::ChildInProgress { .. }
+            | HistoryMatch::LocalActivityInProgress { .. } => {
                 unreachable!("match_side_effect only returns Matched, Diverged or NoMatch")
             }
 
@@ -834,9 +839,11 @@ impl WorkflowContext {
             )),
 
             HistoryMatch::AwaitingExternalCompletion { .. }
-            | HistoryMatch::ChildInProgress { .. } => {
+            | HistoryMatch::ChildInProgress { .. }
+            | HistoryMatch::LocalActivityInProgress { .. } => {
                 unreachable!(
-                    "match_activity never returns AwaitingExternalCompletion or ChildInProgress"
+                    "match_activity never returns AwaitingExternalCompletion, ChildInProgress, \
+                     or LocalActivityInProgress"
                 )
             }
 
@@ -942,6 +949,34 @@ impl WorkflowContext {
                 )
             }
 
+            // Worker crashed after appending `LocalActivityScheduled` but before
+            // recording a terminal event. Re-run with the original `activity_id`
+            // so the idempotency key is stable. Signal the worker not to append a
+            // second scheduled event.
+            HistoryMatch::LocalActivityInProgress { activity_id } => {
+                let (tx, rx) = oneshot::channel();
+                self.push_command(WorkflowCommand::RunLocalActivity {
+                    activity_id,
+                    name: name.to_string(),
+                    input,
+                    start_to_close_secs,
+                    retry_policy,
+                    result_tx: tx,
+                    already_scheduled: true,
+                });
+                match rx.await {
+                    Ok(Ok(output)) => Ok(output),
+                    Ok(Err(error)) => Err(HarvestError::ActivityFailed {
+                        name: name.to_string(),
+                        attempt: 1,
+                        source: error.into(),
+                    }),
+                    Err(_) => Err(HarvestError::Cancelled(format!(
+                        "local activity '{name}' cancelled: result channel dropped"
+                    ))),
+                }
+            }
+
             HistoryMatch::NoMatch => {
                 if self.strict_replay {
                     return Err(HarvestError::NonDeterministic(format!(
@@ -960,6 +995,7 @@ impl WorkflowContext {
                     start_to_close_secs,
                     retry_policy,
                     result_tx: tx,
+                    already_scheduled: false,
                 });
 
                 match rx.await {
@@ -1006,7 +1042,8 @@ impl WorkflowContext {
             HistoryMatch::Failed { .. }
             | HistoryMatch::TimedOut { .. }
             | HistoryMatch::AwaitingExternalCompletion { .. }
-            | HistoryMatch::ChildInProgress { .. } => {
+            | HistoryMatch::ChildInProgress { .. }
+            | HistoryMatch::LocalActivityInProgress { .. } => {
                 unreachable!("timers do not fail or time out in history matching")
             }
 
@@ -1064,7 +1101,9 @@ impl WorkflowContext {
                 attempt,
                 source: error.into(),
             }),
-            HistoryMatch::TimedOut { .. } | HistoryMatch::AwaitingExternalCompletion { .. } => {
+            HistoryMatch::TimedOut { .. }
+            | HistoryMatch::AwaitingExternalCompletion { .. }
+            | HistoryMatch::LocalActivityInProgress { .. } => {
                 unreachable!("child workflows do not time out in match_child_workflow")
             }
             HistoryMatch::Diverged { expected, actual } => Err(HarvestError::NonDeterministic(
@@ -1158,7 +1197,8 @@ impl WorkflowContext {
             HistoryMatch::Failed { .. }
             | HistoryMatch::TimedOut { .. }
             | HistoryMatch::AwaitingExternalCompletion { .. }
-            | HistoryMatch::ChildInProgress { .. } => Err(HarvestError::NonDeterministic(
+            | HistoryMatch::ChildInProgress { .. }
+            | HistoryMatch::LocalActivityInProgress { .. } => Err(HarvestError::NonDeterministic(
                 "signal history contains unexpected failure".into(),
             )),
             HistoryMatch::NoMatch => {
@@ -1298,8 +1338,10 @@ impl WorkflowContext {
                 }
             }
 
-            HistoryMatch::ChildInProgress { .. } => {
-                unreachable!("match_external_activity never returns ChildInProgress")
+            HistoryMatch::ChildInProgress { .. } | HistoryMatch::LocalActivityInProgress { .. } => {
+                unreachable!(
+                    "match_external_activity never returns ChildInProgress or LocalActivityInProgress"
+                )
             }
         }
     }
@@ -1348,7 +1390,8 @@ impl WorkflowContext {
             HistoryMatch::Failed { .. }
             | HistoryMatch::TimedOut { .. }
             | HistoryMatch::AwaitingExternalCompletion { .. }
-            | HistoryMatch::ChildInProgress { .. } => Err(HarvestError::NonDeterministic(
+            | HistoryMatch::ChildInProgress { .. }
+            | HistoryMatch::LocalActivityInProgress { .. } => Err(HarvestError::NonDeterministic(
                 "continue_as_new history contains unexpected terminal state".into(),
             )),
             HistoryMatch::NoMatch => {

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -1783,7 +1783,7 @@ impl ActivityContext {
     /// `1` means the first attempt. The engine sets this automatically; you
     /// only need it when constructing a context manually in tests.
     #[must_use]
-    pub fn with_attempt(mut self, attempt: u32) -> Self {
+    pub const fn with_attempt(mut self, attempt: u32) -> Self {
         self.attempt = Some(attempt);
         self
     }
@@ -1824,7 +1824,7 @@ impl ActivityContext {
     /// ctx.attempt().unwrap_or(1)))` to opt into an attempt-scoped subkey if
     /// your downstream API requires distinct keys per attempt.
     #[must_use]
-    pub fn attempt(&self) -> Option<u32> {
+    pub const fn attempt(&self) -> Option<u32> {
         self.attempt
     }
 

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -3412,6 +3412,13 @@ mod tests {
                 error: "always fails".into(),
                 attempt: 1,
             },
+            // LocalActivityExhausted is the authoritative terminal marker; without
+            // it the context would treat this as a crash-between-retries case.
+            WorkflowEvent::LocalActivityExhausted {
+                activity_id: id,
+                error: "always fails".into(),
+                attempt: 1,
+            },
         ];
         let ctx = WorkflowContext::for_replay(crate::types::ExecutionId::new(), events);
         let result = ctx

--- a/autumn-harvest/src/event.rs
+++ b/autumn-harvest/src/event.rs
@@ -186,8 +186,8 @@ pub enum WorkflowEvent {
     ///
     /// Multiple `LocalActivityFailed` events may appear in sequence (one per
     /// attempt) before a terminal `LocalActivityCompleted` (retry eventually
-    /// succeeded) or before the retry budget is exhausted (the last
-    /// `LocalActivityFailed` with no following `LocalActivityCompleted`).
+    /// succeeded) or before the retry budget is exhausted (followed by a
+    /// `LocalActivityExhausted` event that marks the terminal state).
     LocalActivityFailed {
         /// Unique ID matching the corresponding `LocalActivityScheduled`.
         activity_id: ActivityExecId,
@@ -300,6 +300,23 @@ pub enum WorkflowEvent {
         /// Operator identity for audit.
         operator_id: String,
     },
+    /// All retry attempts for a local activity were exhausted. Appended
+    /// immediately after the final `LocalActivityFailed` event so replay can
+    /// identify the terminal state without knowing the current retry policy.
+    ///
+    /// This makes the terminal-vs-in-progress distinction policy-invariant:
+    /// if this event is present the activity is unambiguously done; if only
+    /// `LocalActivityFailed` events are present (without a following
+    /// `LocalActivityExhausted`) the worker crashed between retries and must
+    /// continue from the next attempt.
+    LocalActivityExhausted {
+        /// Unique ID matching the corresponding `LocalActivityScheduled`.
+        activity_id: ActivityExecId,
+        /// Error from the final attempt.
+        error: String,
+        /// Total attempts that were made (equals `max_attempts`).
+        attempt: u32,
+    },
 }
 
 impl WorkflowEvent {
@@ -338,6 +355,7 @@ impl WorkflowEvent {
             Self::UpdateFailed { .. } => "UpdateFailed",
             Self::WorkflowResetFork { .. } => "WorkflowResetFork",
             Self::WorkflowResetTerminated { .. } => "WorkflowResetTerminated",
+            Self::LocalActivityExhausted { .. } => "LocalActivityExhausted",
         }
     }
 
@@ -426,6 +444,24 @@ mod tests {
             back,
             WorkflowEvent::LocalActivityFailed { attempt: 3, .. }
         ));
+        Ok(())
+    }
+
+    #[test]
+    fn local_activity_exhausted_round_trips() -> Result<(), serde_json::Error> {
+        let id = ActivityExecId::new();
+        let event = WorkflowEvent::LocalActivityExhausted {
+            activity_id: id,
+            error: "always fails".into(),
+            attempt: 3,
+        };
+        let json = serde_json::to_string(&event)?;
+        let back: WorkflowEvent = serde_json::from_str(&json)?;
+        assert!(matches!(
+            back,
+            WorkflowEvent::LocalActivityExhausted { attempt: 3, .. }
+        ));
+        assert_eq!(event.type_name(), "LocalActivityExhausted");
         Ok(())
     }
 

--- a/autumn-harvest/src/history_export.rs
+++ b/autumn-harvest/src/history_export.rs
@@ -76,7 +76,8 @@ impl MermaidExporter {
                 }
                 WorkflowEvent::LocalActivityScheduled { .. }
                 | WorkflowEvent::LocalActivityCompleted { .. }
-                | WorkflowEvent::LocalActivityFailed { .. } => {
+                | WorkflowEvent::LocalActivityFailed { .. }
+                | WorkflowEvent::LocalActivityExhausted { .. } => {
                     self.handle_local_activity_event(event)?;
                 }
                 WorkflowEvent::UpdateAdmitted { .. }

--- a/autumn-harvest/src/history_export.rs
+++ b/autumn-harvest/src/history_export.rs
@@ -325,6 +325,17 @@ impl MermaidExporter {
                     "    Note right of WF: Local Activity Failed (ID: {activity_id}, Attempt: {attempt}): {safe_error}"
                 )?;
             }
+            WorkflowEvent::LocalActivityExhausted {
+                activity_id,
+                error,
+                attempt,
+            } => {
+                let safe_error = error.replace('\n', " ").replace('"', "'");
+                writeln!(
+                    self.out,
+                    "    Note right of WF: Local Activity Exhausted (ID: {activity_id}, Attempts: {attempt}): {safe_error}"
+                )?;
+            }
             _ => unreachable!(),
         }
         Ok(())

--- a/autumn-harvest/src/prelude.rs
+++ b/autumn-harvest/src/prelude.rs
@@ -22,7 +22,7 @@ pub use crate::telemetry::{
     ActivityStatus, MetricsRecorder, NoOpMetrics, NoOpPropagator, TelemetryConfig,
     TraceContextCarrier, TraceContextPropagator, WorkflowStatus,
 };
-pub use crate::types::{ActivityExecId, ExecutionId, TimerId, WorkerId, WorkflowId};
+pub use crate::types::{ActivityExecId, ExecutionId, IdempotencyKey, TimerId, WorkerId, WorkflowId};
 
 // Re-export macros from autumn-harvest-macros.
 pub use autumn_harvest_macros::{activities, activity, dag, dags, workflow, workflows};

--- a/autumn-harvest/src/prelude.rs
+++ b/autumn-harvest/src/prelude.rs
@@ -22,7 +22,9 @@ pub use crate::telemetry::{
     ActivityStatus, MetricsRecorder, NoOpMetrics, NoOpPropagator, TelemetryConfig,
     TraceContextCarrier, TraceContextPropagator, WorkflowStatus,
 };
-pub use crate::types::{ActivityExecId, ExecutionId, IdempotencyKey, TimerId, WorkerId, WorkflowId};
+pub use crate::types::{
+    ActivityExecId, ExecutionId, IdempotencyKey, TimerId, WorkerId, WorkflowId,
+};
 
 // Re-export macros from autumn-harvest-macros.
 pub use autumn_harvest_macros::{activities, activity, dag, dags, workflow, workflows};

--- a/autumn-harvest/src/replay.rs
+++ b/autumn-harvest/src/replay.rs
@@ -66,6 +66,17 @@ pub enum HistoryMatch {
         /// The child execution ID already recorded in history. Must be reused.
         child_id: ExecutionId,
     },
+    /// History has a `LocalActivityScheduled` event but no terminal
+    /// (`LocalActivityCompleted` / `LocalActivityFailed`) event yet.
+    ///
+    /// This happens when a worker appended `LocalActivityScheduled` and then
+    /// crashed before running (or before recording the result). The caller
+    /// must re-execute the local activity using the **same** `activity_id` so
+    /// that the derived idempotency key is unchanged across the crash.
+    LocalActivityInProgress {
+        /// The `ActivityExecId` already recorded in history. Must be reused.
+        activity_id: ActivityExecId,
+    },
 }
 
 /// Walks through recorded workflow events during replay, matching
@@ -1039,8 +1050,10 @@ impl HistoryMatcher {
             return failure;
         }
 
-        // LocalActivityScheduled found but no terminal event yet — incomplete history.
-        HistoryMatch::NoMatch
+        // `LocalActivityScheduled` found but no terminal event yet — the worker
+        // crashed after appending the scheduled event. Return the original
+        // `activity_id` so the retry can reuse it and preserve idempotency.
+        HistoryMatch::LocalActivityInProgress { activity_id }
     }
 
     /// Like [`match_local_activity`](Self::match_local_activity) but also verifies the input payload.

--- a/autumn-harvest/src/replay.rs
+++ b/autumn-harvest/src/replay.rs
@@ -66,16 +66,33 @@ pub enum HistoryMatch {
         /// The child execution ID already recorded in history. Must be reused.
         child_id: ExecutionId,
     },
-    /// History has a `LocalActivityScheduled` event but no terminal
-    /// (`LocalActivityCompleted` / `LocalActivityFailed`) event yet.
+    /// History has a `LocalActivityScheduled` event but no `LocalActivityCompleted`
+    /// event yet.  This covers two cases:
     ///
-    /// This happens when a worker appended `LocalActivityScheduled` and then
-    /// crashed before running (or before recording the result). The caller
-    /// must re-execute the local activity using the **same** `activity_id` so
-    /// that the derived idempotency key is unchanged across the crash.
+    /// 1. **Crash before first run** — the worker appended `LocalActivityScheduled`
+    ///    then crashed before executing the handler. `failed_attempts` is 0.
+    ///
+    /// 2. **Crash between retries** — the worker recorded one or more
+    ///    `LocalActivityFailed` events and then crashed before the next attempt.
+    ///    `failed_attempts` reflects how many failures are already durable.
+    ///
+    ///    This case is also returned when all retry attempts have already been
+    ///    recorded (`failed_attempts >= max_attempts`). In that situation the
+    ///    worker compares `failed_attempts` against its retry policy and returns
+    ///    `last_error` immediately without executing the handler.
+    ///
+    /// The caller must re-execute the local activity using the **same**
+    /// `activity_id` so that the derived idempotency key is unchanged across
+    /// the crash.
     LocalActivityInProgress {
         /// The `ActivityExecId` already recorded in history. Must be reused.
         activity_id: ActivityExecId,
+        /// How many `LocalActivityFailed` events are already durable for this
+        /// invocation. The worker starts its retry loop from `failed_attempts + 1`.
+        failed_attempts: u32,
+        /// Error from the last recorded `LocalActivityFailed`, if any.
+        /// Returned by the worker when `failed_attempts >= max_attempts`.
+        last_error: Option<String>,
     },
 }
 
@@ -997,7 +1014,8 @@ impl HistoryMatcher {
         // Advance past LocalActivityScheduled
         self.cursor += 1;
         let mut scan_cursor = self.cursor;
-        let mut last_failure: Option<HistoryMatch> = None;
+        let mut failed_attempts: u32 = 0;
+        let mut last_error: Option<String> = None;
 
         while scan_cursor < self.events.len() {
             if self.is_consumed(scan_cursor) {
@@ -1018,12 +1036,10 @@ impl HistoryMatcher {
                 WorkflowEvent::LocalActivityFailed {
                     activity_id: id,
                     error,
-                    attempt,
+                    attempt: _,
                 } if *id == activity_id => {
-                    last_failure = Some(HistoryMatch::Failed {
-                        error: error.clone(),
-                        attempt: *attempt,
-                    });
+                    failed_attempts += 1;
+                    last_error = Some(error.clone());
                     scan_cursor += 1;
                 }
                 // Signals can be ingested while a local activity is retrying
@@ -1043,17 +1059,21 @@ impl HistoryMatcher {
             }
         }
 
-        if let Some(failure) = last_failure {
-            // Scanned past all retry failures with no completion — this is terminal.
+        // Whether we saw zero or N failures, there is no completion event yet.
+        // The replay engine cannot know the retry policy, so it always returns
+        // InProgress and lets the worker decide (based on max_attempts) whether
+        // to re-run or return the last error immediately.
+        if failed_attempts > 0 {
+            // Advance the cursor past the recorded failure events so the next
+            // match picks up from the right position on the next worker call.
             self.cursor = scan_cursor;
             self.advance_to_next_unconsumed_event();
-            return failure;
         }
-
-        // `LocalActivityScheduled` found but no terminal event yet — the worker
-        // crashed after appending the scheduled event. Return the original
-        // `activity_id` so the retry can reuse it and preserve idempotency.
-        HistoryMatch::LocalActivityInProgress { activity_id }
+        HistoryMatch::LocalActivityInProgress {
+            activity_id,
+            failed_attempts,
+            last_error,
+        }
     }
 
     /// Like [`match_local_activity`](Self::match_local_activity) but also verifies the input payload.
@@ -1102,7 +1122,8 @@ impl HistoryMatcher {
 
         self.cursor += 1;
         let mut scan_cursor = self.cursor;
-        let mut last_failure: Option<HistoryMatch> = None;
+        let mut failed_attempts: u32 = 0;
+        let mut last_error: Option<String> = None;
 
         while scan_cursor < self.events.len() {
             if self.is_consumed(scan_cursor) {
@@ -1122,12 +1143,10 @@ impl HistoryMatcher {
                 WorkflowEvent::LocalActivityFailed {
                     activity_id: id,
                     error,
-                    attempt,
+                    attempt: _,
                 } if *id == activity_id => {
-                    last_failure = Some(HistoryMatch::Failed {
-                        error: error.clone(),
-                        attempt: *attempt,
-                    });
+                    failed_attempts += 1;
+                    last_error = Some(error.clone());
                     scan_cursor += 1;
                 }
                 WorkflowEvent::SignalReceived {
@@ -1146,10 +1165,14 @@ impl HistoryMatcher {
             }
         }
 
-        if let Some(failure) = last_failure {
+        if failed_attempts > 0 {
             self.cursor = scan_cursor;
             self.advance_to_next_unconsumed_event();
-            return failure;
+            return HistoryMatch::LocalActivityInProgress {
+                activity_id,
+                failed_attempts,
+                last_error,
+            };
         }
 
         HistoryMatch::NoMatch
@@ -2330,7 +2353,11 @@ mod tests {
     }
 
     #[test]
-    fn matcher_replays_failed_local_activity_retries_exhausted() {
+    fn matcher_local_activity_with_recorded_failures_returns_in_progress() {
+        // The replay engine does not know max_attempts, so it always returns
+        // LocalActivityInProgress when there is no completion event — even if
+        // all retries may be exhausted. The worker checks max_attempts and
+        // either returns last_error immediately or runs the next attempt.
         let id = ActivityExecId::new();
         let events = vec![
             WorkflowEvent::LocalActivityScheduled {
@@ -2351,12 +2378,16 @@ mod tests {
         ];
         let mut matcher = HistoryMatcher::new(events);
         let result = matcher.match_local_activity("format_data");
-        assert_eq!(
-            result,
-            HistoryMatch::Failed {
-                error: "still failing".into(),
-                attempt: 2,
-            }
+        assert!(
+            matches!(
+                &result,
+                HistoryMatch::LocalActivityInProgress {
+                    activity_id: rid,
+                    failed_attempts: 2,
+                    last_error: Some(e),
+                } if *rid == id && e == "still failing"
+            ),
+            "expected LocalActivityInProgress with 2 failed attempts, got {result:?}"
         );
     }
 

--- a/autumn-harvest/src/replay.rs
+++ b/autumn-harvest/src/replay.rs
@@ -1033,6 +1033,19 @@ impl HistoryMatcher {
                     self.advance_to_next_unconsumed_event();
                     return HistoryMatch::Matched { output };
                 }
+                // Terminal: all retries exhausted. This event is always
+                // authoritative regardless of the current retry policy.
+                WorkflowEvent::LocalActivityExhausted {
+                    activity_id: id,
+                    error,
+                    attempt,
+                } if *id == activity_id => {
+                    let error = error.clone();
+                    let attempt = *attempt;
+                    self.cursor = scan_cursor + 1;
+                    self.advance_to_next_unconsumed_event();
+                    return HistoryMatch::Failed { error, attempt };
+                }
                 WorkflowEvent::LocalActivityFailed {
                     activity_id: id,
                     error,
@@ -1059,10 +1072,9 @@ impl HistoryMatcher {
             }
         }
 
-        // Whether we saw zero or N failures, there is no completion event yet.
-        // The replay engine cannot know the retry policy, so it always returns
-        // InProgress and lets the worker decide (based on max_attempts) whether
-        // to re-run or return the last error immediately.
+        // No LocalActivityCompleted or LocalActivityExhausted found. The worker
+        // either crashed before the first attempt or between retry attempts.
+        // Return InProgress so the worker can resume from the right attempt.
         if failed_attempts > 0 {
             // Advance the cursor past the recorded failure events so the next
             // match picks up from the right position on the next worker call.
@@ -1139,6 +1151,17 @@ impl HistoryMatcher {
                     self.cursor = scan_cursor + 1;
                     self.advance_to_next_unconsumed_event();
                     return HistoryMatch::Matched { output };
+                }
+                WorkflowEvent::LocalActivityExhausted {
+                    activity_id: id,
+                    error,
+                    attempt,
+                } if *id == activity_id => {
+                    let error = error.clone();
+                    let attempt = *attempt;
+                    self.cursor = scan_cursor + 1;
+                    self.advance_to_next_unconsumed_event();
+                    return HistoryMatch::Failed { error, attempt };
                 }
                 WorkflowEvent::LocalActivityFailed {
                     activity_id: id,
@@ -2388,6 +2411,39 @@ mod tests {
                 } if *rid == id && e == "still failing"
             ),
             "expected LocalActivityInProgress with 2 failed attempts, got {result:?}"
+        );
+    }
+
+    #[test]
+    fn matcher_local_activity_exhausted_event_returns_failed() {
+        // LocalActivityExhausted is the authoritative terminal marker. Replay
+        // must return Failed regardless of any current retry-policy value.
+        let id = ActivityExecId::new();
+        let events = vec![
+            WorkflowEvent::LocalActivityScheduled {
+                activity_id: id,
+                name: "format_data".into(),
+                input: Value::Null,
+            },
+            WorkflowEvent::LocalActivityFailed {
+                activity_id: id,
+                error: "transient".into(),
+                attempt: 1,
+            },
+            WorkflowEvent::LocalActivityExhausted {
+                activity_id: id,
+                error: "transient".into(),
+                attempt: 1,
+            },
+        ];
+        let mut matcher = HistoryMatcher::new(events);
+        let result = matcher.match_local_activity("format_data");
+        assert_eq!(
+            result,
+            HistoryMatch::Failed {
+                error: "transient".into(),
+                attempt: 1,
+            }
         );
     }
 

--- a/autumn-harvest/src/reset.rs
+++ b/autumn-harvest/src/reset.rs
@@ -380,8 +380,15 @@ fn apply_event_to_pending(
             Some(name.clone()),
             event_id,
         ),
+        // LocalActivityFailed is an intermediate event (the worker may still retry),
+        // so it must NOT close the pending entry. Only a true terminal event —
+        // LocalActivityCompleted (success) or LocalActivityExhausted (retries
+        // exhausted) — closes the entry.  Closing on LocalActivityFailed alone
+        // would let an operator reset between intermediate attempts and fork a
+        // history that drops the terminal marker, potentially re-executing the
+        // local activity or losing the exhausted-marker guarantee.
         WorkflowEvent::LocalActivityCompleted { activity_id, .. }
-        | WorkflowEvent::LocalActivityFailed { activity_id, .. } => {
+        | WorkflowEvent::LocalActivityExhausted { activity_id, .. } => {
             remove_pending(pending, "LocalActivityScheduled", &activity_id.to_string());
         }
         WorkflowEvent::ActivityAwaitingExternal {
@@ -984,6 +991,71 @@ mod tests {
             serde_json::from_str::<ResetSignalReapplyPolicy>(r#""buffer""#).unwrap(),
             ResetSignalReapplyPolicy::Buffer
         );
+    }
+
+    #[test]
+    fn reset_point_rejects_reset_after_intermediate_local_activity_failure() {
+        // LocalActivityFailed is NOT terminal — the worker may still retry.
+        // A reset after an intermediate failure must be rejected because the
+        // LocalActivityScheduled pending entry is still open.
+        let activity_id = ActivityExecId::new();
+        let events = vec![
+            WorkflowEvent::WorkflowStarted {
+                input: Value::Null,
+                timestamp: Utc::now(),
+            },
+            WorkflowEvent::LocalActivityScheduled {
+                activity_id,
+                name: "compute".into(),
+                input: Value::Null,
+            },
+            WorkflowEvent::LocalActivityFailed {
+                activity_id,
+                error: "transient".into(),
+                attempt: 1,
+            },
+        ];
+
+        let err = validate_reset_point(&events, 2)
+            .expect_err("local activity is still in-progress after an intermediate failure");
+        assert_eq!(err.unresolved_side_effects.len(), 1);
+        assert_eq!(
+            err.unresolved_side_effects[0].kind,
+            "LocalActivityScheduled"
+        );
+    }
+
+    #[test]
+    fn reset_point_allows_reset_after_local_activity_exhausted() {
+        // LocalActivityExhausted is the definitive terminal marker; a reset
+        // point after it must be accepted.
+        let activity_id = ActivityExecId::new();
+        let events = vec![
+            WorkflowEvent::WorkflowStarted {
+                input: Value::Null,
+                timestamp: Utc::now(),
+            },
+            WorkflowEvent::LocalActivityScheduled {
+                activity_id,
+                name: "compute".into(),
+                input: Value::Null,
+            },
+            WorkflowEvent::LocalActivityFailed {
+                activity_id,
+                error: "always fails".into(),
+                attempt: 1,
+            },
+            WorkflowEvent::LocalActivityExhausted {
+                activity_id,
+                error: "always fails".into(),
+                attempt: 1,
+            },
+        ];
+
+        let plan =
+            validate_reset_point(&events, 3).expect("exhausted local activity is fully resolved");
+        assert_eq!(plan.reset_to_event_id, 3);
+        assert!(plan.unresolved_side_effects.is_empty());
     }
 
     #[test]

--- a/autumn-harvest/src/scheduler.rs
+++ b/autumn-harvest/src/scheduler.rs
@@ -908,8 +908,17 @@ async fn execute_dag_run(
                 .iter()
                 .map(move |upstream| &statuses_ref[*upstream]);
             let dag_run_id = run.id;
+            let node_index = *task_index;
             async move {
-                execute_dag_task(&registry, task, upstream_statuses, &task_input, dag_run_id).await
+                execute_dag_task(
+                    &registry,
+                    task,
+                    upstream_statuses,
+                    &task_input,
+                    dag_run_id,
+                    node_index,
+                )
+                .await
             }
         });
         let results = futures::future::join_all(tasks).await;
@@ -953,6 +962,7 @@ async fn execute_dag_task<'a>(
     upstream_statuses: impl IntoIterator<Item = &'a TaskStatus>,
     conf: &Value,
     dag_run_id: uuid::Uuid,
+    node_index: usize,
 ) -> TaskStatus {
     if !task.trigger_rule.should_run(upstream_statuses) {
         return TaskStatus::Skipped;
@@ -971,9 +981,11 @@ async fn execute_dag_task<'a>(
 
     // Derive a stable ActivityExecId from the DAG run ID and task name so
     // the idempotency key is the same across retries for this logical task.
+    // node_index is included so two nodes that share the same activity_name
+    // within a DAG run receive distinct keys.
     let task_exec_id = ActivityExecId::from_uuid(uuid::Uuid::new_v5(
         &DAG_TASK_KEY_NAMESPACE,
-        format!("{dag_run_id}:{}", task.activity_name).as_bytes(),
+        format!("{dag_run_id}:{node_index}:{}", task.activity_name).as_bytes(),
     ));
     let idempotency_key = IdempotencyKey::from_activity_exec_id(task_exec_id);
 

--- a/autumn-harvest/src/scheduler.rs
+++ b/autumn-harvest/src/scheduler.rs
@@ -23,6 +23,7 @@ use crate::info::DagInfo;
 use crate::models::{DagRun, HarvestSchedule, NewDagRun, NewHarvestSchedule};
 use crate::policy::{RetryPolicy, Schedule, TaskStatus, WorkflowSchedule};
 use crate::schema::{harvest_dag_runs, harvest_schedules, harvest_workflow_executions};
+use crate::types::{ActivityExecId, IdempotencyKey};
 use crate::worker::{DbPool, HandlerRegistry};
 
 const DEFAULT_SCHEDULER_TICK_INTERVAL: Duration = Duration::from_secs(1);
@@ -906,7 +907,10 @@ async fn execute_dag_run(
                 .upstreams
                 .iter()
                 .map(move |upstream| &statuses_ref[*upstream]);
-            async move { execute_dag_task(&registry, task, upstream_statuses, &task_input).await }
+            let dag_run_id = run.id;
+            async move {
+                execute_dag_task(&registry, task, upstream_statuses, &task_input, dag_run_id).await
+            }
         });
         let results = futures::future::join_all(tasks).await;
         for (task_index, result) in level.iter().zip(results) {
@@ -935,11 +939,20 @@ async fn execute_dag_run(
     Ok(())
 }
 
+/// Namespace UUID for deriving stable DAG task idempotency keys.
+///
+/// Keyed on (`dag_run_id`, `task_name`) so each logical DAG task invocation
+/// always produces the same [`ActivityExecId`] regardless of retry attempt.
+const DAG_TASK_KEY_NAMESPACE: uuid::Uuid = uuid::Uuid::from_bytes([
+    0x6b, 0xa7, 0xb8, 0x14, 0x9d, 0xad, 0x11, 0xd1, 0x80, 0xb4, 0x00, 0xc0, 0x4f, 0xd4, 0x30, 0xc8,
+]);
+
 async fn execute_dag_task<'a>(
     registry: &HandlerRegistry,
     task: &crate::dag::DagTask,
     upstream_statuses: impl IntoIterator<Item = &'a TaskStatus>,
     conf: &Value,
+    dag_run_id: uuid::Uuid,
 ) -> TaskStatus {
     if !task.trigger_rule.should_run(upstream_statuses) {
         return TaskStatus::Skipped;
@@ -954,11 +967,21 @@ async fn execute_dag_task<'a>(
         .or_else(|| activity.default_retry_policy.clone());
     let timeout = task.start_to_close.or(activity.default_start_to_close);
     let input = task_input(conf, &task.activity_name);
-    let mut attempt = 1;
+    let mut attempt = 1u32;
+
+    // Derive a stable ActivityExecId from the DAG run ID and task name so
+    // the idempotency key is the same across retries for this logical task.
+    let task_exec_id = ActivityExecId::from_uuid(uuid::Uuid::new_v5(
+        &DAG_TASK_KEY_NAMESPACE,
+        format!("{dag_run_id}:{}", task.activity_name).as_bytes(),
+    ));
+    let idempotency_key = IdempotencyKey::from_activity_exec_id(task_exec_id);
 
     loop {
         let cancel = CancellationToken::new();
-        let ctx = ActivityContext::new(registry.shared_state(), None, cancel.clone());
+        let ctx = ActivityContext::new(registry.shared_state(), None, cancel.clone())
+            .with_idempotency_key(idempotency_key.clone())
+            .with_attempt(attempt);
         let future = (activity.handler)(&ctx, input.clone());
         let result = match timeout {
             Some(timeout) => tokio::time::timeout(timeout, future)

--- a/autumn-harvest/src/types.rs
+++ b/autumn-harvest/src/types.rs
@@ -610,6 +610,102 @@ pub enum WorkflowIdReusePolicy {
     TerminateIfRunning,
 }
 
+// ---------------------------------------------------------------------------
+// IdempotencyKey
+// ---------------------------------------------------------------------------
+
+/// A stable, deterministic idempotency key for a single logical activity
+/// invocation.
+///
+/// The key is derived from the `ActivityExecId` recorded in the
+/// `ActivityScheduled` (or `LocalActivityScheduled`) event the first time the
+/// activity is dispatched.  Because that event is part of the durable history,
+/// the key is identical across:
+///
+/// - worker restarts
+/// - duplicate task-queue dispatch
+/// - deterministic replay
+/// - every retry attempt for the same logical invocation
+///
+/// Two distinct activity invocations in the same workflow execution receive
+/// distinct keys, even when they call the same activity with the same input.
+///
+/// ## Subkeys
+///
+/// Use [`subkey`](Self::subkey) to derive a named child key when one activity
+/// must produce multiple distinct side effects (e.g. charge + notify).
+/// Subkeys are stable and collision-resistant within their parent.
+///
+/// ## HTTP-header safety
+///
+/// Both base keys and subkeys contain only printable ASCII characters and are
+/// safe to use as the value of an `Idempotency-Key` HTTP request header.
+///
+/// ## Example
+///
+/// ```rust
+/// use autumn_harvest::types::{ActivityExecId, IdempotencyKey};
+///
+/// // In production the engine sets this on ActivityContext for you.
+/// let id = ActivityExecId::new();
+/// let key = IdempotencyKey::from_activity_exec_id(id);
+///
+/// // Pass the base key to a payment gateway or email provider.
+/// let _charge_key: &str = key.as_str();
+///
+/// // Derive a subkey for a second outbound call within the same activity.
+/// let notify_key = key.subkey("notify");
+/// assert_ne!(key.as_str(), notify_key.as_str());
+/// ```
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct IdempotencyKey {
+    base: String,
+}
+
+impl IdempotencyKey {
+    /// Build an `IdempotencyKey` from the stable `ActivityExecId` for this
+    /// logical activity invocation.
+    #[must_use]
+    pub fn from_activity_exec_id(id: ActivityExecId) -> Self {
+        Self {
+            base: id.as_uuid().to_string(),
+        }
+    }
+
+    /// The key as a string slice — safe to pass directly as an
+    /// `Idempotency-Key` HTTP header value.
+    #[must_use]
+    pub fn as_str(&self) -> &str {
+        &self.base
+    }
+
+    /// Derive a stable named subkey for a secondary outbound call within the
+    /// same activity.
+    ///
+    /// `name` should be a short, stable identifier (e.g. `"charge"`,
+    /// `"notify"`, `"provision"`).  Distinct names always produce distinct
+    /// subkeys.  The same `(parent_key, name)` pair always produces the same
+    /// subkey, making it safe to use in retry loops.
+    ///
+    /// Subkeys are themselves `IdempotencyKey` values so they can be further
+    /// nested if necessary.
+    #[must_use]
+    pub fn subkey(&self, name: &str) -> Self {
+        // Stable, readable, and unambiguous: the parent UUID prefix ensures
+        // cross-invocation uniqueness; the `name` suffix ensures sibling
+        // subkeys are distinct.
+        Self {
+            base: format!("{}/{name}", self.base),
+        }
+    }
+}
+
+impl fmt::Display for IdempotencyKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.base)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/autumn-harvest/src/types.rs
+++ b/autumn-harvest/src/types.rs
@@ -689,11 +689,19 @@ impl IdempotencyKey {
     ///
     /// Subkeys are themselves `IdempotencyKey` values so they can be further
     /// nested if necessary.
+    ///
+    /// # Panics
+    ///
+    /// Panics if `name` is empty, contains `/`, or contains any character that
+    /// is not printable ASCII (byte range `0x21`–`0x7E`).  Subkey names are
+    /// programmer-provided constants; a panic surfaces the mistake immediately
+    /// rather than silently producing a malformed or colliding key.
     #[must_use]
     pub fn subkey(&self, name: &str) -> Self {
-        // Stable, readable, and unambiguous: the parent UUID prefix ensures
-        // cross-invocation uniqueness; the `name` suffix ensures sibling
-        // subkeys are distinct.
+        assert!(
+            !name.is_empty() && name.bytes().all(|b| b > b' ' && b < b'\x7f' && b != b'/'),
+            "IdempotencyKey::subkey: name must be non-empty printable ASCII without '/'; got {name:?}"
+        );
         Self {
             base: format!("{}/{name}", self.base),
         }

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -714,41 +714,40 @@ async fn run_local_activity_inline(
                     error: error.clone(),
                     attempt,
                 };
-                store::append_events(
-                    conn,
-                    exec_id,
-                    std::slice::from_ref(&failed_event),
-                    *next_event_id,
-                )
-                .await?;
-                *next_event_id += 1;
-                all_new_events.push(failed_event);
 
                 if attempt == max_attempts {
-                    // All retries exhausted. Append an explicit terminal event
-                    // so replay can identify the exhausted state independent
-                    // of the current retry policy, preventing spurious re-runs
-                    // when max_attempts increases between deployments.
+                    // Final attempt: append LocalActivityFailed and
+                    // LocalActivityExhausted atomically so a crash between the
+                    // two cannot leave history without the terminal marker,
+                    // which would make the policy-invariant guarantee unsound.
                     let exhausted_event = WorkflowEvent::LocalActivityExhausted {
                         activity_id: run.activity_id,
                         error: error.clone(),
                         attempt,
                     };
+                    let terminal_pair = [failed_event, exhausted_event];
+                    store::append_events(conn, exec_id, &terminal_pair, *next_event_id).await?;
+                    *next_event_id += i32::try_from(terminal_pair.len())
+                        .map_err(|_| HarvestError::Config("event count overflow".into()))?;
+                    all_new_events.extend(terminal_pair);
+                } else {
                     store::append_events(
                         conn,
                         exec_id,
-                        std::slice::from_ref(&exhausted_event),
+                        std::slice::from_ref(&failed_event),
                         *next_event_id,
                     )
                     .await?;
                     *next_event_id += 1;
-                    all_new_events.push(exhausted_event);
-                } else if let Some(delay) = run
-                    .retry_policy
-                    .as_ref()
-                    .and_then(|p| p.next_delay(attempt))
-                {
-                    tokio::time::sleep(delay).await;
+                    all_new_events.push(failed_event);
+
+                    if let Some(delay) = run
+                        .retry_policy
+                        .as_ref()
+                        .and_then(|p| p.next_delay(attempt))
+                    {
+                        tokio::time::sleep(delay).await;
+                    }
                 }
             }
         }

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -553,6 +553,12 @@ struct LocalActivityRun {
     /// the worker crashed after appending it but before recording a terminal event.
     /// `run_local_activity_inline` must skip re-appending the scheduled event.
     already_scheduled: bool,
+    /// Number of `LocalActivityFailed` events already durable in history.
+    /// `run_local_activity_inline` starts its retry loop from `failed_attempts + 1`.
+    failed_attempts: u32,
+    /// Error from the last recorded `LocalActivityFailed`. Returned immediately
+    /// when `failed_attempts >= max_attempts` without running the handler again.
+    last_error: Option<String>,
 }
 
 /// Extract a `RunLocalActivity` command from an owned command list.
@@ -580,6 +586,8 @@ fn extract_run_local_activity(
                 retry_policy,
                 result_tx,
                 already_scheduled,
+                failed_attempts,
+                last_error,
             } => {
                 drop(result_tx); // coroutine already dropped; close the channel
                 local_run = Some(LocalActivityRun {
@@ -589,6 +597,8 @@ fn extract_run_local_activity(
                     start_to_close_secs,
                     retry_policy,
                     already_scheduled,
+                    failed_attempts,
+                    last_error,
                 });
             }
             _ => {} // unexpected alongside RunLocalActivity; ignore
@@ -647,7 +657,26 @@ async fn run_local_activity_inline(
     let handler = activity.handler;
     let local_idempotency_key = IdempotencyKey::from_activity_exec_id(run.activity_id);
 
-    for attempt in 1..=max_attempts {
+    // When recovering after a crash-between-retries, all attempts up to
+    // `failed_attempts` are already durable in history. If they already cover
+    // max_attempts, every retry was exhausted before the crash — return the
+    // last recorded error without executing the handler again.
+    let start_attempt = run.failed_attempts + 1;
+    if start_attempt > max_attempts {
+        let error = run.last_error.unwrap_or_else(|| {
+            format!(
+                "local activity '{}' failed after {} attempts (recorded in history)",
+                run.name, run.failed_attempts
+            )
+        });
+        return Err(HarvestError::ActivityFailed {
+            name: run.name.clone(),
+            attempt: run.failed_attempts,
+            source: error.into(),
+        });
+    }
+
+    for attempt in start_attempt..=max_attempts {
         let ctx =
             ActivityContext::new_local_activity(registry.shared_state(), CancellationToken::new())
                 .with_idempotency_key(local_idempotency_key.clone())

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -617,6 +617,7 @@ fn extract_run_local_activity(
 /// `LocalActivityFailed` event; on success a `LocalActivityCompleted` event is
 /// appended. Returns all newly-appended events so the caller can extend its
 /// in-memory replay history and avoid a DB round-trip.
+#[allow(clippy::too_many_lines)]
 async fn run_local_activity_inline(
     conn: &mut AsyncPgConnection,
     registry: &HandlerRegistry,
@@ -723,11 +724,29 @@ async fn run_local_activity_inline(
                 *next_event_id += 1;
                 all_new_events.push(failed_event);
 
-                if attempt < max_attempts
-                    && let Some(delay) = run
-                        .retry_policy
-                        .as_ref()
-                        .and_then(|p| p.next_delay(attempt))
+                if attempt == max_attempts {
+                    // All retries exhausted. Append an explicit terminal event
+                    // so replay can identify the exhausted state independent
+                    // of the current retry policy, preventing spurious re-runs
+                    // when max_attempts increases between deployments.
+                    let exhausted_event = WorkflowEvent::LocalActivityExhausted {
+                        activity_id: run.activity_id,
+                        error: error.clone(),
+                        attempt,
+                    };
+                    store::append_events(
+                        conn,
+                        exec_id,
+                        std::slice::from_ref(&exhausted_event),
+                        *next_event_id,
+                    )
+                    .await?;
+                    *next_event_id += 1;
+                    all_new_events.push(exhausted_event);
+                } else if let Some(delay) = run
+                    .retry_policy
+                    .as_ref()
+                    .and_then(|p| p.next_delay(attempt))
                 {
                     tokio::time::sleep(delay).await;
                 }

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -40,7 +40,9 @@ use crate::telemetry::{
     ATTR_ACTIVITY_NAME, ATTR_ATTEMPT, ATTR_EXECUTION_ID, ATTR_QUEUE, ATTR_SHARD_ID,
     ATTR_WORKFLOW_ID, ActivityStatus, TraceContextCarrier, WorkflowStatus,
 };
-use crate::types::{ActivityExecId, ExecutionId, ExternalActivityToken, IdempotencyKey, TimerId, WorkerId};
+use crate::types::{
+    ActivityExecId, ExecutionId, ExternalActivityToken, IdempotencyKey, TimerId, WorkerId,
+};
 
 /// Type alias for the deadpool-managed async Diesel connection pool.
 pub type DbPool = deadpool::managed::Pool<
@@ -637,12 +639,10 @@ async fn run_local_activity_inline(
     let local_idempotency_key = IdempotencyKey::from_activity_exec_id(run.activity_id);
 
     for attempt in 1..=max_attempts {
-        let ctx = ActivityContext::new_local_activity(
-            registry.shared_state(),
-            CancellationToken::new(),
-        )
-        .with_idempotency_key(local_idempotency_key.clone())
-        .with_attempt(attempt);
+        let ctx =
+            ActivityContext::new_local_activity(registry.shared_state(), CancellationToken::new())
+                .with_idempotency_key(local_idempotency_key.clone())
+                .with_attempt(attempt);
         let result = tokio::time::timeout(per_attempt_timeout, (handler)(&ctx, run.input.clone()))
             .await
             .unwrap_or_else(|_| {

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -549,6 +549,10 @@ struct LocalActivityRun {
     input: serde_json::Value,
     start_to_close_secs: Option<u64>,
     retry_policy: Option<crate::policy::RetryPolicy>,
+    /// `true` when `LocalActivityScheduled` is already in the durable history —
+    /// the worker crashed after appending it but before recording a terminal event.
+    /// `run_local_activity_inline` must skip re-appending the scheduled event.
+    already_scheduled: bool,
 }
 
 /// Extract a `RunLocalActivity` command from an owned command list.
@@ -575,6 +579,7 @@ fn extract_run_local_activity(
                 start_to_close_secs,
                 retry_policy,
                 result_tx,
+                already_scheduled,
             } => {
                 drop(result_tx); // coroutine already dropped; close the channel
                 local_run = Some(LocalActivityRun {
@@ -583,6 +588,7 @@ fn extract_run_local_activity(
                     input,
                     start_to_close_secs,
                     retry_policy,
+                    already_scheduled,
                 });
             }
             _ => {} // unexpected alongside RunLocalActivity; ignore
@@ -621,18 +627,21 @@ async fn run_local_activity_inline(
 
     let max_attempts = run.retry_policy.as_ref().map_or(1, |p| p.max_attempts);
 
-    let scheduled_event = WorkflowEvent::LocalActivityScheduled {
-        activity_id: run.activity_id,
-        name: run.name.clone(),
-        input: run.input.clone(),
-    };
-
-    // Append marker events + scheduled event in a single call.
+    // When the worker crashed after appending LocalActivityScheduled but before
+    // recording a terminal event, skip re-appending to avoid a duplicate.
     let mut prefix_events = marker_events;
-    prefix_events.push(scheduled_event);
-    store::append_events(conn, exec_id, &prefix_events, *next_event_id).await?;
-    *next_event_id += i32::try_from(prefix_events.len())
-        .map_err(|_| HarvestError::Config("event count overflow".into()))?;
+    if !run.already_scheduled {
+        prefix_events.push(WorkflowEvent::LocalActivityScheduled {
+            activity_id: run.activity_id,
+            name: run.name.clone(),
+            input: run.input.clone(),
+        });
+    }
+    if !prefix_events.is_empty() {
+        store::append_events(conn, exec_id, &prefix_events, *next_event_id).await?;
+        *next_event_id += i32::try_from(prefix_events.len())
+            .map_err(|_| HarvestError::Config("event count overflow".into()))?;
+    }
 
     let mut all_new_events = prefix_events;
     let handler = activity.handler;

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -40,7 +40,7 @@ use crate::telemetry::{
     ATTR_ACTIVITY_NAME, ATTR_ATTEMPT, ATTR_EXECUTION_ID, ATTR_QUEUE, ATTR_SHARD_ID,
     ATTR_WORKFLOW_ID, ActivityStatus, TraceContextCarrier, WorkflowStatus,
 };
-use crate::types::{ActivityExecId, ExecutionId, ExternalActivityToken, TimerId, WorkerId};
+use crate::types::{ActivityExecId, ExecutionId, ExternalActivityToken, IdempotencyKey, TimerId, WorkerId};
 
 /// Type alias for the deadpool-managed async Diesel connection pool.
 pub type DbPool = deadpool::managed::Pool<
@@ -633,11 +633,16 @@ async fn run_local_activity_inline(
         .map_err(|_| HarvestError::Config("event count overflow".into()))?;
 
     let mut all_new_events = prefix_events;
-    let ctx =
-        ActivityContext::new_local_activity(registry.shared_state(), CancellationToken::new());
     let handler = activity.handler;
+    let local_idempotency_key = IdempotencyKey::from_activity_exec_id(run.activity_id);
 
     for attempt in 1..=max_attempts {
+        let ctx = ActivityContext::new_local_activity(
+            registry.shared_state(),
+            CancellationToken::new(),
+        )
+        .with_idempotency_key(local_idempotency_key.clone())
+        .with_attempt(attempt);
         let result = tokio::time::timeout(per_attempt_timeout, (handler)(&ctx, run.input.clone()))
             .await
             .unwrap_or_else(|_| {
@@ -1835,7 +1840,9 @@ async fn process_activity_task(
         task.id,
         pool.clone(),
     )
-    .with_trace_context(trace_carrier.clone());
+    .with_trace_context(trace_carrier.clone())
+    .with_idempotency_key(IdempotencyKey::from_activity_exec_id(activity_id))
+    .with_attempt(task_attempt(task));
 
     let telemetry = registry.telemetry().clone();
     // ADR-0001 §3: restore the producer's trace context so the activity span

--- a/autumn-harvest/tests/idempotency_tests.rs
+++ b/autumn-harvest/tests/idempotency_tests.rs
@@ -272,8 +272,7 @@ fn context_without_key_returns_config_error() {
     let result = ctx.idempotency_key();
     assert!(
         matches!(result, Err(HarvestError::Config(_))),
-        "missing idempotency key must return HarvestError::Config, got: {:?}",
-        result
+        "missing idempotency key must return HarvestError::Config, got: {result:?}"
     );
 }
 

--- a/autumn-harvest/tests/idempotency_tests.rs
+++ b/autumn-harvest/tests/idempotency_tests.rs
@@ -1,0 +1,286 @@
+//! Tests for the activity idempotency key feature (issue #157).
+//!
+//! Run with: `cargo test --test idempotency_tests --no-default-features --features testing`
+#![cfg(feature = "testing")]
+//!
+//! Covers: `IdempotencyKey` type, `ActivityContext::idempotency_key()`,
+//! `ActivityContext::attempt()`, subkey derivation, HTTP-header safety,
+//! collision resistance, and the duplicate-dispatch / crash-retry scenario
+//! that is the core safety motivation for the feature.
+
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, Mutex};
+
+use autumn_harvest::context::ActivityContext;
+use autumn_harvest::error::HarvestError;
+use autumn_harvest::types::{ActivityExecId, IdempotencyKey};
+
+// ── Basic accessibility ───────────────────────────────────────────────────
+
+#[test]
+fn idempotency_key_accessible_from_test_context() {
+    let ctx = ActivityContext::new_test();
+    assert!(
+        ctx.idempotency_key().is_ok(),
+        "new_test() must provide an idempotency key"
+    );
+}
+
+#[test]
+fn idempotency_key_stable_across_repeated_calls() {
+    let ctx = ActivityContext::new_test();
+    let k1 = ctx.idempotency_key().unwrap().as_str().to_owned();
+    let k2 = ctx.idempotency_key().unwrap().as_str().to_owned();
+    assert_eq!(k1, k2, "idempotency key must not change between calls");
+}
+
+// ── Distinctness across invocations ──────────────────────────────────────
+
+#[test]
+fn distinct_activity_exec_ids_produce_distinct_keys() {
+    let id1 = ActivityExecId::new();
+    let id2 = ActivityExecId::new();
+    let k1 = IdempotencyKey::from_activity_exec_id(id1);
+    let k2 = IdempotencyKey::from_activity_exec_id(id2);
+    assert_ne!(k1.as_str(), k2.as_str());
+}
+
+#[test]
+fn keys_for_ten_thousand_invocations_have_no_collisions() {
+    let keys: HashSet<String> = (0..10_000)
+        .map(|_| {
+            IdempotencyKey::from_activity_exec_id(ActivityExecId::new())
+                .as_str()
+                .to_owned()
+        })
+        .collect();
+    assert_eq!(keys.len(), 10_000, "10,000 distinct invocations must yield 10,000 distinct keys");
+}
+
+// ── Subkey derivation ────────────────────────────────────────────────────
+
+#[test]
+fn subkey_derivation_is_deterministic() {
+    let key = IdempotencyKey::from_activity_exec_id(ActivityExecId::new());
+    let s1 = key.subkey("charge").as_str().to_owned();
+    let s2 = key.subkey("charge").as_str().to_owned();
+    assert_eq!(s1, s2, "subkey(same_name) must return the same value every time");
+}
+
+#[test]
+fn different_subkey_names_produce_different_keys() {
+    let key = IdempotencyKey::from_activity_exec_id(ActivityExecId::new());
+    let charge = key.subkey("charge");
+    let notify = key.subkey("notify");
+    assert_ne!(
+        charge.as_str(),
+        notify.as_str(),
+        "subkeys with distinct names must be distinct"
+    );
+}
+
+#[test]
+fn subkey_is_distinct_from_its_parent() {
+    let key = IdempotencyKey::from_activity_exec_id(ActivityExecId::new());
+    let sub = key.subkey("charge");
+    assert_ne!(key.as_str(), sub.as_str(), "subkey must differ from parent key");
+}
+
+#[test]
+fn same_subkey_name_different_parents_produce_different_keys() {
+    let k1 = IdempotencyKey::from_activity_exec_id(ActivityExecId::new()).subkey("charge");
+    let k2 = IdempotencyKey::from_activity_exec_id(ActivityExecId::new()).subkey("charge");
+    assert_ne!(
+        k1.as_str(),
+        k2.as_str(),
+        "same subkey name on different parents must yield different keys"
+    );
+}
+
+// ── HTTP-header safety ───────────────────────────────────────────────────
+
+fn is_http_header_safe(s: &str) -> bool {
+    !s.is_empty()
+        && s.chars()
+            .all(|c| c.is_ascii() && c >= ' ' && c != '\x7f')
+}
+
+#[test]
+fn base_key_display_is_safe_for_http_headers() {
+    let key = IdempotencyKey::from_activity_exec_id(ActivityExecId::new());
+    assert!(
+        is_http_header_safe(key.as_str()),
+        "base key '{}' must be safe as an HTTP Idempotency-Key header value",
+        key.as_str()
+    );
+}
+
+#[test]
+fn subkey_display_is_safe_for_http_headers() {
+    let key = IdempotencyKey::from_activity_exec_id(ActivityExecId::new());
+    let sub = key.subkey("charge-card");
+    assert!(
+        is_http_header_safe(sub.as_str()),
+        "subkey '{}' must be safe as an HTTP Idempotency-Key header value",
+        sub.as_str()
+    );
+}
+
+#[test]
+fn display_matches_as_str() {
+    let key = IdempotencyKey::from_activity_exec_id(ActivityExecId::new());
+    assert_eq!(format!("{key}"), key.as_str());
+}
+
+// ── Builder methods ───────────────────────────────────────────────────────
+
+#[test]
+fn with_idempotency_key_overrides_default() {
+    let id = ActivityExecId::new();
+    let key = IdempotencyKey::from_activity_exec_id(id);
+    let ctx = ActivityContext::new_test().with_idempotency_key(key.clone());
+    assert_eq!(ctx.idempotency_key().unwrap().as_str(), key.as_str());
+}
+
+#[test]
+fn attempt_returns_one_for_default_test_context() {
+    let ctx = ActivityContext::new_test();
+    assert_eq!(ctx.attempt(), Some(1));
+}
+
+#[test]
+fn with_attempt_sets_attempt_number() {
+    let ctx = ActivityContext::new_test().with_attempt(3);
+    assert_eq!(ctx.attempt(), Some(3));
+}
+
+// ── Default key does not contain PII / input payloads ────────────────────
+
+#[test]
+fn base_key_is_uuid_format() {
+    // The base key must be a UUID string (no arbitrary user data embedded).
+    let id = ActivityExecId::new();
+    let key = IdempotencyKey::from_activity_exec_id(id);
+    let s = key.as_str();
+    // UUID canonical form: 8-4-4-4-12 hex groups separated by hyphens
+    assert_eq!(s.len(), 36);
+    assert!(s.chars().all(|c| c.is_ascii_hexdigit() || c == '-'));
+}
+
+// ── Crash-retry / duplicate-dispatch simulation ──────────────────────────
+
+/// Fake payment gateway that deduplicates on idempotency key.
+/// A second charge with the same key is silently ignored (same semantics as
+/// Stripe's idempotent requests).
+struct FakeGateway {
+    charges: Mutex<HashMap<String, u64>>,
+}
+
+impl FakeGateway {
+    fn new() -> Self {
+        Self {
+            charges: Mutex::new(HashMap::new()),
+        }
+    }
+
+    /// Record a charge. If the key was already used, no new charge is added.
+    fn charge(&self, idempotency_key: &str, amount_cents: u64) {
+        self.charges
+            .lock()
+            .unwrap()
+            .entry(idempotency_key.to_string())
+            .or_insert(amount_cents);
+    }
+
+    fn total_unique_charges(&self) -> usize {
+        self.charges.lock().unwrap().len()
+    }
+
+    fn total_amount_charged(&self) -> u64 {
+        self.charges.lock().unwrap().values().sum()
+    }
+}
+
+#[tokio::test]
+async fn payment_gateway_duplicate_dispatch_commits_exactly_once() {
+    // The same logical activity invocation is dispatched 5 times
+    // (simulating worker crash before Harvest records completion).
+    // Every attempt must carry the *same* idempotency key so the gateway
+    // deduplicates to exactly one charge.
+    let gateway = Arc::new(FakeGateway::new());
+    let idempotency_key =
+        IdempotencyKey::from_activity_exec_id(ActivityExecId::new());
+
+    for attempt in 1u32..=5 {
+        let ctx = ActivityContext::new_test()
+            .with_idempotency_key(idempotency_key.clone())
+            .with_attempt(attempt);
+
+        // Activity reads the Harvest-provided key and passes it to the gateway.
+        let key = ctx.idempotency_key().unwrap();
+        gateway.charge(key.as_str(), 2999);
+    }
+
+    assert_eq!(
+        gateway.total_unique_charges(),
+        1,
+        "5 retries with the same idempotency key must result in exactly 1 gateway charge"
+    );
+    assert_eq!(gateway.total_amount_charged(), 2999);
+}
+
+#[tokio::test]
+async fn payment_gateway_100_forced_retry_trials_each_commit_exactly_once() {
+    // 100 independent workflow executions, each crashing and retrying 3×.
+    // Each workflow has a distinct idempotency key; no cross-execution
+    // collisions; each execution commits exactly one charge.
+    let gateway = Arc::new(FakeGateway::new());
+
+    for _ in 0..100 {
+        let key = IdempotencyKey::from_activity_exec_id(ActivityExecId::new());
+        for attempt in 1u32..=3 {
+            let ctx = ActivityContext::new_test()
+                .with_idempotency_key(key.clone())
+                .with_attempt(attempt);
+            gateway.charge(ctx.idempotency_key().unwrap().as_str(), 100);
+        }
+    }
+
+    assert_eq!(
+        gateway.total_unique_charges(),
+        100,
+        "100 executions × 3 attempts = 100 unique charges (one per logical invocation)"
+    );
+}
+
+// ── Error path: missing key ───────────────────────────────────────────────
+
+#[test]
+fn context_without_key_returns_config_error() {
+    // A context created via the internal `new` path without a key set
+    // must return a descriptive HarvestError::Config, not panic or return
+    // a meaningless value.
+    let ctx = ActivityContext::new_for_idempotency_test_no_key();
+    let result = ctx.idempotency_key();
+    assert!(
+        matches!(result, Err(HarvestError::Config(_))),
+        "missing idempotency key must return HarvestError::Config, got: {:?}",
+        result
+    );
+}
+
+// ── Subkey chaining ───────────────────────────────────────────────────────
+
+#[test]
+fn nested_subkeys_are_stable_and_distinct() {
+    let key = IdempotencyKey::from_activity_exec_id(ActivityExecId::new());
+    let charge = key.subkey("payment").subkey("charge");
+    let refund = key.subkey("payment").subkey("refund");
+    // Stable
+    assert_eq!(
+        key.subkey("payment").subkey("charge").as_str(),
+        charge.as_str()
+    );
+    // Distinct siblings
+    assert_ne!(charge.as_str(), refund.as_str());
+}

--- a/autumn-harvest/tests/idempotency_tests.rs
+++ b/autumn-harvest/tests/idempotency_tests.rs
@@ -284,3 +284,47 @@ fn nested_subkeys_are_stable_and_distinct() {
     // Distinct siblings
     assert_ne!(charge.as_str(), refund.as_str());
 }
+
+// ── Subkey name validation ────────────────────────────────────────────────
+
+#[test]
+fn subkey_slash_in_name_does_not_collide_with_nested_subkey() {
+    // "a/b" as a single name must not equal subkey("a").subkey("b").
+    // The slash is rejected by the validator, so the collision is impossible
+    // at the API level.
+    let key = IdempotencyKey::from_activity_exec_id(ActivityExecId::new());
+    // Nested: key -> "a" -> "b"
+    let nested = key.subkey("a").subkey("b");
+    // A flat name that *looks* like the path "a/b" would panic — test that
+    // the flat and nested forms are provably distinct by ensuring the nested
+    // path prefix includes the intermediate segment.
+    assert!(nested.as_str().contains("/a/"), "nested path must include both segments");
+}
+
+#[test]
+#[should_panic(expected = "non-empty printable ASCII without '/'")]
+fn subkey_panics_on_slash_in_name() {
+    let key = IdempotencyKey::from_activity_exec_id(ActivityExecId::new());
+    let _ = key.subkey("a/b");
+}
+
+#[test]
+#[should_panic(expected = "non-empty printable ASCII without '/'")]
+fn subkey_panics_on_empty_name() {
+    let key = IdempotencyKey::from_activity_exec_id(ActivityExecId::new());
+    let _ = key.subkey("");
+}
+
+#[test]
+#[should_panic(expected = "non-empty printable ASCII without '/'")]
+fn subkey_panics_on_non_ascii_name() {
+    let key = IdempotencyKey::from_activity_exec_id(ActivityExecId::new());
+    let _ = key.subkey("café");
+}
+
+#[test]
+#[should_panic(expected = "non-empty printable ASCII without '/'")]
+fn subkey_panics_on_control_char_in_name() {
+    let key = IdempotencyKey::from_activity_exec_id(ActivityExecId::new());
+    let _ = key.subkey("charge\tcard");
+}

--- a/autumn-harvest/tests/idempotency_tests.rs
+++ b/autumn-harvest/tests/idempotency_tests.rs
@@ -54,7 +54,11 @@ fn keys_for_ten_thousand_invocations_have_no_collisions() {
                 .to_owned()
         })
         .collect();
-    assert_eq!(keys.len(), 10_000, "10,000 distinct invocations must yield 10,000 distinct keys");
+    assert_eq!(
+        keys.len(),
+        10_000,
+        "10,000 distinct invocations must yield 10,000 distinct keys"
+    );
 }
 
 // ── Subkey derivation ────────────────────────────────────────────────────
@@ -64,7 +68,10 @@ fn subkey_derivation_is_deterministic() {
     let key = IdempotencyKey::from_activity_exec_id(ActivityExecId::new());
     let s1 = key.subkey("charge").as_str().to_owned();
     let s2 = key.subkey("charge").as_str().to_owned();
-    assert_eq!(s1, s2, "subkey(same_name) must return the same value every time");
+    assert_eq!(
+        s1, s2,
+        "subkey(same_name) must return the same value every time"
+    );
 }
 
 #[test]
@@ -83,7 +90,11 @@ fn different_subkey_names_produce_different_keys() {
 fn subkey_is_distinct_from_its_parent() {
     let key = IdempotencyKey::from_activity_exec_id(ActivityExecId::new());
     let sub = key.subkey("charge");
-    assert_ne!(key.as_str(), sub.as_str(), "subkey must differ from parent key");
+    assert_ne!(
+        key.as_str(),
+        sub.as_str(),
+        "subkey must differ from parent key"
+    );
 }
 
 #[test]
@@ -100,9 +111,7 @@ fn same_subkey_name_different_parents_produce_different_keys() {
 // ── HTTP-header safety ───────────────────────────────────────────────────
 
 fn is_http_header_safe(s: &str) -> bool {
-    !s.is_empty()
-        && s.chars()
-            .all(|c| c.is_ascii() && c >= ' ' && c != '\x7f')
+    !s.is_empty() && s.chars().all(|c| c.is_ascii() && c >= ' ' && c != '\x7f')
 }
 
 #[test]
@@ -208,8 +217,7 @@ async fn payment_gateway_duplicate_dispatch_commits_exactly_once() {
     // Every attempt must carry the *same* idempotency key so the gateway
     // deduplicates to exactly one charge.
     let gateway = Arc::new(FakeGateway::new());
-    let idempotency_key =
-        IdempotencyKey::from_activity_exec_id(ActivityExecId::new());
+    let idempotency_key = IdempotencyKey::from_activity_exec_id(ActivityExecId::new());
 
     for attempt in 1u32..=5 {
         let ctx = ActivityContext::new_test()
@@ -298,7 +306,10 @@ fn subkey_slash_in_name_does_not_collide_with_nested_subkey() {
     // A flat name that *looks* like the path "a/b" would panic — test that
     // the flat and nested forms are provably distinct by ensuring the nested
     // path prefix includes the intermediate segment.
-    assert!(nested.as_str().contains("/a/"), "nested path must include both segments");
+    assert!(
+        nested.as_str().contains("/a/"),
+        "nested path must include both segments"
+    );
 }
 
 #[test]


### PR DESCRIPTION
## Summary

Implements stable, deterministic idempotency keys for activity invocations to enable safe retry semantics. Activities are at-least-once (worker crashes and timeouts trigger retries), and this feature allows downstream APIs to deduplicate requests using a stable key that persists across all retry attempts for the same logical invocation.

## Key Changes

- **New `IdempotencyKey` type** (`types.rs`): A stable, deterministic key derived from `ActivityExecId` that is identical across worker restarts, duplicate dispatch, deterministic replay, and all retry attempts for the same logical invocation. Includes:
  - `from_activity_exec_id()` constructor
  - `as_str()` accessor (HTTP-header safe)
  - `subkey(name)` method for deriving named child keys when one activity produces multiple side effects
  - `Display` implementation

- **`ActivityContext` enhancements** (`context.rs`):
  - Added `idempotency_key: Option<IdempotencyKey>` field
  - Added `attempt: Option<u32>` field to track which attempt (1-indexed)
  - New `idempotency_key()` method returning `Result<&IdempotencyKey, HarvestError>`
  - New `attempt()` method returning `Option<u32>`
  - New `with_idempotency_key()` and `with_attempt()` builder methods
  - Updated `new_test()` to automatically provide a key and attempt=1
  - Added `new_for_idempotency_test_no_key()` for testing error paths

- **Worker integration** (`worker.rs`):
  - Local activities now receive idempotency keys derived from `LocalActivityScheduled` event's `activity_id`
  - Keys and attempt numbers are attached to context for each retry attempt
  - Regular activities receive keys from their `ActivityScheduled` event

- **Comprehensive test suite** (`idempotency_tests.rs`):
  - Basic accessibility and stability tests
  - Collision resistance (10,000 invocations produce 10,000 distinct keys)
  - Subkey derivation (deterministic, distinct, nestable)
  - HTTP-header safety validation
  - Crash-retry simulation with fake payment gateway (duplicate dispatch deduplicates to exactly one charge)
  - 100-execution stress test with 3 retries each
  - Error path validation (missing key returns `HarvestError::Config`)

- **Documentation** (`README.md`):
  - Added "Activity idempotency keys" section explaining the feature
  - Billing/payment example showing Stripe integration
  - Subkey example for multiple side effects
  - Attempt-scoped key opt-in guidance

## Implementation Details

- Keys are UUID strings (36 characters, printable ASCII) derived directly from `ActivityExecId`
- Subkeys use format `{parent_uuid}/{name}` for stability and readability
- Keys are **retry-stable** by default (same value across all attempts); attempt-scoped keys are opt-in via `subkey(&format!("attempt-{}", attempt))`
- Local activities fully supported; key derived from `LocalActivityScheduled` event's `activity_id`
- No PII or user input embedded in default keys
- Comprehensive error handling: missing key returns descriptive `HarvestError::Config` rather than panicking or returning meaningless values

https://claude.ai/code/session_014oWBTc1VQ2WV5msjEWjxJD