### PR TITLE
⚒️ Forge: Refactor context and worker for clarity

### DIFF
--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -701,12 +701,7 @@ impl WorkflowContext {
             }
 
             HistoryMatch::NoMatch => {
-                if self.strict_replay {
-                    return Err(HarvestError::NonDeterministic(format!(
-                        "early completion mismatch: expected <end of history>, \
-                         got SideEffectRecorded({id})"
-                    )));
-                }
+                self.check_strict_replay_no_match(format_args!("SideEffectRecorded({id})"))?;
 
                 let result = f();
                 let output = serde_json::to_value(&result)?;
@@ -841,12 +836,7 @@ impl WorkflowContext {
             HistoryMatch::NoMatch => {
                 // Strict replay: a command with no matching history entry means
                 // the new code issues a command the recorded history never saw.
-                if self.strict_replay {
-                    return Err(HarvestError::NonDeterministic(format!(
-                        "early completion mismatch: expected <end of history>, \
-                         got ActivityScheduled({name})"
-                    )));
-                }
+                self.check_strict_replay_no_match(format_args!("ActivityScheduled({name})"))?;
 
                 // Live execution: emit a ScheduleActivity command and suspend
                 // until the worker sends the result through the oneshot channel.
@@ -941,12 +931,7 @@ impl WorkflowContext {
             }
 
             HistoryMatch::NoMatch => {
-                if self.strict_replay {
-                    return Err(HarvestError::NonDeterministic(format!(
-                        "early completion mismatch: expected <end of history>, \
-                         got LocalActivityScheduled({name})"
-                    )));
-                }
+                self.check_strict_replay_no_match(format_args!("LocalActivityScheduled({name})"))?;
 
                 let activity_id = self.next_activity_id();
                 let (tx, rx) = oneshot::channel();
@@ -1009,12 +994,7 @@ impl WorkflowContext {
             }
 
             HistoryMatch::NoMatch => {
-                if self.strict_replay {
-                    return Err(HarvestError::NonDeterministic(format!(
-                        "early completion mismatch: expected <end of history>, \
-                         got TimerStarted({timer_id})"
-                    )));
-                }
+                self.check_strict_replay_no_match(format_args!("TimerStarted({timer_id})"))?;
 
                 let (tx, rx) = oneshot::channel();
                 self.push_command(WorkflowCommand::StartTimer {
@@ -1104,12 +1084,9 @@ impl WorkflowContext {
                 }
             }
             HistoryMatch::NoMatch => {
-                if self.strict_replay {
-                    return Err(HarvestError::NonDeterministic(format!(
-                        "early completion mismatch: expected <end of history>, \
-                         got ChildWorkflowStarted({workflow_name})"
-                    )));
-                }
+                self.check_strict_replay_no_match(format_args!(
+                    "ChildWorkflowStarted({workflow_name})"
+                ))?;
 
                 let (tx, rx) = oneshot::channel();
                 self.push_command(WorkflowCommand::StartChildWorkflow {
@@ -1160,12 +1137,7 @@ impl WorkflowContext {
                 "signal history contains unexpected failure".into(),
             )),
             HistoryMatch::NoMatch => {
-                if self.strict_replay {
-                    return Err(HarvestError::NonDeterministic(format!(
-                        "early completion mismatch: expected <end of history>, \
-                         got WaitForSignal({signal_name})"
-                    )));
-                }
+                self.check_strict_replay_no_match(format_args!("WaitForSignal({signal_name})"))?;
 
                 let (tx, rx) = oneshot::channel();
                 self.push_command(WorkflowCommand::WaitForSignal {
@@ -1263,12 +1235,9 @@ impl WorkflowContext {
             }
 
             HistoryMatch::NoMatch => {
-                if self.strict_replay {
-                    return Err(HarvestError::NonDeterministic(format!(
-                        "early completion mismatch: expected <end of history>, \
-                         got ExternalActivityScheduled({name})"
-                    )));
-                }
+                self.check_strict_replay_no_match(format_args!(
+                    "ExternalActivityScheduled({name})"
+                ))?;
 
                 // First time — generate a fresh token and schedule.
                 let activity_id = self.next_activity_id();
@@ -1350,13 +1319,7 @@ impl WorkflowContext {
                 "continue_as_new history contains unexpected terminal state".into(),
             )),
             HistoryMatch::NoMatch => {
-                if self.strict_replay {
-                    return Err(HarvestError::NonDeterministic(
-                        "early completion mismatch: expected <end of history>, \
-                         got ContinueAsNew"
-                            .to_string(),
-                    ));
-                }
+                self.check_strict_replay_no_match(format_args!("ContinueAsNew"))?;
                 self.push_command(WorkflowCommand::ContinueAsNew { input });
                 park_until_dropped().await
             }
@@ -1610,6 +1573,17 @@ impl WorkflowContext {
     }
 
     // ── Internal helpers ──────────────────────────────────────────────
+
+    /// Check for early completion mismatch during strict replay.
+    fn check_strict_replay_no_match(&self, expected: std::fmt::Arguments<'_>) -> HarvestResult<()> {
+        if self.strict_replay {
+            Err(HarvestError::NonDeterministic(format!(
+                "early completion mismatch: expected <end of history>, got {expected}"
+            )))
+        } else {
+            Ok(())
+        }
+    }
 
     /// Generate the next sequential activity execution ID.
     fn next_activity_id(&self) -> ActivityExecId {

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -2389,6 +2389,76 @@ async fn persist_workflow_outcome(
 }
 
 #[allow(clippy::too_many_lines)]
+#[allow(clippy::too_many_arguments)]
+async fn run_workflow_task_loop(
+    conn: &mut AsyncPgConnection,
+    registry: &HandlerRegistry,
+    task: &TaskQueueItem,
+    mut history_events: Vec<WorkflowEvent>,
+    mut next_event_id: i32,
+    workflow: &WorkflowInfo,
+    max_local_activity_start_to_close: Duration,
+    trace_carrier: Option<&TraceContextCarrier>,
+    exec_id: ExecutionId,
+    workflow_name: &str,
+    shard_id: i32,
+) -> HarvestResult<(WorkflowOutcome, Vec<WorkflowCommand>, tracing::Span, i32)> {
+    let telemetry = registry.telemetry().clone();
+
+    let loop_result = loop {
+        let is_replay = history_events.len() > 1;
+
+        let _iter_parent_guard = trace_carrier
+            .filter(|_| !is_replay)
+            .map(|c| telemetry.install_trace_context(c));
+
+        let span_meta = WorkflowExecuteSpanMeta {
+            workflow_name: workflow_name.to_string(),
+            shard_id: i64::from(shard_id),
+            queue_name: task.queue_name.clone(),
+            is_replay,
+            link_traceparent: trace_carrier
+                .filter(|_| is_replay)
+                .and_then(|c| c.link_traceparent.clone().or_else(|| c.traceparent.clone())),
+        };
+
+        let (run_outcome, pending_cmds, execute_span) = run_workflow_with_state(
+            exec_id,
+            history_events.clone(),
+            workflow.handler,
+            task.input.clone(),
+            registry.shared_state(),
+            Some(&span_meta),
+        )
+        .await;
+
+        match run_outcome {
+            WorkflowOutcome::Suspended { commands }
+                if commands
+                    .iter()
+                    .any(|c| matches!(c, WorkflowCommand::RunLocalActivity { .. })) =>
+            {
+                drop(execute_span);
+                let (markers, local_run) = extract_run_local_activity(commands);
+                let new_events = run_local_activity_inline(
+                    conn,
+                    registry,
+                    exec_id,
+                    markers,
+                    local_run,
+                    max_local_activity_start_to_close,
+                    &mut next_event_id,
+                )
+                .await?;
+                history_events.extend(new_events);
+            }
+            other => break (other, pending_cmds, execute_span, next_event_id),
+        }
+    };
+
+    Ok(loop_result)
+}
+
 async fn process_workflow_task(
     conn: &mut AsyncPgConnection,
     registry: &HandlerRegistry,
@@ -2474,76 +2544,20 @@ async fn process_workflow_task(
     // is executed here, its events are appended to history, and the workflow
     // is re-run with the extended history. Any other suspension (regular
     // activity, timer, signal wait, …) breaks out of the loop.
-    let mut history_events = prepared.history_events;
-    let mut next_event_id = prepared.next_event_id;
-
-    let loop_result = loop {
-        // Recompute is_replay each iteration: after local-activity events are
-        // appended the workflow re-runs in replay mode (history_events.len() > 1).
-        // ADR-0001 §2.1: span metadata must reflect the current replay state so
-        // harvest.replay and link.traceparent are accurate on every executor call.
-        let is_replay = history_events.len() > 1;
-
-        // ADR-0001 §3 + §4: install the producer's trace context only for live
-        // (non-replay) iterations so the harvest.workflow.execute span is
-        // correctly parented.  For replay iterations the context must NOT be
-        // installed — replay spans must be new root spans (the original trace
-        // may have long since expired).  Installing per-iteration ensures that
-        // when local-activity events push history_events.len() > 1 the
-        // transition to is_replay=true correctly clears the live parent context.
-        let _iter_parent_guard = trace_carrier
-            .as_ref()
-            .filter(|_| !is_replay)
-            .map(|c| telemetry.install_trace_context(c));
-
-        let span_meta = WorkflowExecuteSpanMeta {
-            workflow_name: prepared.execution.workflow_name.clone(),
-            shard_id: i64::from(prepared.execution.shard_id),
-            queue_name: task.queue_name.clone(),
-            is_replay,
-            link_traceparent: trace_carrier
-                .as_ref()
-                .filter(|_| is_replay)
-                .and_then(|c| c.link_traceparent.clone().or_else(|| c.traceparent.clone())),
-        };
-
-        let (run_outcome, pending_cmds, execute_span) = run_workflow_with_state(
-            prepared.exec_id,
-            history_events.clone(),
-            workflow.handler,
-            task.input.clone(),
-            registry.shared_state(),
-            Some(&span_meta),
-        )
-        .await;
-
-        match run_outcome {
-            WorkflowOutcome::Suspended { commands }
-                if commands
-                    .iter()
-                    .any(|c| matches!(c, WorkflowCommand::RunLocalActivity { .. })) =>
-            {
-                // Local-activity re-run: drop this iteration's execute span
-                // so the OTel span closes before we start inline execution.
-                drop(execute_span);
-                let (markers, local_run) = extract_run_local_activity(commands);
-                let new_events = run_local_activity_inline(
-                    conn,
-                    registry,
-                    prepared.exec_id,
-                    markers,
-                    local_run,
-                    max_local_activity_start_to_close,
-                    &mut next_event_id,
-                )
-                .await?;
-                history_events.extend(new_events);
-            }
-            other => break (other, pending_cmds, execute_span),
-        }
-    };
-
-    let (outcome, pending_cmds, execute_span) = loop_result;
+    let (outcome, pending_cmds, execute_span, mut next_event_id) = run_workflow_task_loop(
+        conn,
+        registry,
+        task,
+        prepared.history_events,
+        prepared.next_event_id,
+        workflow,
+        max_local_activity_start_to_close,
+        trace_carrier.as_ref(),
+        prepared.exec_id,
+        &prepared.execution.workflow_name,
+        prepared.execution.shard_id,
+    )
+    .await?;
 
     let status = match &outcome {
         WorkflowOutcome::Completed { .. } => WorkflowStatus::Completed,

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -2418,7 +2418,8 @@ async fn run_workflow_task_loop(
     let (outcome, pending_cmds, execute_span) = loop {
         let is_replay = ctx.history_events.len() > 1;
 
-        let _iter_parent_guard = ctx.trace_carrier
+        let _iter_parent_guard = ctx
+            .trace_carrier
             .filter(|_| !is_replay)
             .map(|c| telemetry.install_trace_context(c));
 
@@ -2427,7 +2428,8 @@ async fn run_workflow_task_loop(
             shard_id: i64::from(ctx.shard_id),
             queue_name: ctx.task.queue_name.clone(),
             is_replay,
-            link_traceparent: ctx.trace_carrier
+            link_traceparent: ctx
+                .trace_carrier
                 .filter(|_| is_replay)
                 .and_then(|c| c.link_traceparent.clone().or_else(|| c.traceparent.clone())),
         };

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -2389,44 +2389,54 @@ async fn persist_workflow_outcome(
 }
 
 #[allow(clippy::too_many_lines)]
-#[allow(clippy::too_many_arguments)]
+struct WorkflowLoopContext<'a> {
+    task: &'a TaskQueueItem,
+    history_events: Vec<WorkflowEvent>,
+    next_event_id: i32,
+    workflow: &'a WorkflowInfo,
+    max_local_activity_start_to_close: Duration,
+    trace_carrier: Option<&'a TraceContextCarrier>,
+    exec_id: ExecutionId,
+    workflow_name: &'a str,
+    shard_id: i32,
+}
+
+struct WorkflowLoopResult {
+    outcome: WorkflowOutcome,
+    pending_cmds: Vec<WorkflowCommand>,
+    execute_span: tracing::Span,
+    next_event_id: i32,
+}
+
 async fn run_workflow_task_loop(
     conn: &mut AsyncPgConnection,
     registry: &HandlerRegistry,
-    task: &TaskQueueItem,
-    mut history_events: Vec<WorkflowEvent>,
-    mut next_event_id: i32,
-    workflow: &WorkflowInfo,
-    max_local_activity_start_to_close: Duration,
-    trace_carrier: Option<&TraceContextCarrier>,
-    exec_id: ExecutionId,
-    workflow_name: &str,
-    shard_id: i32,
-) -> HarvestResult<(WorkflowOutcome, Vec<WorkflowCommand>, tracing::Span, i32)> {
+    mut ctx: WorkflowLoopContext<'_>,
+) -> HarvestResult<WorkflowLoopResult> {
     let telemetry = registry.telemetry().clone();
 
-    let loop_result = loop {
-        let is_replay = history_events.len() > 1;
+    let (outcome, pending_cmds, execute_span) = loop {
+        let is_replay = ctx.history_events.len() > 1;
 
-        let _iter_parent_guard = trace_carrier
+        let _iter_parent_guard = ctx.trace_carrier
             .filter(|_| !is_replay)
             .map(|c| telemetry.install_trace_context(c));
 
         let span_meta = WorkflowExecuteSpanMeta {
-            workflow_name: workflow_name.to_string(),
-            shard_id: i64::from(shard_id),
-            queue_name: task.queue_name.clone(),
+            workflow_name: ctx.workflow_name.to_string(),
+            shard_id: i64::from(ctx.shard_id),
+            queue_name: ctx.task.queue_name.clone(),
             is_replay,
-            link_traceparent: trace_carrier
+            link_traceparent: ctx.trace_carrier
                 .filter(|_| is_replay)
                 .and_then(|c| c.link_traceparent.clone().or_else(|| c.traceparent.clone())),
         };
 
         let (run_outcome, pending_cmds, execute_span) = run_workflow_with_state(
-            exec_id,
-            history_events.clone(),
-            workflow.handler,
-            task.input.clone(),
+            ctx.exec_id,
+            ctx.history_events.clone(),
+            ctx.workflow.handler,
+            ctx.task.input.clone(),
             registry.shared_state(),
             Some(&span_meta),
         )
@@ -2443,20 +2453,25 @@ async fn run_workflow_task_loop(
                 let new_events = run_local_activity_inline(
                     conn,
                     registry,
-                    exec_id,
+                    ctx.exec_id,
                     markers,
                     local_run,
-                    max_local_activity_start_to_close,
-                    &mut next_event_id,
+                    ctx.max_local_activity_start_to_close,
+                    &mut ctx.next_event_id,
                 )
                 .await?;
-                history_events.extend(new_events);
+                ctx.history_events.extend(new_events);
             }
-            other => break (other, pending_cmds, execute_span, next_event_id),
+            other => break (other, pending_cmds, execute_span),
         }
     };
 
-    Ok(loop_result)
+    Ok(WorkflowLoopResult {
+        outcome,
+        pending_cmds,
+        execute_span,
+        next_event_id: ctx.next_event_id,
+    })
 }
 
 async fn process_workflow_task(
@@ -2544,20 +2559,24 @@ async fn process_workflow_task(
     // is executed here, its events are appended to history, and the workflow
     // is re-run with the extended history. Any other suspension (regular
     // activity, timer, signal wait, …) breaks out of the loop.
-    let (outcome, pending_cmds, execute_span, mut next_event_id) = run_workflow_task_loop(
-        conn,
-        registry,
+    let loop_ctx = WorkflowLoopContext {
         task,
-        prepared.history_events,
-        prepared.next_event_id,
+        history_events: prepared.history_events,
+        next_event_id: prepared.next_event_id,
         workflow,
         max_local_activity_start_to_close,
-        trace_carrier.as_ref(),
-        prepared.exec_id,
-        &prepared.execution.workflow_name,
-        prepared.execution.shard_id,
-    )
-    .await?;
+        trace_carrier: trace_carrier.as_ref(),
+        exec_id: prepared.exec_id,
+        workflow_name: &prepared.execution.workflow_name,
+        shard_id: prepared.execution.shard_id,
+    };
+
+    let WorkflowLoopResult {
+        outcome,
+        pending_cmds,
+        execute_span,
+        mut next_event_id,
+    } = run_workflow_task_loop(conn, registry, loop_ctx).await?;
 
     let status = match &outcome {
         WorkflowOutcome::Completed { .. } => WorkflowStatus::Completed,

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,0 +1,4 @@
+🚮 **Smell**: Repetitive pattern matching on `HistoryMatch` causing "boolean blindness" and massive boilerplate strings, as well as `worker.rs` having "God Functions" containing deeply nested drive loops causing significant cognitive load.
+✨ **Solution**: Extracted `strict_replay` checking into `check_strict_replay_no_match` in `context.rs` using `format_args!` to avoid string allocation regressions. Extracted the core loop of `process_workflow_task` in `worker.rs` into a standalone `run_workflow_task_loop` helper.
+🧼 **Benefit**: Massively reduces boilerplate checking across all 8 execution dispatch functions in the `context.rs`. Drastically flattens and shrinks `process_workflow_task`, making it straightforward to read and audit.
+🛡️ **Verification**: Tests passed successfully. `cargo clippy` and `cargo fmt` executed safely.

--- a/pr_description.md
+++ b/pr_description.md
@@ -1,4 +1,0 @@
-🚮 **Smell**: Repetitive pattern matching on `HistoryMatch` causing "boolean blindness" and massive boilerplate strings, as well as `worker.rs` having "God Functions" containing deeply nested drive loops causing significant cognitive load.
-✨ **Solution**: Extracted `strict_replay` checking into `check_strict_replay_no_match` in `context.rs` using `format_args!` to avoid string allocation regressions. Extracted the core loop of `process_workflow_task` in `worker.rs` into a standalone `run_workflow_task_loop` helper.
-🧼 **Benefit**: Massively reduces boilerplate checking across all 8 execution dispatch functions in the `context.rs`. Drastically flattens and shrinks `process_workflow_task`, making it straightforward to read and audit.
-🛡️ **Verification**: Tests passed successfully. `cargo clippy` and `cargo fmt` executed safely.


### PR DESCRIPTION
🚮 **Smell**: Repetitive pattern matching on `HistoryMatch` causing "boolean blindness" and massive boilerplate strings, as well as `worker.rs` having "God Functions" containing deeply nested drive loops causing significant cognitive load.
✨ **Solution**: Extracted `strict_replay` checking into `check_strict_replay_no_match` in `context.rs` using `format_args!` to avoid string allocation regressions. Extracted the core loop of `process_workflow_task` in `worker.rs` into a standalone `run_workflow_task_loop` helper.
🧼 **Benefit**: Massively reduces boilerplate checking across all 8 execution dispatch functions in the `context.rs`. Drastically flattens and shrinks `process_workflow_task`, making it straightforward to read and audit.
🛡️ **Verification**: Tests passed successfully. `cargo clippy` and `cargo fmt` executed safely.

---
*PR created automatically by Jules for task [4460159488883962602](https://jules.google.com/task/4460159488883962602) started by @madmax983*