### PR TITLE
Add compensation when payment capture signal missing capture_id

### DIFF
--- a/examples/billing-autumn-web/src/tests.rs
+++ b/examples/billing-autumn-web/src/tests.rs
@@ -189,6 +189,7 @@ async fn billing_checkout_compensates_when_capture_id_missing() {
     assert!(scheduled.contains(&"cancel_subscription_record"));
     assert!(scheduled.contains(&"void_payment_authorization"));
     assert!(scheduled.contains(&"delete_customer_profile"));
+    assert!(scheduled.contains(&"void_invoice"));
 }
 
 #[tokio::test]

--- a/examples/billing-autumn-web/src/tests.rs
+++ b/examples/billing-autumn-web/src/tests.rs
@@ -163,10 +163,7 @@ async fn billing_checkout_compensates_when_capture_id_missing() {
                 Ok(json!({ "deleted": true }))
             })
             .mock_activity("void_invoice", |_| Ok(json!({ "voided": true })))
-            .send_signal(
-                "payment_captured",
-                json!({ "captured": true }),
-            )
+            .send_signal("payment_captured", json!({ "captured": true }))
             .run(json!(checkout()))
             .await;
 

--- a/examples/billing-autumn-web/src/tests.rs
+++ b/examples/billing-autumn-web/src/tests.rs
@@ -131,6 +131,67 @@ async fn billing_checkout_happy_path_uses_saga_child_signal_version_and_timer() 
 }
 
 #[tokio::test]
+async fn billing_checkout_compensates_when_capture_id_missing() {
+    let result =
+        WorkflowSimulator::new(workflows::__autumn_workflow_info_billing_checkout().handler)
+            .mock_activity("validate_checkout", Ok)
+            .mock_activity("create_customer_profile", |_| {
+                Ok(json!({ "customer_profile_id": "cus_demo" }))
+            })
+            .mock_activity("authorize_payment", |_| {
+                Ok(json!({ "authorization_id": "auth_demo", "amount_cents": 14_500 }))
+            })
+            .mock_activity("create_subscription_record", |input| {
+                Ok(json!({
+                    "subscription_id": input["subscription_id"],
+                    "state": "pending_capture",
+                }))
+            })
+            .mock_child_workflow("issue_initial_invoice", |_| {
+                Ok(json!({
+                    "invoice_id": "inv_demo",
+                    "total_cents": 15_950,
+                }))
+            })
+            .mock_activity("cancel_subscription_record", |_| {
+                Ok(json!({ "cancelled": true }))
+            })
+            .mock_activity("void_payment_authorization", |_| {
+                Ok(json!({ "voided": true }))
+            })
+            .mock_activity("delete_customer_profile", |_| {
+                Ok(json!({ "deleted": true }))
+            })
+            .mock_activity("void_invoice", |_| Ok(json!({ "voided": true })))
+            .send_signal(
+                "payment_captured",
+                json!({ "captured": true }),
+            )
+            .run(json!(checkout()))
+            .await;
+
+    let error = result
+        .final_output
+        .expect_err("billing checkout should fail when capture_id is absent");
+    assert!(
+        error.contains("capture_id"),
+        "error should mention capture_id, got: {error}"
+    );
+
+    let scheduled: Vec<&str> = result
+        .history
+        .iter()
+        .filter_map(|event| match event {
+            WorkflowEvent::ActivityScheduled { name, .. } => Some(name.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert!(scheduled.contains(&"cancel_subscription_record"));
+    assert!(scheduled.contains(&"void_payment_authorization"));
+    assert!(scheduled.contains(&"delete_customer_profile"));
+}
+
+#[tokio::test]
 async fn billing_checkout_compensates_when_invoice_child_fails() {
     let result =
         WorkflowSimulator::new(workflows::__autumn_workflow_info_billing_checkout().handler)

--- a/examples/billing-autumn-web/src/workflows.rs
+++ b/examples/billing-autumn-web/src/workflows.rs
@@ -156,11 +156,16 @@ pub async fn billing_checkout(
             reason: "payment capture was rejected".to_owned(),
         });
     }
-    let capture_id = capture
-        .get("capture_id")
-        .and_then(Value::as_str)
-        .unwrap_or("capture-missing")
-        .to_owned();
+    let capture_id = match capture.get("capture_id").and_then(Value::as_str) {
+        Some(id) => id.to_owned(),
+        None => {
+            saga.compensate_all().await?;
+            return Err(HarvestError::WorkflowFailed {
+                name: "billing_checkout".to_owned(),
+                reason: "payment_captured signal missing capture_id".to_owned(),
+            });
+        }
+    };
 
     ctx.execute_activity_raw(
         "record_payment_capture",

--- a/examples/billing-autumn-web/src/workflows.rs
+++ b/examples/billing-autumn-web/src/workflows.rs
@@ -156,16 +156,14 @@ pub async fn billing_checkout(
             reason: "payment capture was rejected".to_owned(),
         });
     }
-    let capture_id = match capture.get("capture_id").and_then(Value::as_str) {
-        Some(id) => id.to_owned(),
-        None => {
-            saga.compensate_all().await?;
-            return Err(HarvestError::WorkflowFailed {
-                name: "billing_checkout".to_owned(),
-                reason: "payment_captured signal missing capture_id".to_owned(),
-            });
-        }
+    let Some(capture_id) = capture.get("capture_id").and_then(Value::as_str) else {
+        saga.compensate_all().await?;
+        return Err(HarvestError::WorkflowFailed {
+            name: "billing_checkout".to_owned(),
+            reason: "payment_captured signal missing capture_id".to_owned(),
+        });
     };
+    let capture_id = capture_id.to_owned();
 
     ctx.execute_activity_raw(
         "record_payment_capture",


### PR DESCRIPTION
## Summary
Enhanced the billing checkout workflow to properly handle the case where a payment capture signal is received without a `capture_id`. Previously, the workflow would use a placeholder value and continue; now it explicitly fails and triggers compensation logic to clean up partial state.

## Changes
- **Workflow logic**: Modified `billing_checkout` in `workflows.rs` to validate that the `capture_id` is present in the payment capture signal. If missing, the workflow now:
  - Calls `saga.compensate_all()` to reverse all previously completed activities
  - Returns a `WorkflowFailed` error with a descriptive message
  
- **Test coverage**: Added `billing_checkout_compensates_when_capture_id_missing` test to verify:
  - The workflow fails when `capture_id` is absent from the signal
  - All compensation activities are properly scheduled (cancel subscription, void authorization, delete customer profile)
  - The error message mentions the missing `capture_id`

## Implementation Details
The change replaces a lenient fallback (`unwrap_or("capture-missing")`) with explicit error handling that ensures data consistency by compensating all prior workflow steps before failing. This prevents orphaned resources and maintains transactional semantics in the billing workflow.

https://claude.ai/code/session_012TcwBaAccMLKjRa1SMBhef