### PR TITLE
Wrap high-value subscription approval in saga step

### DIFF
--- a/examples/billing-autumn-web/src/workflows.rs
+++ b/examples/billing-autumn-web/src/workflows.rs
@@ -109,14 +109,20 @@ pub async fn billing_checkout(
         .await?;
 
     if checkout.requires_manual_review() {
-        ctx.execute_activity_external(
-            "approve_high_value_subscription",
-            json!({
-                "subscription": subscription_record,
-                "authorization": authorization,
-            }),
-            OPS_QUEUE,
-            24 * 60 * 60,
+        saga.step(
+            || async {
+                ctx.execute_activity_external(
+                    "approve_high_value_subscription",
+                    json!({
+                        "subscription": subscription_record,
+                        "authorization": authorization,
+                    }),
+                    OPS_QUEUE,
+                    24 * 60 * 60,
+                )
+                .await
+            },
+            |_| async { Ok::<(), HarvestError>(()) },
         )
         .await?;
     }


### PR DESCRIPTION
## Summary
Updated the billing checkout workflow to wrap the high-value subscription approval activity in a saga step, enabling proper compensation/rollback handling.

## Key Changes
- Wrapped `execute_activity_external` call for `approve_high_value_subscription` in a `saga.step()` call
- Added a compensation function that returns `Ok(())` to handle rollback scenarios
- Maintains the same external activity execution with identical parameters (OPS_QUEUE, 24-hour timeout)

## Implementation Details
The change converts a standalone activity execution into a saga-managed step, which provides:
- Automatic compensation/rollback capability if the workflow needs to undo this operation
- Better integration with the saga pattern for distributed transaction management
- The compensation function is a no-op (`Ok(())`) since the external approval activity doesn't require explicit cleanup

https://claude.ai/code/session_01BWRC2cTj5rypDve3GckvFr