### PR TITLE
 feat(harvest): add deployment preflight checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ runtime-owned behavior stay behind the same API surface your service exposes.
 
 ```bash
 cargo run -p autumn-harvest-cli -- health
+cargo run -p autumn-harvest-cli -- preflight
 cargo run -p autumn-harvest-cli -- workflow list --limit 25
 cargo run -p autumn-harvest-cli -- workflow list --state RUNNING --search-attr tenant=acme
 cargo run -p autumn-harvest-cli -- workflow get <execution-id>
@@ -162,6 +163,28 @@ a bearer token. Successful responses are printed as pretty JSON by default; use
 `--output json` for compact script-friendly output. JSON request payloads accept
 inline `--*-json` values or `--*-file PATH`; use `-` as the file path to read
 from stdin.
+
+### Deployment preflight
+
+Run preflight before promoting a Harvest-backed service:
+
+```bash
+cargo run -p autumn-harvest-cli -- --base-url http://localhost:3000/api/harvest preflight
+cargo run -p autumn-harvest-cli -- --base-url http://localhost:3000/api/harvest --output json preflight
+```
+
+`harvest preflight` calls `GET /api/harvest/admin/preflight` and performs only
+read-only checks. It reports API/runtime readiness, Harvest migrations on every
+configured shard, shard read/write availability, catalog and schedule
+resolvability, worker queue coverage and freshness, DLQ read access, retention
+visibility, and whether the admin API has an auth boundary in non-dev profiles.
+The default output is a compact table; `--output json` returns the same response
+shape as the API for CI and release scripts.
+
+Exit codes are deploy-gate friendly: `0` means `overall_status = pass`, `2`
+means `warn`, and `1` means `fail` or a transport/API error. Use warning exit
+code `2` when your release process allows a separate "promote with caution"
+branch; otherwise treat any nonzero exit as a failed gate.
 
 ### Controlling duplicate workflow starts
 

--- a/autumn-harvest-cli/src/lib.rs
+++ b/autumn-harvest-cli/src/lib.rs
@@ -171,12 +171,33 @@ pub enum CliError {
         /// Original CLI argument value.
         value: String,
     },
+
+    /// Preflight completed but reported a non-passing deploy-gate status.
+    #[error("preflight overall_status={status}")]
+    PreflightGate {
+        /// Reported preflight status.
+        status: String,
+    },
+}
+
+impl CliError {
+    /// Process exit code associated with this error.
+    #[must_use]
+    pub fn exit_code(&self) -> i32 {
+        if matches!(self, Self::PreflightGate { status } if status == "warn") {
+            2
+        } else {
+            1
+        }
+    }
 }
 
 #[derive(Debug, Subcommand)]
 enum Commands {
     /// Check management API health.
     Health,
+    /// Run read-only deployment readiness checks.
+    Preflight,
     /// Manage workflow executions.
     Workflow {
         #[command(subcommand)]
@@ -622,6 +643,7 @@ impl Cli {
     pub fn api_request(&self) -> Result<ApiRequest, CliError> {
         match &self.command {
             Commands::Health => Ok(ApiRequest::get("/health")),
+            Commands::Preflight => Ok(ApiRequest::get("/admin/preflight")),
             Commands::Workflow { command } => workflow_request(command),
             Commands::Dag { command } => dag_request(command),
             Commands::Schedule { command } => schedule_request(command),
@@ -677,6 +699,17 @@ pub async fn run_cli(cli: Cli) -> Result<(), CliError> {
     let response = execute(&cli).await?;
     let rendered = render_response(&cli, &response)?;
     println!("{rendered}");
+    if matches!(cli.command, Commands::Preflight) {
+        let exit_code = preflight_exit_code(&response);
+        if exit_code != 0 {
+            let status = response
+                .get("overall_status")
+                .and_then(Value::as_str)
+                .unwrap_or("fail")
+                .to_string();
+            return Err(CliError::PreflightGate { status });
+        }
+    }
     Ok(())
 }
 
@@ -749,6 +782,9 @@ pub fn format_output(value: &Value, output: OutputFormat) -> Result<String, CliE
 }
 
 fn render_response(cli: &Cli, value: &Value) -> Result<String, CliError> {
+    if preflight_wants_table(cli) {
+        return Ok(format_preflight_table(value));
+    }
     if workflow_children_wants_table(cli) {
         return Ok(format_workflow_children_table(value));
     }
@@ -762,6 +798,85 @@ fn render_response(cli: &Cli, value: &Value) -> Result<String, CliError> {
         cli.output
     };
     format_output(value, output)
+}
+
+fn preflight_wants_table(cli: &Cli) -> bool {
+    matches!(&cli.command, Commands::Preflight) && cli.output == OutputFormat::PrettyJson
+}
+
+fn preflight_exit_code(value: &Value) -> i32 {
+    match value.get("overall_status").and_then(Value::as_str) {
+        Some("pass") => 0,
+        Some("warn") => 2,
+        _ => 1,
+    }
+}
+
+fn format_preflight_table(value: &Value) -> String {
+    let overall = value
+        .get("overall_status")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let observed_at = value
+        .get("observed_at")
+        .and_then(Value::as_str)
+        .unwrap_or("-");
+    let Some(checks) = value.get("checks").and_then(Value::as_array) else {
+        return format!(
+            "overall_status: {overall}\nobserved_at: {observed_at}\nNo checks returned."
+        );
+    };
+
+    let mut rows = Vec::with_capacity(checks.len() + 1);
+    rows.push(vec![
+        "STATUS".to_string(),
+        "CHECK".to_string(),
+        "SCOPE".to_string(),
+        "SUMMARY".to_string(),
+    ]);
+    for check in checks {
+        let shards = check
+            .get("affected_shards")
+            .and_then(Value::as_array)
+            .filter(|values| !values.is_empty())
+            .map_or_else(
+                || "-".to_string(),
+                |values| {
+                    let ids = values
+                        .iter()
+                        .filter_map(Value::as_i64)
+                        .map(|id| id.to_string())
+                        .collect::<Vec<_>>()
+                        .join(",");
+                    format!("shards={ids}")
+                },
+            );
+        rows.push(vec![
+            cell_str(check.get("status")),
+            cell_str(check.get("name")),
+            shards,
+            cell_str(check.get("summary")),
+        ]);
+    }
+
+    let widths = (0..rows[0].len())
+        .map(|col| rows.iter().map(|row| row[col].len()).max().unwrap_or(0))
+        .collect::<Vec<_>>();
+    let table = rows
+        .iter()
+        .map(|row| {
+            row.iter()
+                .enumerate()
+                .map(|(col, cell)| format!("{cell:<width$}", width = widths[col]))
+                .collect::<Vec<_>>()
+                .join("  ")
+                .trim_end()
+                .to_string()
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    format!("overall_status: {overall}\nobserved_at: {observed_at}\n\n{table}")
 }
 
 fn audit_list_wants_table(cli: &Cli) -> bool {
@@ -1668,5 +1783,63 @@ mod reuse_policy_tests {
         let rendered = render_response(&cli, &payload).expect("json output should render");
 
         assert_eq!(rendered, r#"{"items":[],"next_cursor":null}"#);
+    }
+
+    #[test]
+    fn preflight_default_output_renders_compact_table() {
+        let cli = parse(&["preflight"]);
+        let payload = json!({
+            "overall_status": "warn",
+            "observed_at": "2026-05-06T12:00:00Z",
+            "version": {
+                "package": "autumn-harvest-plugin",
+                "version": "0.2.0",
+                "core_version": "0.2.0"
+            },
+            "checks": [{
+                "name": "worker_coverage",
+                "status": "warn",
+                "summary": "queue coverage exists but one worker is stale",
+                "remediation": "Restart or replace stale workers before promotion.",
+                "affected_shards": [0],
+                "details": {}
+            }]
+        });
+
+        let rendered = render_response(&cli, &payload).expect("table output should render");
+
+        assert!(rendered.contains("STATUS"));
+        assert!(rendered.contains("worker_coverage"));
+        assert!(rendered.contains("warn"));
+        assert!(!rendered.trim_start().starts_with('{'));
+    }
+
+    #[test]
+    fn preflight_json_output_preserves_raw_payload_shape() {
+        let cli = parse(&["--output", "json", "preflight"]);
+        let payload = json!({
+            "overall_status": "pass",
+            "observed_at": "2026-05-06T12:00:00Z",
+            "version": {
+                "package": "autumn-harvest-plugin",
+                "version": "0.2.0",
+                "core_version": "0.2.0"
+            },
+            "checks": []
+        });
+
+        let rendered = render_response(&cli, &payload).expect("json output should render");
+
+        assert_eq!(
+            rendered,
+            r#"{"checks":[],"observed_at":"2026-05-06T12:00:00Z","overall_status":"pass","version":{"core_version":"0.2.0","package":"autumn-harvest-plugin","version":"0.2.0"}}"#
+        );
+    }
+
+    #[test]
+    fn preflight_exit_codes_match_deploy_gate_status() {
+        assert_eq!(preflight_exit_code(&json!({ "overall_status": "pass" })), 0);
+        assert_eq!(preflight_exit_code(&json!({ "overall_status": "warn" })), 2);
+        assert_eq!(preflight_exit_code(&json!({ "overall_status": "fail" })), 1);
     }
 }

--- a/autumn-harvest-cli/src/main.rs
+++ b/autumn-harvest-cli/src/main.rs
@@ -6,7 +6,8 @@ use autumn_harvest_cli::{Cli, run_cli};
 async fn main() {
     let cli = Cli::parse();
     if let Err(error) = run_cli(cli).await {
+        let exit_code = error.exit_code();
         eprintln!("error: {error}");
-        std::process::exit(1);
+        std::process::exit(exit_code);
     }
 }

--- a/autumn-harvest-cli/tests/request_mapping.rs
+++ b/autumn-harvest-cli/tests/request_mapping.rs
@@ -3,6 +3,17 @@ use clap::Parser;
 use serde_json::json;
 
 #[test]
+fn preflight_maps_to_management_api_request() {
+    let cli = Cli::try_parse_from(["harvest", "preflight"]).expect("preflight args should parse");
+
+    let request = cli.api_request().expect("preflight request should build");
+
+    assert_eq!(request.method, ApiMethod::Get);
+    assert_eq!(request.path, "/admin/preflight");
+    assert_eq!(request.body, None);
+}
+
+#[test]
 fn workflow_start_maps_to_management_api_request() {
     let cli = Cli::try_parse_from([
         "harvest",

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -73,6 +73,7 @@ use autumn_harvest::{
     StartWorkflowParams, cancel_workflow_execution, start_or_load_workflow_execution,
 };
 
+use crate::preflight::{PreflightReport, build_preflight_report};
 use crate::state::HarvestDbPool;
 
 #[derive(Clone)]
@@ -180,6 +181,10 @@ pub struct HarvestApiState {
     actor_extractor: Arc<Mutex<Option<ActorExtractorFn>>>,
     /// Audit log retention in days (default: 90).
     audit_retention_days: Arc<Mutex<Option<i64>>>,
+    /// Runtime profile used to decide whether unauthenticated admin routes are acceptable.
+    deployment_profile: Arc<Mutex<String>>,
+    /// Whether the management API was mounted behind an embedder-provided auth boundary.
+    admin_auth_boundary: Arc<Mutex<bool>>,
 }
 
 impl Default for HarvestApiState {
@@ -190,6 +195,8 @@ impl Default for HarvestApiState {
             worker_stale_threshold: Arc::new(Mutex::new(std::time::Duration::from_secs(10))),
             actor_extractor: Arc::default(),
             audit_retention_days: Arc::new(Mutex::new(None)),
+            deployment_profile: Arc::new(Mutex::new("unknown".to_string())),
+            admin_auth_boundary: Arc::new(Mutex::new(false)),
         }
     }
 }
@@ -255,11 +262,55 @@ impl HarvestApiState {
             .expect("harvest api state lock poisoned") = Some(days);
     }
 
+    /// Record the host application's deployment profile for preflight checks.
+    ///
+    /// `dev` allows an unauthenticated local management API; every other
+    /// profile is treated as non-dev and must have an auth boundary.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal mutex is poisoned.
+    pub fn set_deployment_profile(&self, profile: impl Into<String>) {
+        *self
+            .deployment_profile
+            .lock()
+            .expect("harvest api state lock poisoned") = profile.into();
+    }
+
+    /// Mark whether the Harvest management API is mounted behind auth.
+    ///
+    /// This reports the boundary provided via [`HarvestPlugin::api_with_auth`]
+    /// or an equivalent standalone integration. It does not implement RBAC.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal mutex is poisoned.
+    pub fn set_admin_auth_boundary(&self, present: bool) {
+        *self
+            .admin_auth_boundary
+            .lock()
+            .expect("harvest api state lock poisoned") = present;
+    }
+
     /// Returns `Some(days)` only when explicitly set via [`set_audit_retention_days`];
     /// `None` means "use the builder's retention config unchanged".
     pub(crate) fn audit_retention_days(&self) -> Option<i64> {
         *self
             .audit_retention_days
+            .lock()
+            .expect("harvest api state lock poisoned")
+    }
+
+    pub(crate) fn deployment_profile(&self) -> String {
+        self.deployment_profile
+            .lock()
+            .expect("harvest api state lock poisoned")
+            .clone()
+    }
+
+    pub(crate) fn admin_auth_boundary(&self) -> bool {
+        *self
+            .admin_auth_boundary
             .lock()
             .expect("harvest api state lock poisoned")
     }
@@ -331,7 +382,7 @@ impl HarvestApiState {
             .expect("harvest api state lock poisoned") = None;
     }
 
-    fn runtime(&self) -> HarvestResult<HarvestApiRuntime> {
+    pub(crate) fn runtime(&self) -> HarvestResult<HarvestApiRuntime> {
         self.runtime
             .lock()
             .expect("harvest api state lock poisoned")
@@ -347,6 +398,28 @@ impl HarvestApiState {
             .ok_or_else(|| {
                 HarvestError::Config("harvest storage pool is not configured".to_string())
             })
+    }
+}
+
+impl HarvestApiRuntime {
+    pub(crate) const fn registry(&self) -> &Arc<HandlerRegistry> {
+        &self.registry
+    }
+
+    pub(crate) const fn dags(&self) -> &Arc<DagCatalog> {
+        &self.dags
+    }
+
+    pub(crate) fn queues(&self) -> &[String] {
+        &self.queues
+    }
+
+    pub(crate) fn scheduler_snapshot(&self) -> SchedulerSnapshot {
+        self.scheduler.snapshot()
+    }
+
+    pub(crate) const fn retention_config(&self) -> &RetentionConfig {
+        &self.retention.config
     }
 }
 
@@ -730,6 +803,7 @@ pub fn harvest_api_router(api_state: HarvestApiState) -> Router<AppState> {
         )
         .route("/dead-letters/{id}/replay", post(replay_dead_letter))
         .route("/health", get(health))
+        .route("/admin/preflight", get(preflight))
         .route("/admin/retention", get(retention_status))
         .route("/admin/retention/run-now", post(retention_run_now))
         .route("/admin/concurrency", get(concurrency_status))
@@ -768,6 +842,14 @@ pub fn harvest_api_router(api_state: HarvestApiState) -> Router<AppState> {
         // API mutations. See `audit::ALL_MUTATION_ROUTES` for covered paths.
         .route("/admin/audit", get(list_audit_records))
         .layer(Extension(api_state))
+}
+
+async fn preflight(
+    Extension(api_state): Extension<HarvestApiState>,
+    axum::extract::State(autumn_state): axum::extract::State<AppState>,
+) -> Json<PreflightReport> {
+    api_state.set_deployment_profile(autumn_state.profile().to_string());
+    Json(build_preflight_report(&api_state).await)
 }
 
 #[derive(Debug, Deserialize)]

--- a/autumn-harvest-plugin/src/lib.rs
+++ b/autumn-harvest-plugin/src/lib.rs
@@ -4,6 +4,7 @@ pub mod api;
 pub mod config;
 pub mod outbox;
 pub mod plugin;
+pub mod preflight;
 pub mod prelude;
 pub mod runner;
 pub mod state;

--- a/autumn-harvest-plugin/src/plugin.rs
+++ b/autumn-harvest-plugin/src/plugin.rs
@@ -180,6 +180,7 @@ impl Plugin for HarvestPlugin {
             runtime: None,
         }));
         let api_state = HarvestApiState::new();
+        api_state.set_admin_auth_boundary(api_middleware.is_some());
 
         let startup_slot = Arc::clone(&slot);
         let shutdown_slot = Arc::clone(&slot);
@@ -218,6 +219,7 @@ fn start_harvest_runtime(
     slot: &Arc<Mutex<HarvestRuntimeSlot>>,
     api_state: &HarvestApiState,
 ) -> autumn_web::AutumnResult<()> {
+    api_state.set_deployment_profile(state.profile().to_string());
     let app_config = AutumnConfig::load()
         .map_err(|error| AutumnError::service_unavailable_msg(error.to_string()))?;
     let harvest_config = HarvestRuntimeConfig::load()

--- a/autumn-harvest-plugin/src/preflight.rs
+++ b/autumn-harvest-plugin/src/preflight.rs
@@ -1,0 +1,994 @@
+//! Read-only deployment preflight checks for the Harvest management API.
+
+use std::collections::{BTreeSet, HashSet};
+
+use autumn_harvest::dlq;
+use autumn_harvest::models::HarvestSchedule;
+use autumn_harvest::schema::harvest_schedules;
+use autumn_harvest::types::ShardId;
+use autumn_harvest::worker::DbPool;
+use autumn_harvest::workers::{WorkerFilters, WorkerHealth, WorkerRow, WorkerStatus, list_workers};
+use chrono::{DateTime, Utc};
+use diesel::QueryDsl;
+use diesel::SelectableHelper;
+use diesel::migration::MigrationSource;
+use diesel::pg::Pg;
+use diesel_async::RunQueryDsl;
+use serde::Serialize;
+use serde_json::{Value, json};
+
+use crate::api::HarvestApiState;
+
+/// Status for the overall preflight report and each individual check.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum PreflightStatus {
+    Pass,
+    Warn,
+    Fail,
+}
+
+impl PreflightStatus {
+    const fn rank(self) -> u8 {
+        match self {
+            Self::Pass => 0,
+            Self::Warn => 1,
+            Self::Fail => 2,
+        }
+    }
+}
+
+/// Version metadata returned with every preflight report.
+#[derive(Debug, Clone, Serialize)]
+pub struct PreflightVersion {
+    pub package: &'static str,
+    pub version: &'static str,
+    pub core_version: &'static str,
+}
+
+/// One preflight check result.
+#[derive(Debug, Clone, Serialize)]
+pub struct PreflightCheckResult {
+    pub name: String,
+    pub status: PreflightStatus,
+    pub summary: String,
+    pub remediation: Option<String>,
+    pub affected_shards: Vec<i32>,
+    pub details: Value,
+}
+
+/// Deployment-readiness report returned by `GET /admin/preflight`.
+#[derive(Debug, Clone, Serialize)]
+pub struct PreflightReport {
+    pub overall_status: PreflightStatus,
+    pub observed_at: DateTime<Utc>,
+    pub version: PreflightVersion,
+    pub checks: Vec<PreflightCheckResult>,
+}
+
+/// Build a read-only deployment preflight report.
+pub async fn build_preflight_report(api_state: &HarvestApiState) -> PreflightReport {
+    let mut checks = Vec::new();
+    checks.push(check_api_reachability(api_state));
+    checks.push(check_migrations(api_state).await);
+    checks.push(check_shard_availability(api_state).await);
+    checks.push(check_catalog_consistency(api_state));
+    checks.push(check_schedule_resolvability(api_state).await);
+    checks.push(check_worker_coverage(api_state).await);
+    checks.push(check_dlq_read_access(api_state).await);
+    checks.push(check_retention_visibility(api_state));
+    checks.push(check_admin_auth_boundary(api_state));
+
+    let overall_status = checks
+        .iter()
+        .map(|check| check.status)
+        .max_by_key(|status| status.rank())
+        .unwrap_or(PreflightStatus::Fail);
+
+    PreflightReport {
+        overall_status,
+        observed_at: Utc::now(),
+        version: PreflightVersion {
+            package: env!("CARGO_PKG_NAME"),
+            version: env!("CARGO_PKG_VERSION"),
+            core_version: env!("CARGO_PKG_VERSION"),
+        },
+        checks,
+    }
+}
+
+fn check(
+    name: impl Into<String>,
+    status: PreflightStatus,
+    summary: impl Into<String>,
+    remediation: Option<&str>,
+    mut affected_shards: Vec<i32>,
+    details: Value,
+) -> PreflightCheckResult {
+    affected_shards.sort_unstable();
+    affected_shards.dedup();
+    PreflightCheckResult {
+        name: name.into(),
+        status,
+        summary: summary.into(),
+        remediation: remediation.map(str::to_string),
+        affected_shards,
+        details,
+    }
+}
+
+fn check_api_reachability(api_state: &HarvestApiState) -> PreflightCheckResult {
+    api_state.runtime().map_or_else(
+        |_| {
+            check(
+                "api_reachability",
+                PreflightStatus::Fail,
+                "management API is reachable but the Harvest runtime is not installed",
+                Some("Start HarvestPlugin before running deployment preflight."),
+                Vec::new(),
+                json!({ "runtime_ready": false }),
+            )
+        },
+        |runtime| {
+            check(
+                "api_reachability",
+                PreflightStatus::Pass,
+                "management API is reachable and a Harvest runtime snapshot is installed",
+                None,
+                Vec::new(),
+                json!({
+                    "runtime_ready": true,
+                    "queues": runtime.queues(),
+                    "workflow_count": runtime.registry().workflows.len(),
+                    "activity_count": runtime.registry().activities.len(),
+                    "dag_count": runtime.dags().len(),
+                }),
+            )
+        },
+    )
+}
+
+#[derive(diesel::QueryableByName)]
+struct MigrationVersionRow {
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    version: String,
+}
+
+async fn check_migrations(api_state: &HarvestApiState) -> PreflightCheckResult {
+    let required = match required_migration_versions() {
+        Ok(required) => required,
+        Err(reason) => {
+            return check(
+                "migrations",
+                PreflightStatus::Fail,
+                "Harvest embedded migration metadata could not be loaded",
+                Some("Rebuild the binary with the packaged autumn-harvest migrations."),
+                Vec::new(),
+                json!({ "error": reason }),
+            );
+        }
+    };
+    let required_set = required.iter().cloned().collect::<HashSet<_>>();
+    let Ok(pool) = api_state.storage_pool() else {
+        return check(
+            "migrations",
+            PreflightStatus::Fail,
+            "Harvest storage pool is not configured",
+            Some("Install the Harvest storage pool before mounting the management API."),
+            Vec::new(),
+            json!({ "required_migrations": required }),
+        );
+    };
+
+    let mut affected = Vec::new();
+    let mut shards = Vec::new();
+    for (shard, shard_pool) in pool.iter_shards() {
+        let shard_id = shard.as_i32();
+        let observation = observe_migration_shard(shard_id, shard_pool, &required_set).await;
+        if !observation.passed {
+            affected.push(shard_id);
+        }
+        shards.push(observation.details);
+    }
+
+    let status = if affected.is_empty() {
+        PreflightStatus::Pass
+    } else {
+        PreflightStatus::Fail
+    };
+    check(
+        "migrations",
+        status,
+        if status == PreflightStatus::Pass {
+            "required Harvest migrations are present on every configured shard"
+        } else {
+            "one or more configured shards are missing required Harvest migrations"
+        },
+        (status == PreflightStatus::Fail)
+            .then_some("Run the Harvest migration stack on every affected shard before promotion."),
+        affected,
+        json!({
+            "required_migrations": required,
+            "shards": shards,
+        }),
+    )
+}
+
+struct ShardObservation {
+    passed: bool,
+    details: Value,
+}
+
+async fn observe_migration_shard(
+    shard_id: i32,
+    shard_pool: &DbPool,
+    required_set: &HashSet<String>,
+) -> ShardObservation {
+    let Ok(mut conn) = shard_pool.get().await else {
+        return ShardObservation {
+            passed: false,
+            details: json!({
+                "shard_id": shard_id,
+                "status": "fail",
+                "error": "database connection could not be acquired",
+            }),
+        };
+    };
+
+    let rows = diesel::sql_query("SELECT version::TEXT AS version FROM __diesel_schema_migrations")
+        .load::<MigrationVersionRow>(&mut conn)
+        .await;
+    let Ok(rows) = rows else {
+        return ShardObservation {
+            passed: false,
+            details: json!({
+                "shard_id": shard_id,
+                "status": "fail",
+                "error": "migration table is not readable",
+            }),
+        };
+    };
+
+    let present = rows
+        .into_iter()
+        .map(|row| row.version)
+        .collect::<HashSet<_>>();
+    let mut missing = required_set
+        .difference(&present)
+        .cloned()
+        .collect::<Vec<_>>();
+    missing.sort();
+    if missing.is_empty() {
+        ShardObservation {
+            passed: true,
+            details: json!({
+                "shard_id": shard_id,
+                "status": "pass",
+                "applied_count": present.len(),
+            }),
+        }
+    } else {
+        ShardObservation {
+            passed: false,
+            details: json!({
+                "shard_id": shard_id,
+                "status": "fail",
+                "missing_versions": missing,
+            }),
+        }
+    }
+}
+
+fn required_migration_versions() -> Result<Vec<String>, String> {
+    let migrations = <diesel_migrations::EmbeddedMigrations as MigrationSource<Pg>>::migrations(
+        &autumn_harvest::MIGRATIONS,
+    )
+    .map_err(|error| error.to_string())?;
+
+    Ok(migrations
+        .iter()
+        .map(|migration| {
+            let name = migration.name().to_string();
+            name.split('_').next().unwrap_or(&name).to_string()
+        })
+        .collect())
+}
+
+#[derive(diesel::QueryableByName)]
+struct ReadOnlyRow {
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    transaction_read_only: String,
+}
+
+#[derive(diesel::QueryableByName)]
+struct RecoveryRow {
+    #[diesel(sql_type = diesel::sql_types::Bool)]
+    in_recovery: bool,
+}
+
+async fn check_shard_availability(api_state: &HarvestApiState) -> PreflightCheckResult {
+    let Ok(pool) = api_state.storage_pool() else {
+        return check(
+            "shard_availability",
+            PreflightStatus::Fail,
+            "Harvest storage pool is not configured",
+            Some("Install the Harvest storage pool before mounting the management API."),
+            Vec::new(),
+            json!({ "shards": [] }),
+        );
+    };
+
+    let mut affected = Vec::new();
+    let mut shards = Vec::new();
+    for (shard, shard_pool) in pool.iter_shards() {
+        let shard_id = shard.as_i32();
+        let observation = observe_shard_availability(shard_id, shard_pool).await;
+        if !observation.passed {
+            affected.push(shard_id);
+        }
+        shards.push(observation.details);
+    }
+
+    let status = if affected.is_empty() {
+        PreflightStatus::Pass
+    } else {
+        PreflightStatus::Fail
+    };
+    check(
+        "shard_availability",
+        status,
+        if status == PreflightStatus::Pass {
+            "every configured shard is readable and writable"
+        } else {
+            "one or more configured shards are not readable and writable"
+        },
+        (status == PreflightStatus::Fail).then_some(
+            "Fix the affected shard connection or promote a writable primary before deployment.",
+        ),
+        affected,
+        json!({ "shards": shards }),
+    )
+}
+
+async fn observe_shard_availability(shard_id: i32, shard_pool: &DbPool) -> ShardObservation {
+    let Ok(mut conn) = shard_pool.get().await else {
+        return ShardObservation {
+            passed: false,
+            details: json!({
+                "shard_id": shard_id,
+                "status": "fail",
+                "readable": false,
+                "writable": false,
+                "error": "database connection could not be acquired",
+            }),
+        };
+    };
+
+    let read_only = diesel::sql_query(
+        "SELECT current_setting('transaction_read_only') AS transaction_read_only",
+    )
+    .get_result::<ReadOnlyRow>(&mut conn)
+    .await;
+    let recovery = diesel::sql_query("SELECT pg_is_in_recovery() AS in_recovery")
+        .get_result::<RecoveryRow>(&mut conn)
+        .await;
+    match (read_only, recovery) {
+        (Ok(read_only), Ok(recovery))
+            if read_only.transaction_read_only == "off" && !recovery.in_recovery =>
+        {
+            ShardObservation {
+                passed: true,
+                details: json!({
+                    "shard_id": shard_id,
+                    "status": "pass",
+                    "readable": true,
+                    "writable": true,
+                }),
+            }
+        }
+        (Ok(read_only), Ok(recovery)) => ShardObservation {
+            passed: false,
+            details: json!({
+                "shard_id": shard_id,
+                "status": "fail",
+                "readable": true,
+                "writable": false,
+                "transaction_read_only": read_only.transaction_read_only,
+                "in_recovery": recovery.in_recovery,
+            }),
+        },
+        _ => ShardObservation {
+            passed: false,
+            details: json!({
+                "shard_id": shard_id,
+                "status": "fail",
+                "readable": false,
+                "writable": false,
+                "error": "read-only availability probe failed",
+            }),
+        },
+    }
+}
+
+fn check_catalog_consistency(api_state: &HarvestApiState) -> PreflightCheckResult {
+    let Ok(runtime) = api_state.runtime() else {
+        return check(
+            "catalog_consistency",
+            PreflightStatus::Fail,
+            "Harvest runtime catalog is unavailable",
+            Some(
+                "Start HarvestPlugin so workflow, activity, and DAG registrations can be inspected.",
+            ),
+            Vec::new(),
+            json!({}),
+        );
+    };
+
+    let mut failures = Vec::new();
+    for dag in runtime.dags().values() {
+        for task in dag.definition.tasks() {
+            if !runtime
+                .registry()
+                .activities
+                .contains_key(&task.activity_name)
+            {
+                failures.push(format!(
+                    "dag '{}' references unregistered activity '{}'",
+                    dag.name, task.activity_name
+                ));
+            }
+        }
+    }
+    for activity in runtime.registry().activities.values() {
+        if activity.default_queue == Some("") {
+            failures.push(format!(
+                "activity '{}' declares an empty default queue",
+                activity.name
+            ));
+        }
+    }
+
+    let status = if failures.is_empty() {
+        PreflightStatus::Pass
+    } else {
+        PreflightStatus::Fail
+    };
+    check(
+        "catalog_consistency",
+        status,
+        if status == PreflightStatus::Pass {
+            "registered workflows, activities, and DAGs are internally consistent"
+        } else {
+            "registered catalog contains unresolved workflow runtime references"
+        },
+        (status == PreflightStatus::Fail)
+            .then_some("Fix the affected registration before starting workflows."),
+        Vec::new(),
+        json!({
+            "workflow_count": runtime.registry().workflows.len(),
+            "activity_count": runtime.registry().activities.len(),
+            "dag_count": runtime.dags().len(),
+            "failures": failures,
+        }),
+    )
+}
+
+async fn check_schedule_resolvability(api_state: &HarvestApiState) -> PreflightCheckResult {
+    let Ok(runtime) = api_state.runtime() else {
+        return check(
+            "schedule_resolvability",
+            PreflightStatus::Fail,
+            "Harvest runtime catalog is unavailable",
+            Some("Start HarvestPlugin so schedules can be resolved against registrations."),
+            Vec::new(),
+            json!({}),
+        );
+    };
+    let (db_schedules, schedule_read_failures) = load_schedules_from_shards(api_state).await;
+    let mut failures = Vec::new();
+    let mut affected = schedule_read_failures
+        .iter()
+        .map(|failure| failure.shard_id)
+        .collect::<Vec<_>>();
+
+    for schedule in runtime.workflow_schedules() {
+        if !runtime
+            .registry()
+            .workflows
+            .contains_key(&schedule.workflow_name)
+        {
+            failures.push(json!({
+                "kind": "workflow",
+                "name": schedule.workflow_name,
+                "source": "runtime",
+            }));
+        }
+    }
+    for row in &db_schedules {
+        if let Some(workflow_name) = row.schedule.workflow_name.as_deref()
+            && !runtime.registry().workflows.contains_key(workflow_name)
+        {
+            affected.push(row.shard.as_i32());
+            failures.push(json!({
+                "kind": "workflow",
+                "name": workflow_name,
+                "source": "database",
+                "shard_id": row.shard.as_i32(),
+            }));
+        }
+        if let Some(dag_name) = row.schedule.dag_name.as_deref()
+            && !runtime.dags().contains_key(dag_name)
+        {
+            affected.push(row.shard.as_i32());
+            failures.push(json!({
+                "kind": "dag",
+                "name": dag_name,
+                "source": "database",
+                "shard_id": row.shard.as_i32(),
+            }));
+        }
+    }
+
+    let schedule_count = runtime.workflow_schedules().len() + db_schedules.len();
+    let scheduler = runtime.scheduler_snapshot();
+    if schedule_count > 0 && !scheduler.running {
+        failures.push(json!({
+            "kind": "scheduler",
+            "name": "scheduler_path",
+            "source": "runtime",
+        }));
+    }
+
+    let status = if failures.is_empty() && schedule_read_failures.is_empty() {
+        PreflightStatus::Pass
+    } else {
+        PreflightStatus::Fail
+    };
+    check(
+        "schedule_resolvability",
+        status,
+        if status == PreflightStatus::Pass {
+            if schedule_count == 0 {
+                "no registered schedules require scheduler coverage"
+            } else {
+                "registered schedules resolve to runtime registrations and scheduler coverage is available"
+            }
+        } else {
+            "one or more registered schedules cannot be resolved or evaluated"
+        },
+        (status == PreflightStatus::Fail).then_some(
+            "Register the missing workflow or DAG, or enable the scheduler path before deployment.",
+        ),
+        affected,
+        json!({
+            "runtime_schedule_count": runtime.workflow_schedules().len(),
+            "database_schedule_count": db_schedules.len(),
+            "scheduler": scheduler,
+            "failures": failures,
+            "read_failures": schedule_read_failures,
+        }),
+    )
+}
+
+#[derive(Debug, Serialize)]
+struct ShardReadFailure {
+    shard_id: i32,
+    error: &'static str,
+}
+
+struct ScheduleShardRow {
+    shard: ShardId,
+    schedule: HarvestSchedule,
+}
+
+async fn load_schedules_from_shards(
+    api_state: &HarvestApiState,
+) -> (Vec<ScheduleShardRow>, Vec<ShardReadFailure>) {
+    let Ok(pool) = api_state.storage_pool() else {
+        return (
+            Vec::new(),
+            vec![ShardReadFailure {
+                shard_id: -1,
+                error: "storage pool is not configured",
+            }],
+        );
+    };
+    let mut schedules = Vec::new();
+    let mut failures = Vec::new();
+    for (shard, shard_pool) in pool.iter_shards() {
+        match shard_pool.get().await {
+            Ok(mut conn) => {
+                let rows = harvest_schedules::table
+                    .select(HarvestSchedule::as_select())
+                    .load::<HarvestSchedule>(&mut conn)
+                    .await;
+                match rows {
+                    Ok(rows) => schedules.extend(
+                        rows.into_iter()
+                            .map(|schedule| ScheduleShardRow { shard, schedule }),
+                    ),
+                    Err(_) => failures.push(ShardReadFailure {
+                        shard_id: shard.as_i32(),
+                        error: "schedule table is not readable",
+                    }),
+                }
+            }
+            Err(_) => failures.push(ShardReadFailure {
+                shard_id: shard.as_i32(),
+                error: "database connection could not be acquired",
+            }),
+        }
+    }
+    (schedules, failures)
+}
+
+async fn check_worker_coverage(api_state: &HarvestApiState) -> PreflightCheckResult {
+    let Ok(runtime) = api_state.runtime() else {
+        return check(
+            "worker_coverage",
+            PreflightStatus::Fail,
+            "Harvest runtime catalog is unavailable",
+            Some("Start HarvestPlugin so required task queues can be inspected."),
+            Vec::new(),
+            json!({}),
+        );
+    };
+    let Ok(pool) = api_state.storage_pool() else {
+        return check(
+            "worker_coverage",
+            PreflightStatus::Fail,
+            "Harvest storage pool is not configured",
+            Some("Install the Harvest storage pool so worker liveness can be read."),
+            Vec::new(),
+            json!({}),
+        );
+    };
+
+    let mut required_queues = required_queues(&runtime);
+    let (db_schedules, _) = load_schedules_from_shards(api_state).await;
+    for row in db_schedules {
+        if let Some(queue_name) = row.schedule.queue_name {
+            required_queues.insert(queue_name);
+        }
+    }
+
+    if required_queues.is_empty() {
+        return check(
+            "worker_coverage",
+            PreflightStatus::Pass,
+            "no runtime queues are referenced by the current Harvest catalog",
+            None,
+            Vec::new(),
+            json!({ "required_queues": [] }),
+        );
+    }
+
+    let mut observations = Vec::new();
+    let mut hard_failures = Vec::new();
+    let mut warnings = Vec::new();
+    let mut affected = Vec::new();
+    let stale_threshold = api_state.worker_stale_threshold();
+    for (shard, shard_pool) in pool.iter_shards() {
+        let shard_id = shard.as_i32();
+        let shard_coverage =
+            observe_worker_coverage_shard(shard_id, shard_pool, stale_threshold, &required_queues)
+                .await;
+        if shard_coverage.affected {
+            affected.push(shard_id);
+        }
+        observations.extend(shard_coverage.observations);
+        warnings.extend(shard_coverage.warnings);
+        hard_failures.extend(shard_coverage.hard_failures);
+    }
+
+    let status = if !hard_failures.is_empty() {
+        PreflightStatus::Fail
+    } else if !warnings.is_empty() {
+        PreflightStatus::Warn
+    } else {
+        PreflightStatus::Pass
+    };
+    check(
+        "worker_coverage",
+        status,
+        match status {
+            PreflightStatus::Pass => {
+                "active fresh worker coverage exists for every referenced queue and shard"
+            }
+            PreflightStatus::Warn => {
+                "worker coverage exists but at least one matching worker is stale or draining"
+            }
+            PreflightStatus::Fail => "at least one referenced queue has no active worker coverage",
+        },
+        match status {
+            PreflightStatus::Pass => None,
+            PreflightStatus::Warn => Some(
+                "Restart stale workers or wait for draining workers to be replaced before promotion.",
+            ),
+            PreflightStatus::Fail => Some(
+                "Start at least one active worker for every referenced queue on each affected shard.",
+            ),
+        },
+        affected,
+        json!({
+            "required_queues": required_queues,
+            "observations": observations,
+            "warnings": warnings,
+            "failures": hard_failures,
+        }),
+    )
+}
+
+struct WorkerCoverageShard {
+    affected: bool,
+    observations: Vec<Value>,
+    warnings: Vec<Value>,
+    hard_failures: Vec<Value>,
+}
+
+async fn observe_worker_coverage_shard(
+    shard_id: i32,
+    shard_pool: &DbPool,
+    stale_threshold: std::time::Duration,
+    required_queues: &BTreeSet<String>,
+) -> WorkerCoverageShard {
+    let Ok(workers) = list_shard_workers(shard_pool, stale_threshold).await else {
+        return WorkerCoverageShard {
+            affected: true,
+            observations: Vec::new(),
+            warnings: Vec::new(),
+            hard_failures: vec![json!({
+                "shard_id": shard_id,
+                "reason": "worker table is not readable",
+            })],
+        };
+    };
+
+    let mut observations = Vec::new();
+    let mut warnings = Vec::new();
+    let mut hard_failures = Vec::new();
+    let mut affected = false;
+    for queue in required_queues {
+        let matching = workers
+            .iter()
+            .filter(|worker| worker_can_cover(worker, queue, shard_id))
+            .collect::<Vec<_>>();
+        if matching.is_empty() {
+            affected = true;
+            hard_failures.push(json!({
+                "queue": queue,
+                "shard_id": shard_id,
+                "reason": "no active worker registration covers this queue and shard",
+            }));
+            observations.push(json!({
+                "queue": queue,
+                "shard_id": shard_id,
+                "status": "fail",
+            }));
+        } else if matching.iter().any(|worker| {
+            worker.health == WorkerHealth::Stale
+                || worker.worker.status == WorkerStatus::Draining.as_str()
+        }) {
+            affected = true;
+            warnings.push(json!({
+                "queue": queue,
+                "shard_id": shard_id,
+                "reason": "coverage exists but at least one worker is stale or draining",
+            }));
+            observations.push(json!({
+                "queue": queue,
+                "shard_id": shard_id,
+                "status": "warn",
+            }));
+        } else {
+            observations.push(json!({
+                "queue": queue,
+                "shard_id": shard_id,
+                "status": "pass",
+            }));
+        }
+    }
+
+    WorkerCoverageShard {
+        affected,
+        observations,
+        warnings,
+        hard_failures,
+    }
+}
+
+fn required_queues(runtime: &crate::api::HarvestApiRuntime) -> BTreeSet<String> {
+    let mut queues = runtime.queues().iter().cloned().collect::<BTreeSet<_>>();
+    if !runtime.registry().workflows.is_empty() {
+        queues.insert("default".to_string());
+    }
+    for activity in runtime.registry().activities.values() {
+        if !activity.is_local {
+            queues.insert(activity.default_queue.unwrap_or("default").to_string());
+        }
+    }
+    for schedule in runtime.workflow_schedules() {
+        queues.insert(schedule.queue_name.clone());
+    }
+    queues.retain(|queue| !queue.trim().is_empty());
+    queues
+}
+
+async fn list_shard_workers(
+    pool: &DbPool,
+    stale_threshold: std::time::Duration,
+) -> Result<Vec<WorkerRow>, ()> {
+    let mut conn = pool.get().await.map_err(|_| ())?;
+    let filters = WorkerFilters {
+        limit: i64::MAX,
+        ..WorkerFilters::new()
+    };
+    list_workers(&mut conn, &filters, stale_threshold)
+        .await
+        .map_err(|_| ())
+}
+
+fn worker_can_cover(worker: &WorkerRow, queue: &str, shard_id: i32) -> bool {
+    if worker.worker.status == WorkerStatus::Stopped.as_str() {
+        return false;
+    }
+    let has_queue = worker
+        .worker
+        .queues
+        .as_array()
+        .is_some_and(|queues| queues.iter().any(|value| value.as_str() == Some(queue)));
+    let has_shard = worker
+        .worker
+        .shard_assignments
+        .as_array()
+        .is_some_and(|shards| {
+            shards
+                .iter()
+                .any(|value| value.as_i64() == Some(i64::from(shard_id)))
+        });
+    has_queue && has_shard
+}
+
+async fn check_dlq_read_access(api_state: &HarvestApiState) -> PreflightCheckResult {
+    let Ok(pool) = api_state.storage_pool() else {
+        return check(
+            "dlq_read_access",
+            PreflightStatus::Fail,
+            "Harvest storage pool is not configured",
+            Some("Install the Harvest storage pool so DLQ visibility can be checked."),
+            Vec::new(),
+            json!({}),
+        );
+    };
+
+    let mut affected = Vec::new();
+    let mut shards = Vec::new();
+    for (shard, shard_pool) in pool.iter_shards() {
+        let shard_id = shard.as_i32();
+        let observation = observe_dlq_read_access(shard_id, shard_pool).await;
+        if !observation.passed {
+            affected.push(shard_id);
+        }
+        shards.push(observation.details);
+    }
+    let status = if affected.is_empty() {
+        PreflightStatus::Pass
+    } else {
+        PreflightStatus::Fail
+    };
+    check(
+        "dlq_read_access",
+        status,
+        if status == PreflightStatus::Pass {
+            "dead-letter queue read access is available on every configured shard"
+        } else {
+            "dead-letter queue read access failed on one or more shards"
+        },
+        (status == PreflightStatus::Fail).then_some(
+            "Apply Harvest migrations and verify database permissions on affected shards.",
+        ),
+        affected,
+        json!({ "shards": shards }),
+    )
+}
+
+async fn observe_dlq_read_access(shard_id: i32, shard_pool: &DbPool) -> ShardObservation {
+    let Ok(mut conn) = shard_pool.get().await else {
+        return ShardObservation {
+            passed: false,
+            details: json!({
+                "shard_id": shard_id,
+                "status": "fail",
+                "error": "database connection could not be acquired",
+            }),
+        };
+    };
+
+    dlq::dead_letter_count(&mut conn).await.map_or_else(
+        |_| ShardObservation {
+            passed: false,
+            details: json!({
+                "shard_id": shard_id,
+                "status": "fail",
+                "error": "dead-letter table is not readable",
+            }),
+        },
+        |count| ShardObservation {
+            passed: true,
+            details: json!({
+                "shard_id": shard_id,
+                "status": "pass",
+                "dead_letter_count": count,
+            }),
+        },
+    )
+}
+
+fn check_retention_visibility(api_state: &HarvestApiState) -> PreflightCheckResult {
+    api_state.runtime().map_or_else(
+        |_| {
+            check(
+                "retention_visibility",
+                PreflightStatus::Fail,
+                "retention configuration is not visible because the runtime is unavailable",
+                Some("Start HarvestPlugin so retention configuration can be inspected."),
+                Vec::new(),
+                json!({}),
+            )
+        },
+        |runtime| {
+            check(
+                "retention_visibility",
+                PreflightStatus::Pass,
+                "retention configuration is visible to the management API",
+                None,
+                Vec::new(),
+                json!({ "config": runtime.retention_config() }),
+            )
+        },
+    )
+}
+
+fn check_admin_auth_boundary(api_state: &HarvestApiState) -> PreflightCheckResult {
+    let profile = api_state.deployment_profile();
+    let has_boundary = api_state.admin_auth_boundary();
+    let is_dev = profile == "dev";
+    let status = if is_dev || has_boundary {
+        PreflightStatus::Pass
+    } else if profile == "unknown" {
+        PreflightStatus::Warn
+    } else {
+        PreflightStatus::Fail
+    };
+
+    check(
+        "admin_auth_boundary",
+        status,
+        match status {
+            PreflightStatus::Pass if is_dev => {
+                "admin API auth boundary is optional for the dev profile"
+            }
+            PreflightStatus::Pass => "admin API is mounted with an auth boundary",
+            PreflightStatus::Warn => {
+                "admin API auth boundary cannot be confirmed because the deployment profile is unknown"
+            }
+            PreflightStatus::Fail => {
+                "admin API is mounted without an auth boundary in a non-dev profile"
+            }
+        },
+        match status {
+            PreflightStatus::Pass => None,
+            PreflightStatus::Warn => {
+                Some("Set the deployment profile or mark the admin auth boundary explicitly.")
+            }
+            PreflightStatus::Fail => Some(
+                "Use HarvestPlugin::api_with_auth or mount equivalent middleware before the Harvest admin API.",
+            ),
+        },
+        Vec::new(),
+        json!({
+            "profile": profile,
+            "auth_boundary_present": has_boundary,
+        }),
+    )
+}

--- a/autumn-harvest-plugin/src/preflight.rs
+++ b/autumn-harvest-plugin/src/preflight.rs
@@ -309,19 +309,19 @@ struct RecoveryRow {
 const HARVEST_WRITE_PRIVILEGE_REQUIREMENTS: &[(&str, &[&str])] = &[
     (
         "harvest_workflow_executions",
-        &["INSERT", "UPDATE", "DELETE"],
+        &["SELECT", "INSERT", "UPDATE", "DELETE"],
     ),
-    ("harvest_events", &["INSERT"]),
-    ("harvest_task_queue", &["INSERT", "UPDATE"]),
-    ("harvest_dag_runs", &["INSERT", "UPDATE"]),
-    ("harvest_schedules", &["INSERT", "UPDATE"]),
-    ("harvest_signals", &["INSERT", "UPDATE"]),
-    ("harvest_timers", &["INSERT", "UPDATE", "DELETE"]),
-    ("harvest_dead_letters", &["INSERT", "DELETE"]),
-    ("harvest_external_tasks", &["INSERT", "UPDATE"]),
-    ("harvest_workers", &["INSERT", "UPDATE"]),
-    ("harvest_batch_jobs", &["INSERT", "UPDATE"]),
-    ("harvest_audit_log", &["INSERT", "DELETE"]),
+    ("harvest_events", &["SELECT", "INSERT"]),
+    ("harvest_task_queue", &["SELECT", "INSERT", "UPDATE"]),
+    ("harvest_dag_runs", &["SELECT", "INSERT", "UPDATE"]),
+    ("harvest_schedules", &["SELECT", "INSERT", "UPDATE"]),
+    ("harvest_signals", &["SELECT", "INSERT", "UPDATE"]),
+    ("harvest_timers", &["SELECT", "INSERT", "UPDATE", "DELETE"]),
+    ("harvest_dead_letters", &["SELECT", "INSERT", "DELETE"]),
+    ("harvest_external_tasks", &["SELECT", "INSERT", "UPDATE"]),
+    ("harvest_workers", &["SELECT", "INSERT", "UPDATE"]),
+    ("harvest_batch_jobs", &["SELECT", "INSERT", "UPDATE"]),
+    ("harvest_audit_log", &["SELECT", "INSERT", "DELETE"]),
 ];
 
 const HARVEST_SEQUENCE_PRIVILEGE_REQUIREMENTS: &[(&str, &[&str])] =
@@ -1280,6 +1280,16 @@ mod tests {
         assert!(sql.contains("INSERT"));
         assert!(sql.contains("UPDATE"));
         assert!(sql.contains("DELETE"));
+    }
+
+    #[test]
+    fn every_harvest_runtime_table_requires_select_privilege() {
+        for (table, privileges) in HARVEST_WRITE_PRIVILEGE_REQUIREMENTS {
+            assert!(
+                privileges.contains(&"SELECT"),
+                "{table} must require SELECT so readable/writable preflight matches runtime access"
+            );
+        }
     }
 
     #[test]

--- a/autumn-harvest-plugin/src/preflight.rs
+++ b/autumn-harvest-plugin/src/preflight.rs
@@ -805,7 +805,7 @@ async fn observe_worker_coverage_shard(
 
 fn required_queues(runtime: &crate::api::HarvestApiRuntime) -> BTreeSet<String> {
     let mut queues = runtime.queues().iter().cloned().collect::<BTreeSet<_>>();
-    if !runtime.registry().workflows.is_empty() {
+    if !runtime.registry().workflows.is_empty() && queues.is_empty() {
         queues.insert("default".to_string());
     }
     for activity in runtime.registry().activities.values() {

--- a/autumn-harvest-plugin/src/preflight.rs
+++ b/autumn-harvest-plugin/src/preflight.rs
@@ -1,6 +1,6 @@
 //! Read-only deployment preflight checks for the Harvest management API.
 
-use std::collections::{BTreeSet, HashSet};
+use std::collections::{BTreeMap, BTreeSet, HashSet};
 
 use autumn_harvest::dlq;
 use autumn_harvest::models::HarvestSchedule;
@@ -306,6 +306,99 @@ struct RecoveryRow {
     in_recovery: bool,
 }
 
+const HARVEST_WRITE_PRIVILEGE_REQUIREMENTS: &[(&str, &[&str])] = &[
+    (
+        "harvest_workflow_executions",
+        &["INSERT", "UPDATE", "DELETE"],
+    ),
+    ("harvest_events", &["INSERT"]),
+    ("harvest_task_queue", &["INSERT", "UPDATE"]),
+    ("harvest_dag_runs", &["INSERT", "UPDATE"]),
+    ("harvest_schedules", &["INSERT", "UPDATE"]),
+    ("harvest_signals", &["INSERT", "UPDATE"]),
+    ("harvest_timers", &["INSERT", "UPDATE", "DELETE"]),
+    ("harvest_dead_letters", &["INSERT", "DELETE"]),
+    ("harvest_external_tasks", &["INSERT", "UPDATE"]),
+    ("harvest_workers", &["INSERT", "UPDATE"]),
+    ("harvest_batch_jobs", &["INSERT", "UPDATE"]),
+    ("harvest_audit_log", &["INSERT", "DELETE"]),
+];
+
+#[derive(diesel::QueryableByName, Debug, Clone)]
+struct TablePrivilegeRow {
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    table_name: String,
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    privilege: String,
+    #[diesel(sql_type = diesel::sql_types::Bool)]
+    granted: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct MissingWritePrivilege {
+    table: String,
+    privileges: Vec<String>,
+}
+
+fn harvest_write_privilege_query() -> String {
+    let mut values = String::new();
+    for (table, privileges) in HARVEST_WRITE_PRIVILEGE_REQUIREMENTS {
+        for privilege in *privileges {
+            if !values.is_empty() {
+                values.push_str(", ");
+            }
+            values.push_str("('");
+            values.push_str(table);
+            values.push_str("', '");
+            values.push_str(privilege);
+            values.push_str("')");
+        }
+    }
+
+    format!(
+        "WITH required(table_name, privilege) AS (VALUES {values}) \
+         SELECT table_name::TEXT AS table_name, \
+                privilege::TEXT AS privilege, \
+                COALESCE( \
+                    has_table_privilege( \
+                        to_regclass(table_name::TEXT), \
+                        privilege::TEXT \
+                    ), \
+                    false \
+                ) AS granted \
+         FROM required \
+         ORDER BY table_name, privilege"
+    )
+}
+
+fn missing_write_privileges(rows: Vec<TablePrivilegeRow>) -> Vec<MissingWritePrivilege> {
+    let mut by_table = BTreeMap::<String, Vec<String>>::new();
+    for row in rows {
+        if !row.granted {
+            by_table
+                .entry(row.table_name)
+                .or_default()
+                .push(row.privilege);
+        }
+    }
+    for privileges in by_table.values_mut() {
+        privileges.sort();
+    }
+    by_table
+        .into_iter()
+        .map(|(table, privileges)| MissingWritePrivilege { table, privileges })
+        .collect()
+}
+
+async fn missing_harvest_write_privileges(
+    conn: &mut diesel_async::AsyncPgConnection,
+) -> Result<Vec<MissingWritePrivilege>, diesel::result::Error> {
+    let rows = diesel::sql_query(harvest_write_privilege_query())
+        .load::<TablePrivilegeRow>(conn)
+        .await?;
+    Ok(missing_write_privileges(rows))
+}
+
 async fn check_shard_availability(api_state: &HarvestApiState) -> PreflightCheckResult {
     let Ok(pool) = api_state.storage_pool() else {
         return check(
@@ -338,12 +431,12 @@ async fn check_shard_availability(api_state: &HarvestApiState) -> PreflightCheck
         "shard_availability",
         status,
         if status == PreflightStatus::Pass {
-            "every configured shard is readable and writable"
+            "every configured shard is readable and writable by the Harvest role"
         } else {
-            "one or more configured shards are not readable and writable"
+            "one or more configured shards are not readable and writable by the Harvest role"
         },
         (status == PreflightStatus::Fail).then_some(
-            "Fix the affected shard connection or promote a writable primary before deployment.",
+            "Fix the affected shard connection, promote a writable primary, or grant the Harvest role required table write privileges before deployment.",
         ),
         affected,
         json!({ "shards": shards }),
@@ -372,9 +465,12 @@ async fn observe_shard_availability(shard_id: i32, shard_pool: &DbPool) -> Shard
     let recovery = diesel::sql_query("SELECT pg_is_in_recovery() AS in_recovery")
         .get_result::<RecoveryRow>(&mut conn)
         .await;
-    match (read_only, recovery) {
-        (Ok(read_only), Ok(recovery))
-            if read_only.transaction_read_only == "off" && !recovery.in_recovery =>
+    let missing_privileges = missing_harvest_write_privileges(&mut conn).await;
+    match (read_only, recovery, missing_privileges) {
+        (Ok(read_only), Ok(recovery), Ok(missing_privileges))
+            if read_only.transaction_read_only == "off"
+                && !recovery.in_recovery
+                && missing_privileges.is_empty() =>
         {
             ShardObservation {
                 passed: true,
@@ -386,7 +482,7 @@ async fn observe_shard_availability(shard_id: i32, shard_pool: &DbPool) -> Shard
                 }),
             }
         }
-        (Ok(read_only), Ok(recovery)) => ShardObservation {
+        (Ok(read_only), Ok(recovery), Ok(missing_privileges)) => ShardObservation {
             passed: false,
             details: json!({
                 "shard_id": shard_id,
@@ -395,6 +491,19 @@ async fn observe_shard_availability(shard_id: i32, shard_pool: &DbPool) -> Shard
                 "writable": false,
                 "transaction_read_only": read_only.transaction_read_only,
                 "in_recovery": recovery.in_recovery,
+                "missing_write_privileges": missing_privileges,
+            }),
+        },
+        (Ok(read_only), Ok(recovery), Err(_)) => ShardObservation {
+            passed: false,
+            details: json!({
+                "shard_id": shard_id,
+                "status": "fail",
+                "readable": true,
+                "writable": false,
+                "transaction_read_only": read_only.transaction_read_only,
+                "in_recovery": recovery.in_recovery,
+                "error": "write privilege probe failed",
             }),
         },
         _ => ShardObservation {
@@ -997,4 +1106,65 @@ fn check_admin_auth_boundary(api_state: &HarvestApiState) -> PreflightCheckResul
             "auth_boundary_present": has_boundary,
         }),
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn privilege_row(table_name: &str, privilege: &str, granted: bool) -> TablePrivilegeRow {
+        TablePrivilegeRow {
+            table_name: table_name.to_string(),
+            privilege: privilege.to_string(),
+            granted,
+        }
+    }
+
+    #[test]
+    fn missing_write_privileges_groups_denied_privileges_by_table() {
+        let missing = missing_write_privileges(vec![
+            privilege_row("harvest_task_queue", "INSERT", true),
+            privilege_row("harvest_task_queue", "UPDATE", false),
+            privilege_row("harvest_dead_letters", "INSERT", false),
+            privilege_row("harvest_dead_letters", "DELETE", false),
+        ]);
+
+        assert_eq!(
+            missing,
+            vec![
+                MissingWritePrivilege {
+                    table: "harvest_dead_letters".to_string(),
+                    privileges: vec!["DELETE".to_string(), "INSERT".to_string()],
+                },
+                MissingWritePrivilege {
+                    table: "harvest_task_queue".to_string(),
+                    privileges: vec!["UPDATE".to_string()],
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn missing_write_privileges_is_empty_when_every_probe_is_granted() {
+        let missing = missing_write_privileges(vec![
+            privilege_row("harvest_task_queue", "INSERT", true),
+            privilege_row("harvest_task_queue", "UPDATE", true),
+        ]);
+
+        assert!(missing.is_empty());
+    }
+
+    #[test]
+    fn write_privilege_query_checks_harvest_runtime_write_tables() {
+        let sql = harvest_write_privilege_query();
+
+        assert!(sql.contains("has_table_privilege"));
+        assert!(sql.contains("harvest_workflow_executions"));
+        assert!(sql.contains("harvest_task_queue"));
+        assert!(sql.contains("harvest_dead_letters"));
+        assert!(sql.contains("harvest_workers"));
+        assert!(sql.contains("INSERT"));
+        assert!(sql.contains("UPDATE"));
+        assert!(sql.contains("DELETE"));
+    }
 }

--- a/autumn-harvest-plugin/src/preflight.rs
+++ b/autumn-harvest-plugin/src/preflight.rs
@@ -698,7 +698,9 @@ async fn check_worker_coverage(api_state: &HarvestApiState) -> PreflightCheckRes
             PreflightStatus::Warn => {
                 "worker coverage exists but at least one matching worker is stale or draining"
             }
-            PreflightStatus::Fail => "at least one referenced queue has no active worker coverage",
+            PreflightStatus::Fail => {
+                "at least one referenced queue has no healthy active worker coverage"
+            }
         },
         match status {
             PreflightStatus::Pass => None,
@@ -706,7 +708,7 @@ async fn check_worker_coverage(api_state: &HarvestApiState) -> PreflightCheckRes
                 "Restart stale workers or wait for draining workers to be replaced before promotion.",
             ),
             PreflightStatus::Fail => Some(
-                "Start at least one active worker for every referenced queue on each affected shard.",
+                "Start at least one healthy active worker for every referenced queue on each affected shard.",
             ),
         },
         affected,
@@ -753,12 +755,16 @@ async fn observe_worker_coverage_shard(
             .iter()
             .filter(|worker| worker_can_cover(worker, queue, shard_id))
             .collect::<Vec<_>>();
-        if matching.is_empty() {
+        let has_healthy_active_worker = matching.iter().any(|worker| {
+            worker.health == WorkerHealth::Healthy
+                && worker.worker.status == WorkerStatus::Active.as_str()
+        });
+        if !has_healthy_active_worker {
             affected = true;
             hard_failures.push(json!({
                 "queue": queue,
                 "shard_id": shard_id,
-                "reason": "no active worker registration covers this queue and shard",
+                "reason": "no healthy active worker registration covers this queue and shard",
             }));
             observations.push(json!({
                 "queue": queue,

--- a/autumn-harvest-plugin/src/preflight.rs
+++ b/autumn-harvest-plugin/src/preflight.rs
@@ -324,6 +324,9 @@ const HARVEST_WRITE_PRIVILEGE_REQUIREMENTS: &[(&str, &[&str])] = &[
     ("harvest_audit_log", &["INSERT", "DELETE"]),
 ];
 
+const HARVEST_SEQUENCE_PRIVILEGE_REQUIREMENTS: &[(&str, &[&str])] =
+    &[("harvest_events_id_seq", &["USAGE"])];
+
 #[derive(diesel::QueryableByName, Debug, Clone)]
 struct TablePrivilegeRow {
     #[diesel(sql_type = diesel::sql_types::Text)]
@@ -337,6 +340,22 @@ struct TablePrivilegeRow {
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 struct MissingWritePrivilege {
     table: String,
+    privileges: Vec<String>,
+}
+
+#[derive(diesel::QueryableByName, Debug, Clone)]
+struct SequencePrivilegeRow {
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    sequence_name: String,
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    privilege: String,
+    #[diesel(sql_type = diesel::sql_types::Bool)]
+    granted: bool,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+struct MissingSequencePrivilege {
+    sequence: String,
     privileges: Vec<String>,
 }
 
@@ -371,6 +390,37 @@ fn harvest_write_privilege_query() -> String {
     )
 }
 
+fn harvest_sequence_privilege_query() -> String {
+    let mut values = String::new();
+    for (sequence, privileges) in HARVEST_SEQUENCE_PRIVILEGE_REQUIREMENTS {
+        for privilege in *privileges {
+            if !values.is_empty() {
+                values.push_str(", ");
+            }
+            values.push_str("('");
+            values.push_str(sequence);
+            values.push_str("', '");
+            values.push_str(privilege);
+            values.push_str("')");
+        }
+    }
+
+    format!(
+        "WITH required(sequence_name, privilege) AS (VALUES {values}) \
+         SELECT sequence_name::TEXT AS sequence_name, \
+                privilege::TEXT AS privilege, \
+                COALESCE( \
+                    has_sequence_privilege( \
+                        to_regclass(sequence_name::TEXT), \
+                        privilege::TEXT \
+                    ), \
+                    false \
+                ) AS granted \
+         FROM required \
+         ORDER BY sequence_name, privilege"
+    )
+}
+
 fn missing_write_privileges(rows: Vec<TablePrivilegeRow>) -> Vec<MissingWritePrivilege> {
     let mut by_table = BTreeMap::<String, Vec<String>>::new();
     for row in rows {
@@ -390,6 +440,28 @@ fn missing_write_privileges(rows: Vec<TablePrivilegeRow>) -> Vec<MissingWritePri
         .collect()
 }
 
+fn missing_sequence_privileges(rows: Vec<SequencePrivilegeRow>) -> Vec<MissingSequencePrivilege> {
+    let mut by_sequence = BTreeMap::<String, Vec<String>>::new();
+    for row in rows {
+        if !row.granted {
+            by_sequence
+                .entry(row.sequence_name)
+                .or_default()
+                .push(row.privilege);
+        }
+    }
+    for privileges in by_sequence.values_mut() {
+        privileges.sort();
+    }
+    by_sequence
+        .into_iter()
+        .map(|(sequence, privileges)| MissingSequencePrivilege {
+            sequence,
+            privileges,
+        })
+        .collect()
+}
+
 async fn missing_harvest_write_privileges(
     conn: &mut diesel_async::AsyncPgConnection,
 ) -> Result<Vec<MissingWritePrivilege>, diesel::result::Error> {
@@ -397,6 +469,15 @@ async fn missing_harvest_write_privileges(
         .load::<TablePrivilegeRow>(conn)
         .await?;
     Ok(missing_write_privileges(rows))
+}
+
+async fn missing_harvest_sequence_privileges(
+    conn: &mut diesel_async::AsyncPgConnection,
+) -> Result<Vec<MissingSequencePrivilege>, diesel::result::Error> {
+    let rows = diesel::sql_query(harvest_sequence_privilege_query())
+        .load::<SequencePrivilegeRow>(conn)
+        .await?;
+    Ok(missing_sequence_privileges(rows))
 }
 
 async fn check_shard_availability(api_state: &HarvestApiState) -> PreflightCheckResult {
@@ -436,7 +517,7 @@ async fn check_shard_availability(api_state: &HarvestApiState) -> PreflightCheck
             "one or more configured shards are not readable and writable by the Harvest role"
         },
         (status == PreflightStatus::Fail).then_some(
-            "Fix the affected shard connection, promote a writable primary, or grant the Harvest role required table write privileges before deployment.",
+            "Fix the affected shard connection, promote a writable primary, or grant the Harvest role required table and sequence privileges before deployment.",
         ),
         affected,
         json!({ "shards": shards }),
@@ -465,47 +546,68 @@ async fn observe_shard_availability(shard_id: i32, shard_pool: &DbPool) -> Shard
     let recovery = diesel::sql_query("SELECT pg_is_in_recovery() AS in_recovery")
         .get_result::<RecoveryRow>(&mut conn)
         .await;
-    let missing_privileges = missing_harvest_write_privileges(&mut conn).await;
-    match (read_only, recovery, missing_privileges) {
-        (Ok(read_only), Ok(recovery), Ok(missing_privileges))
-            if read_only.transaction_read_only == "off"
-                && !recovery.in_recovery
-                && missing_privileges.is_empty() =>
-        {
-            ShardObservation {
-                passed: true,
-                details: json!({
-                    "shard_id": shard_id,
-                    "status": "pass",
-                    "readable": true,
-                    "writable": true,
-                }),
+    match (read_only, recovery) {
+        (Ok(read_only), Ok(recovery)) => {
+            let missing_write_privileges = missing_harvest_write_privileges(&mut conn).await;
+            let missing_sequence_privileges = missing_harvest_sequence_privileges(&mut conn).await;
+            match (missing_write_privileges, missing_sequence_privileges) {
+                (Ok(missing_write_privileges), Ok(missing_sequence_privileges))
+                    if read_only.transaction_read_only == "off"
+                        && !recovery.in_recovery
+                        && missing_write_privileges.is_empty()
+                        && missing_sequence_privileges.is_empty() =>
+                {
+                    ShardObservation {
+                        passed: true,
+                        details: json!({
+                            "shard_id": shard_id,
+                            "status": "pass",
+                            "readable": true,
+                            "writable": true,
+                        }),
+                    }
+                }
+                (Ok(missing_write_privileges), Ok(missing_sequence_privileges)) => {
+                    ShardObservation {
+                        passed: false,
+                        details: json!({
+                            "shard_id": shard_id,
+                            "status": "fail",
+                            "readable": true,
+                            "writable": false,
+                            "transaction_read_only": read_only.transaction_read_only,
+                            "in_recovery": recovery.in_recovery,
+                            "missing_write_privileges": missing_write_privileges,
+                            "missing_sequence_privileges": missing_sequence_privileges,
+                        }),
+                    }
+                }
+                (Err(_), _) => ShardObservation {
+                    passed: false,
+                    details: json!({
+                        "shard_id": shard_id,
+                        "status": "fail",
+                        "readable": true,
+                        "writable": false,
+                        "transaction_read_only": read_only.transaction_read_only,
+                        "in_recovery": recovery.in_recovery,
+                        "error": "write privilege probe failed",
+                    }),
+                },
+                (_, Err(_)) => ShardObservation {
+                    passed: false,
+                    details: json!({
+                        "shard_id": shard_id,
+                        "status": "fail",
+                        "readable": true,
+                        "writable": false,
+                        "transaction_read_only": read_only.transaction_read_only,
+                        "in_recovery": recovery.in_recovery,
+                        "error": "sequence privilege probe failed",
+                    }),
+                },
             }
         }
-        (Ok(read_only), Ok(recovery), Ok(missing_privileges)) => ShardObservation {
-            passed: false,
-            details: json!({
-                "shard_id": shard_id,
-                "status": "fail",
-                "readable": true,
-                "writable": false,
-                "transaction_read_only": read_only.transaction_read_only,
-                "in_recovery": recovery.in_recovery,
-                "missing_write_privileges": missing_privileges,
-            }),
-        },
-        (Ok(read_only), Ok(recovery), Err(_)) => ShardObservation {
-            passed: false,
-            details: json!({
-                "shard_id": shard_id,
-                "status": "fail",
-                "readable": true,
-                "writable": false,
-                "transaction_read_only": read_only.transaction_read_only,
-                "in_recovery": recovery.in_recovery,
-                "error": "write privilege probe failed",
-            }),
-        },
         _ => ShardObservation {
             passed: false,
             details: json!({
@@ -1120,6 +1222,18 @@ mod tests {
         }
     }
 
+    fn sequence_privilege_row(
+        sequence_name: &str,
+        privilege: &str,
+        granted: bool,
+    ) -> SequencePrivilegeRow {
+        SequencePrivilegeRow {
+            sequence_name: sequence_name.to_string(),
+            privilege: privilege.to_string(),
+            granted,
+        }
+    }
+
     #[test]
     fn missing_write_privileges_groups_denied_privileges_by_table() {
         let missing = missing_write_privileges(vec![
@@ -1166,5 +1280,41 @@ mod tests {
         assert!(sql.contains("INSERT"));
         assert!(sql.contains("UPDATE"));
         assert!(sql.contains("DELETE"));
+    }
+
+    #[test]
+    fn missing_sequence_privileges_groups_denied_privileges_by_sequence() {
+        let missing = missing_sequence_privileges(vec![
+            sequence_privilege_row("harvest_events_id_seq", "USAGE", false),
+            sequence_privilege_row("harvest_events_id_seq", "SELECT", true),
+        ]);
+
+        assert_eq!(
+            missing,
+            vec![MissingSequencePrivilege {
+                sequence: "harvest_events_id_seq".to_string(),
+                privileges: vec!["USAGE".to_string()],
+            }]
+        );
+    }
+
+    #[test]
+    fn missing_sequence_privileges_is_empty_when_every_probe_is_granted() {
+        let missing = missing_sequence_privileges(vec![sequence_privilege_row(
+            "harvest_events_id_seq",
+            "USAGE",
+            true,
+        )]);
+
+        assert!(missing.is_empty());
+    }
+
+    #[test]
+    fn sequence_privilege_query_checks_harvest_event_id_sequence() {
+        let sql = harvest_sequence_privilege_query();
+
+        assert!(sql.contains("has_sequence_privilege"));
+        assert!(sql.contains("harvest_events_id_seq"));
+        assert!(sql.contains("USAGE"));
     }
 }

--- a/autumn-harvest-plugin/tests/preflight_integration.rs
+++ b/autumn-harvest-plugin/tests/preflight_integration.rs
@@ -32,6 +32,7 @@ use tower::ServiceExt;
 type HarvestApiApp = axum::Router;
 
 const READ_ONLY_TEST_PASSWORD: &str = "harvest_readonly_password";
+const WRITE_NO_SEQUENCE_TEST_PASSWORD: &str = "harvest_write_no_sequence_password";
 
 fn build_test_pool(database_url: &str) -> DbPool {
     let manager = AsyncDieselConnectionManager::<AsyncPgConnection>::new(database_url);
@@ -91,6 +92,31 @@ async fn create_read_only_harvest_role(database_url: &str) -> String {
     .expect("failed to grant table reads to read-only role");
 
     database_url_with_credentials(database_url, &role, READ_ONLY_TEST_PASSWORD)
+}
+
+async fn create_harvest_role_without_sequence_usage(database_url: &str) -> String {
+    let role = format!("harvest_no_seq_{}", uuid::Uuid::new_v4().simple());
+    let mut conn = <AsyncPgConnection as AsyncConnection>::establish(database_url)
+        .await
+        .expect("failed to connect as migration owner");
+    diesel::sql_query(format!(
+        "CREATE ROLE {role} LOGIN PASSWORD '{WRITE_NO_SEQUENCE_TEST_PASSWORD}'"
+    ))
+    .execute(&mut conn)
+    .await
+    .expect("failed to create no-sequence role");
+    diesel::sql_query(format!("GRANT USAGE ON SCHEMA public TO {role}"))
+        .execute(&mut conn)
+        .await
+        .expect("failed to grant schema usage to no-sequence role");
+    diesel::sql_query(format!(
+        "GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO {role}"
+    ))
+    .execute(&mut conn)
+    .await
+    .expect("failed to grant table writes to no-sequence role");
+
+    database_url_with_credentials(database_url, &role, WRITE_NO_SEQUENCE_TEST_PASSWORD)
 }
 
 async fn setup_two_shards_with_migrations() -> ((String, String), ContainerAsync<Postgres>) {
@@ -443,6 +469,51 @@ async fn shard_availability_fails_when_role_lacks_harvest_table_write_privileges
             .expect("missing privileges should be reported")
             .iter()
             .any(|entry| entry["table"] == "harvest_task_queue")
+    );
+}
+
+#[tokio::test]
+async fn shard_availability_fails_when_role_lacks_harvest_sequence_usage() {
+    let (database_url, _container) = setup_database_url_with_migrations().await;
+    let admin_pool = build_test_pool(&database_url);
+    register_active_worker(
+        &admin_pool,
+        "preflight-worker",
+        &["default".to_string(), "email".to_string()],
+        &[0],
+    )
+    .await;
+    let no_sequence_url = create_harvest_role_without_sequence_usage(&database_url).await;
+    let state = api_state(
+        HarvestDbPool::from(build_test_pool(&no_sequence_url)),
+        runtime_for(
+            &["default", "email"],
+            Vec::new(),
+            ShardRouter::single(),
+            SchedulerMonitor::offline(),
+        ),
+        "prod",
+        true,
+    );
+
+    let report = build_preflight_report(&state).await;
+
+    let shard = report
+        .checks
+        .iter()
+        .find(|check| check.name == "shard_availability")
+        .expect("shard availability check should exist");
+    assert_eq!(shard.status, PreflightStatus::Fail);
+    assert_eq!(shard.affected_shards, vec![0]);
+    let observed = &shard.details["shards"].as_array().unwrap()[0];
+    assert_eq!(observed["readable"], true);
+    assert_eq!(observed["writable"], false);
+    assert!(
+        observed["missing_sequence_privileges"]
+            .as_array()
+            .expect("missing sequence privileges should be reported")
+            .iter()
+            .any(|entry| entry["sequence"] == "harvest_events_id_seq")
     );
 }
 

--- a/autumn-harvest-plugin/tests/preflight_integration.rs
+++ b/autumn-harvest-plugin/tests/preflight_integration.rs
@@ -373,9 +373,103 @@ async fn registered_queue_without_active_worker_fails_preflight() {
 }
 
 #[tokio::test]
-async fn stale_worker_is_warning_not_failure_when_queue_coverage_exists() {
+async fn stale_worker_only_coverage_fails_preflight() {
     let (database_url, _container) = setup_database_url_with_migrations().await;
     let pool = build_test_pool(&database_url);
+    register_active_worker(
+        &pool,
+        "stale-worker",
+        &["default".to_string(), "email".to_string()],
+        &[0],
+    )
+    .await;
+    let mut conn = pool.get().await.expect("stale update connection");
+    diesel::sql_query(
+        "UPDATE harvest_workers
+         SET last_heartbeat_at = NOW() - INTERVAL '10 minutes',
+             status = $1
+         WHERE worker_id = 'stale-worker'",
+    )
+    .bind::<diesel::sql_types::Text, _>(WorkerStatus::Active.as_str())
+    .execute(&mut conn)
+    .await
+    .expect("worker should be marked stale");
+
+    let state = api_state(
+        HarvestDbPool::from(pool),
+        runtime_for(
+            &["default", "email"],
+            Vec::new(),
+            ShardRouter::single(),
+            SchedulerMonitor::offline(),
+        ),
+        "prod",
+        true,
+    );
+
+    let report = build_preflight_report(&state).await;
+
+    assert_eq!(report.overall_status, PreflightStatus::Fail);
+    assert_eq!(
+        check_status(&report, "worker_coverage"),
+        PreflightStatus::Fail
+    );
+}
+
+#[tokio::test]
+async fn draining_worker_only_coverage_fails_preflight() {
+    let (database_url, _container) = setup_database_url_with_migrations().await;
+    let pool = build_test_pool(&database_url);
+    register_active_worker(
+        &pool,
+        "draining-worker",
+        &["default".to_string(), "email".to_string()],
+        &[0],
+    )
+    .await;
+    let mut conn = pool.get().await.expect("draining update connection");
+    diesel::sql_query(
+        "UPDATE harvest_workers
+         SET status = $1
+         WHERE worker_id = 'draining-worker'",
+    )
+    .bind::<diesel::sql_types::Text, _>(WorkerStatus::Draining.as_str())
+    .execute(&mut conn)
+    .await
+    .expect("worker should be marked draining");
+
+    let state = api_state(
+        HarvestDbPool::from(pool),
+        runtime_for(
+            &["default", "email"],
+            Vec::new(),
+            ShardRouter::single(),
+            SchedulerMonitor::offline(),
+        ),
+        "prod",
+        true,
+    );
+
+    let report = build_preflight_report(&state).await;
+
+    assert_eq!(report.overall_status, PreflightStatus::Fail);
+    assert_eq!(
+        check_status(&report, "worker_coverage"),
+        PreflightStatus::Fail
+    );
+}
+
+#[tokio::test]
+async fn degraded_worker_is_warning_when_healthy_active_coverage_exists() {
+    let (database_url, _container) = setup_database_url_with_migrations().await;
+    let pool = build_test_pool(&database_url);
+    register_active_worker(
+        &pool,
+        "healthy-worker",
+        &["default".to_string(), "email".to_string()],
+        &[0],
+    )
+    .await;
     register_active_worker(
         &pool,
         "stale-worker",

--- a/autumn-harvest-plugin/tests/preflight_integration.rs
+++ b/autumn-harvest-plugin/tests/preflight_integration.rs
@@ -31,6 +31,8 @@ use tower::ServiceExt;
 
 type HarvestApiApp = axum::Router;
 
+const READ_ONLY_TEST_PASSWORD: &str = "harvest_readonly_password";
+
 fn build_test_pool(database_url: &str) -> DbPool {
     let manager = AsyncDieselConnectionManager::<AsyncPgConnection>::new(database_url);
     deadpool::managed::Pool::builder(manager)
@@ -56,6 +58,39 @@ async fn setup_database_url_with_migrations() -> (String, ContainerAsync<Postgre
     autumn_web::migrate::run_pending(&url, autumn_harvest::MIGRATIONS)
         .expect("failed to run Harvest migrations");
     (url, container)
+}
+
+fn database_url_with_credentials(database_url: &str, user: &str, password: &str) -> String {
+    database_url.replacen(
+        "postgres://postgres:postgres@",
+        &format!("postgres://{user}:{password}@"),
+        1,
+    )
+}
+
+async fn create_read_only_harvest_role(database_url: &str) -> String {
+    let role = format!("harvest_ro_{}", uuid::Uuid::new_v4().simple());
+    let mut conn = <AsyncPgConnection as AsyncConnection>::establish(database_url)
+        .await
+        .expect("failed to connect as migration owner");
+    diesel::sql_query(format!(
+        "CREATE ROLE {role} LOGIN PASSWORD '{READ_ONLY_TEST_PASSWORD}'"
+    ))
+    .execute(&mut conn)
+    .await
+    .expect("failed to create read-only role");
+    diesel::sql_query(format!("GRANT USAGE ON SCHEMA public TO {role}"))
+        .execute(&mut conn)
+        .await
+        .expect("failed to grant schema usage to read-only role");
+    diesel::sql_query(format!(
+        "GRANT SELECT ON ALL TABLES IN SCHEMA public TO {role}"
+    ))
+    .execute(&mut conn)
+    .await
+    .expect("failed to grant table reads to read-only role");
+
+    database_url_with_credentials(database_url, &role, READ_ONLY_TEST_PASSWORD)
 }
 
 async fn setup_two_shards_with_migrations() -> ((String, String), ContainerAsync<Postgres>) {
@@ -364,6 +399,51 @@ async fn unreachable_shard_is_reported_without_hiding_healthy_shard() {
     assert_eq!(shard.status, PreflightStatus::Fail);
     assert_eq!(shard.affected_shards, vec![1]);
     assert!(shard.details["shards"].as_array().unwrap().len() >= 2);
+}
+
+#[tokio::test]
+async fn shard_availability_fails_when_role_lacks_harvest_table_write_privileges() {
+    let (database_url, _container) = setup_database_url_with_migrations().await;
+    let admin_pool = build_test_pool(&database_url);
+    register_active_worker(
+        &admin_pool,
+        "preflight-worker",
+        &["default".to_string(), "email".to_string()],
+        &[0],
+    )
+    .await;
+    let read_only_url = create_read_only_harvest_role(&database_url).await;
+    let state = api_state(
+        HarvestDbPool::from(build_test_pool(&read_only_url)),
+        runtime_for(
+            &["default", "email"],
+            Vec::new(),
+            ShardRouter::single(),
+            SchedulerMonitor::offline(),
+        ),
+        "prod",
+        true,
+    );
+
+    let report = build_preflight_report(&state).await;
+
+    let shard = report
+        .checks
+        .iter()
+        .find(|check| check.name == "shard_availability")
+        .expect("shard availability check should exist");
+    assert_eq!(shard.status, PreflightStatus::Fail);
+    assert_eq!(shard.affected_shards, vec![0]);
+    let observed = &shard.details["shards"].as_array().unwrap()[0];
+    assert_eq!(observed["readable"], true);
+    assert_eq!(observed["writable"], false);
+    assert!(
+        observed["missing_write_privileges"]
+            .as_array()
+            .expect("missing privileges should be reported")
+            .iter()
+            .any(|entry| entry["table"] == "harvest_task_queue")
+    );
 }
 
 #[tokio::test]

--- a/autumn-harvest-plugin/tests/preflight_integration.rs
+++ b/autumn-harvest-plugin/tests/preflight_integration.rs
@@ -32,6 +32,7 @@ use tower::ServiceExt;
 type HarvestApiApp = axum::Router;
 
 const READ_ONLY_TEST_PASSWORD: &str = "harvest_readonly_password";
+const WRITE_NO_SELECT_TEST_PASSWORD: &str = "harvest_write_no_select_password";
 const WRITE_NO_SEQUENCE_TEST_PASSWORD: &str = "harvest_write_no_sequence_password";
 
 fn build_test_pool(database_url: &str) -> DbPool {
@@ -92,6 +93,37 @@ async fn create_read_only_harvest_role(database_url: &str) -> String {
     .expect("failed to grant table reads to read-only role");
 
     database_url_with_credentials(database_url, &role, READ_ONLY_TEST_PASSWORD)
+}
+
+async fn create_harvest_role_without_table_select(database_url: &str) -> String {
+    let role = format!("harvest_no_select_{}", uuid::Uuid::new_v4().simple());
+    let mut conn = <AsyncPgConnection as AsyncConnection>::establish(database_url)
+        .await
+        .expect("failed to connect as migration owner");
+    diesel::sql_query(format!(
+        "CREATE ROLE {role} LOGIN PASSWORD '{WRITE_NO_SELECT_TEST_PASSWORD}'"
+    ))
+    .execute(&mut conn)
+    .await
+    .expect("failed to create no-select role");
+    diesel::sql_query(format!("GRANT USAGE ON SCHEMA public TO {role}"))
+        .execute(&mut conn)
+        .await
+        .expect("failed to grant schema usage to no-select role");
+    diesel::sql_query(format!(
+        "GRANT INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA public TO {role}"
+    ))
+    .execute(&mut conn)
+    .await
+    .expect("failed to grant table writes to no-select role");
+    diesel::sql_query(format!(
+        "GRANT USAGE ON ALL SEQUENCES IN SCHEMA public TO {role}"
+    ))
+    .execute(&mut conn)
+    .await
+    .expect("failed to grant sequence usage to no-select role");
+
+    database_url_with_credentials(database_url, &role, WRITE_NO_SELECT_TEST_PASSWORD)
 }
 
 async fn create_harvest_role_without_sequence_usage(database_url: &str) -> String {
@@ -470,6 +502,59 @@ async fn shard_availability_fails_when_role_lacks_harvest_table_write_privileges
             .iter()
             .any(|entry| entry["table"] == "harvest_task_queue")
     );
+}
+
+#[tokio::test]
+async fn shard_availability_fails_when_role_lacks_harvest_table_select_privileges() {
+    let (database_url, _container) = setup_database_url_with_migrations().await;
+    let admin_pool = build_test_pool(&database_url);
+    register_active_worker(
+        &admin_pool,
+        "preflight-worker",
+        &["default".to_string(), "email".to_string()],
+        &[0],
+    )
+    .await;
+    let no_select_url = create_harvest_role_without_table_select(&database_url).await;
+    let state = api_state(
+        HarvestDbPool::from(build_test_pool(&no_select_url)),
+        runtime_for(
+            &["default", "email"],
+            Vec::new(),
+            ShardRouter::single(),
+            SchedulerMonitor::offline(),
+        ),
+        "prod",
+        true,
+    );
+
+    let report = build_preflight_report(&state).await;
+
+    let shard = report
+        .checks
+        .iter()
+        .find(|check| check.name == "shard_availability")
+        .expect("shard availability check should exist");
+    assert_eq!(shard.status, PreflightStatus::Fail);
+    assert_eq!(shard.affected_shards, vec![0]);
+    let observed = &shard.details["shards"].as_array().unwrap()[0];
+    assert_eq!(observed["readable"], true);
+    assert_eq!(observed["writable"], false);
+    let missing = observed["missing_write_privileges"]
+        .as_array()
+        .expect("missing table privileges should be reported");
+    assert!(missing.iter().any(|entry| {
+        entry["table"] == "harvest_workflow_executions"
+            && entry["privileges"]
+                .as_array()
+                .is_some_and(|privileges| privileges.iter().any(|value| value == "SELECT"))
+    }));
+    assert!(missing.iter().any(|entry| {
+        entry["table"] == "harvest_task_queue"
+            && entry["privileges"]
+                .as_array()
+                .is_some_and(|privileges| privileges.iter().any(|value| value == "SELECT"))
+    }));
 }
 
 #[tokio::test]

--- a/autumn-harvest-plugin/tests/preflight_integration.rs
+++ b/autumn-harvest-plugin/tests/preflight_integration.rs
@@ -1,0 +1,527 @@
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use autumn_harvest::info::{ActivityInfo, WorkflowInfo};
+use autumn_harvest::policy::{Schedule, WorkflowSchedule};
+use autumn_harvest::retention::RetentionConfig;
+use autumn_harvest::scheduler::{DagCatalog, SchedulerMonitor};
+use autumn_harvest::shard::{ShardRouter, ShardedDbPool};
+use autumn_harvest::types::ShardId;
+use autumn_harvest::worker::{DbPool, HandlerRegistry};
+use autumn_harvest::workers::{WorkerStatus, register_worker};
+use autumn_harvest_plugin::HarvestDbPool;
+use autumn_harvest_plugin::api::{
+    HarvestApiRuntime, HarvestApiState, HarvestRetentionRuntime, harvest_api_router,
+};
+use autumn_harvest_plugin::preflight::{PreflightStatus, build_preflight_report};
+use autumn_web::AppState;
+use autumn_web::reexports::axum;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use diesel_async::AsyncConnection;
+use diesel_async::AsyncPgConnection;
+use diesel_async::RunQueryDsl;
+use diesel_async::pooled_connection::AsyncDieselConnectionManager;
+use serde_json::Value;
+use testcontainers::ContainerAsync;
+use testcontainers_modules::postgres::Postgres;
+use testcontainers_modules::testcontainers::runners::AsyncRunner;
+use tower::ServiceExt;
+
+type HarvestApiApp = axum::Router;
+
+fn build_test_pool(database_url: &str) -> DbPool {
+    let manager = AsyncDieselConnectionManager::<AsyncPgConnection>::new(database_url);
+    deadpool::managed::Pool::builder(manager)
+        .max_size(4)
+        .build()
+        .expect("failed to build test pool")
+}
+
+async fn setup_database_url_with_migrations() -> (String, ContainerAsync<Postgres>) {
+    let container = Postgres::default()
+        .start()
+        .await
+        .expect("failed to start Postgres container");
+    let host = container
+        .get_host()
+        .await
+        .expect("failed to get container host");
+    let port = container
+        .get_host_port_ipv4(5432)
+        .await
+        .expect("failed to get container port");
+    let url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+    autumn_web::migrate::run_pending(&url, autumn_harvest::MIGRATIONS)
+        .expect("failed to run Harvest migrations");
+    (url, container)
+}
+
+async fn setup_two_shards_with_migrations() -> ((String, String), ContainerAsync<Postgres>) {
+    let container = Postgres::default()
+        .start()
+        .await
+        .expect("failed to start Postgres container");
+    let host = container
+        .get_host()
+        .await
+        .expect("failed to get container host");
+    let port = container
+        .get_host_port_ipv4(5432)
+        .await
+        .expect("failed to get container port");
+    let admin_url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+    let shard0_db = format!("harvest_preflight_shard0_{}", uuid::Uuid::new_v4().simple());
+    let shard1_db = format!("harvest_preflight_shard1_{}", uuid::Uuid::new_v4().simple());
+
+    let mut admin_conn = <AsyncPgConnection as AsyncConnection>::establish(&admin_url)
+        .await
+        .expect("failed to connect to admin database");
+    diesel::sql_query(format!("CREATE DATABASE {shard0_db}"))
+        .execute(&mut admin_conn)
+        .await
+        .expect("failed to create shard 0 database");
+    diesel::sql_query(format!("CREATE DATABASE {shard1_db}"))
+        .execute(&mut admin_conn)
+        .await
+        .expect("failed to create shard 1 database");
+
+    let shard0_url = format!("postgres://postgres:postgres@{host}:{port}/{shard0_db}");
+    let shard1_url = format!("postgres://postgres:postgres@{host}:{port}/{shard1_db}");
+    autumn_web::migrate::run_pending(&shard0_url, autumn_harvest::MIGRATIONS)
+        .expect("failed to migrate shard 0");
+    autumn_web::migrate::run_pending(&shard1_url, autumn_harvest::MIGRATIONS)
+        .expect("failed to migrate shard 1");
+    ((shard0_url, shard1_url), container)
+}
+
+fn build_two_shard_pool(shard0_url: &str, shard1_url: &str) -> HarvestDbPool {
+    let mut pools = BTreeMap::new();
+    pools.insert(ShardId::new(0), build_test_pool(shard0_url));
+    pools.insert(ShardId::new(1), build_test_pool(shard1_url));
+    HarvestDbPool::sharded(ShardedDbPool::from_map(pools, ShardId::new(0)))
+}
+
+fn two_shard_router() -> ShardRouter {
+    ShardRouter::new(
+        vec![ShardId::new(0), ShardId::new(1)],
+        vec![ShardId::new(0), ShardId::new(1)],
+        ShardId::new(0),
+    )
+}
+
+fn workflow_info() -> WorkflowInfo {
+    WorkflowInfo {
+        name: "echo_workflow",
+        module: "tests",
+        handler: |_ctx, input| Box::pin(async move { Ok(input) }),
+    }
+}
+
+fn activity_info(queue: Option<&'static str>) -> ActivityInfo {
+    ActivityInfo {
+        name: "send_email",
+        module: "tests",
+        default_retry_policy: None,
+        default_start_to_close: None,
+        default_heartbeat_timeout: None,
+        default_schedule_to_start: None,
+        default_queue: queue,
+        max_concurrent: None,
+        concurrency_key: None,
+        is_local: false,
+        handler: |_ctx, input| Box::pin(async move { Ok(input) }),
+    }
+}
+
+fn runtime_for(
+    queues: &[&str],
+    schedules: Vec<WorkflowSchedule>,
+    router: ShardRouter,
+    scheduler_monitor: SchedulerMonitor,
+) -> HarvestApiRuntime {
+    HarvestApiRuntime::new(
+        Arc::new(HandlerRegistry::new(
+            vec![workflow_info()],
+            vec![activity_info(Some("email"))],
+        )),
+        Arc::new(DagCatalog::new()),
+        Arc::new(schedules),
+        None,
+        queues.iter().map(|queue| (*queue).to_string()).collect(),
+        scheduler_monitor,
+        HarvestRetentionRuntime::disabled(RetentionConfig::default()),
+        router,
+    )
+}
+
+fn api_state(
+    pool: HarvestDbPool,
+    runtime: HarvestApiRuntime,
+    profile: &str,
+    admin_auth_boundary: bool,
+) -> HarvestApiState {
+    let state = HarvestApiState::new();
+    state.install_storage_pool(pool);
+    state.install(runtime);
+    state.set_deployment_profile(profile);
+    state.set_admin_auth_boundary(admin_auth_boundary);
+    state
+}
+
+async fn register_active_worker(pool: &DbPool, worker_id: &str, queues: &[String], shards: &[i32]) {
+    let mut conn = pool.get().await.expect("worker registration connection");
+    register_worker(
+        &mut conn,
+        worker_id,
+        queues,
+        shards,
+        10,
+        "localhost",
+        Some(env!("CARGO_PKG_VERSION")),
+    )
+    .await
+    .expect("worker registration should succeed");
+}
+
+fn check_status(
+    report: &autumn_harvest_plugin::preflight::PreflightReport,
+    name: &str,
+) -> PreflightStatus {
+    report
+        .checks
+        .iter()
+        .find(|check| check.name == name)
+        .unwrap_or_else(|| panic!("missing check {name}; got {:?}", report.checks))
+        .status
+}
+
+async fn read_json_response(response: axum::response::Response) -> Value {
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("failed to read response body");
+    serde_json::from_slice(&body).expect("response must be JSON")
+}
+
+async fn get_json(app: &HarvestApiApp, uri: impl Into<String>) -> (StatusCode, Value) {
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(uri.into())
+                .body(Body::empty())
+                .expect("request should build"),
+        )
+        .await
+        .expect("request should complete");
+    let status = response.status();
+    let json = read_json_response(response).await;
+    (status, json)
+}
+
+#[tokio::test]
+async fn preflight_endpoint_returns_all_green_single_shard_report() {
+    let (database_url, _container) = setup_database_url_with_migrations().await;
+    let pool = build_test_pool(&database_url);
+    register_active_worker(
+        &pool,
+        "preflight-worker",
+        &["default".to_string(), "email".to_string()],
+        &[0],
+    )
+    .await;
+    let state = api_state(
+        HarvestDbPool::from(pool),
+        runtime_for(
+            &["default", "email"],
+            Vec::new(),
+            ShardRouter::single(),
+            SchedulerMonitor::offline(),
+        ),
+        "prod",
+        true,
+    );
+    let app = harvest_api_router(state).with_state(AppState::for_test().with_profile("prod"));
+
+    let (status, body) = get_json(&app, "/admin/preflight").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["overall_status"], "pass");
+    assert!(body["observed_at"].is_string());
+    assert_eq!(body["version"]["package"], "autumn-harvest-plugin");
+    assert!(
+        body["checks"]
+            .as_array()
+            .expect("checks should be an array")
+            .iter()
+            .any(|check| check["name"] == "worker_coverage")
+    );
+}
+
+#[tokio::test]
+async fn missing_migration_on_one_shard_identifies_only_that_shard() {
+    let ((shard0_url, shard1_url), _container) = setup_two_shards_with_migrations().await;
+    let mut shard1_conn = <AsyncPgConnection as AsyncConnection>::establish(&shard1_url)
+        .await
+        .expect("shard 1 connection");
+    diesel::sql_query("DELETE FROM __diesel_schema_migrations WHERE version = (SELECT max(version) FROM __diesel_schema_migrations)")
+        .execute(&mut shard1_conn)
+        .await
+        .expect("should remove latest migration marker");
+
+    let pool = build_two_shard_pool(&shard0_url, &shard1_url);
+    register_active_worker(
+        pool.pool_for(ShardId::new(0)),
+        "preflight-worker-0",
+        &["default".to_string(), "email".to_string()],
+        &[0],
+    )
+    .await;
+    register_active_worker(
+        pool.pool_for(ShardId::new(1)),
+        "preflight-worker-1",
+        &["default".to_string(), "email".to_string()],
+        &[1],
+    )
+    .await;
+    let state = api_state(
+        pool,
+        runtime_for(
+            &["default", "email"],
+            Vec::new(),
+            two_shard_router(),
+            SchedulerMonitor::offline(),
+        ),
+        "prod",
+        true,
+    );
+
+    let report = build_preflight_report(&state).await;
+
+    assert_eq!(report.overall_status, PreflightStatus::Fail);
+    let migration = report
+        .checks
+        .iter()
+        .find(|check| check.name == "migrations")
+        .expect("migration check should exist");
+    assert_eq!(migration.status, PreflightStatus::Fail);
+    assert_eq!(migration.affected_shards, vec![1]);
+    assert!(migration.details["shards"].as_array().unwrap().len() >= 2);
+}
+
+#[tokio::test]
+async fn unreachable_shard_is_reported_without_hiding_healthy_shard() {
+    let (shard0_url, _container) = setup_database_url_with_migrations().await;
+    let bad_url = "postgres://postgres:postgres@127.0.0.1:1/unreachable";
+    let pool = build_two_shard_pool(&shard0_url, bad_url);
+    register_active_worker(
+        pool.pool_for(ShardId::new(0)),
+        "preflight-worker-0",
+        &["default".to_string(), "email".to_string()],
+        &[0],
+    )
+    .await;
+    let state = api_state(
+        pool,
+        runtime_for(
+            &["default", "email"],
+            Vec::new(),
+            two_shard_router(),
+            SchedulerMonitor::offline(),
+        ),
+        "prod",
+        true,
+    );
+
+    let report = build_preflight_report(&state).await;
+
+    assert_eq!(report.overall_status, PreflightStatus::Fail);
+    let shard = report
+        .checks
+        .iter()
+        .find(|check| check.name == "shard_availability")
+        .expect("shard availability check should exist");
+    assert_eq!(shard.status, PreflightStatus::Fail);
+    assert_eq!(shard.affected_shards, vec![1]);
+    assert!(shard.details["shards"].as_array().unwrap().len() >= 2);
+}
+
+#[tokio::test]
+async fn registered_queue_without_active_worker_fails_preflight() {
+    let (database_url, _container) = setup_database_url_with_migrations().await;
+    let state = api_state(
+        HarvestDbPool::from(build_test_pool(&database_url)),
+        runtime_for(
+            &["default", "email"],
+            Vec::new(),
+            ShardRouter::single(),
+            SchedulerMonitor::offline(),
+        ),
+        "prod",
+        true,
+    );
+
+    let report = build_preflight_report(&state).await;
+
+    assert_eq!(report.overall_status, PreflightStatus::Fail);
+    assert_eq!(
+        check_status(&report, "worker_coverage"),
+        PreflightStatus::Fail
+    );
+}
+
+#[tokio::test]
+async fn stale_worker_is_warning_not_failure_when_queue_coverage_exists() {
+    let (database_url, _container) = setup_database_url_with_migrations().await;
+    let pool = build_test_pool(&database_url);
+    register_active_worker(
+        &pool,
+        "stale-worker",
+        &["default".to_string(), "email".to_string()],
+        &[0],
+    )
+    .await;
+    let mut conn = pool.get().await.expect("stale update connection");
+    diesel::sql_query(
+        "UPDATE harvest_workers
+         SET last_heartbeat_at = NOW() - INTERVAL '10 minutes',
+             status = $1
+         WHERE worker_id = 'stale-worker'",
+    )
+    .bind::<diesel::sql_types::Text, _>(WorkerStatus::Active.as_str())
+    .execute(&mut conn)
+    .await
+    .expect("worker should be marked stale");
+
+    let state = api_state(
+        HarvestDbPool::from(pool),
+        runtime_for(
+            &["default", "email"],
+            Vec::new(),
+            ShardRouter::single(),
+            SchedulerMonitor::offline(),
+        ),
+        "prod",
+        true,
+    );
+
+    let report = build_preflight_report(&state).await;
+
+    assert_eq!(report.overall_status, PreflightStatus::Warn);
+    assert_eq!(
+        check_status(&report, "worker_coverage"),
+        PreflightStatus::Warn
+    );
+}
+
+#[tokio::test]
+async fn schedule_referencing_missing_runtime_registration_fails() {
+    let (database_url, _container) = setup_database_url_with_migrations().await;
+    let pool = build_test_pool(&database_url);
+    register_active_worker(
+        &pool,
+        "preflight-worker",
+        &["default".to_string(), "email".to_string()],
+        &[0],
+    )
+    .await;
+    let mut conn = pool.get().await.expect("schedule insert connection");
+    diesel::sql_query(
+        "INSERT INTO harvest_schedules
+            (id, dag_name, workflow_name, schedule_expr, timezone, catchup, max_active_runs, is_paused, workflow_input, queue_name)
+         VALUES
+            ($1, NULL, 'missing_workflow', 'interval:60', 'UTC', false, 1, false, 'null'::jsonb, 'default')",
+    )
+    .bind::<diesel::sql_types::Uuid, _>(uuid::Uuid::new_v4())
+    .execute(&mut conn)
+    .await
+    .expect("schedule insert should succeed");
+
+    let state = api_state(
+        HarvestDbPool::from(pool),
+        runtime_for(
+            &["default", "email"],
+            Vec::new(),
+            ShardRouter::single(),
+            SchedulerMonitor::new(1),
+        ),
+        "prod",
+        true,
+    );
+
+    let report = build_preflight_report(&state).await;
+
+    assert_eq!(report.overall_status, PreflightStatus::Fail);
+    assert_eq!(
+        check_status(&report, "schedule_resolvability"),
+        PreflightStatus::Fail
+    );
+}
+
+#[tokio::test]
+async fn admin_api_without_auth_boundary_fails_in_non_dev_profile() {
+    let (database_url, _container) = setup_database_url_with_migrations().await;
+    let pool = build_test_pool(&database_url);
+    register_active_worker(
+        &pool,
+        "preflight-worker",
+        &["default".to_string(), "email".to_string()],
+        &[0],
+    )
+    .await;
+    let state = api_state(
+        HarvestDbPool::from(pool),
+        runtime_for(
+            &["default", "email"],
+            Vec::new(),
+            ShardRouter::single(),
+            SchedulerMonitor::offline(),
+        ),
+        "prod",
+        false,
+    );
+
+    let report = build_preflight_report(&state).await;
+
+    assert_eq!(report.overall_status, PreflightStatus::Fail);
+    assert_eq!(
+        check_status(&report, "admin_auth_boundary"),
+        PreflightStatus::Fail
+    );
+}
+
+#[tokio::test]
+async fn registered_schedules_require_running_scheduler_path() {
+    let (database_url, _container) = setup_database_url_with_migrations().await;
+    let pool = build_test_pool(&database_url);
+    register_active_worker(
+        &pool,
+        "preflight-worker",
+        &["default".to_string(), "email".to_string()],
+        &[0],
+    )
+    .await;
+    let schedule =
+        WorkflowSchedule::new("echo_workflow", Schedule::Interval(Duration::from_secs(60)));
+    let state = api_state(
+        HarvestDbPool::from(pool),
+        runtime_for(
+            &["default", "email"],
+            vec![schedule],
+            ShardRouter::single(),
+            SchedulerMonitor::offline(),
+        ),
+        "prod",
+        true,
+    );
+
+    let report = build_preflight_report(&state).await;
+
+    assert_eq!(report.overall_status, PreflightStatus::Fail);
+    assert_eq!(
+        check_status(&report, "schedule_resolvability"),
+        PreflightStatus::Fail
+    );
+}

--- a/autumn-harvest-plugin/tests/preflight_integration.rs
+++ b/autumn-harvest-plugin/tests/preflight_integration.rs
@@ -23,7 +23,7 @@ use diesel_async::AsyncConnection;
 use diesel_async::AsyncPgConnection;
 use diesel_async::RunQueryDsl;
 use diesel_async::pooled_connection::AsyncDieselConnectionManager;
-use serde_json::Value;
+use serde_json::{Value, json};
 use testcontainers::ContainerAsync;
 use testcontainers_modules::postgres::Postgres;
 use testcontainers_modules::testcontainers::runners::AsyncRunner;
@@ -146,6 +146,24 @@ fn runtime_for(
             vec![workflow_info()],
             vec![activity_info(Some("email"))],
         )),
+        Arc::new(DagCatalog::new()),
+        Arc::new(schedules),
+        None,
+        queues.iter().map(|queue| (*queue).to_string()).collect(),
+        scheduler_monitor,
+        HarvestRetentionRuntime::disabled(RetentionConfig::default()),
+        router,
+    )
+}
+
+fn workflow_runtime_for(
+    queues: &[&str],
+    schedules: Vec<WorkflowSchedule>,
+    router: ShardRouter,
+    scheduler_monitor: SchedulerMonitor,
+) -> HarvestApiRuntime {
+    HarvestApiRuntime::new(
+        Arc::new(HandlerRegistry::new(vec![workflow_info()], Vec::new())),
         Arc::new(DagCatalog::new()),
         Arc::new(schedules),
         None,
@@ -369,6 +387,41 @@ async fn registered_queue_without_active_worker_fails_preflight() {
     assert_eq!(
         check_status(&report, "worker_coverage"),
         PreflightStatus::Fail
+    );
+}
+
+#[tokio::test]
+async fn workflow_runtime_with_custom_queue_does_not_require_default_worker() {
+    let (database_url, _container) = setup_database_url_with_migrations().await;
+    let pool = build_test_pool(&database_url);
+    register_active_worker(&pool, "billing-worker", &["billing".to_string()], &[0]).await;
+    let state = api_state(
+        HarvestDbPool::from(pool),
+        workflow_runtime_for(
+            &["billing"],
+            Vec::new(),
+            ShardRouter::single(),
+            SchedulerMonitor::offline(),
+        ),
+        "prod",
+        true,
+    );
+
+    let report = build_preflight_report(&state).await;
+
+    assert_eq!(report.overall_status, PreflightStatus::Pass);
+    assert_eq!(
+        check_status(&report, "worker_coverage"),
+        PreflightStatus::Pass
+    );
+    let worker_coverage = report
+        .checks
+        .iter()
+        .find(|check| check.name == "worker_coverage")
+        .expect("worker coverage check should exist");
+    assert_eq!(
+        worker_coverage.details["required_queues"],
+        json!(["billing"])
     );
 }
 

--- a/docs/plans/2026-05-06-deployment-preflight.md
+++ b/docs/plans/2026-05-06-deployment-preflight.md
@@ -1,0 +1,57 @@
+# Deployment Preflight Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Add a read-only Harvest deployment preflight API and CLI command that catches production-readiness blockers before workflows are started.
+
+**Architecture:** Implement preflight report generation as an additive `autumn-harvest-plugin` module used by `GET /admin/preflight`. The report aggregates runtime catalog metadata, shard read/migration visibility, schedule resolvability, worker coverage, DLQ access, retention visibility, and management auth-boundary state without mutating workflow, DAG, task queue, DLQ, or audit state. Add `harvest preflight` as a CLI GET command that renders a compact table by default and JSON when `--output json` is selected.
+
+**Tech Stack:** Rust 2024, Axum, Diesel async, Postgres, clap, serde JSON, testcontainers-backed integration tests.
+
+---
+
+### Task 1: RED - CLI Contract
+
+**Files:**
+- Modify: `autumn-harvest-cli/tests/request_mapping.rs`
+- Modify: `autumn-harvest-cli/src/lib.rs`
+- Modify: `autumn-harvest-cli/src/main.rs`
+
+**Steps:**
+1. Add a failing request-mapping test proving `harvest preflight` maps to `GET /admin/preflight`.
+2. Add a failing rendering test proving default output is a compact table, while `--output json` preserves the raw response shape.
+3. Add a failing exit-code test proving `overall_status = warn` exits `2`, `fail` exits `1`, and `pass` exits `0`.
+4. Run `cargo test -p autumn-harvest-cli preflight` and confirm the failures are for missing preflight support.
+5. Implement the minimal clap command, rendering helper, and exit-code helper.
+6. Re-run the targeted CLI tests.
+
+### Task 2: RED - API Report Contract
+
+**Files:**
+- Create: `autumn-harvest-plugin/src/preflight.rs`
+- Modify: `autumn-harvest-plugin/src/api.rs`
+- Modify: `autumn-harvest-plugin/src/lib.rs`
+- Create: `autumn-harvest-plugin/tests/preflight_integration.rs`
+
+**Steps:**
+1. Add failing integration tests for an all-green single-shard report and a non-dev admin API mounted without auth.
+2. Add failing integration tests for one shard missing migrations and one unreachable shard.
+3. Add failing integration tests for missing worker coverage, stale worker warning, and schedule rows referencing missing runtime registrations.
+4. Run `cargo test -p autumn-harvest-plugin --test preflight_integration` and confirm the failures are for missing preflight types/route/report generation.
+5. Implement the minimal report model and checker pipeline.
+6. Re-run the targeted plugin integration tests.
+
+### Task 3: Refactor and Docs
+
+**Files:**
+- Modify: `README.md`
+- Modify: `examples/quickstart/README.md`
+- Modify: `examples/billing-autumn-web/README.md`
+- Modify: `examples/standalone-runner/README.md`
+
+**Steps:**
+1. Document `harvest preflight` as a production deploy gate in the root README, including exit codes.
+2. Add one `harvest preflight` command to the quickstart and both advanced example run instructions.
+3. Run `cargo fmt`.
+4. Run targeted CLI and plugin tests.
+5. Scan affected areas for TODO/FIXME/stubs and review the diff.

--- a/examples/billing-autumn-web/README.md
+++ b/examples/billing-autumn-web/README.md
@@ -29,6 +29,12 @@ The app listens on `http://localhost:8081`.
 - Harvest API: `GET /api/harvest/health`
 - Harvest UI: `GET /api/harvest/ui`
 
