### PR TITLE
🔒 Warden: Security scan log (no vulnerabilities found)

### DIFF
--- a/security_scan_log.md
+++ b/security_scan_log.md
@@ -1,0 +1,19 @@
+# Warden Security Scan Log
+
+## Surveillance
+
+### Supply Chain
+- **Audit Tool:** `cargo audit`
+- **Result:** Scanned `Cargo.lock` for vulnerabilities across 549 crate dependencies. No vulnerabilities were detected.
+
+### Memory Safety & Unsafe
+- **Audit Tool:** `grep -rn "unsafe" .`
+- **Result:** Scanned the codebase for raw pointer dereferencing and FFI boundary risks. Found exactly one instance of the word "unsafe" in `autumn-harvest/src/batch.rs:691`, which was merely a comment: `// re-dispatched, and an offset-based cursor is unsafe when the RUNNING`. No actual `unsafe` blocks or memory safety risks were identified.
+
+### Input & Logic
+- **Audit Tool:** Manual code review via `grep` and source code inspection.
+- **Deserialization:** Reviewed `serde_json::from_value` usages (e.g. `autumn-harvest/src/batch.rs`). Confirmed parsing boundaries are protected, and payloads are strictly typed.
+- **Integer Overflows:** Reviewed math operations (`checked_add`, `saturating_add`, `checked_mul`). Confirmed critical logic paths, such as `task_duration` in `autumn-harvest/src/lib.rs`, employ memory exhaustion boundaries (e.g. `current_num.len() > 20`) alongside `checked_*` traits for numeric operations, preventing integer overflows and DoS.
+
+## Conclusion
+No security vulnerabilities, unhandled inputs, or manual memory risks were found. The codebase demonstrates strong defense-in-depth principles. Scan complete. No patching PR required.


### PR DESCRIPTION
This PR adds `security_scan_log.md` summarizing the security scan.

Following the instructions for the "Warden" persona: "If no security risks are found, confirm with a scan log and stop", I have thoroughly reviewed the codebase using `cargo audit` and manual inspections for memory safety, unsafe blocks, deserialization flaws, and integer overflow vulnerabilities.

Since the application is hardened against these vectors and no risks were found, this PR simply commits the documented findings.

---
*PR created automatically by Jules for task [7665958298217418407](https://jules.google.com/task/7665958298217418407) started by @madmax983*