### PR TITLE
feat: add shard readiness health gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -699,7 +699,19 @@ assert_eq!(exec_id.shard(), shard);
 ```
 
 Adding a shard (new workflows only): provision and migrate the new database,
-add it to `readable_shards`, restart the plugin, then flip it into
+add it to `readable_shards`, restart the plugin, then run the readiness gate
+before promotion:
+
+```bash
+cargo run -p autumn-harvest-cli -- shard health --candidate-shard 1 --fail-on-unready
+cargo run -p autumn-harvest-cli -- --output json shard health --candidate-shard 1 --fail-on-unready
+```
+
+The matching management API endpoint is `GET /api/harvest/admin/shards/health`.
+It returns one row per configured shard, including shard roles, reachability,
+schema readiness, worker queue coverage, scheduler freshness when schedules are
+enabled, queue/DLQ pressure, and explicit promotion blockers. Only after the
+candidate row reports `readiness: "ready"` should you flip it into
 `writable_shards`. In-flight workflows drain on their original shard.
 
 ## Testing workflow code changes with the replayer

--- a/autumn-harvest-cli/src/lib.rs
+++ b/autumn-harvest-cli/src/lib.rs
@@ -178,16 +178,19 @@ pub enum CliError {
         /// Reported preflight status.
         status: String,
     },
+
+    /// Shard health completed but the deploy gate found an unready target.
+    #[error("shard health readiness gate failed")]
+    ShardHealthGate,
 }
 
 impl CliError {
     /// Process exit code associated with this error.
     #[must_use]
     pub fn exit_code(&self) -> i32 {
-        if matches!(self, Self::PreflightGate { status } if status == "warn") {
-            2
-        } else {
-            1
+        match self {
+            Self::PreflightGate { status } if status == "warn" => 2,
+            _ => 1,
         }
     }
 }
@@ -198,6 +201,11 @@ enum Commands {
     Health,
     /// Run read-only deployment readiness checks.
     Preflight,
+    /// Inspect shard rollout readiness.
+    Shard {
+        #[command(subcommand)]
+        command: ShardCommand,
+    },
     /// Manage workflow executions.
     Workflow {
         #[command(subcommand)]
@@ -272,6 +280,19 @@ enum AuditCommand {
         /// Maximum number of records to return [1–500].
         #[arg(long, value_parser = clap::value_parser!(i64).range(1..=500))]
         limit: Option<i64>,
+    },
+}
+
+#[derive(Debug, Subcommand)]
+enum ShardCommand {
+    /// Show per-shard readiness and rollout blockers.
+    Health {
+        /// Evaluate this readable shard as a promotion candidate.
+        #[arg(long)]
+        candidate_shard: Option<i32>,
+        /// Exit non-zero if any writable shard or named candidate is unready.
+        #[arg(long)]
+        fail_on_unready: bool,
     },
 }
 
@@ -644,6 +665,7 @@ impl Cli {
         match &self.command {
             Commands::Health => Ok(ApiRequest::get("/health")),
             Commands::Preflight => Ok(ApiRequest::get("/admin/preflight")),
+            Commands::Shard { command } => Ok(shard_request(command)),
             Commands::Workflow { command } => workflow_request(command),
             Commands::Dag { command } => dag_request(command),
             Commands::Schedule { command } => schedule_request(command),
@@ -709,6 +731,9 @@ pub async fn run_cli(cli: Cli) -> Result<(), CliError> {
                 .to_string();
             return Err(CliError::PreflightGate { status });
         }
+    }
+    if shard_health_fail_on_unready(&cli) && shard_health_exit_code(&response) != 0 {
+        return Err(CliError::ShardHealthGate);
     }
     Ok(())
 }
@@ -785,6 +810,9 @@ fn render_response(cli: &Cli, value: &Value) -> Result<String, CliError> {
     if preflight_wants_table(cli) {
         return Ok(format_preflight_table(value));
     }
+    if shard_health_wants_table(cli) {
+        return Ok(format_shard_health_table(value));
+    }
     if workflow_children_wants_table(cli) {
         return Ok(format_workflow_children_table(value));
     }
@@ -804,12 +832,55 @@ fn preflight_wants_table(cli: &Cli) -> bool {
     matches!(&cli.command, Commands::Preflight) && cli.output == OutputFormat::PrettyJson
 }
 
+fn shard_health_wants_table(cli: &Cli) -> bool {
+    matches!(
+        &cli.command,
+        Commands::Shard {
+            command: ShardCommand::Health { .. }
+        }
+    ) && cli.output == OutputFormat::PrettyJson
+}
+
+const fn shard_health_fail_on_unready(cli: &Cli) -> bool {
+    matches!(
+        &cli.command,
+        Commands::Shard {
+            command: ShardCommand::Health {
+                fail_on_unready: true,
+                ..
+            }
+        }
+    )
+}
+
 fn preflight_exit_code(value: &Value) -> i32 {
     match value.get("overall_status").and_then(Value::as_str) {
         Some("pass") => 0,
         Some("warn") => 2,
         _ => 1,
     }
+}
+
+fn shard_health_exit_code(value: &Value) -> i32 {
+    let Some(shards) = value.get("shards").and_then(Value::as_array) else {
+        return 1;
+    };
+    let has_unready_gate_target = shards.iter().any(|shard| {
+        let readiness = shard.get("readiness").and_then(Value::as_str);
+        if readiness == Some("ready") {
+            return false;
+        }
+        let candidate = shard
+            .get("candidate")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        let writable = shard
+            .get("roles")
+            .and_then(Value::as_array)
+            .is_some_and(|roles| roles.iter().any(|role| role.as_str() == Some("writable")));
+        candidate || writable
+    });
+    i32::from(has_unready_gate_target)
 }
 
 fn format_preflight_table(value: &Value) -> String {
@@ -877,6 +948,73 @@ fn format_preflight_table(value: &Value) -> String {
         .join("\n");
 
     format!("overall_status: {overall}\nobserved_at: {observed_at}\n\n{table}")
+}
+
+fn format_shard_health_table(value: &Value) -> String {
+    let overall = value
+        .get("overall_readiness")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let observed_at = value
+        .get("observed_at")
+        .and_then(Value::as_str)
+        .unwrap_or("-");
+    let Some(shards) = value.get("shards").and_then(Value::as_array) else {
+        return format!(
+            "overall_readiness: {overall}\nobserved_at: {observed_at}\nNo shard rows returned."
+        );
+    };
+
+    let mut rows = Vec::with_capacity(shards.len() + 1);
+    rows.push(vec![
+        "SHARD".to_string(),
+        "ROLES".to_string(),
+        "READY".to_string(),
+        "REACH".to_string(),
+        "SCHEMA".to_string(),
+        "WORKERS".to_string(),
+        "SCHED".to_string(),
+        "QUEUE".to_string(),
+        "DLQ".to_string(),
+        "BLOCKERS".to_string(),
+    ]);
+    for shard in shards {
+        rows.push(vec![
+            cell_number(shard.get("shard_id")),
+            roles_cell(shard),
+            cell_str(shard.get("readiness")),
+            bool_cell(shard.get("reachable")),
+            bool_cell(shard.get("schema").and_then(|schema| schema.get("ready"))),
+            worker_coverage_cell(shard),
+            scheduler_cell(shard),
+            cell_number(
+                shard
+                    .get("queue_depth")
+                    .and_then(|summary| summary.get("total_pending")),
+            ),
+            cell_optional_number(shard.get("dlq").and_then(|summary| summary.get("count"))),
+            blockers_cell(shard),
+        ]);
+    }
+
+    let widths = (0..rows[0].len())
+        .map(|col| rows.iter().map(|row| row[col].len()).max().unwrap_or(0))
+        .collect::<Vec<_>>();
+    let table = rows
+        .iter()
+        .map(|row| {
+            row.iter()
+                .enumerate()
+                .map(|(col, cell)| format!("{cell:<width$}", width = widths[col]))
+                .collect::<Vec<_>>()
+                .join("  ")
+                .trim_end()
+                .to_string()
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    format!("overall_readiness: {overall}\nobserved_at: {observed_at}\n\n{table}")
 }
 
 fn audit_list_wants_table(cli: &Cli) -> bool {
@@ -1026,6 +1164,115 @@ fn cell_number(value: Option<&Value>) -> String {
     value
         .and_then(Value::as_i64)
         .map_or_else(String::new, |number| number.to_string())
+}
+
+fn cell_optional_number(value: Option<&Value>) -> String {
+    value
+        .and_then(Value::as_i64)
+        .map_or_else(|| "-".to_string(), |number| number.to_string())
+}
+
+fn bool_cell(value: Option<&Value>) -> String {
+    match value.and_then(Value::as_bool) {
+        Some(true) => "yes".to_string(),
+        Some(false) => "no".to_string(),
+        None => "-".to_string(),
+    }
+}
+
+fn roles_cell(shard: &Value) -> String {
+    let mut roles = shard
+        .get("roles")
+        .and_then(Value::as_array)
+        .map_or_else(Vec::new, |roles| {
+            roles
+                .iter()
+                .filter_map(Value::as_str)
+                .map(ToOwned::to_owned)
+                .collect::<Vec<_>>()
+        });
+    if shard
+        .get("candidate")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        roles.push("candidate".to_string());
+    }
+    if roles.is_empty() {
+        "-".to_string()
+    } else {
+        roles.join(",")
+    }
+}
+
+fn worker_coverage_cell(shard: &Value) -> String {
+    let Some(coverage) = shard.get("worker_coverage").and_then(Value::as_array) else {
+        return "-".to_string();
+    };
+    if coverage.is_empty() {
+        return "-".to_string();
+    }
+    coverage
+        .iter()
+        .map(|queue| {
+            let name = queue.get("queue").and_then(Value::as_str).unwrap_or("?");
+            let healthy = queue
+                .get("healthy_active")
+                .and_then(Value::as_i64)
+                .unwrap_or(0);
+            let ready = queue.get("ready").and_then(Value::as_bool).unwrap_or(false);
+            let mark = if ready { "ok" } else { "miss" };
+            format!("{name}:{healthy}/{mark}")
+        })
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
+fn scheduler_cell(shard: &Value) -> String {
+    let Some(scheduler) = shard.get("scheduler") else {
+        return "-".to_string();
+    };
+    if !scheduler
+        .get("enabled")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        return "off".to_string();
+    }
+    if scheduler
+        .get("ready")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+    {
+        "ok".to_string()
+    } else {
+        "stale".to_string()
+    }
+}
+
+fn blockers_cell(shard: &Value) -> String {
+    let Some(reasons) = shard.get("blocking_reasons").and_then(Value::as_array) else {
+        return "-".to_string();
+    };
+    if reasons.is_empty() {
+        return "-".to_string();
+    }
+    reasons
+        .iter()
+        .filter_map(Value::as_str)
+        .collect::<Vec<_>>()
+        .join("; ")
+}
+
+fn shard_request(command: &ShardCommand) -> ApiRequest {
+    match command {
+        ShardCommand::Health {
+            candidate_shard, ..
+        } => candidate_shard.as_ref().map_or_else(
+            || ApiRequest::get("/admin/shards/health"),
+            |shard| ApiRequest::get(format!("/admin/shards/health?candidate_shard={shard}")),
+        ),
+    }
 }
 
 #[allow(clippy::too_many_lines)]
@@ -1841,5 +2088,109 @@ mod reuse_policy_tests {
         assert_eq!(preflight_exit_code(&json!({ "overall_status": "pass" })), 0);
         assert_eq!(preflight_exit_code(&json!({ "overall_status": "warn" })), 2);
         assert_eq!(preflight_exit_code(&json!({ "overall_status": "fail" })), 1);
+    }
+
+    #[test]
+    fn shard_health_default_output_renders_compact_table() {
+        let cli = parse(&["shard", "health"]);
+        let payload = json!({
+            "overall_readiness": "unready",
+            "observed_at": "2026-05-06T12:00:00Z",
+            "shards": [{
+                "shard_id": 1,
+                "roles": ["readable"],
+                "candidate": true,
+                "readiness": "unready",
+                "reachable": true,
+                "schema": { "ready": true },
+                "worker_coverage": [{
+                    "queue": "default",
+                    "healthy_active": 0,
+                    "stale": 0,
+                    "draining": 0,
+                    "ready": false
+                }],
+                "scheduler": {
+                    "enabled": false,
+                    "ready": true,
+                    "last_tick_at": null
+                },
+                "queue_depth": {
+                    "total_pending": 0,
+                    "by_queue": {}
+                },
+                "dlq": { "count": 0 },
+                "blocking_reasons": [
+                    "no healthy active worker covers required queue 'default'"
+                ],
+                "error_summary": null
+            }]
+        });
+
+        let rendered = render_response(&cli, &payload).expect("table output should render");
+
+        assert!(rendered.contains("SHARD"));
+        assert!(rendered.contains("readable"));
+        assert!(rendered.contains("unready"));
+        assert!(rendered.contains("default"));
+        assert!(!rendered.trim_start().starts_with('{'));
+    }
+
+    #[test]
+    fn shard_health_json_output_preserves_raw_payload_shape() {
+        let cli = parse(&["--output", "json", "shard", "health"]);
+        let payload = json!({
+            "overall_readiness": "ready",
+            "observed_at": "2026-05-06T12:00:00Z",
+            "shards": []
+        });
+
+        let rendered = render_response(&cli, &payload).expect("json output should render");
+
+        assert_eq!(
+            rendered,
+            r#"{"observed_at":"2026-05-06T12:00:00Z","overall_readiness":"ready","shards":[]}"#
+        );
+    }
+
+    #[test]
+    fn shard_health_gate_fails_on_unready_writable_or_candidate_shards_only() {
+        let payload = json!({
+            "shards": [
+                {
+                    "shard_id": 0,
+                    "roles": ["readable", "writable", "default"],
+                    "candidate": false,
+                    "readiness": "ready"
+                },
+                {
+                    "shard_id": 1,
+                    "roles": ["readable"],
+                    "candidate": false,
+                    "readiness": "unready"
+                }
+            ]
+        });
+        assert_eq!(shard_health_exit_code(&payload), 0);
+
+        let writable_unready = json!({
+            "shards": [{
+                "shard_id": 0,
+                "roles": ["readable", "writable", "default"],
+                "candidate": false,
+                "readiness": "unready"
+            }]
+        });
+        assert_eq!(shard_health_exit_code(&writable_unready), 1);
+
+        let candidate_unready = json!({
+            "shards": [{
+                "shard_id": 2,
+                "roles": ["readable"],
+                "candidate": true,
+                "readiness": "unready"
+            }]
+        });
+        assert_eq!(shard_health_exit_code(&candidate_unready), 1);
     }
 }

--- a/autumn-harvest-cli/tests/request_mapping.rs
+++ b/autumn-harvest-cli/tests/request_mapping.rs
@@ -14,6 +14,41 @@ fn preflight_maps_to_management_api_request() {
 }
 
 #[test]
+fn shard_health_maps_to_management_api_request() {
+    let cli = Cli::try_parse_from(["harvest", "shard", "health"])
+        .expect("shard health args should parse");
+
+    let request = cli
+        .api_request()
+        .expect("shard health request should build");
+
+    assert_eq!(request.method, ApiMethod::Get);
+    assert_eq!(request.path, "/admin/shards/health");
+    assert_eq!(request.body, None);
+}
+
+#[test]
+fn shard_health_candidate_maps_to_query_string() {
+    let cli = Cli::try_parse_from([
+        "harvest",
+        "shard",
+        "health",
+        "--candidate-shard",
+        "2",
+        "--fail-on-unready",
+    ])
+    .expect("shard health candidate args should parse");
+
+    let request = cli
+        .api_request()
+        .expect("shard health request should build");
+
+    assert_eq!(request.method, ApiMethod::Get);
+    assert_eq!(request.path, "/admin/shards/health?candidate_shard=2");
+    assert_eq!(request.body, None);
+}
+
+#[test]
 fn workflow_start_maps_to_management_api_request() {
     let cli = Cli::try_parse_from([
         "harvest",

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -74,6 +74,7 @@ use autumn_harvest::{
 };
 
 use crate::preflight::{PreflightReport, build_preflight_report};
+use crate::shard_health::{ShardHealthReport, build_shard_health_report};
 use crate::state::HarvestDbPool;
 
 #[derive(Clone)]
@@ -546,6 +547,11 @@ struct HarvestHealth {
     scheduler: SchedulerSnapshot,
 }
 
+#[derive(Debug, Deserialize)]
+struct ShardHealthQuery {
+    candidate_shard: Option<i32>,
+}
+
 #[derive(Debug, Serialize)]
 struct ReplayDeadLetterResponse {
     ok: bool,
@@ -804,6 +810,7 @@ pub fn harvest_api_router(api_state: HarvestApiState) -> Router<AppState> {
         .route("/dead-letters/{id}/replay", post(replay_dead_letter))
         .route("/health", get(health))
         .route("/admin/preflight", get(preflight))
+        .route("/admin/shards/health", get(shards_health))
         .route("/admin/retention", get(retention_status))
         .route("/admin/retention/run-now", post(retention_run_now))
         .route("/admin/concurrency", get(concurrency_status))
@@ -850,6 +857,13 @@ async fn preflight(
 ) -> Json<PreflightReport> {
     api_state.set_deployment_profile(autumn_state.profile().to_string());
     Json(build_preflight_report(&api_state).await)
+}
+
+async fn shards_health(
+    Extension(api_state): Extension<HarvestApiState>,
+    Query(query): Query<ShardHealthQuery>,
+) -> Json<ShardHealthReport> {
+    Json(build_shard_health_report(&api_state, query.candidate_shard).await)
 }
 
 #[derive(Debug, Deserialize)]

--- a/autumn-harvest-plugin/src/lib.rs
+++ b/autumn-harvest-plugin/src/lib.rs
@@ -7,6 +7,7 @@ pub mod plugin;
 pub mod preflight;
 pub mod prelude;
 pub mod runner;
+pub mod shard_health;
 pub mod state;
 pub mod ui;
 

--- a/autumn-harvest-plugin/src/shard_health.rs
+++ b/autumn-harvest-plugin/src/shard_health.rs
@@ -1,0 +1,804 @@
+//! Read-only shard readiness aggregation for rollout gates.
+
+use std::collections::{BTreeMap, BTreeSet, HashSet};
+use std::time::Duration;
+
+use autumn_harvest::dlq;
+use autumn_harvest::policy::Schedule;
+use autumn_harvest::scheduler::SchedulerMonitor;
+use autumn_harvest::types::ShardId;
+use autumn_harvest::worker::DbPool;
+use autumn_harvest::workers::{WorkerFilters, WorkerHealth, WorkerRow, WorkerStatus, list_workers};
+use chrono::{DateTime, Utc};
+use diesel::migration::MigrationSource;
+use diesel::pg::Pg;
+use diesel_async::AsyncPgConnection;
+use diesel_async::RunQueryDsl;
+use futures::future::join_all;
+use serde::Serialize;
+
+use crate::api::{HarvestApiRuntime, HarvestApiState};
+
+/// Deployment readiness for a shard.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ShardReadiness {
+    Ready,
+    Unready,
+}
+
+/// Operational role for a configured shard.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum ShardRole {
+    Readable,
+    Writable,
+    Default,
+}
+
+/// Response returned by `GET /admin/shards/health`.
+#[derive(Debug, Clone, Serialize)]
+pub struct ShardHealthReport {
+    pub overall_readiness: ShardReadiness,
+    pub observed_at: DateTime<Utc>,
+    pub freshness_window_secs: u64,
+    pub candidate_shard: Option<i32>,
+    pub shards: Vec<ShardHealthRow>,
+}
+
+/// One shard row in the health response.
+#[derive(Debug, Clone, Serialize)]
+pub struct ShardHealthRow {
+    pub shard_id: i32,
+    pub roles: Vec<ShardRole>,
+    pub candidate: bool,
+    pub reachable: bool,
+    pub schema: ShardSchemaHealth,
+    pub worker_coverage: Vec<QueueWorkerCoverage>,
+    pub scheduler: ShardSchedulerCoverage,
+    pub queue_depth: QueueDepthSummary,
+    pub dlq: DlqSummary,
+    pub last_health_sample_time: Option<DateTime<Utc>>,
+    pub readiness: ShardReadiness,
+    pub blocking_reasons: Vec<String>,
+    pub error_summary: Option<String>,
+}
+
+/// Migration/schema readiness details for a shard.
+#[derive(Debug, Clone, Serialize)]
+pub struct ShardSchemaHealth {
+    pub ready: bool,
+    pub applied_count: Option<usize>,
+    pub missing_migrations: Vec<String>,
+    pub error: Option<String>,
+}
+
+/// Worker coverage for a required queue on one shard.
+#[derive(Debug, Clone, Serialize)]
+pub struct QueueWorkerCoverage {
+    pub queue: String,
+    pub ready: bool,
+    pub healthy_active: usize,
+    pub stale: usize,
+    pub draining: usize,
+    pub stopped: usize,
+    pub total_matching: usize,
+}
+
+/// Scheduler coverage for a shard when schedules exist.
+#[derive(Debug, Clone, Serialize)]
+pub struct ShardSchedulerCoverage {
+    pub enabled: bool,
+    pub ready: bool,
+    pub running: bool,
+    pub last_tick_at: Option<DateTime<Utc>>,
+    pub tick_interval_ms: u64,
+    pub freshness_window_secs: u64,
+    pub schedule_count: usize,
+    pub error: Option<String>,
+}
+
+/// Pending task count summary for a shard.
+#[derive(Debug, Clone, Serialize)]
+pub struct QueueDepthSummary {
+    pub total_pending: i64,
+    pub by_queue: BTreeMap<String, i64>,
+    pub error: Option<String>,
+}
+
+/// Dead-letter count summary for a shard.
+#[derive(Debug, Clone, Serialize)]
+pub struct DlqSummary {
+    pub count: Option<i64>,
+    pub error: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+struct ScheduleProbe {
+    schedule_expr: Option<String>,
+    is_paused: bool,
+    queue_name: Option<String>,
+}
+
+struct WorkerReadiness {
+    coverage: Vec<QueueWorkerCoverage>,
+    last_health_sample_time: Option<DateTime<Utc>>,
+    blocking_reasons: Vec<String>,
+    error_summary: Option<String>,
+}
+
+/// Build the shard readiness report without mutating workflow state.
+pub async fn build_shard_health_report(
+    api_state: &HarvestApiState,
+    candidate_shard: Option<i32>,
+) -> ShardHealthReport {
+    let observed_at = Utc::now();
+    let freshness_window = api_state.worker_stale_threshold();
+    let runtime = api_state.runtime().ok();
+    let required_migrations = required_migration_versions();
+
+    let mut rows = Vec::new();
+    let mut seen = BTreeSet::new();
+    if let Ok(pool) = api_state.storage_pool() {
+        let shard_observations = pool
+            .iter_shards()
+            .map(|(shard, shard_pool)| {
+                observe_shard(
+                    shard.as_i32(),
+                    shard_pool,
+                    runtime.as_ref(),
+                    candidate_shard,
+                    freshness_window,
+                    &required_migrations,
+                    observed_at,
+                )
+            })
+            .collect::<Vec<_>>();
+        for row in join_all(shard_observations).await {
+            seen.insert(row.shard_id);
+            rows.push(row);
+        }
+    } else {
+        let fallback = runtime.as_ref().map_or_else(
+            || vec![ShardId::new(0)],
+            |runtime| runtime.router().readable_shards().to_vec(),
+        );
+        for shard in fallback {
+            let shard_id = shard.as_i32();
+            seen.insert(shard_id);
+            rows.push(unavailable_row(
+                shard_id,
+                roles_for_shard(shard_id, runtime.as_ref()),
+                candidate_shard == Some(shard_id),
+                freshness_window,
+                "harvest storage pool is not configured".to_string(),
+            ));
+        }
+    }
+
+    if let Some(candidate) = candidate_shard
+        && !seen.contains(&candidate)
+    {
+        rows.push(unavailable_row(
+            candidate,
+            roles_for_shard(candidate, runtime.as_ref()),
+            true,
+            freshness_window,
+            format!("candidate shard {candidate} is not configured"),
+        ));
+    }
+
+    rows.sort_by_key(|row| row.shard_id);
+    let overall_readiness = if rows.iter().any(gated_row_is_unready) {
+        ShardReadiness::Unready
+    } else {
+        ShardReadiness::Ready
+    };
+
+    ShardHealthReport {
+        overall_readiness,
+        observed_at,
+        freshness_window_secs: freshness_window.as_secs(),
+        candidate_shard,
+        shards: rows,
+    }
+}
+
+fn gated_row_is_unready(row: &ShardHealthRow) -> bool {
+    (row.candidate || row.roles.contains(&ShardRole::Writable))
+        && row.readiness == ShardReadiness::Unready
+}
+
+async fn observe_shard(
+    shard_id: i32,
+    shard_pool: &DbPool,
+    runtime: Option<&HarvestApiRuntime>,
+    candidate_shard: Option<i32>,
+    freshness_window: Duration,
+    required_migrations: &Result<Vec<String>, String>,
+    observed_at: DateTime<Utc>,
+) -> ShardHealthRow {
+    let roles = roles_for_shard(shard_id, runtime);
+    let candidate = candidate_shard == Some(shard_id);
+    let Ok(mut conn) = shard_pool.get().await else {
+        return unavailable_row(
+            shard_id,
+            roles,
+            candidate,
+            freshness_window,
+            "database connection could not be acquired".to_string(),
+        );
+    };
+
+    let schema = observe_schema(&mut conn, required_migrations).await;
+    let schedules = load_schedule_probes(&mut conn).await;
+    let required_queues = required_queues(runtime, schedules.as_deref().ok());
+    let workers = load_workers(&mut conn, freshness_window).await;
+    let queue_depth = load_queue_depth(&mut conn).await;
+    let dlq = load_dlq(&mut conn).await;
+
+    let mut blocking_reasons = Vec::new();
+    let mut error_summary = None;
+
+    if !schema.ready {
+        if let Some(error) = &schema.error {
+            blocking_reasons.push(format!("schema readiness could not be confirmed: {error}"));
+            error_summary = Some(error.clone());
+        } else {
+            blocking_reasons.push(format!(
+                "schema is missing required migrations: {}",
+                schema.missing_migrations.join(", ")
+            ));
+        }
+    }
+
+    let mut worker_readiness = worker_readiness(
+        shard_id,
+        &required_queues,
+        workers,
+        freshness_window,
+        observed_at,
+    );
+    blocking_reasons.append(&mut worker_readiness.blocking_reasons);
+    if let Some(error) = worker_readiness.error_summary {
+        error_summary.get_or_insert(error);
+    }
+
+    let scheduler_status = scheduler_coverage(
+        runtime,
+        schedules.as_deref().ok(),
+        shard_id,
+        freshness_window,
+        observed_at,
+    );
+    if !scheduler_status.ready {
+        blocking_reasons.push(
+            scheduler_status
+                .error
+                .clone()
+                .unwrap_or_else(|| "scheduler coverage is not fresh".to_string()),
+        );
+    }
+
+    if let Some(error) = &queue_depth.error {
+        error_summary.get_or_insert_with(|| error.clone());
+    }
+    if let Some(error) = &dlq.error {
+        error_summary.get_or_insert_with(|| error.clone());
+    }
+
+    let reachable = true;
+    let readiness = if blocking_reasons.is_empty() {
+        ShardReadiness::Ready
+    } else {
+        ShardReadiness::Unready
+    };
+
+    ShardHealthRow {
+        shard_id,
+        roles,
+        candidate,
+        reachable,
+        schema,
+        worker_coverage: worker_readiness.coverage,
+        scheduler: scheduler_status,
+        queue_depth,
+        dlq,
+        last_health_sample_time: worker_readiness.last_health_sample_time,
+        readiness,
+        blocking_reasons,
+        error_summary,
+    }
+}
+
+fn unavailable_row(
+    shard_id: i32,
+    roles: Vec<ShardRole>,
+    candidate: bool,
+    freshness_window: Duration,
+    error_summary: String,
+) -> ShardHealthRow {
+    ShardHealthRow {
+        shard_id,
+        roles,
+        candidate,
+        reachable: false,
+        schema: ShardSchemaHealth {
+            ready: false,
+            applied_count: None,
+            missing_migrations: Vec::new(),
+            error: Some(error_summary.clone()),
+        },
+        worker_coverage: Vec::new(),
+        scheduler: ShardSchedulerCoverage {
+            enabled: false,
+            ready: false,
+            running: false,
+            last_tick_at: None,
+            tick_interval_ms: 0,
+            freshness_window_secs: freshness_window.as_secs(),
+            schedule_count: 0,
+            error: Some(error_summary.clone()),
+        },
+        queue_depth: QueueDepthSummary {
+            total_pending: 0,
+            by_queue: BTreeMap::new(),
+            error: Some(error_summary.clone()),
+        },
+        dlq: DlqSummary {
+            count: None,
+            error: Some(error_summary.clone()),
+        },
+        last_health_sample_time: None,
+        readiness: ShardReadiness::Unready,
+        blocking_reasons: vec![error_summary.clone()],
+        error_summary: Some(error_summary),
+    }
+}
+
+fn roles_for_shard(shard_id: i32, runtime: Option<&HarvestApiRuntime>) -> Vec<ShardRole> {
+    let Some(runtime) = runtime else {
+        return if shard_id == 0 {
+            vec![ShardRole::Readable, ShardRole::Writable, ShardRole::Default]
+        } else {
+            Vec::new()
+        };
+    };
+
+    let shard = ShardId::new(shard_id);
+    let mut roles = Vec::new();
+    if runtime.router().readable_shards().contains(&shard) {
+        roles.push(ShardRole::Readable);
+    }
+    if runtime.router().writable_shards().contains(&shard) {
+        roles.push(ShardRole::Writable);
+    }
+    if runtime.router().default_shard() == shard {
+        roles.push(ShardRole::Default);
+    }
+    roles
+}
+
+#[derive(diesel::QueryableByName)]
+struct MigrationVersionRow {
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    version: String,
+}
+
+fn required_migration_versions() -> Result<Vec<String>, String> {
+    let migrations = <diesel_migrations::EmbeddedMigrations as MigrationSource<Pg>>::migrations(
+        &autumn_harvest::MIGRATIONS,
+    )
+    .map_err(|error| error.to_string())?;
+
+    Ok(migrations
+        .iter()
+        .map(|migration| {
+            let name = migration.name().to_string();
+            name.split('_').next().unwrap_or(&name).to_string()
+        })
+        .collect())
+}
+
+async fn observe_schema(
+    conn: &mut AsyncPgConnection,
+    required_migrations: &Result<Vec<String>, String>,
+) -> ShardSchemaHealth {
+    let Ok(required) = required_migrations else {
+        return ShardSchemaHealth {
+            ready: false,
+            applied_count: None,
+            missing_migrations: Vec::new(),
+            error: Some("Harvest embedded migration metadata could not be loaded".to_string()),
+        };
+    };
+
+    let required_set = required.iter().cloned().collect::<HashSet<_>>();
+    let rows = diesel::sql_query("SELECT version::TEXT AS version FROM __diesel_schema_migrations")
+        .load::<MigrationVersionRow>(conn)
+        .await;
+    let Ok(rows) = rows else {
+        return ShardSchemaHealth {
+            ready: false,
+            applied_count: None,
+            missing_migrations: required.clone(),
+            error: Some("migration table is not readable".to_string()),
+        };
+    };
+
+    let present = rows
+        .into_iter()
+        .map(|row| row.version)
+        .collect::<HashSet<_>>();
+    let mut missing = required_set
+        .difference(&present)
+        .cloned()
+        .collect::<Vec<_>>();
+    missing.sort();
+    ShardSchemaHealth {
+        ready: missing.is_empty(),
+        applied_count: Some(present.len()),
+        missing_migrations: missing,
+        error: None,
+    }
+}
+
+async fn load_workers(
+    conn: &mut AsyncPgConnection,
+    freshness_window: Duration,
+) -> Result<Vec<WorkerRow>, String> {
+    let filters = WorkerFilters {
+        limit: i64::MAX,
+        ..WorkerFilters::new()
+    };
+    list_workers(conn, &filters, freshness_window)
+        .await
+        .map_err(|error| error.to_string())
+}
+
+fn worker_readiness(
+    shard_id: i32,
+    required_queues: &BTreeSet<String>,
+    workers: Result<Vec<WorkerRow>, String>,
+    freshness_window: Duration,
+    observed_at: DateTime<Utc>,
+) -> WorkerReadiness {
+    let mut blocking_reasons = Vec::new();
+    match workers {
+        Ok(workers) => {
+            let coverage = worker_coverage_by_queue(shard_id, required_queues, &workers);
+            for queue in &coverage {
+                if !queue.ready {
+                    blocking_reasons.push(format!(
+                        "no healthy active worker covers required queue '{}' on shard {shard_id}",
+                        queue.queue
+                    ));
+                }
+            }
+            let last_seen = workers
+                .iter()
+                .map(|worker| worker.worker.last_heartbeat_at)
+                .max();
+            if !required_queues.is_empty() {
+                push_health_freshness_blocker(
+                    last_seen,
+                    freshness_window,
+                    observed_at,
+                    &mut blocking_reasons,
+                );
+            }
+            WorkerReadiness {
+                coverage,
+                last_health_sample_time: last_seen,
+                blocking_reasons,
+                error_summary: None,
+            }
+        }
+        Err(error) => {
+            blocking_reasons.push(format!("worker coverage could not be read: {error}"));
+            WorkerReadiness {
+                coverage: Vec::new(),
+                last_health_sample_time: None,
+                blocking_reasons,
+                error_summary: Some(error),
+            }
+        }
+    }
+}
+
+fn push_health_freshness_blocker(
+    last_seen: Option<DateTime<Utc>>,
+    freshness_window: Duration,
+    observed_at: DateTime<Utc>,
+    blocking_reasons: &mut Vec<String>,
+) {
+    let Some(last_seen) = last_seen else {
+        blocking_reasons.push("no worker health data recorded on shard".to_string());
+        return;
+    };
+    let elapsed = observed_at
+        .signed_duration_since(last_seen)
+        .to_std()
+        .unwrap_or(Duration::ZERO);
+    if elapsed > freshness_window {
+        blocking_reasons.push(format!(
+            "health data is stale; latest worker heartbeat exceeds {}s freshness window",
+            freshness_window.as_secs()
+        ));
+    }
+}
+
+fn worker_coverage_by_queue(
+    shard_id: i32,
+    required_queues: &BTreeSet<String>,
+    workers: &[WorkerRow],
+) -> Vec<QueueWorkerCoverage> {
+    required_queues
+        .iter()
+        .map(|queue| {
+            let matching = workers
+                .iter()
+                .filter(|worker| worker_can_cover(worker, queue, shard_id))
+                .collect::<Vec<_>>();
+            let healthy_active = matching
+                .iter()
+                .filter(|worker| {
+                    worker.health == WorkerHealth::Healthy
+                        && worker.worker.status == WorkerStatus::Active.as_str()
+                })
+                .count();
+            let stale = matching
+                .iter()
+                .filter(|worker| worker.health == WorkerHealth::Stale)
+                .count();
+            let draining = matching
+                .iter()
+                .filter(|worker| worker.worker.status == WorkerStatus::Draining.as_str())
+                .count();
+            let stopped = matching
+                .iter()
+                .filter(|worker| worker.worker.status == WorkerStatus::Stopped.as_str())
+                .count();
+            QueueWorkerCoverage {
+                queue: queue.clone(),
+                ready: healthy_active > 0,
+                healthy_active,
+                stale,
+                draining,
+                stopped,
+                total_matching: matching.len(),
+            }
+        })
+        .collect()
+}
+
+fn worker_can_cover(worker: &WorkerRow, queue: &str, shard_id: i32) -> bool {
+    let has_queue = worker
+        .worker
+        .queues
+        .as_array()
+        .is_some_and(|queues| queues.iter().any(|value| value.as_str() == Some(queue)));
+    let has_shard = worker
+        .worker
+        .shard_assignments
+        .as_array()
+        .is_some_and(|shards| {
+            shards
+                .iter()
+                .any(|value| value.as_i64() == Some(i64::from(shard_id)))
+        });
+    has_queue && has_shard
+}
+
+#[derive(diesel::QueryableByName)]
+struct QueueDepthRow {
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    queue_name: String,
+    #[diesel(sql_type = diesel::sql_types::BigInt)]
+    depth: i64,
+}
+
+async fn load_queue_depth(conn: &mut AsyncPgConnection) -> QueueDepthSummary {
+    let rows = diesel::sql_query(
+        "SELECT queue_name::TEXT AS queue_name, COUNT(*)::BIGINT AS depth \
+         FROM harvest_task_queue \
+         WHERE state = 'PENDING' \
+           AND scheduled_at <= NOW() \
+         GROUP BY queue_name \
+         ORDER BY queue_name",
+    )
+    .load::<QueueDepthRow>(conn)
+    .await;
+
+    rows.map_or_else(
+        |error| QueueDepthSummary {
+            total_pending: 0,
+            by_queue: BTreeMap::new(),
+            error: Some(error.to_string()),
+        },
+        |rows| {
+            let mut total_pending = 0;
+            let mut by_queue = BTreeMap::new();
+            for row in rows {
+                total_pending += row.depth;
+                by_queue.insert(row.queue_name, row.depth);
+            }
+            QueueDepthSummary {
+                total_pending,
+                by_queue,
+                error: None,
+            }
+        },
+    )
+}
+
+async fn load_dlq(conn: &mut AsyncPgConnection) -> DlqSummary {
+    dlq::dead_letter_count(conn).await.map_or_else(
+        |error| DlqSummary {
+            count: None,
+            error: Some(error.to_string()),
+        },
+        |count| DlqSummary {
+            count: Some(count),
+            error: None,
+        },
+    )
+}
+
+#[derive(diesel::QueryableByName)]
+struct ScheduleProbeRow {
+    #[diesel(sql_type = diesel::sql_types::Nullable<diesel::sql_types::Text>)]
+    schedule_expr: Option<String>,
+    #[diesel(sql_type = diesel::sql_types::Bool)]
+    is_paused: bool,
+    #[diesel(sql_type = diesel::sql_types::Nullable<diesel::sql_types::Text>)]
+    queue_name: Option<String>,
+}
+
+async fn load_schedule_probes(conn: &mut AsyncPgConnection) -> Result<Vec<ScheduleProbe>, String> {
+    let rows = diesel::sql_query(
+        "SELECT schedule_expr::TEXT AS schedule_expr, \
+                is_paused, \
+                queue_name::TEXT AS queue_name \
+         FROM harvest_schedules",
+    )
+    .load::<ScheduleProbeRow>(conn)
+    .await
+    .map_err(|error| error.to_string())?;
+
+    Ok(rows
+        .into_iter()
+        .map(|row| ScheduleProbe {
+            schedule_expr: row.schedule_expr,
+            is_paused: row.is_paused,
+            queue_name: row.queue_name,
+        })
+        .collect())
+}
+
+fn required_queues(
+    runtime: Option<&HarvestApiRuntime>,
+    schedules: Option<&[ScheduleProbe]>,
+) -> BTreeSet<String> {
+    let mut queues = BTreeSet::new();
+    if let Some(runtime) = runtime {
+        queues.extend(runtime.queues().iter().cloned());
+        if !runtime.registry().workflows.is_empty() && queues.is_empty() {
+            queues.insert("default".to_string());
+        }
+        for activity in runtime.registry().activities.values() {
+            if !activity.is_local {
+                queues.insert(activity.default_queue.unwrap_or("default").to_string());
+            }
+        }
+        for schedule in runtime.workflow_schedules() {
+            queues.insert(schedule.queue_name.clone());
+        }
+    }
+    if let Some(schedules) = schedules {
+        for schedule in schedules {
+            if let Some(queue) = &schedule.queue_name {
+                queues.insert(queue.clone());
+            }
+        }
+    }
+    queues.retain(|queue| !queue.trim().is_empty());
+
+    queues
+}
+
+fn scheduler_coverage(
+    runtime: Option<&HarvestApiRuntime>,
+    schedules: Option<&[ScheduleProbe]>,
+    shard_id: i32,
+    freshness_window: Duration,
+    observed_at: DateTime<Utc>,
+) -> ShardSchedulerCoverage {
+    let snapshot = runtime.map_or_else(
+        || SchedulerMonitor::offline().snapshot(),
+        HarvestApiRuntime::scheduler_snapshot,
+    );
+    let schedule_count = schedule_count_for_shard(runtime, schedules, shard_id);
+    if schedule_count == 0 {
+        return ShardSchedulerCoverage {
+            enabled: false,
+            ready: true,
+            running: snapshot.running,
+            last_tick_at: snapshot.last_tick_at,
+            tick_interval_ms: snapshot.tick_interval_ms,
+            freshness_window_secs: freshness_window.as_secs(),
+            schedule_count,
+            error: None,
+        };
+    }
+
+    let scheduler_window =
+        Duration::from_millis(snapshot.tick_interval_ms.saturating_mul(2)).max(freshness_window);
+    let mut error = None;
+    if !snapshot.running {
+        error = Some("scheduler coverage is required but scheduler is not running".to_string());
+    } else if let Some(last_tick_at) = snapshot.last_tick_at {
+        let elapsed = observed_at
+            .signed_duration_since(last_tick_at)
+            .to_std()
+            .unwrap_or(Duration::ZERO);
+        if elapsed > scheduler_window {
+            error = Some(format!(
+                "scheduler coverage is stale; last tick exceeds {}s freshness window",
+                scheduler_window.as_secs()
+            ));
+        }
+    } else {
+        error =
+            Some("scheduler coverage is stale; no scheduler tick has been recorded".to_string());
+    }
+
+    ShardSchedulerCoverage {
+        enabled: true,
+        ready: error.is_none(),
+        running: snapshot.running,
+        last_tick_at: snapshot.last_tick_at,
+        tick_interval_ms: snapshot.tick_interval_ms,
+        freshness_window_secs: scheduler_window.as_secs(),
+        schedule_count,
+        error,
+    }
+}
+
+fn schedule_count_for_shard(
+    runtime: Option<&HarvestApiRuntime>,
+    schedules: Option<&[ScheduleProbe]>,
+    shard_id: i32,
+) -> usize {
+    let mut count = 0;
+    if let Some(runtime) = runtime {
+        count += runtime
+            .workflow_schedules()
+            .iter()
+            .filter(|schedule| !schedule.paused && !matches!(schedule.schedule, Schedule::Manual))
+            .count();
+        count += runtime
+            .dags()
+            .values()
+            .filter(|dag| {
+                dag.schedule
+                    .as_ref()
+                    .is_some_and(|schedule| !matches!(schedule, Schedule::Manual))
+                    && runtime.router().pick_for_dag(&dag.name) == ShardId::new(shard_id)
+            })
+            .count();
+    }
+    if let Some(schedules) = schedules {
+        count += schedules
+            .iter()
+            .filter(|schedule| {
+                !schedule.is_paused
+                    && schedule
+                        .schedule_expr
+                        .as_deref()
+                        .is_some_and(|expr| !expr.eq_ignore_ascii_case("manual"))
+            })
+            .count();
+    }
+    count
+}

--- a/autumn-harvest-plugin/src/shard_health.rs
+++ b/autumn-harvest-plugin/src/shard_health.rs
@@ -158,10 +158,30 @@ pub async fn build_shard_health_report(
             seen.insert(row.shard_id);
             rows.push(row);
         }
+        if let Some(runtime) = runtime.as_ref() {
+            for shard_id in router_shard_ids(runtime) {
+                if seen.insert(shard_id) {
+                    rows.push(unavailable_row(
+                        shard_id,
+                        roles_for_shard(shard_id, Some(runtime)),
+                        candidate_shard == Some(shard_id),
+                        freshness_window,
+                        format!(
+                            "shard {shard_id} is configured in router but has no installed pool"
+                        ),
+                    ));
+                }
+            }
+        }
     } else {
         let fallback = runtime.as_ref().map_or_else(
             || vec![ShardId::new(0)],
-            |runtime| runtime.router().readable_shards().to_vec(),
+            |runtime| {
+                router_shard_ids(runtime)
+                    .into_iter()
+                    .map(ShardId::new)
+                    .collect()
+            },
         );
         for shard in fallback {
             let shard_id = shard.as_i32();
@@ -243,7 +263,7 @@ async fn observe_shard(
     if !schema.ready {
         if let Some(error) = &schema.error {
             blocking_reasons.push(format!("schema readiness could not be confirmed: {error}"));
-            error_summary = Some(error.clone());
+            error_summary.get_or_insert_with(|| error.clone());
         } else {
             blocking_reasons.push(format!(
                 "schema is missing required migrations: {}",
@@ -377,6 +397,26 @@ fn roles_for_shard(shard_id: i32, runtime: Option<&HarvestApiRuntime>) -> Vec<Sh
         roles.push(ShardRole::Default);
     }
     roles
+}
+
+fn router_shard_ids(runtime: &HarvestApiRuntime) -> BTreeSet<i32> {
+    let mut shards = BTreeSet::new();
+    shards.extend(
+        runtime
+            .router()
+            .readable_shards()
+            .iter()
+            .map(|shard| shard.as_i32()),
+    );
+    shards.extend(
+        runtime
+            .router()
+            .writable_shards()
+            .iter()
+            .map(|shard| shard.as_i32()),
+    );
+    shards.insert(runtime.router().default_shard().as_i32());
+    shards
 }
 
 #[derive(diesel::QueryableByName)]

--- a/autumn-harvest-plugin/tests/shard_health_integration.rs
+++ b/autumn-harvest-plugin/tests/shard_health_integration.rs
@@ -527,3 +527,47 @@ async fn migration_mismatch_marks_only_affected_shard_unready() {
         "schema mismatch should list missing migrations: {mismatched}"
     );
 }
+
+#[tokio::test]
+async fn router_only_writable_shard_is_reported_unready() {
+    let mut pools = BTreeMap::new();
+    pools.insert(
+        ShardId::new(0),
+        build_test_pool("postgres://postgres:postgres@127.0.0.1:1/shard0"),
+    );
+    let pool = HarvestDbPool::sharded(ShardedDbPool::from_map(pools, ShardId::new(0)));
+    let router = ShardRouter::new(
+        vec![ShardId::new(0), ShardId::new(1)],
+        vec![ShardId::new(0), ShardId::new(1)],
+        ShardId::new(0),
+    );
+    let state = api_state(
+        pool,
+        runtime_for(
+            &["default"],
+            None,
+            Vec::new(),
+            router,
+            SchedulerMonitor::offline(),
+        ),
+    );
+    let app = harvest_api_router(state).with_state(AppState::for_test().with_profile("test"));
+
+    let (status, body) = get_json(&app, "/admin/shards/health").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["overall_readiness"], "unready");
+    let router_only = find_shard(&body, 1);
+    assert_eq!(router_only["reachable"], false);
+    assert_eq!(router_only["readiness"], "unready");
+    assert_eq!(
+        roles(router_only),
+        vec!["readable".to_string(), "writable".to_string()]
+    );
+    assert!(
+        router_only["error_summary"].as_str().is_some_and(
+            |summary| summary.contains("configured in router but has no installed pool")
+        ),
+        "router-only shard should explain missing pool: {router_only}"
+    );
+}

--- a/autumn-harvest-plugin/tests/shard_health_integration.rs
+++ b/autumn-harvest-plugin/tests/shard_health_integration.rs
@@ -1,0 +1,529 @@
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use autumn_harvest::info::{ActivityInfo, WorkflowInfo};
+use autumn_harvest::policy::{Schedule, WorkflowSchedule};
+use autumn_harvest::retention::RetentionConfig;
+use autumn_harvest::scheduler::{DagCatalog, SchedulerMonitor};
+use autumn_harvest::shard::{ShardRouter, ShardedDbPool};
+use autumn_harvest::types::ShardId;
+use autumn_harvest::worker::{DbPool, HandlerRegistry};
+use autumn_harvest::workers::{WorkerStatus, register_worker};
+use autumn_harvest_plugin::HarvestDbPool;
+use autumn_harvest_plugin::api::{
+    HarvestApiRuntime, HarvestApiState, HarvestRetentionRuntime, harvest_api_router,
+};
+use autumn_web::AppState;
+use autumn_web::reexports::axum;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use diesel_async::AsyncConnection;
+use diesel_async::AsyncPgConnection;
+use diesel_async::RunQueryDsl;
+use diesel_async::pooled_connection::AsyncDieselConnectionManager;
+use serde_json::Value;
+use testcontainers::ContainerAsync;
+use testcontainers_modules::postgres::Postgres;
+use testcontainers_modules::testcontainers::runners::AsyncRunner;
+use tower::ServiceExt;
+
+type HarvestApiApp = axum::Router;
+
+fn build_test_pool(database_url: &str) -> DbPool {
+    let manager = AsyncDieselConnectionManager::<AsyncPgConnection>::new(database_url);
+    deadpool::managed::Pool::builder(manager)
+        .max_size(4)
+        .build()
+        .expect("failed to build test pool")
+}
+
+async fn setup_database_url_with_migrations() -> (String, ContainerAsync<Postgres>) {
+    let container = Postgres::default()
+        .start()
+        .await
+        .expect("failed to start Postgres container");
+    let host = container
+        .get_host()
+        .await
+        .expect("failed to get container host");
+    let port = container
+        .get_host_port_ipv4(5432)
+        .await
+        .expect("failed to get container port");
+    let url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+    autumn_web::migrate::run_pending(&url, autumn_harvest::MIGRATIONS)
+        .expect("failed to run Harvest migrations");
+    (url, container)
+}
+
+async fn setup_two_shards_with_migrations() -> ((String, String), ContainerAsync<Postgres>) {
+    let container = Postgres::default()
+        .start()
+        .await
+        .expect("failed to start Postgres container");
+    let host = container
+        .get_host()
+        .await
+        .expect("failed to get container host");
+    let port = container
+        .get_host_port_ipv4(5432)
+        .await
+        .expect("failed to get container port");
+    let admin_url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+    let shard0_db = format!("harvest_shard_health_0_{}", uuid::Uuid::new_v4().simple());
+    let shard1_db = format!("harvest_shard_health_1_{}", uuid::Uuid::new_v4().simple());
+
+    let mut admin_conn = <AsyncPgConnection as AsyncConnection>::establish(&admin_url)
+        .await
+        .expect("failed to connect to admin database");
+    diesel::sql_query(format!("CREATE DATABASE {shard0_db}"))
+        .execute(&mut admin_conn)
+        .await
+        .expect("failed to create shard 0 database");
+    diesel::sql_query(format!("CREATE DATABASE {shard1_db}"))
+        .execute(&mut admin_conn)
+        .await
+        .expect("failed to create shard 1 database");
+
+    let shard0_url = format!("postgres://postgres:postgres@{host}:{port}/{shard0_db}");
+    let shard1_url = format!("postgres://postgres:postgres@{host}:{port}/{shard1_db}");
+    autumn_web::migrate::run_pending(&shard0_url, autumn_harvest::MIGRATIONS)
+        .expect("failed to migrate shard 0");
+    autumn_web::migrate::run_pending(&shard1_url, autumn_harvest::MIGRATIONS)
+        .expect("failed to migrate shard 1");
+    ((shard0_url, shard1_url), container)
+}
+
+fn build_two_shard_pool(shard0_url: &str, shard1_url: &str) -> HarvestDbPool {
+    let mut pools = BTreeMap::new();
+    pools.insert(ShardId::new(0), build_test_pool(shard0_url));
+    pools.insert(ShardId::new(1), build_test_pool(shard1_url));
+    HarvestDbPool::sharded(ShardedDbPool::from_map(pools, ShardId::new(0)))
+}
+
+fn workflow_info() -> WorkflowInfo {
+    WorkflowInfo {
+        name: "echo_workflow",
+        module: "tests",
+        handler: |_ctx, input| Box::pin(async move { Ok(input) }),
+    }
+}
+
+fn activity_info(queue: Option<&'static str>) -> ActivityInfo {
+    ActivityInfo {
+        name: "send_email",
+        module: "tests",
+        default_retry_policy: None,
+        default_start_to_close: None,
+        default_heartbeat_timeout: None,
+        default_schedule_to_start: None,
+        default_queue: queue,
+        max_concurrent: None,
+        concurrency_key: None,
+        is_local: false,
+        handler: |_ctx, input| Box::pin(async move { Ok(input) }),
+    }
+}
+
+fn runtime_for(
+    queues: &[&str],
+    activity_queue: Option<&'static str>,
+    schedules: Vec<WorkflowSchedule>,
+    router: ShardRouter,
+    scheduler_monitor: SchedulerMonitor,
+) -> HarvestApiRuntime {
+    let activities = activity_queue
+        .map(|queue| activity_info(Some(queue)))
+        .into_iter()
+        .collect::<Vec<_>>();
+    HarvestApiRuntime::new(
+        Arc::new(HandlerRegistry::new(vec![workflow_info()], activities)),
+        Arc::new(DagCatalog::new()),
+        Arc::new(schedules),
+        None,
+        queues.iter().map(|queue| (*queue).to_string()).collect(),
+        scheduler_monitor,
+        HarvestRetentionRuntime::disabled(RetentionConfig::default()),
+        router,
+    )
+}
+
+fn api_state(pool: HarvestDbPool, runtime: HarvestApiRuntime) -> HarvestApiState {
+    let state = HarvestApiState::new();
+    state.install_storage_pool(pool);
+    state.install(runtime);
+    state.set_worker_stale_threshold(Duration::from_secs(10));
+    state
+}
+
+async fn register_active_worker(pool: &DbPool, worker_id: &str, queues: &[&str], shards: &[i32]) {
+    let queue_names = queues
+        .iter()
+        .map(|queue| (*queue).to_string())
+        .collect::<Vec<_>>();
+    let mut conn = pool.get().await.expect("worker registration connection");
+    register_worker(
+        &mut conn,
+        worker_id,
+        &queue_names,
+        shards,
+        10,
+        "localhost",
+        Some(env!("CARGO_PKG_VERSION")),
+    )
+    .await
+    .expect("worker registration should succeed");
+}
+
+async fn mark_worker_stale(pool: &DbPool, worker_id: &str) {
+    let mut conn = pool.get().await.expect("stale update connection");
+    diesel::sql_query(
+        "UPDATE harvest_workers
+         SET last_heartbeat_at = NOW() - INTERVAL '10 minutes',
+             status = $1
+         WHERE worker_id = $2",
+    )
+    .bind::<diesel::sql_types::Text, _>(WorkerStatus::Active.as_str())
+    .bind::<diesel::sql_types::Text, _>(worker_id)
+    .execute(&mut conn)
+    .await
+    .expect("worker should be marked stale");
+}
+
+async fn read_json_response(response: axum::response::Response) -> Value {
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("failed to read response body");
+    serde_json::from_slice(&body).expect("response must be JSON")
+}
+
+async fn get_json(app: &HarvestApiApp, uri: impl Into<String>) -> (StatusCode, Value) {
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(uri.into())
+                .body(Body::empty())
+                .expect("request should build"),
+        )
+        .await
+        .expect("request should complete");
+    let status = response.status();
+    let json = read_json_response(response).await;
+    (status, json)
+}
+
+fn roles(row: &Value) -> Vec<String> {
+    row["roles"]
+        .as_array()
+        .expect("roles should be an array")
+        .iter()
+        .map(|role| role.as_str().expect("role should be a string").to_string())
+        .collect()
+}
+
+fn blocking_reasons(row: &Value) -> Vec<String> {
+    row["blocking_reasons"]
+        .as_array()
+        .expect("blocking reasons should be an array")
+        .iter()
+        .map(|reason| {
+            reason
+                .as_str()
+                .expect("blocking reason should be a string")
+                .to_string()
+        })
+        .collect()
+}
+
+fn find_shard(body: &Value, shard_id: i64) -> &Value {
+    body["shards"]
+        .as_array()
+        .expect("shards should be an array")
+        .iter()
+        .find(|row| row["shard_id"] == shard_id)
+        .unwrap_or_else(|| panic!("missing shard {shard_id}: {body}"))
+}
+
+#[tokio::test]
+async fn single_shard_ready_state_uses_shard_zero_response_shape() {
+    let (database_url, _container) = setup_database_url_with_migrations().await;
+    let pool = build_test_pool(&database_url);
+    register_active_worker(&pool, "ready-worker", &["default", "email"], &[0]).await;
+    let state = api_state(
+        HarvestDbPool::from(pool),
+        runtime_for(
+            &["default", "email"],
+            Some("email"),
+            Vec::new(),
+            ShardRouter::single(),
+            SchedulerMonitor::offline(),
+        ),
+    );
+    let app = harvest_api_router(state).with_state(AppState::for_test().with_profile("test"));
+
+    let (status, body) = get_json(&app, "/admin/shards/health").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["overall_readiness"], "ready");
+    let shard = find_shard(&body, 0);
+    assert_eq!(shard["readiness"], "ready");
+    assert_eq!(shard["reachable"], true);
+    assert_eq!(shard["schema"]["ready"], true);
+    assert_eq!(shard["queue_depth"]["total_pending"], 0);
+    assert_eq!(shard["dlq"]["count"], 0);
+    assert_eq!(
+        roles(shard),
+        vec![
+            "readable".to_string(),
+            "writable".to_string(),
+            "default".to_string()
+        ]
+    );
+    assert!(shard["last_health_sample_time"].is_string());
+}
+
+#[tokio::test]
+async fn readable_only_candidate_without_workers_lists_promotion_blockers() {
+    let ((shard0_url, shard1_url), _container) = setup_two_shards_with_migrations().await;
+    let pool = build_two_shard_pool(&shard0_url, &shard1_url);
+    register_active_worker(
+        pool.pool_for(ShardId::new(0)),
+        "ready-worker-0",
+        &["default"],
+        &[0],
+    )
+    .await;
+    let router = ShardRouter::new(
+        vec![ShardId::new(0), ShardId::new(1)],
+        vec![ShardId::new(0)],
+        ShardId::new(0),
+    );
+    let state = api_state(
+        pool,
+        runtime_for(
+            &["default"],
+            None,
+            Vec::new(),
+            router,
+            SchedulerMonitor::offline(),
+        ),
+    );
+    let app = harvest_api_router(state).with_state(AppState::for_test().with_profile("test"));
+
+    let (status, body) = get_json(&app, "/admin/shards/health?candidate_shard=1").await;
+
+    assert_eq!(status, StatusCode::OK);
+    let candidate = find_shard(&body, 1);
+    assert_eq!(candidate["candidate"], true);
+    assert_eq!(candidate["readiness"], "unready");
+    assert_eq!(roles(candidate), vec!["readable".to_string()]);
+    assert!(
+        blocking_reasons(candidate)
+            .iter()
+            .any(|reason| reason
+                .contains("no healthy active worker covers required queue 'default'")),
+        "candidate should explain missing worker coverage: {candidate}"
+    );
+}
+
+#[tokio::test]
+async fn writable_shard_with_missing_queue_coverage_is_unready() {
+    let (database_url, _container) = setup_database_url_with_migrations().await;
+    let pool = build_test_pool(&database_url);
+    register_active_worker(&pool, "default-worker", &["default"], &[0]).await;
+    let state = api_state(
+        HarvestDbPool::from(pool),
+        runtime_for(
+            &["default", "email"],
+            Some("email"),
+            Vec::new(),
+            ShardRouter::single(),
+            SchedulerMonitor::offline(),
+        ),
+    );
+    let app = harvest_api_router(state).with_state(AppState::for_test().with_profile("test"));
+
+    let (status, body) = get_json(&app, "/admin/shards/health").await;
+
+    assert_eq!(status, StatusCode::OK);
+    let shard = find_shard(&body, 0);
+    assert_eq!(shard["readiness"], "unready");
+    assert!(
+        blocking_reasons(shard)
+            .iter()
+            .any(|reason| reason.contains("required queue 'email'")),
+        "missing email worker coverage should be named: {shard}"
+    );
+}
+
+#[tokio::test]
+async fn stale_worker_coverage_makes_writable_shard_unready() {
+    let (database_url, _container) = setup_database_url_with_migrations().await;
+    let pool = build_test_pool(&database_url);
+    register_active_worker(&pool, "stale-worker", &["default"], &[0]).await;
+    mark_worker_stale(&pool, "stale-worker").await;
+    let state = api_state(
+        HarvestDbPool::from(pool),
+        runtime_for(
+            &["default"],
+            None,
+            Vec::new(),
+            ShardRouter::single(),
+            SchedulerMonitor::offline(),
+        ),
+    );
+    let app = harvest_api_router(state).with_state(AppState::for_test().with_profile("test"));
+
+    let (status, body) = get_json(&app, "/admin/shards/health").await;
+
+    assert_eq!(status, StatusCode::OK);
+    let shard = find_shard(&body, 0);
+    assert_eq!(shard["readiness"], "unready");
+    assert!(
+        blocking_reasons(shard)
+            .iter()
+            .any(|reason| reason.contains("health data is stale")
+                || reason.contains("no healthy active worker covers required queue 'default'")),
+        "stale coverage should be an explicit blocker: {shard}"
+    );
+}
+
+#[tokio::test]
+async fn stale_scheduler_coverage_makes_scheduled_writable_shard_unready() {
+    let (database_url, _container) = setup_database_url_with_migrations().await;
+    let pool = build_test_pool(&database_url);
+    register_active_worker(&pool, "ready-worker", &["default"], &[0]).await;
+    let schedule =
+        WorkflowSchedule::new("echo_workflow", Schedule::Interval(Duration::from_secs(60)));
+    let state = api_state(
+        HarvestDbPool::from(pool),
+        runtime_for(
+            &["default"],
+            None,
+            vec![schedule],
+            ShardRouter::single(),
+            SchedulerMonitor::new(1),
+        ),
+    );
+    let app = harvest_api_router(state).with_state(AppState::for_test().with_profile("test"));
+
+    let (status, body) = get_json(&app, "/admin/shards/health").await;
+
+    assert_eq!(status, StatusCode::OK);
+    let shard = find_shard(&body, 0);
+    assert_eq!(shard["readiness"], "unready");
+    assert!(
+        blocking_reasons(shard)
+            .iter()
+            .any(|reason| reason.contains("scheduler")),
+        "scheduler freshness should be an explicit blocker: {shard}"
+    );
+}
+
+#[tokio::test]
+async fn unreachable_shard_returns_partial_health_for_reachable_shards() {
+    let (shard0_url, _container) = setup_database_url_with_migrations().await;
+    let pool = build_two_shard_pool(&shard0_url, "postgres://postgres:postgres@127.0.0.1:1/nope");
+    register_active_worker(
+        pool.pool_for(ShardId::new(0)),
+        "ready-worker-0",
+        &["default"],
+        &[0],
+    )
+    .await;
+    let router = ShardRouter::new(
+        vec![ShardId::new(0), ShardId::new(1)],
+        vec![ShardId::new(0), ShardId::new(1)],
+        ShardId::new(0),
+    );
+    let state = api_state(
+        pool,
+        runtime_for(
+            &["default"],
+            None,
+            Vec::new(),
+            router,
+            SchedulerMonitor::offline(),
+        ),
+    );
+    let app = harvest_api_router(state).with_state(AppState::for_test().with_profile("test"));
+
+    let (status, body) = get_json(&app, "/admin/shards/health").await;
+
+    assert_eq!(status, StatusCode::OK);
+    let healthy = find_shard(&body, 0);
+    let degraded = find_shard(&body, 1);
+    assert_eq!(healthy["reachable"], true);
+    assert_eq!(degraded["reachable"], false);
+    assert_eq!(degraded["readiness"], "unready");
+    assert!(
+        degraded["error_summary"]
+            .as_str()
+            .is_some_and(|summary| summary.contains("database connection could not be acquired")),
+        "unreachable shard should include operator-facing error summary: {degraded}"
+    );
+}
+
+#[tokio::test]
+async fn migration_mismatch_marks_only_affected_shard_unready() {
+    let ((shard0_url, shard1_url), _container) = setup_two_shards_with_migrations().await;
+    let mut shard1_conn = <AsyncPgConnection as AsyncConnection>::establish(&shard1_url)
+        .await
+        .expect("shard 1 connection");
+    diesel::sql_query(
+        "DELETE FROM __diesel_schema_migrations
+         WHERE version = (SELECT max(version) FROM __diesel_schema_migrations)",
+    )
+    .execute(&mut shard1_conn)
+    .await
+    .expect("should remove latest migration marker");
+
+    let pool = build_two_shard_pool(&shard0_url, &shard1_url);
+    register_active_worker(
+        pool.pool_for(ShardId::new(0)),
+        "ready-worker-0",
+        &["default"],
+        &[0],
+    )
+    .await;
+    register_active_worker(
+        pool.pool_for(ShardId::new(1)),
+        "ready-worker-1",
+        &["default"],
+        &[1],
+    )
+    .await;
+    let router = ShardRouter::new(
+        vec![ShardId::new(0), ShardId::new(1)],
+        vec![ShardId::new(0), ShardId::new(1)],
+        ShardId::new(0),
+    );
+    let state = api_state(
+        pool,
+        runtime_for(
+            &["default"],
+            None,
+            Vec::new(),
+            router,
+            SchedulerMonitor::offline(),
+        ),
+    );
+    let app = harvest_api_router(state).with_state(AppState::for_test().with_profile("test"));
+
+    let (status, body) = get_json(&app, "/admin/shards/health").await;
+
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(find_shard(&body, 0)["readiness"], "ready");
+    let mismatched = find_shard(&body, 1);
+    assert_eq!(mismatched["readiness"], "unready");
+    assert_eq!(mismatched["schema"]["ready"], false);
+    assert!(
+        mismatched["schema"]["missing_migrations"]
+            .as_array()
+            .is_some_and(|missing| !missing.is_empty()),
+        "schema mismatch should list missing migrations: {mismatched}"
+    );
+}


### PR DESCRIPTION
  Optional body:

  Add /admin/shards/health readiness reporting with per-shard blockers,
  worker/scheduler/schema/queue/DLQ checks, and CLI support via
  harvest shard health --fail-on-unready.

  Refs #161