+Run the deployment preflight before starting work:
+
+```bash
+cargo run -p autumn-harvest-cli -- --base-url http://localhost:8081/api/harvest preflight
+```
+
 ## Start Checkout Through The App
 
 ```bash

--- a/examples/quickstart/README.md
+++ b/examples/quickstart/README.md
@@ -28,7 +28,13 @@ The app starts on **http://localhost:8080**.
 The management API is at **http://localhost:8080/api/harvest**.  
 The workflow dashboard is at **http://localhost:8080/api/harvest/ui**.
 
-## Step 3 — Trigger a workflow execution
+## Step 3 — Run preflight
+
+```bash
+cargo run -p autumn-harvest-cli -- --base-url http://localhost:8080/api/harvest preflight
+```
+
+## Step 4 — Trigger a workflow execution
 
 ```bash
 curl -s -X POST http://localhost:8080/api/harvest/workflows/greeting/start \
@@ -43,7 +49,7 @@ The `greeting` workflow will:
 3. Run `send_greeting` again — logs `farewell to World!`
 4. Complete with the final greeting string
 
-## Step 4 — Observe in the dashboard
+## Step 5 — Observe in the dashboard
 
 Open **http://localhost:8080/api/harvest/ui** in your browser to watch the execution progress through each step in real time.
 
