### PR TITLE
⚡ Bolt: Remove unnecessary heap allocations when formatting `WorkflowCommand::UpsertSearchAttributes` in Debug trait

### DIFF
--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -308,7 +308,7 @@ impl std::fmt::Debug for WorkflowCommand {
                 .finish_non_exhaustive(),
             Self::UpsertSearchAttributes { patch } => f
                 .debug_struct("UpsertSearchAttributes")
-                .field("keys", &patch.keys().collect::<Vec<_>>())
+                .field("keys", &patch.keys())
                 .finish(),
             Self::RecordUpdateResult { update_id, result } => f
                 .debug_struct("RecordUpdateResult")


### PR DESCRIPTION
💡 What: Replaced `&patch.keys().collect::<Vec<_>>()` with `&patch.keys()` when debugging `UpsertSearchAttributes`.
🎯 Why: `std::collections::hash_map::Keys` already implements `std::fmt::Debug`. Collecting it into a `Vec` just to print out its items causes unnecessary memory allocation on the heap on the logging/debug hot path.
📊 Impact: Removes one vector allocation per `UpsertSearchAttributes` debug format operation. 
🔬 Measurement: Verify via `cargo check` and running `cargo test -p autumn-harvest context` to confirm no formatting regression and no lifetime issues with the borrow checker.

---
*PR created automatically by Jules for task [4797269386259835704](https://jules.google.com/task/4797269386259835704) started by @madmax983*