### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/autumn-harvest/src/reset.rs
+++ b/autumn-harvest/src/reset.rs
@@ -178,6 +178,7 @@ pub enum WorkflowResetError {
     },
     #[error("continue-as-new histories cannot be reset in v1")]
     ContinueAsNew,
+    /// An underlying storage or database error occurred during the reset operation.
     #[error(transparent)]
     Harvest(#[from] HarvestError),
 }

--- a/autumn-harvest/src/retention.rs
+++ b/autumn-harvest/src/retention.rs
@@ -40,11 +40,36 @@ const DEFAULT_TICK_INTERVAL: Duration = Duration::from_secs(60 * 60);
 const DEFAULT_BATCH_SIZE: usize = 1_000;
 const MIN_MAX_AGE: Duration = Duration::from_secs(1);
 const MAX_MAX_AGE: Duration = Duration::from_secs(60 * 60 * 24 * 365 * 10);
+
+/// Configuration for the background retention job.
+///
+/// **Why does this exist?**
+/// Workflow histories and audit logs can grow unbounded. This configuration allows operators
+/// to define constraints for automatically pruning old, closed workflows and stale audit events
+/// to prevent storage exhaustion.
+///
+/// ## Examples
+///
+/// ```rust
+/// use autumn_harvest::retention::RetentionConfig;
+/// use std::time::Duration;
+///
+/// let config = RetentionConfig::with_max_age(Duration::from_secs(86400))
+///     .with_audit_retention_days(30);
+///
+/// assert!(config.enabled());
+/// ```
 #[derive(Debug, Clone, Serialize)]
 pub struct RetentionConfig {
+    /// Maximum age in seconds for closed workflows before they are eligible for deletion.
+    /// If `None`, workflow history retention is disabled.
     pub max_age_secs: Option<u64>,
+    /// How often the background retention job wakes up to scan for expired data.
     pub tick_interval_secs: u64,
+    /// The maximum number of records to process in a single transaction/batch.
     pub batch_size: usize,
+    /// If `true`, the retention job simulates deletions and logs what would have been deleted
+    /// without actually modifying the database.
     pub dry_run: bool,
     /// Audit log retention in days, independent of workflow-history retention.
     /// Defaults to 90 days (3 months). Set to 0 to disable audit purging.
@@ -64,6 +89,7 @@ impl Default for RetentionConfig {
 }
 
 impl RetentionConfig {
+    /// Bootstraps a fresh configuration template that explicitly opts-in to the workflow retention features.
     #[must_use]
     pub fn with_max_age(max_age: Duration) -> Self {
         Self {
@@ -79,11 +105,14 @@ impl RetentionConfig {
         self
     }
 
+    /// Safely unpacks the raw configuration integer into a standard rust [`Duration`], gracefully
+    /// handling systems where the feature is entirely turned off.
     #[must_use]
     pub fn max_age(&self) -> Option<Duration> {
         self.max_age_secs.map(Duration::from_secs)
     }
 
+    /// Translates the raw numeric tick value into a standard [`Duration`] for the scheduler loop.
     #[must_use]
     pub const fn tick_interval(&self) -> Duration {
         Duration::from_secs(self.tick_interval_secs)
@@ -112,35 +141,64 @@ impl RetentionConfig {
         Ok(())
     }
 
+    /// Returns `true` if any retention features (workflow history or audit log purging) are enabled.
     #[must_use]
     pub const fn enabled(&self) -> bool {
         self.max_age_secs.is_some() || self.audit_retention_days > 0
     }
 }
 
+/// The result of a single execution tick of the retention job on a specific shard.
+///
+/// **Why does this exist?**
+/// Provides observability into the retention job's performance and impact. It captures
+/// how many records were evaluated, how many were deleted, and any errors encountered,
+/// allowing operators to monitor the health of the background cleanup process.
 #[derive(Debug, Clone, Serialize, Default)]
 pub struct RetentionTickResult {
+    /// The ID of the shard this retention tick operated on.
     pub shard: u16,
+    /// The timestamp when this retention tick started.
     pub ran_at: Option<DateTime<Utc>>,
+    /// The number of expired candidate records identified during the tick.
     pub candidate_count: usize,
+    /// The actual number of records successfully deleted during the tick.
     pub deleted_count: usize,
+    /// The age (in seconds) of the oldest closed workflow that was skipped (not yet expired).
+    /// Used for tuning the `max_age_secs` configuration.
     pub oldest_age_secs_skipped: Option<u64>,
+    /// The duration of the retention tick in milliseconds.
     pub duration_ms: u128,
+    /// The last error encountered during the tick, if any.
     pub last_error: Option<String>,
 }
 
+/// The current overall status of the retention subsystem.
+///
+/// **Why does this exist?**
+/// Aggregates the static configuration and the dynamic runtime state (per-shard results)
+/// to provide a comprehensive snapshot of the retention process for diagnostic APIs.
 #[derive(Debug, Clone, Serialize, Default)]
 pub struct RetentionStatus {
+    /// The active retention configuration.
     pub config: RetentionConfig,
+    /// The latest execution results for each active shard.
     pub per_shard: Vec<RetentionTickResult>,
 }
 
+/// A thread-safe monitor for observing the background retention process.
+///
+/// **Why does this exist?**
+/// Enables the background retention job to asynchronously report its progress and results,
+/// while allowing external components (like administrative APIs or telemetry systems)
+/// to safely query the latest status without blocking or tearing.
 #[derive(Debug, Clone)]
 pub struct RetentionMonitor {
     inner: Arc<Mutex<RetentionStatus>>,
 }
 
 impl RetentionMonitor {
+    /// Boots up a clean monitoring tracker that acts as the initial blank canvas before shards report results.
     #[must_use]
     pub fn new(config: RetentionConfig, shards: impl Iterator<Item = ShardId>) -> Self {
         let per_shard = shards
@@ -178,6 +236,12 @@ impl RetentionMonitor {
     }
 }
 
+/// Represents the running background task that processes retention policies.
+///
+/// **Why does this exist?**
+/// Provides a handle to control and monitor the active background retention job.
+/// It encapsulates the background tokio task, the cancellation token for graceful shutdown,
+/// and the channel used to force immediate retention sweeps.
 #[cfg(feature = "db")]
 pub struct RetentionRuntime {
     shutdown: CancellationToken,
@@ -308,20 +372,25 @@ impl RetentionRuntime {
         })
     }
 
+    /// Shares a snapshot interface allowing telemetry dashboards to safely peek at the process.
     #[must_use]
     pub fn monitor(&self) -> RetentionMonitor {
         self.monitor.clone()
     }
 
+    /// Forces the background worker to wake up and aggressively prune immediately without waiting
+    /// for the next interval loop.
     pub fn run_now(&self) {
         let _ = self.trigger_tx.try_send(());
     }
 
+    /// Exposes a direct channel to bypass scheduling and command the worker to act right now.
     #[must_use]
     pub fn trigger_sender(&self) -> mpsc::Sender<()> {
         self.trigger_tx.clone()
     }
 
+    /// Triggers the emergency stop sequence to abort any running operations gracefully.
     pub fn shutdown(&self) {
         self.shutdown.cancel();
     }

--- a/autumn-harvest/src/workers.rs
+++ b/autumn-harvest/src/workers.rs
@@ -27,13 +27,23 @@ use crate::error::{HarvestError, HarvestResult};
 
 /// Static fields that identify a worker process, used for initial registration
 /// and heartbeat self-healing.
+///
+/// **Why does this exist?**
+/// Provides all the essential static identity and capability information required
+/// to register a worker against the central scheduler database.
 #[derive(Debug, Clone)]
 pub struct WorkerRegistration {
+    /// A unique identifier for this specific worker instance (e.g., UUID or hostname + PID).
     pub worker_id: String,
+    /// The list of task queues this worker is polling.
     pub queues: Vec<String>,
+    /// Optional assigned shards if using sticky or deterministic routing.
     pub shard_assignments: Vec<i32>,
+    /// The maximum number of concurrent tasks this worker will execute.
     pub max_concurrency: i32,
+    /// The host name or IP address of the machine running the worker.
     pub host: String,
+    /// The version of the `autumn-harvest` crate or worker software.
     pub version: Option<String>,
 }
 use crate::models::{HarvestWorker, NewHarvestWorker};
@@ -45,14 +55,22 @@ use crate::worker::DbPool;
 // ---------------------------------------------------------------------------
 
 /// Lifecycle status of a worker process.
+///
+/// **Why does this exist?**
+/// Tracks whether a worker is actively picking up tasks, finishing its current tasks before
+/// shutdown, or completely halted. This affects routing decisions by the scheduler.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum WorkerStatus {
+    /// The worker is actively polling queues and accepting new tasks.
     Active,
+    /// The worker is finishing existing tasks but not accepting new ones.
     Draining,
+    /// The worker has stopped polling completely.
     Stopped,
 }
 
 impl WorkerStatus {
+    /// Converts the enum variant to its exact canonical string identifier used by the database API.
     #[must_use]
     pub const fn as_str(self) -> &'static str {
         match self {
@@ -62,6 +80,7 @@ impl WorkerStatus {
         }
     }
 
+    /// Safely attempts to match an incoming string from an API request to a known `WorkerStatus` state.
     #[must_use]
     #[allow(clippy::should_implement_trait)]
     pub fn from_str(s: &str) -> Option<Self> {
@@ -85,10 +104,17 @@ impl std::fmt::Display for WorkerStatus {
 // ---------------------------------------------------------------------------
 
 /// Health classification derived from `last_heartbeat_at`.
+///
+/// **Why does this exist?**
+/// Allows the scheduler to differentiate between workers that are currently
+/// connected and functioning normally versus those that might have crashed
+/// or disconnected silently.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
 #[serde(rename_all = "lowercase")]
 pub enum WorkerHealth {
+    /// The worker has sent a heartbeat recently enough to be considered active.
     Healthy,
+    /// The worker has not sent a heartbeat within the expected threshold.
     Stale,
 }
 
@@ -119,19 +145,31 @@ impl WorkerHealth {
 // ---------------------------------------------------------------------------
 
 /// Filters for `list_workers` queries from the management API.
+///
+/// **Why does this exist?**
+/// Provides structured search criteria when requesting lists of workers from the database,
+/// allowing operators to filter by queue, shard, or current health status.
 #[derive(Debug, Default, Clone)]
 pub struct WorkerFilters {
+    /// Filter workers that are polling this specific queue.
     pub queue: Option<String>,
+    /// Filter workers that are assigned to this shard.
     pub shard_id: Option<i32>,
+    /// Filter workers by their current lifecycle status (e.g., "Active").
     pub status: Option<String>,
+    /// Filter workers by their derived health classification.
     pub health: Option<WorkerHealth>,
+    /// The maximum number of workers to return in the result set.
     pub limit: i64,
 }
 
 impl WorkerFilters {
+    /// Protects the API layer against runaway unbounded queries by setting a safe baseline limit.
     pub const DEFAULT_LIMIT: i64 = 100;
+    /// Prevent abusive or excessively large requests from crashing the database worker.
     pub const MAX_LIMIT: i64 = 500;
 
+    /// Initializes a blank query filter that inherits the safe system baseline `DEFAULT_LIMIT`.
     #[must_use]
     pub fn new() -> Self {
         Self {
@@ -480,10 +518,16 @@ pub async fn fleet_health(
 // ---------------------------------------------------------------------------
 
 /// A worker row enriched with the derived health classification.
+///
+/// **Why does this exist?**
+/// Provides a unified API response model that combines the raw database row (`HarvestWorker`)
+/// with the dynamically computed `WorkerHealth` status and currently active task IDs.
 #[derive(Debug, Clone, serde::Serialize)]
 pub struct WorkerRow {
+    /// The raw worker record from the database.
     #[serde(flatten)]
     pub worker: HarvestWorker,
+    /// The computed health status of the worker based on its last heartbeat.
     pub health: WorkerHealth,
     /// IDs of task-queue items currently claimed by this worker (`state = RUNNING`).
     /// Populated only by `get_worker`; the list endpoint returns an empty vec.
@@ -491,12 +535,21 @@ pub struct WorkerRow {
 }
 
 /// Aggregated fleet health roll-up.
+///
+/// **Why does this exist?**
+/// Summarizes the current state of the entire worker fleet, providing a high-level
+/// dashboard view of cluster capacity and potential issues (like too many stale workers).
 #[derive(Debug, serde::Serialize)]
 pub struct FleetHealth {
+    /// Total count of workers considered healthy.
     pub healthy: usize,
+    /// Total count of workers considered stale (missing heartbeats).
     pub stale: usize,
+    /// Total count of workers currently in the draining state.
     pub draining: usize,
+    /// A breakdown of total active worker counts per task queue.
     pub by_queue: std::collections::HashMap<String, usize>,
+    /// A breakdown of total active worker counts per assigned shard.
     pub by_shard: std::collections::HashMap<i32, usize>,
 }
 


### PR DESCRIPTION
📖 **Chapter:** The `retention`, `workers`, and `reset` modules.
🔦 **Insight:** Clarified the background retention job configuration and status monitoring mechanics. Explained the worker registration fields, health states, and fleet rollup mechanics, ensuring that operators understand *why* these configurations exist and how they impact the system. Added context to database storage errors during workflow resets.
🧪 **Example:** Added an executable doctest for `RetentionConfig` enabling operators to see how to initialize retention limits programmatically.
🖼️ **Preview:** Documentation now successfully compiles via `cargo doc` with enhanced context for internal types.

---
*PR created automatically by Jules for task [11043517043476440874](https://jules.google.com/task/11043517043476440874) started by @madmax983*