@@ -63,7 +69,7 @@ AUTUMN_MANIFEST_DIR=examples/quickstart AUTUMN_PROFILE=dev cargo run -p quicksta
 
 Check the dashboard to confirm the workflow reaches the `COMPLETED` state after the restart, with the full event history intact.
 
-## Step 5 — Tear down
+## Step 6 — Tear down
 
 ```bash
 docker compose -f examples/quickstart/compose.yaml down -v

--- a/examples/standalone-runner/README.md
+++ b/examples/standalone-runner/README.md
@@ -26,6 +26,12 @@ The raw Axum process listens on `http://localhost:8082`.
 - Harvest API: `GET /api/harvest/health`
 - Start workflow: `POST /api/harvest/workflows/standalone_order/start`
 
+Run the deployment preflight before starting work:
+
+```bash
+cargo run -p autumn-harvest-cli -- --base-url http://localhost:8082/api/harvest preflight
+```
+
 ```bash
 curl -s -X POST http://localhost:8082/api/harvest/workflows/standalone_order/start \
   -H 'Content-Type: application/json' \


### PR DESCRIPTION
  Add a read-only Harvest preflight report exposed at GET /admin/preflight and
  wire the CLI `harvest preflight` command as a deploy gate with pass/warn/fail
  exit codes.

  Checks cover migrations, shard availability, catalog consistency, schedule
  resolvability, worker coverage, DLQ visibility, retention config visibility,
  and admin auth boundary state. Also add targeted CLI tests, plugin integration
  coverage, and README/example docs.