### PR TITLE
feat: version-gate retirement check (issue #164)

### DIFF
--- a/autumn-harvest-cli/src/lib.rs
+++ b/autumn-harvest-cli/src/lib.rs
@@ -2192,11 +2192,7 @@ fn retirement_check_exit_code(value: &Value) -> i32 {
         .and_then(Value::as_str)
         .unwrap_or("unavailable");
     // Non-zero on any non-safe outcome
-    if matches!(status, "safe") {
-        0
-    } else {
-        1
-    }
+    if matches!(status, "safe") { 0 } else { 1 }
 }
 
 fn retirement_check_request(

--- a/autumn-harvest-cli/src/lib.rs
+++ b/autumn-harvest-cli/src/lib.rs
@@ -2192,7 +2192,7 @@ fn retirement_check_exit_code(value: &Value) -> i32 {
         .and_then(Value::as_str)
         .unwrap_or("unavailable");
     // Non-zero on any non-safe outcome
-    if matches!(status, "safe") { 0 } else { 1 }
+    i32::from(!matches!(status, "safe"))
 }
 
 fn retirement_check_request(

--- a/autumn-harvest-cli/src/lib.rs
+++ b/autumn-harvest-cli/src/lib.rs
@@ -207,6 +207,10 @@ pub enum CliError {
     /// Version-gate guard found active usage or incomplete shard inspection.
     #[error("version usage guard failed")]
     VersionUsageGate,
+
+    /// Retirement check found active old-version executions or an unavailable shard.
+    #[error("version-gate retirement check failed")]
+    RetirementCheckGate,
 }
 
 impl CliError {
@@ -293,6 +297,32 @@ enum Commands {
         /// Exit non-zero if any active execution still matches the filtered version gate.
         #[arg(long, requires = "change_id", requires = "recorded_version")]
         guard: bool,
+    },
+    /// Check whether a version-gate change id is safe to retire below a version threshold.
+    ///
+    /// Exits non-zero when `--check` is passed and any non-terminal execution still carries
+    /// a recorded version below `--min-safe-version`, or when any shard is unavailable.
+    #[command(alias = "version-gate-check")]
+    VersionGateRetirement {
+        /// Version-gate change id to inspect (required).
+        #[arg(long)]
+        change_id: String,
+        /// Versions strictly below this value are considered old branches to retire.
+        #[arg(long, value_parser = clap::value_parser!(u32))]
+        min_safe_version: u32,
+        /// Narrow results to this workflow name.
+        #[arg(long)]
+        workflow_name: Option<String>,
+        /// Filter by execution state group.
+        #[arg(long, value_enum)]
+        state_group: Option<VersionUsageStateGroup>,
+        /// Restrict inspection to one shard.
+        #[arg(long)]
+        shard_id: Option<i32>,
+        /// Exit non-zero while any non-terminal execution still uses an old version,
+        /// or while any shard is unavailable.
+        #[arg(long)]
+        check: bool,
     },
     /// Open the TUI dashboard to monitor workflows.
     Tui,
@@ -735,6 +765,20 @@ impl Cli {
                 *shard_id,
                 *guard,
             )),
+            Commands::VersionGateRetirement {
+                change_id,
+                min_safe_version,
+                workflow_name,
+                state_group,
+                shard_id,
+                check: _,
+            } => Ok(retirement_check_request(
+                change_id,
+                *min_safe_version,
+                workflow_name.as_deref(),
+                *state_group,
+                *shard_id,
+            )),
             Commands::Tui => unreachable!("Tui command handles its own requests"),
         }
     }
@@ -798,6 +842,9 @@ pub async fn run_cli(cli: Cli) -> Result<(), CliError> {
     }
     if version_usage_should_guard(&cli) && version_usage_guard_exit_code(&response) != 0 {
         return Err(CliError::VersionUsageGate);
+    }
+    if retirement_check_should_check(&cli) && retirement_check_exit_code(&response) != 0 {
+        return Err(CliError::RetirementCheckGate);
     }
     Ok(())
 }
@@ -885,6 +932,9 @@ fn render_response(cli: &Cli, value: &Value) -> Result<String, CliError> {
     }
     if version_usage_wants_table(cli) {
         return Ok(format_version_usage_table(value));
+    }
+    if retirement_check_wants_table(cli) {
+        return Ok(format_retirement_check_table(value));
     }
 
     let output = if workflow_children_wants_raw_json(cli) {
@@ -2122,6 +2172,158 @@ fn query_encode(input: &str) -> String {
     out
 }
 
+// ─── Version-gate retirement check helpers ────────────────────────────────────
+
+const fn retirement_check_should_check(cli: &Cli) -> bool {
+    matches!(
+        &cli.command,
+        Commands::VersionGateRetirement { check: true, .. }
+    )
+}
+
+fn retirement_check_wants_table(cli: &Cli) -> bool {
+    matches!(&cli.command, Commands::VersionGateRetirement { .. })
+        && cli.output == OutputFormat::PrettyJson
+}
+
+fn retirement_check_exit_code(value: &Value) -> i32 {
+    let status = value
+        .get("status")
+        .and_then(Value::as_str)
+        .unwrap_or("unavailable");
+    // Non-zero on any non-safe outcome
+    if matches!(status, "safe") {
+        0
+    } else {
+        1
+    }
+}
+
+fn retirement_check_request(
+    change_id: &str,
+    min_safe_version: u32,
+    workflow_name: Option<&str>,
+    state_group: Option<VersionUsageStateGroup>,
+    shard_id: Option<i32>,
+) -> ApiRequest {
+    let mut params: Vec<(&'static str, String)> = Vec::new();
+    params.push(("change_id", change_id.to_string()));
+    params.push(("min_safe_version", min_safe_version.to_string()));
+    if let Some(name) = workflow_name {
+        params.push(("workflow_name", name.to_string()));
+    }
+    if let Some(sg) = state_group {
+        params.push(("state_group", sg.as_wire().to_string()));
+    }
+    if let Some(sid) = shard_id {
+        params.push(("shard_id", sid.to_string()));
+    }
+    let encoded = params
+        .iter()
+        .map(|(key, value)| format!("{key}={}", query_encode(value)))
+        .collect::<Vec<_>>()
+        .join("&");
+    ApiRequest::get(format!("/admin/version-gates/retirement-check?{encoded}"))
+}
+
+fn format_retirement_check_table(value: &Value) -> String {
+    let status = value
+        .get("status")
+        .and_then(Value::as_str)
+        .unwrap_or("unknown");
+    let safe = value
+        .get("safe_to_retire")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+    let observed_at = value
+        .get("observed_at")
+        .and_then(Value::as_str)
+        .unwrap_or("-");
+    let change_id = value
+        .get("filters")
+        .and_then(|f| f.get("change_id"))
+        .and_then(Value::as_str)
+        .unwrap_or("-");
+    let min_safe = value
+        .get("filters")
+        .and_then(|f| f.get("min_safe_version"))
+        .and_then(Value::as_i64)
+        .map_or_else(|| "-".to_string(), |v| v.to_string());
+    let safe_str = if safe { "yes" } else { "no" };
+    let header = format!(
+        "status: {status}  safe_to_retire: {safe_str}  change_id: {change_id}  min_safe_version: {min_safe}\nobserved_at: {observed_at}"
+    );
+
+    let Some(blockers) = value.get("blockers").and_then(Value::as_array) else {
+        return format!("{header}\nNo blockers returned.");
+    };
+    if blockers.is_empty() {
+        return format!("{header}\nNo old-version executions found.");
+    }
+
+    let mut rows: Vec<Vec<String>> = Vec::with_capacity(blockers.len() + 1);
+    rows.push(vec![
+        "WORKFLOW".to_string(),
+        "VERSION".to_string(),
+        "ACTIVE".to_string(),
+        "TERMINAL".to_string(),
+        "OLDEST_AGE_S".to_string(),
+        "NEWEST_AGE_S".to_string(),
+        "SHARDS".to_string(),
+        "UNAVAILABLE".to_string(),
+    ]);
+    for blocker in blockers {
+        rows.push(vec![
+            cell_str(blocker.get("workflow_name")),
+            cell_number(blocker.get("recorded_version")),
+            cell_number(blocker.get("active_executions")),
+            cell_number(blocker.get("terminal_executions")),
+            cell_number(blocker.get("oldest_blocker_age_secs")),
+            cell_number(blocker.get("newest_blocker_age_secs")),
+            retirement_shard_array_cell(blocker, "matched_shards"),
+            retirement_shard_array_cell(blocker, "unavailable_shards"),
+        ]);
+    }
+
+    let widths = (0..rows[0].len())
+        .map(|col| rows.iter().map(|row| row[col].len()).max().unwrap_or(0))
+        .collect::<Vec<_>>();
+    let table = rows
+        .iter()
+        .map(|row| {
+            row.iter()
+                .enumerate()
+                .map(|(col, cell)| format!("{cell:<width$}", width = widths[col]))
+                .collect::<Vec<_>>()
+                .join("  ")
+                .trim_end()
+                .to_string()
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    format!("{header}\n\n{table}")
+}
+
+fn retirement_shard_array_cell(item: &Value, field: &str) -> String {
+    let Some(values) = item
+        .get("shard_coverage")
+        .and_then(|coverage| coverage.get(field))
+        .and_then(Value::as_array)
+    else {
+        return "-".to_string();
+    };
+    if values.is_empty() {
+        return "-".to_string();
+    }
+    values
+        .iter()
+        .filter_map(Value::as_i64)
+        .map(|value| value.to_string())
+        .collect::<Vec<_>>()
+        .join(",")
+}
+
 #[cfg(test)]
 mod reuse_policy_tests {
     use super::*;
@@ -2558,5 +2760,198 @@ mod reuse_policy_tests {
             "items": []
         });
         assert_eq!(version_usage_guard_exit_code(&partial), 1);
+    }
+
+    // ─── VersionGateRetirement CLI tests ─────────────────────────────────────
+
+    #[test]
+    fn version_gate_retirement_builds_correct_api_request() {
+        let cli = parse(&[
+            "version-gate-retirement",
+            "--change-id",
+            "tax_v2",
+            "--min-safe-version",
+            "2",
+        ]);
+        let req = cli.api_request().expect("request should build");
+        assert_eq!(req.method, ApiMethod::Get);
+        assert!(
+            req.path
+                .starts_with("/admin/version-gates/retirement-check"),
+            "path should target retirement-check endpoint; got {}",
+            req.path
+        );
+        assert!(req.path.contains("change_id=tax_v2"));
+        assert!(req.path.contains("min_safe_version=2"));
+    }
+
+    #[test]
+    fn version_gate_retirement_includes_optional_workflow_name() {
+        let cli = parse(&[
+            "version-gate-retirement",
+            "--change-id",
+            "tax_v2",
+            "--min-safe-version",
+            "3",
+            "--workflow-name",
+            "billing_checkout",
+        ]);
+        let req = cli.api_request().expect("request should build");
+        assert!(req.path.contains("workflow_name=billing_checkout"));
+    }
+
+    #[test]
+    fn retirement_check_exit_code_zero_on_safe() {
+        let safe = json!({ "status": "safe", "safe_to_retire": true, "blockers": [] });
+        assert_eq!(retirement_check_exit_code(&safe), 0);
+    }
+
+    #[test]
+    fn retirement_check_exit_code_nonzero_on_blocked() {
+        let blocked = json!({
+            "status": "blocked",
+            "safe_to_retire": false,
+            "blockers": [{ "active_executions": 3 }]
+        });
+        assert_eq!(retirement_check_exit_code(&blocked), 1);
+    }
+
+    #[test]
+    fn retirement_check_exit_code_nonzero_on_partial() {
+        let partial = json!({ "status": "partial", "safe_to_retire": false });
+        assert_eq!(retirement_check_exit_code(&partial), 1);
+    }
+
+    #[test]
+    fn retirement_check_exit_code_nonzero_on_unavailable() {
+        let unavailable = json!({ "status": "unavailable", "safe_to_retire": false });
+        assert_eq!(retirement_check_exit_code(&unavailable), 1);
+    }
+
+    #[test]
+    fn version_gate_retirement_check_flag_not_set_by_default() {
+        let cli = parse(&[
+            "version-gate-retirement",
+            "--change-id",
+            "tax_v2",
+            "--min-safe-version",
+            "2",
+        ]);
+        assert!(!retirement_check_should_check(&cli));
+    }
+
+    #[test]
+    fn version_gate_retirement_check_flag_set_when_passed() {
+        let cli = parse(&[
+            "version-gate-retirement",
+            "--change-id",
+            "tax_v2",
+            "--min-safe-version",
+            "2",
+            "--check",
+        ]);
+        assert!(retirement_check_should_check(&cli));
+    }
+
+    #[test]
+    fn version_gate_retirement_default_output_renders_table() {
+        let cli = parse(&[
+            "version-gate-retirement",
+            "--change-id",
+            "tax_v2",
+            "--min-safe-version",
+            "2",
+        ]);
+        let payload = json!({
+            "status": "blocked",
+            "safe_to_retire": false,
+            "observed_at": "2026-05-07T12:00:00Z",
+            "filters": {
+                "change_id": "tax_v2",
+                "min_safe_version": 2,
+                "workflow_name": null,
+                "state_group": "all",
+                "shard_id": null
+            },
+            "blockers": [{
+                "workflow_name": "billing_checkout",
+                "change_id": "tax_v2",
+                "recorded_version": 1,
+                "active_executions": 2,
+                "terminal_executions": 5,
+                "oldest_blocker_age_secs": 3600,
+                "newest_blocker_age_secs": 60,
+                "sample_active_execution_ids": [],
+                "shard_coverage": {
+                    "inspected_shards": [0],
+                    "matched_shards": [0],
+                    "unavailable_shards": []
+                }
+            }],
+            "shards": [{ "shard_id": 0, "status": "inspected", "matched_groups": 1, "error": null }]
+        });
+
+        let rendered = render_response(&cli, &payload).expect("table should render");
+
+        assert!(rendered.contains("WORKFLOW"));
+        assert!(rendered.contains("billing_checkout"));
+        assert!(rendered.contains("blocked"));
+        assert!(rendered.contains("tax_v2"));
+        assert!(!rendered.trim_start().starts_with('{'));
+    }
+
+    #[test]
+    fn version_gate_retirement_json_output_preserves_raw_payload() {
+        let cli = parse(&[
+            "--output",
+            "json",
+            "version-gate-retirement",
+            "--change-id",
+            "tax_v2",
+            "--min-safe-version",
+            "2",
+        ]);
+        let payload = json!({
+            "status": "safe",
+            "safe_to_retire": true,
+            "observed_at": "2026-05-07T12:00:00Z",
+            "filters": {},
+            "blockers": [],
+            "shards": []
+        });
+
+        let rendered = render_response(&cli, &payload).expect("json output should render");
+
+        assert!(rendered.trim_start().starts_with('{'));
+        assert!(rendered.contains("\"safe_to_retire\":true"));
+    }
+
+    #[test]
+    fn version_gate_retirement_empty_blockers_shows_no_old_version_message() {
+        let cli = parse(&[
+            "version-gate-retirement",
+            "--change-id",
+            "tax_v2",
+            "--min-safe-version",
+            "2",
+        ]);
+        let payload = json!({
+            "status": "safe",
+            "safe_to_retire": true,
+            "observed_at": "2026-05-07T12:00:00Z",
+            "filters": {
+                "change_id": "tax_v2",
+                "min_safe_version": 2,
+                "workflow_name": null,
+                "state_group": "all",
+                "shard_id": null
+            },
+            "blockers": [],
+            "shards": [{ "shard_id": 0, "status": "inspected", "matched_groups": 0, "error": null }]
+        });
+
+        let rendered = render_response(&cli, &payload).expect("table should render");
+
+        assert!(rendered.contains("No old-version executions found"));
     }
 }

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -79,6 +79,7 @@ use crate::preflight::{PreflightReport, build_preflight_report};
 use crate::shard_health::{ShardHealthReport, ShardReadiness, build_shard_health_report};
 use crate::state::HarvestDbPool;
 use crate::version_usage::{VersionUsageQuery, build_version_usage_report};
+use crate::version_gate_retirement::{RetirementCheckQuery, build_retirement_check_report};
 
 #[derive(Clone)]
 pub struct HarvestRetentionRuntime {
@@ -844,6 +845,10 @@ pub fn harvest_api_router(api_state: HarvestApiState) -> Router<AppState> {
         .route("/admin/preflight", get(preflight))
         .route("/admin/shards/health", get(shards_health))
         .route("/admin/version-gates/usage", get(version_usage))
+        .route(
+            "/admin/version-gates/retirement-check",
+            get(version_gate_retirement_check),
+        )
         .route("/admin/retention", get(retention_status))
         .route("/admin/retention/run-now", post(retention_run_now))
         .route("/admin/concurrency", get(concurrency_status))
@@ -904,6 +909,16 @@ async fn version_usage(
     Query(query): Query<VersionUsageQuery>,
 ) -> axum::response::Response {
     match build_version_usage_report(&api_state, query).await {
+        Ok(report) => Json(report).into_response(),
+        Err(error) => error.into_response(),
+    }
+}
+
+async fn version_gate_retirement_check(
+    Extension(api_state): Extension<HarvestApiState>,
+    Query(query): Query<RetirementCheckQuery>,
+) -> axum::response::Response {
+    match build_retirement_check_report(&api_state, query).await {
         Ok(report) => Json(report).into_response(),
         Err(error) => error.into_response(),
     }

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -78,8 +78,8 @@ use autumn_harvest::{
 use crate::preflight::{PreflightReport, build_preflight_report};
 use crate::shard_health::{ShardHealthReport, ShardReadiness, build_shard_health_report};
 use crate::state::HarvestDbPool;
-use crate::version_usage::{VersionUsageQuery, build_version_usage_report};
 use crate::version_gate_retirement::{RetirementCheckQuery, build_retirement_check_report};
+use crate::version_usage::{VersionUsageQuery, build_version_usage_report};
 
 #[derive(Clone)]
 pub struct HarvestRetentionRuntime {

--- a/autumn-harvest-plugin/src/lib.rs
+++ b/autumn-harvest-plugin/src/lib.rs
@@ -11,6 +11,7 @@ pub mod shard_health;
 pub mod state;
 pub mod ui;
 pub mod version_usage;
+pub mod version_gate_retirement;
 
 pub use api::{HarvestApiRuntime, HarvestApiState, HarvestRetentionRuntime, harvest_api_router};
 pub use config::{

--- a/autumn-harvest-plugin/src/lib.rs
+++ b/autumn-harvest-plugin/src/lib.rs
@@ -10,8 +10,8 @@ pub mod runner;
 pub mod shard_health;
 pub mod state;
 pub mod ui;
-pub mod version_usage;
 pub mod version_gate_retirement;
+pub mod version_usage;
 
 pub use api::{HarvestApiRuntime, HarvestApiState, HarvestRetentionRuntime, harvest_api_router};
 pub use config::{

--- a/autumn-harvest-plugin/src/version_gate_retirement.rs
+++ b/autumn-harvest-plugin/src/version_gate_retirement.rs
@@ -329,10 +329,7 @@ fn build_report_from_observations(
         .collect::<Vec<_>>();
 
     let status = compute_status(
-        blockers
-            .iter()
-            .map(|b| b.active_executions)
-            .sum::<i64>(),
+        blockers.iter().map(|b| b.active_executions).sum::<i64>(),
         inspected_shards.is_empty(),
         unavailable_shards.is_empty(),
     );
@@ -528,7 +525,10 @@ mod tests {
         );
         assert_eq!(report.status, RetirementCheckStatus::Partial);
         assert!(!report.safe_to_retire);
-        assert_eq!(report.blockers[0].shard_coverage.unavailable_shards, vec![1]);
+        assert_eq!(
+            report.blockers[0].shard_coverage.unavailable_shards,
+            vec![1]
+        );
     }
 
     #[test]
@@ -568,10 +568,7 @@ mod tests {
         assert_eq!(report.blockers.len(), 1);
         assert_eq!(report.blockers[0].active_executions, 6);
         assert_eq!(report.blockers[0].terminal_executions, 4);
-        assert_eq!(
-            report.blockers[0].shard_coverage.matched_shards,
-            vec![0, 1]
-        );
+        assert_eq!(report.blockers[0].shard_coverage.matched_shards, vec![0, 1]);
     }
 
     #[test]

--- a/autumn-harvest-plugin/src/version_gate_retirement.rs
+++ b/autumn-harvest-plugin/src/version_gate_retirement.rs
@@ -1,0 +1,611 @@
+//! Management read model for the version-gate retirement check.
+//!
+//! Answers "is change id X safe to retire below version N?" by aggregating
+//! [`load_retirement_check`] results across all configured shards and surfacing
+//! per-shard availability status so callers know whether the result is
+//! conclusive.
+
+use std::collections::{BTreeMap, BTreeSet};
+
+use autumn_harvest::version_gate_retirement::{
+    RetirementCheckFilters, RetirementCheckShardRow, load_retirement_check,
+};
+use autumn_harvest::version_usage::VersionExecutionStateGroup;
+use autumn_harvest::worker::DbPool;
+use autumn_web::error::AutumnError;
+use chrono::{DateTime, Utc};
+use futures::future::join_all;
+use serde::{Deserialize, Serialize};
+use uuid::Uuid;
+
+use crate::api::{HarvestApiState, map_error};
+
+/// Query string accepted by `GET /admin/version-gates/retirement-check`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct RetirementCheckQuery {
+    /// Change id to inspect (required).
+    pub change_id: String,
+    /// Versions strictly below this value are considered "old branches to retire".
+    pub min_safe_version: u32,
+    /// Narrow results to this workflow name.
+    pub workflow_name: Option<String>,
+    /// `"active"`, `"terminal"`, or `"all"` (default `"all"`).
+    pub state_group: Option<String>,
+    /// Restrict inspection to one shard.
+    pub shard_id: Option<i32>,
+}
+
+/// Overall retirement-check report status.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RetirementCheckStatus {
+    /// All shards were inspected and no active old-version executions remain.
+    Safe,
+    /// All shards were inspected but active old-version executions still exist.
+    Blocked,
+    /// Some shards were inspected; at least one was unavailable.
+    Partial,
+    /// No shards could be inspected.
+    Unavailable,
+}
+
+impl RetirementCheckStatus {
+    #[must_use]
+    pub const fn is_safe(self) -> bool {
+        matches!(self, Self::Safe)
+    }
+}
+
+/// Per-shard inspection status.
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum RetirementShardInspectionStatus {
+    Inspected,
+    Unavailable,
+}
+
+/// Top-level report returned by `GET /admin/version-gates/retirement-check`.
+#[derive(Debug, Clone, Serialize)]
+pub struct RetirementCheckReport {
+    pub status: RetirementCheckStatus,
+    /// `true` only when `status == "safe"` — all shards inspected, zero active blockers.
+    pub safe_to_retire: bool,
+    pub observed_at: DateTime<Utc>,
+    pub filters: RetirementCheckReportFilters,
+    /// One row per `(workflow_name, recorded_version)` group that has at least one
+    /// execution with a version below `min_safe_version`.
+    pub blockers: Vec<RetirementBlockerReportRow>,
+    pub shards: Vec<RetirementShardInspection>,
+}
+
+/// Echo of the filters applied to the report.
+#[derive(Debug, Clone, Serialize)]
+pub struct RetirementCheckReportFilters {
+    pub change_id: String,
+    pub min_safe_version: u32,
+    pub workflow_name: Option<String>,
+    pub state_group: VersionExecutionStateGroup,
+    pub shard_id: Option<i32>,
+}
+
+/// Aggregated blocker row across all inspected shards.
+#[derive(Debug, Clone, Serialize)]
+pub struct RetirementBlockerReportRow {
+    pub workflow_name: String,
+    pub change_id: String,
+    pub recorded_version: u32,
+    pub active_executions: i64,
+    pub terminal_executions: i64,
+    pub oldest_blocker_started_at: DateTime<Utc>,
+    pub newest_blocker_started_at: DateTime<Utc>,
+    pub oldest_blocker_age_secs: i64,
+    pub newest_blocker_age_secs: i64,
+    /// Sample of active execution IDs (up to 10 per shard, deduplicated).
+    pub sample_active_execution_ids: Vec<Uuid>,
+    pub shard_coverage: RetirementShardCoverage,
+}
+
+/// Per-row shard coverage metadata.
+#[derive(Debug, Clone, Serialize)]
+pub struct RetirementShardCoverage {
+    pub inspected_shards: Vec<i32>,
+    pub matched_shards: Vec<i32>,
+    pub unavailable_shards: Vec<i32>,
+}
+
+/// Per-shard inspection summary included in every report.
+#[derive(Debug, Clone, Serialize)]
+pub struct RetirementShardInspection {
+    pub shard_id: i32,
+    pub status: RetirementShardInspectionStatus,
+    pub matched_groups: Option<usize>,
+    pub error: Option<String>,
+}
+
+#[derive(Debug)]
+struct ShardObservation {
+    shard_id: i32,
+    rows: Vec<RetirementCheckShardRow>,
+    error: Option<String>,
+}
+
+#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd)]
+struct RetirementKey {
+    workflow_name: String,
+    change_id: String,
+    recorded_version: u32,
+}
+
+#[derive(Debug)]
+struct RetirementAccumulator {
+    active_executions: i64,
+    terminal_executions: i64,
+    oldest_blocker_started_at: DateTime<Utc>,
+    newest_blocker_started_at: DateTime<Utc>,
+    matched_shards: BTreeSet<i32>,
+    sample_active_execution_ids: Vec<Uuid>,
+}
+
+/// Build the retirement-check report without mutating workflow state.
+///
+/// # Errors
+///
+/// Returns an [`AutumnError`] when the `state_group` query parameter contains
+/// an unknown value.
+pub async fn build_retirement_check_report(
+    api_state: &HarvestApiState,
+    query: RetirementCheckQuery,
+) -> Result<RetirementCheckReport, AutumnError> {
+    let observed_at = Utc::now();
+    let state_group = query
+        .state_group
+        .as_deref()
+        .unwrap_or("all")
+        .parse::<VersionExecutionStateGroup>()
+        .map_err(map_error)?;
+
+    let filters = RetirementCheckFilters {
+        workflow_name: query.workflow_name.clone(),
+        change_id: query.change_id.clone(),
+        min_safe_version: query.min_safe_version,
+        state_group,
+        shard_id: query.shard_id,
+    };
+
+    let expected_shards = expected_shards(api_state, query.shard_id);
+    let pools = pools_by_shard(api_state);
+
+    let observations = expected_shards
+        .iter()
+        .map(|shard_id| {
+            let pool = pools.get(shard_id).cloned();
+            observe_shard(*shard_id, pool, filters.clone())
+        })
+        .collect::<Vec<_>>();
+    let observations = join_all(observations).await;
+
+    Ok(build_report_from_observations(
+        observed_at,
+        RetirementCheckReportFilters {
+            change_id: query.change_id,
+            min_safe_version: query.min_safe_version,
+            workflow_name: query.workflow_name,
+            state_group,
+            shard_id: query.shard_id,
+        },
+        observations,
+    ))
+}
+
+fn expected_shards(api_state: &HarvestApiState, shard_filter: Option<i32>) -> BTreeSet<i32> {
+    if let Some(shard_id) = shard_filter {
+        return BTreeSet::from([shard_id]);
+    }
+
+    let mut shards = BTreeSet::new();
+    if let Ok(pool) = api_state.storage_pool() {
+        shards.extend(pool.iter_shards().map(|(shard, _)| shard.as_i32()));
+    }
+    if let Ok(runtime) = api_state.runtime() {
+        shards.extend(
+            runtime
+                .router()
+                .readable_shards()
+                .iter()
+                .map(|shard| shard.as_i32()),
+        );
+        shards.insert(runtime.router().default_shard().as_i32());
+    }
+    if shards.is_empty() {
+        shards.insert(0);
+    }
+    shards
+}
+
+fn pools_by_shard(api_state: &HarvestApiState) -> BTreeMap<i32, DbPool> {
+    api_state.storage_pool().map_or_else(
+        |_| BTreeMap::new(),
+        |pool| {
+            pool.iter_shards()
+                .map(|(shard, db_pool)| (shard.as_i32(), db_pool.clone()))
+                .collect()
+        },
+    )
+}
+
+async fn observe_shard(
+    shard_id: i32,
+    pool: Option<DbPool>,
+    mut filters: RetirementCheckFilters,
+) -> ShardObservation {
+    let Some(pool) = pool else {
+        return ShardObservation {
+            shard_id,
+            rows: Vec::new(),
+            error: Some(format!("shard {shard_id} has no configured storage pool")),
+        };
+    };
+
+    filters.shard_id = Some(shard_id);
+    let Ok(mut conn) = pool.get().await else {
+        return ShardObservation {
+            shard_id,
+            rows: Vec::new(),
+            error: Some(format!(
+                "database connection for shard {shard_id} could not be acquired"
+            )),
+        };
+    };
+
+    match load_retirement_check(&mut conn, &filters).await {
+        Ok(rows) => ShardObservation {
+            shard_id,
+            rows,
+            error: None,
+        },
+        Err(error) => ShardObservation {
+            shard_id,
+            rows: Vec::new(),
+            error: Some(error.to_string()),
+        },
+    }
+}
+
+fn build_report_from_observations(
+    observed_at: DateTime<Utc>,
+    filters: RetirementCheckReportFilters,
+    observations: Vec<ShardObservation>,
+) -> RetirementCheckReport {
+    let inspected_shards = observations
+        .iter()
+        .filter(|o| o.error.is_none())
+        .map(|o| o.shard_id)
+        .collect::<BTreeSet<_>>();
+    let unavailable_shards = observations
+        .iter()
+        .filter(|o| o.error.is_some())
+        .map(|o| o.shard_id)
+        .collect::<BTreeSet<_>>();
+
+    let mut rows = BTreeMap::<RetirementKey, RetirementAccumulator>::new();
+    for observation in &observations {
+        for row in &observation.rows {
+            let key = RetirementKey {
+                workflow_name: row.workflow_name.clone(),
+                change_id: row.change_id.clone(),
+                recorded_version: row.recorded_version,
+            };
+            rows.entry(key)
+                .and_modify(|acc| merge_row(acc, row))
+                .or_insert_with(|| accumulator_from_row(row));
+        }
+    }
+
+    let blockers = rows
+        .into_iter()
+        .map(|(key, acc)| {
+            blocker_from_accumulator(
+                key,
+                &acc,
+                &inspected_shards,
+                &unavailable_shards,
+                observed_at,
+            )
+        })
+        .collect::<Vec<_>>();
+
+    let shards = observations
+        .into_iter()
+        .map(|o| RetirementShardInspection {
+            shard_id: o.shard_id,
+            status: if o.error.is_some() {
+                RetirementShardInspectionStatus::Unavailable
+            } else {
+                RetirementShardInspectionStatus::Inspected
+            },
+            matched_groups: o.error.as_ref().map_or(Some(o.rows.len()), |_| None),
+            error: o.error,
+        })
+        .collect::<Vec<_>>();
+
+    let status = compute_status(
+        blockers
+            .iter()
+            .map(|b| b.active_executions)
+            .sum::<i64>(),
+        inspected_shards.is_empty(),
+        unavailable_shards.is_empty(),
+    );
+
+    RetirementCheckReport {
+        safe_to_retire: status.is_safe(),
+        status,
+        observed_at,
+        filters,
+        blockers,
+        shards,
+    }
+}
+
+fn merge_row(acc: &mut RetirementAccumulator, row: &RetirementCheckShardRow) {
+    acc.active_executions += row.active_executions;
+    acc.terminal_executions += row.terminal_executions;
+    acc.oldest_blocker_started_at = acc
+        .oldest_blocker_started_at
+        .min(row.oldest_blocker_started_at);
+    acc.newest_blocker_started_at = acc
+        .newest_blocker_started_at
+        .max(row.newest_blocker_started_at);
+    acc.matched_shards.insert(row.shard_id);
+    acc.sample_active_execution_ids
+        .extend_from_slice(&row.sample_active_execution_ids);
+    acc.sample_active_execution_ids.truncate(10);
+}
+
+fn accumulator_from_row(row: &RetirementCheckShardRow) -> RetirementAccumulator {
+    RetirementAccumulator {
+        active_executions: row.active_executions,
+        terminal_executions: row.terminal_executions,
+        oldest_blocker_started_at: row.oldest_blocker_started_at,
+        newest_blocker_started_at: row.newest_blocker_started_at,
+        matched_shards: BTreeSet::from([row.shard_id]),
+        sample_active_execution_ids: row.sample_active_execution_ids.clone(),
+    }
+}
+
+fn blocker_from_accumulator(
+    key: RetirementKey,
+    acc: &RetirementAccumulator,
+    inspected_shards: &BTreeSet<i32>,
+    unavailable_shards: &BTreeSet<i32>,
+    observed_at: DateTime<Utc>,
+) -> RetirementBlockerReportRow {
+    RetirementBlockerReportRow {
+        workflow_name: key.workflow_name,
+        change_id: key.change_id,
+        recorded_version: key.recorded_version,
+        active_executions: acc.active_executions,
+        terminal_executions: acc.terminal_executions,
+        oldest_blocker_started_at: acc.oldest_blocker_started_at,
+        newest_blocker_started_at: acc.newest_blocker_started_at,
+        oldest_blocker_age_secs: age_secs(observed_at, acc.oldest_blocker_started_at),
+        newest_blocker_age_secs: age_secs(observed_at, acc.newest_blocker_started_at),
+        sample_active_execution_ids: acc.sample_active_execution_ids.clone(),
+        shard_coverage: RetirementShardCoverage {
+            inspected_shards: inspected_shards.iter().copied().collect(),
+            matched_shards: acc.matched_shards.iter().copied().collect(),
+            unavailable_shards: unavailable_shards.iter().copied().collect(),
+        },
+    }
+}
+
+fn age_secs(observed_at: DateTime<Utc>, started_at: DateTime<Utc>) -> i64 {
+    observed_at
+        .signed_duration_since(started_at)
+        .num_seconds()
+        .max(0)
+}
+
+const fn compute_status(
+    total_active: i64,
+    no_inspected_shards: bool,
+    no_unavailable_shards: bool,
+) -> RetirementCheckStatus {
+    if no_inspected_shards {
+        RetirementCheckStatus::Unavailable
+    } else if !no_unavailable_shards {
+        RetirementCheckStatus::Partial
+    } else if total_active > 0 {
+        RetirementCheckStatus::Blocked
+    } else {
+        RetirementCheckStatus::Safe
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::TimeZone as _;
+
+    fn at(seconds: i64) -> DateTime<Utc> {
+        Utc.timestamp_opt(seconds, 0).unwrap()
+    }
+
+    fn shard_row(
+        shard_id: i32,
+        workflow_name: &str,
+        change_id: &str,
+        recorded_version: u32,
+        active_executions: i64,
+        terminal_executions: i64,
+    ) -> RetirementCheckShardRow {
+        RetirementCheckShardRow {
+            workflow_name: workflow_name.to_string(),
+            change_id: change_id.to_string(),
+            recorded_version,
+            active_executions,
+            terminal_executions,
+            oldest_blocker_started_at: at(100),
+            newest_blocker_started_at: at(200),
+            sample_active_execution_ids: Vec::new(),
+            shard_id,
+        }
+    }
+
+    fn default_filters() -> RetirementCheckReportFilters {
+        RetirementCheckReportFilters {
+            change_id: "tax_v2".to_string(),
+            min_safe_version: 2,
+            workflow_name: None,
+            state_group: VersionExecutionStateGroup::All,
+            shard_id: None,
+        }
+    }
+
+    #[test]
+    fn safe_status_when_no_active_executions_and_all_shards_inspected() {
+        let report = build_report_from_observations(
+            at(300),
+            default_filters(),
+            vec![ShardObservation {
+                shard_id: 0,
+                rows: vec![shard_row(0, "billing", "tax_v2", 1, 0, 5)],
+                error: None,
+            }],
+        );
+        assert_eq!(report.status, RetirementCheckStatus::Safe);
+        assert!(report.safe_to_retire);
+    }
+
+    #[test]
+    fn blocked_status_when_active_executions_exist() {
+        let report = build_report_from_observations(
+            at(300),
+            default_filters(),
+            vec![ShardObservation {
+                shard_id: 0,
+                rows: vec![shard_row(0, "billing", "tax_v2", 1, 3, 7)],
+                error: None,
+            }],
+        );
+        assert_eq!(report.status, RetirementCheckStatus::Blocked);
+        assert!(!report.safe_to_retire);
+        assert_eq!(report.blockers[0].active_executions, 3);
+    }
+
+    #[test]
+    fn unavailable_status_when_all_shards_fail() {
+        let report = build_report_from_observations(
+            at(300),
+            default_filters(),
+            vec![ShardObservation {
+                shard_id: 0,
+                rows: Vec::new(),
+                error: Some("connection refused".to_string()),
+            }],
+        );
+        assert_eq!(report.status, RetirementCheckStatus::Unavailable);
+        assert!(!report.safe_to_retire);
+    }
+
+    #[test]
+    fn partial_status_when_one_shard_unavailable() {
+        let report = build_report_from_observations(
+            at(300),
+            default_filters(),
+            vec![
+                ShardObservation {
+                    shard_id: 0,
+                    rows: vec![shard_row(0, "billing", "tax_v2", 1, 0, 5)],
+                    error: None,
+                },
+                ShardObservation {
+                    shard_id: 1,
+                    rows: Vec::new(),
+                    error: Some("pool missing".to_string()),
+                },
+            ],
+        );
+        assert_eq!(report.status, RetirementCheckStatus::Partial);
+        assert!(!report.safe_to_retire);
+        assert_eq!(report.blockers[0].shard_coverage.unavailable_shards, vec![1]);
+    }
+
+    #[test]
+    fn empty_report_when_no_markers_found() {
+        let report = build_report_from_observations(
+            at(300),
+            default_filters(),
+            vec![ShardObservation {
+                shard_id: 0,
+                rows: Vec::new(),
+                error: None,
+            }],
+        );
+        assert_eq!(report.status, RetirementCheckStatus::Safe);
+        assert!(report.safe_to_retire);
+        assert!(report.blockers.is_empty());
+    }
+
+    #[test]
+    fn cross_shard_active_counts_are_summed() {
+        let report = build_report_from_observations(
+            at(300),
+            default_filters(),
+            vec![
+                ShardObservation {
+                    shard_id: 0,
+                    rows: vec![shard_row(0, "billing", "tax_v2", 1, 2, 3)],
+                    error: None,
+                },
+                ShardObservation {
+                    shard_id: 1,
+                    rows: vec![shard_row(1, "billing", "tax_v2", 1, 4, 1)],
+                    error: None,
+                },
+            ],
+        );
+        assert_eq!(report.blockers.len(), 1);
+        assert_eq!(report.blockers[0].active_executions, 6);
+        assert_eq!(report.blockers[0].terminal_executions, 4);
+        assert_eq!(
+            report.blockers[0].shard_coverage.matched_shards,
+            vec![0, 1]
+        );
+    }
+
+    #[test]
+    fn multiple_old_versions_produce_separate_blocker_rows() {
+        let report = build_report_from_observations(
+            at(300),
+            default_filters(),
+            vec![ShardObservation {
+                shard_id: 0,
+                rows: vec![
+                    shard_row(0, "billing", "tax_v2", 1, 1, 0),
+                    shard_row(0, "billing", "tax_v2", 0, 0, 2),
+                ],
+                error: None,
+            }],
+        );
+        assert_eq!(report.blockers.len(), 2);
+        let versions: Vec<u32> = report.blockers.iter().map(|b| b.recorded_version).collect();
+        assert!(versions.contains(&0));
+        assert!(versions.contains(&1));
+    }
+
+    #[test]
+    fn status_serializes_as_snake_case() {
+        let blocked = serde_json::to_value(RetirementCheckStatus::Blocked).unwrap();
+        assert_eq!(blocked, serde_json::json!("blocked"));
+
+        let safe = serde_json::to_value(RetirementCheckStatus::Safe).unwrap();
+        assert_eq!(safe, serde_json::json!("safe"));
+
+        let partial = serde_json::to_value(RetirementCheckStatus::Partial).unwrap();
+        assert_eq!(partial, serde_json::json!("partial"));
+
+        let unavailable = serde_json::to_value(RetirementCheckStatus::Unavailable).unwrap();
+        assert_eq!(unavailable, serde_json::json!("unavailable"));
+    }
+}

--- a/autumn-harvest-plugin/tests/retirement_check_integration.rs
+++ b/autumn-harvest-plugin/tests/retirement_check_integration.rs
@@ -287,7 +287,10 @@ async fn retirement_check_blocked_while_v1_running_safe_after_terminal() {
     .await;
 
     assert_eq!(status, StatusCode::OK, "body: {body}");
-    assert_eq!(body["status"], "blocked", "v1 running should block retirement");
+    assert_eq!(
+        body["status"], "blocked",
+        "v1 running should block retirement"
+    );
     assert_eq!(body["safe_to_retire"], false);
 
     let blockers = body["blockers"].as_array().expect("blockers array");
@@ -318,8 +321,7 @@ async fn retirement_check_blocked_while_v1_running_safe_after_terminal() {
     )
     .set((
         autumn_harvest::schema::harvest_workflow_executions::state.eq("COMPLETED"),
-        autumn_harvest::schema::harvest_workflow_executions::completed_at
-            .eq(Some(Utc::now())),
+        autumn_harvest::schema::harvest_workflow_executions::completed_at.eq(Some(Utc::now())),
     ))
     .execute(&mut conn)
     .await

--- a/autumn-harvest-plugin/tests/retirement_check_integration.rs
+++ b/autumn-harvest-plugin/tests/retirement_check_integration.rs
@@ -208,6 +208,64 @@ async fn insert_versioned_execution(
     exec_id
 }
 
+/// Insert a workflow execution with NO version marker (pre-gate execution).
+async fn insert_execution_without_marker(
+    database_url: &str,
+    shard: ShardId,
+    workflow_name: &str,
+    workflow_id: &str,
+    state: &str,
+) -> ExecutionId {
+    let exec_id = ExecutionId::new_for_shard(shard);
+    let mut conn = <AsyncPgConnection as AsyncConnection>::establish(database_url)
+        .await
+        .expect("failed to connect to test database");
+    let row = NewWorkflowExecution {
+        id: exec_id.as_uuid(),
+        workflow_name,
+        workflow_id,
+        run_id: uuid::Uuid::new_v4(),
+        shard_id: shard.as_i32(),
+        input: json!({}),
+        parent_id: None,
+        queue_name: "default",
+        execution_timeout: None,
+        memo: None,
+        search_attrs: None,
+    };
+    diesel::insert_into(autumn_harvest::schema::harvest_workflow_executions::table)
+        .values(&row)
+        .execute(&mut conn)
+        .await
+        .expect("failed to insert workflow execution");
+
+    let completed_at = if state == "RUNNING" {
+        None
+    } else {
+        Some(Utc::now())
+    };
+    diesel::update(
+        autumn_harvest::schema::harvest_workflow_executions::table.find(exec_id.as_uuid()),
+    )
+    .set((
+        autumn_harvest::schema::harvest_workflow_executions::state.eq(state),
+        autumn_harvest::schema::harvest_workflow_executions::completed_at.eq(completed_at),
+    ))
+    .execute(&mut conn)
+    .await
+    .expect("failed to update workflow state");
+
+    // Only append WorkflowStarted — no MarkerRecorded event for any change id.
+    let events = vec![WorkflowEvent::WorkflowStarted {
+        input: json!({}),
+        timestamp: Utc::now(),
+    }];
+    store::append_events(&mut conn, exec_id, &events, 0)
+        .await
+        .expect("failed to append start event");
+    exec_id
+}
+
 // ─── Tests ───────────────────────────────────────────────────────────────────
 
 #[tokio::test]
@@ -477,4 +535,92 @@ async fn retirement_check_degraded_when_one_shard_unavailable() {
         .find(|s| s["status"] == "unavailable")
         .expect("exactly one unavailable shard");
     assert_eq!(unavailable_shard["shard_id"], 1);
+}
+
+/// Executions that started before a version gate was inserted carry no
+/// `MarkerRecorded` event for that change id.  When the gate is later added to
+/// the code and `workflow_name` is supplied to the retirement check, these
+/// pre-gate executions must appear as blockers (recorded_version = 0) so that
+/// operators are not misled into retiring the old branch prematurely.
+#[tokio::test]
+async fn retirement_check_includes_pre_gate_executions_as_blockers() {
+    let (database_url, _container) = setup_database_url_with_migrations().await;
+
+    // Insert an execution that has no version marker for "billing_v3_tax" at all.
+    let pre_gate_id = insert_execution_without_marker(
+        &database_url,
+        ShardId::new(0),
+        "billing_checkout",
+        "pre-gate-run",
+        "RUNNING",
+    )
+    .await;
+
+    // Also insert a properly-gated v1 execution for the same workflow.
+    insert_versioned_execution(
+        &database_url,
+        ShardId::new(0),
+        "billing_checkout",
+        "gated-v1",
+        "RUNNING",
+        "billing_v3_tax",
+        1,
+    )
+    .await;
+
+    let app = build_api_app(
+        HarvestDbPool::single(build_test_pool(&database_url)),
+        ShardRouter::single(),
+    );
+
+    // Without workflow_name: pre-gate execution is invisible (no marker to match).
+    let (status_no_wf, body_no_wf) = get_json(
+        &app,
+        "/admin/version-gates/retirement-check?change_id=billing_v3_tax&min_safe_version=2",
+    )
+    .await;
+    assert_eq!(status_no_wf, StatusCode::OK, "body: {body_no_wf}");
+    let total_active_no_wf: i64 = body_no_wf["blockers"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|b| b["active_executions"].as_i64())
+        .sum();
+    assert_eq!(
+        total_active_no_wf, 1,
+        "without workflow_name filter only the gated v1 execution is visible"
+    );
+
+    // With workflow_name: pre-gate execution must appear as a blocker.
+    let (status, body) = get_json(
+        &app,
+        "/admin/version-gates/retirement-check?change_id=billing_v3_tax&min_safe_version=2&workflow_name=billing_checkout",
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    assert_eq!(body["status"], "blocked");
+    assert_eq!(body["safe_to_retire"], false);
+
+    // There must be a blocker row with recorded_version=0 for pre-gate executions.
+    let blockers = body["blockers"].as_array().expect("blockers array");
+    let pre_gate_row = blockers
+        .iter()
+        .find(|b| b["recorded_version"] == 0)
+        .expect("pre-gate blocker row with recorded_version=0 must be present");
+    assert!(
+        pre_gate_row["active_executions"].as_i64().unwrap() >= 1,
+        "pre-gate row must count the markerless running execution"
+    );
+
+    // The pre-gate execution id should appear in sample_active_execution_ids.
+    let sample_ids: Vec<String> = pre_gate_row["sample_active_execution_ids"]
+        .as_array()
+        .expect("sample ids")
+        .iter()
+        .filter_map(|v| v.as_str().map(ToString::to_string))
+        .collect();
+    assert!(
+        sample_ids.contains(&pre_gate_id.as_uuid().to_string()),
+        "pre-gate execution must be listed in sample ids; got {sample_ids:?}"
+    );
 }

--- a/autumn-harvest-plugin/tests/retirement_check_integration.rs
+++ b/autumn-harvest-plugin/tests/retirement_check_integration.rs
@@ -1,0 +1,478 @@
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use autumn_harvest::WorkflowEvent;
+use autumn_harvest::models::NewWorkflowExecution;
+use autumn_harvest::policy::WorkflowSchedule;
+use autumn_harvest::scheduler::{DagCatalog, SchedulerMonitor};
+use autumn_harvest::shard::{ShardRouter, ShardedDbPool};
+use autumn_harvest::store;
+use autumn_harvest::types::{ExecutionId, ShardId};
+use autumn_harvest::worker::{DbPool, HandlerRegistry};
+use autumn_harvest_plugin::HarvestDbPool;
+use autumn_harvest_plugin::api::{
+    HarvestApiRuntime, HarvestApiState, HarvestRetentionRuntime, harvest_api_router,
+};
+use autumn_web::reexports::axum;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use chrono::Utc;
+use diesel::{ExpressionMethods, QueryDsl};
+use diesel_async::pooled_connection::AsyncDieselConnectionManager;
+use diesel_async::{AsyncConnection, AsyncPgConnection, RunQueryDsl};
+use serde_json::{Value, json};
+use testcontainers::ContainerAsync;
+use testcontainers_modules::postgres::Postgres;
+use testcontainers_modules::testcontainers::runners::AsyncRunner;
+use tower::ServiceExt;
+
+type HarvestApiApp = axum::Router;
+
+fn build_test_pool(database_url: &str) -> DbPool {
+    let manager = AsyncDieselConnectionManager::<AsyncPgConnection>::new(database_url);
+    deadpool::managed::Pool::builder(manager)
+        .max_size(4)
+        .build()
+        .expect("failed to build test pool")
+}
+
+async fn setup_database_url_with_migrations() -> (String, ContainerAsync<Postgres>) {
+    let container = Postgres::default()
+        .start()
+        .await
+        .expect("failed to start Postgres container");
+    let host = container
+        .get_host()
+        .await
+        .expect("failed to get container host");
+    let port = container
+        .get_host_port_ipv4(5432)
+        .await
+        .expect("failed to get container port");
+    let url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+    autumn_web::migrate::run_pending(&url, autumn_harvest::MIGRATIONS)
+        .expect("failed to run Harvest migrations");
+    (url, container)
+}
+
+async fn setup_two_shards_with_migrations() -> ((String, String), ContainerAsync<Postgres>) {
+    let container = Postgres::default()
+        .start()
+        .await
+        .expect("failed to start Postgres container");
+    let host = container
+        .get_host()
+        .await
+        .expect("failed to get container host");
+    let port = container
+        .get_host_port_ipv4(5432)
+        .await
+        .expect("failed to get container port");
+    let admin_url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+    let shard0_db = format!("harvest_retirement_0_{}", uuid::Uuid::new_v4().simple());
+    let shard1_db = format!("harvest_retirement_1_{}", uuid::Uuid::new_v4().simple());
+
+    let mut admin_conn = <AsyncPgConnection as AsyncConnection>::establish(&admin_url)
+        .await
+        .expect("failed to connect to admin database");
+    diesel::sql_query(format!("CREATE DATABASE {shard0_db}"))
+        .execute(&mut admin_conn)
+        .await
+        .expect("failed to create shard 0 database");
+    diesel::sql_query(format!("CREATE DATABASE {shard1_db}"))
+        .execute(&mut admin_conn)
+        .await
+        .expect("failed to create shard 1 database");
+
+    let shard0_url = format!("postgres://postgres:postgres@{host}:{port}/{shard0_db}");
+    let shard1_url = format!("postgres://postgres:postgres@{host}:{port}/{shard1_db}");
+    autumn_web::migrate::run_pending(&shard0_url, autumn_harvest::MIGRATIONS)
+        .expect("failed to migrate shard 0");
+    autumn_web::migrate::run_pending(&shard1_url, autumn_harvest::MIGRATIONS)
+        .expect("failed to migrate shard 1");
+    ((shard0_url, shard1_url), container)
+}
+
+fn build_two_shard_pool(shard0_url: &str, shard1_url: &str) -> HarvestDbPool {
+    let mut pools = BTreeMap::new();
+    pools.insert(ShardId::new(0), build_test_pool(shard0_url));
+    pools.insert(ShardId::new(1), build_test_pool(shard1_url));
+    HarvestDbPool::sharded(ShardedDbPool::from_map(pools, ShardId::new(0)))
+}
+
+fn two_shard_router() -> ShardRouter {
+    ShardRouter::new(
+        vec![ShardId::new(0), ShardId::new(1)],
+        vec![ShardId::new(0), ShardId::new(1)],
+        ShardId::new(0),
+    )
+}
+
+fn build_api_app(pool: HarvestDbPool, router: ShardRouter) -> HarvestApiApp {
+    let api_state = HarvestApiState::new();
+    api_state.install_storage_pool(pool);
+    api_state.install(HarvestApiRuntime::new(
+        Arc::new(HandlerRegistry::new(vec![], vec![])),
+        Arc::new(DagCatalog::default()),
+        Arc::new(Vec::<WorkflowSchedule>::new()),
+        None,
+        vec!["default".to_string()],
+        SchedulerMonitor::offline(),
+        HarvestRetentionRuntime::disabled(autumn_harvest::RetentionConfig::default()),
+        router,
+    ));
+    harvest_api_router(api_state).with_state(autumn_web::AppState::for_test())
+}
+
+async fn read_json_response(response: axum::response::Response) -> Value {
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("failed to read response body");
+    serde_json::from_slice(&body).expect("response must be JSON")
+}
+
+async fn get_json(app: &HarvestApiApp, uri: impl Into<String>) -> (StatusCode, Value) {
+    let uri = uri.into();
+    let response = app
+        .clone()
+        .oneshot(Request::builder().uri(&uri).body(Body::empty()).unwrap())
+        .await
+        .expect("GET request failed");
+    let status = response.status();
+    let json = read_json_response(response).await;
+    (status, json)
+}
+
+/// Insert a workflow execution with a single version marker event.
+async fn insert_versioned_execution(
+    database_url: &str,
+    shard: ShardId,
+    workflow_name: &str,
+    workflow_id: &str,
+    state: &str,
+    change_id: &str,
+    recorded_version: u32,
+) -> ExecutionId {
+    let exec_id = ExecutionId::new_for_shard(shard);
+    let mut conn = <AsyncPgConnection as AsyncConnection>::establish(database_url)
+        .await
+        .expect("failed to connect to test database");
+    let row = NewWorkflowExecution {
+        id: exec_id.as_uuid(),
+        workflow_name,
+        workflow_id,
+        run_id: uuid::Uuid::new_v4(),
+        shard_id: shard.as_i32(),
+        input: json!({}),
+        parent_id: None,
+        queue_name: "default",
+        execution_timeout: None,
+        memo: None,
+        search_attrs: None,
+    };
+    diesel::insert_into(autumn_harvest::schema::harvest_workflow_executions::table)
+        .values(&row)
+        .execute(&mut conn)
+        .await
+        .expect("failed to insert workflow execution");
+
+    let completed_at = if state == "RUNNING" {
+        None
+    } else {
+        Some(Utc::now())
+    };
+    diesel::update(
+        autumn_harvest::schema::harvest_workflow_executions::table.find(exec_id.as_uuid()),
+    )
+    .set((
+        autumn_harvest::schema::harvest_workflow_executions::state.eq(state),
+        autumn_harvest::schema::harvest_workflow_executions::completed_at.eq(completed_at),
+    ))
+    .execute(&mut conn)
+    .await
+    .expect("failed to update workflow state");
+
+    let events = vec![
+        WorkflowEvent::WorkflowStarted {
+            input: json!({}),
+            timestamp: Utc::now(),
+        },
+        WorkflowEvent::MarkerRecorded {
+            name: format!("version:{change_id}"),
+            details: json!(recorded_version),
+        },
+    ];
+    store::append_events(&mut conn, exec_id, &events, 0)
+        .await
+        .expect("failed to append version marker");
+    exec_id
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn retirement_check_returns_404_equivalent_empty_for_unknown_change_id() {
+    let (database_url, _container) = setup_database_url_with_migrations().await;
+    let app = build_api_app(
+        HarvestDbPool::single(build_test_pool(&database_url)),
+        ShardRouter::single(),
+    );
+
+    let (status, body) = get_json(
+        &app,
+        "/admin/version-gates/retirement-check?change_id=nonexistent&min_safe_version=2",
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    // Empty report — not a 404 or panic
+    assert_eq!(body["status"], "safe");
+    assert_eq!(body["safe_to_retire"], true);
+    assert!(
+        body["blockers"].as_array().unwrap().is_empty(),
+        "no blockers for unknown change id"
+    );
+}
+
+#[tokio::test]
+async fn retirement_check_blocked_while_v1_running_safe_after_terminal() {
+    let (database_url, _container) = setup_database_url_with_migrations().await;
+
+    // Insert v1 running execution — blocks retirement
+    let exec_id = insert_versioned_execution(
+        &database_url,
+        ShardId::new(0),
+        "billing_checkout",
+        "run-v1",
+        "RUNNING",
+        "billing_v2_tax",
+        1,
+    )
+    .await;
+
+    // Insert v2 running execution — not a blocker (version >= min_safe_version)
+    insert_versioned_execution(
+        &database_url,
+        ShardId::new(0),
+        "billing_checkout",
+        "run-v2",
+        "RUNNING",
+        "billing_v2_tax",
+        2,
+    )
+    .await;
+
+    // Insert v1 terminal execution — not a blocker (terminal)
+    insert_versioned_execution(
+        &database_url,
+        ShardId::new(0),
+        "billing_checkout",
+        "done-v1",
+        "COMPLETED",
+        "billing_v2_tax",
+        1,
+    )
+    .await;
+
+    let app = build_api_app(
+        HarvestDbPool::single(build_test_pool(&database_url)),
+        ShardRouter::single(),
+    );
+
+    // Retirement check for v1 (min_safe_version=2 means v<2 is old)
+    let (status, body) = get_json(
+        &app,
+        "/admin/version-gates/retirement-check?change_id=billing_v2_tax&min_safe_version=2",
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    assert_eq!(body["status"], "blocked", "v1 running should block retirement");
+    assert_eq!(body["safe_to_retire"], false);
+
+    let blockers = body["blockers"].as_array().expect("blockers array");
+    assert_eq!(blockers.len(), 1, "one version-1 blocker row");
+    let blocker = &blockers[0];
+    assert_eq!(blocker["recorded_version"], 1);
+    assert_eq!(blocker["active_executions"], 1);
+    assert_eq!(blocker["terminal_executions"], 1);
+
+    // Sample IDs must include the running execution
+    let sample_ids: Vec<String> = blocker["sample_active_execution_ids"]
+        .as_array()
+        .expect("sample ids array")
+        .iter()
+        .filter_map(|v| v.as_str().map(ToString::to_string))
+        .collect();
+    assert!(
+        sample_ids.contains(&exec_id.as_uuid().to_string()),
+        "sample IDs should include the running v1 execution; got {sample_ids:?}"
+    );
+
+    // Now mark the v1 execution as COMPLETED
+    let mut conn = <AsyncPgConnection as AsyncConnection>::establish(&database_url)
+        .await
+        .unwrap();
+    diesel::update(
+        autumn_harvest::schema::harvest_workflow_executions::table.find(exec_id.as_uuid()),
+    )
+    .set((
+        autumn_harvest::schema::harvest_workflow_executions::state.eq("COMPLETED"),
+        autumn_harvest::schema::harvest_workflow_executions::completed_at
+            .eq(Some(Utc::now())),
+    ))
+    .execute(&mut conn)
+    .await
+    .unwrap();
+
+    // Re-check — should now be safe
+    let (status2, body2) = get_json(
+        &app,
+        "/admin/version-gates/retirement-check?change_id=billing_v2_tax&min_safe_version=2",
+    )
+    .await;
+
+    assert_eq!(status2, StatusCode::OK, "body: {body2}");
+    assert_eq!(
+        body2["status"], "safe",
+        "all v1 executions are now terminal"
+    );
+    assert_eq!(body2["safe_to_retire"], true);
+    // Blocker row still appears but with zero active
+    let blockers2 = body2["blockers"].as_array().expect("blockers2");
+    if !blockers2.is_empty() {
+        assert_eq!(blockers2[0]["active_executions"], 0);
+    }
+}
+
+#[tokio::test]
+async fn retirement_check_state_group_active_hides_terminal_rows() {
+    let (database_url, _container) = setup_database_url_with_migrations().await;
+
+    // Only terminal v1 — should not appear when state_group=active
+    insert_versioned_execution(
+        &database_url,
+        ShardId::new(0),
+        "billing_checkout",
+        "done-only",
+        "COMPLETED",
+        "billing_v2_tax",
+        1,
+    )
+    .await;
+
+    let app = build_api_app(
+        HarvestDbPool::single(build_test_pool(&database_url)),
+        ShardRouter::single(),
+    );
+
+    let (status, body) = get_json(
+        &app,
+        "/admin/version-gates/retirement-check?change_id=billing_v2_tax&min_safe_version=2&state_group=active",
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    assert_eq!(body["status"], "safe");
+    assert!(body["blockers"].as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn retirement_check_aggregates_counts_across_two_shards() {
+    let ((shard0_url, shard1_url), _container) = setup_two_shards_with_migrations().await;
+
+    // One v1 running on each shard
+    insert_versioned_execution(
+        &shard0_url,
+        ShardId::new(0),
+        "billing_checkout",
+        "shard0-v1",
+        "RUNNING",
+        "billing_v2_tax",
+        1,
+    )
+    .await;
+    insert_versioned_execution(
+        &shard1_url,
+        ShardId::new(1),
+        "billing_checkout",
+        "shard1-v1",
+        "RUNNING",
+        "billing_v2_tax",
+        1,
+    )
+    .await;
+
+    let app = build_api_app(
+        build_two_shard_pool(&shard0_url, &shard1_url),
+        two_shard_router(),
+    );
+
+    let (status, body) = get_json(
+        &app,
+        "/admin/version-gates/retirement-check?change_id=billing_v2_tax&min_safe_version=2",
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    assert_eq!(body["status"], "blocked");
+    assert_eq!(body["blockers"][0]["active_executions"], 2);
+    assert_eq!(
+        body["blockers"][0]["shard_coverage"]["matched_shards"],
+        json!([0, 1])
+    );
+    assert_eq!(body["shards"][0]["status"], "inspected");
+    assert_eq!(body["shards"][1]["status"], "inspected");
+}
+
+#[tokio::test]
+async fn retirement_check_degraded_when_one_shard_unavailable() {
+    let (database_url, _container) = setup_database_url_with_migrations().await;
+
+    insert_versioned_execution(
+        &database_url,
+        ShardId::new(0),
+        "billing_checkout",
+        "shard0-v1",
+        "RUNNING",
+        "billing_v2_tax",
+        1,
+    )
+    .await;
+
+    // Shard 1 has a broken pool (bad URL)
+    let bad_pool = {
+        let manager = AsyncDieselConnectionManager::<AsyncPgConnection>::new(
+            "postgres://postgres:postgres@127.0.0.1:1/nonexistent",
+        );
+        deadpool::managed::Pool::builder(manager)
+            .max_size(1)
+            .build()
+            .expect("pool builds even with bad url")
+    };
+    let mut pools = BTreeMap::new();
+    pools.insert(ShardId::new(0), build_test_pool(&database_url));
+    pools.insert(ShardId::new(1), bad_pool);
+    let pool = HarvestDbPool::sharded(ShardedDbPool::from_map(pools, ShardId::new(0)));
+    let router = two_shard_router();
+    let app = build_api_app(pool, router);
+
+    let (status, body) = get_json(
+        &app,
+        "/admin/version-gates/retirement-check?change_id=billing_v2_tax&min_safe_version=2",
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    // Must be partial (not safe), naming the unavailable shard
+    assert_eq!(body["status"], "partial", "one shard unavailable → partial");
+    assert_eq!(body["safe_to_retire"], false);
+
+    let unavailable_shard = body["shards"]
+        .as_array()
+        .expect("shards array")
+        .iter()
+        .find(|s| s["status"] == "unavailable")
+        .expect("exactly one unavailable shard");
+    assert_eq!(unavailable_shard["shard_id"], 1);
+}

--- a/autumn-harvest-plugin/tests/retirement_check_integration.rs
+++ b/autumn-harvest-plugin/tests/retirement_check_integration.rs
@@ -540,7 +540,7 @@ async fn retirement_check_degraded_when_one_shard_unavailable() {
 /// Executions that started before a version gate was inserted carry no
 /// `MarkerRecorded` event for that change id.  When the gate is later added to
 /// the code and `workflow_name` is supplied to the retirement check, these
-/// pre-gate executions must appear as blockers (recorded_version = 0) so that
+/// pre-gate executions must appear as blockers (`recorded_version` = 0) so that
 /// operators are not misled into retiring the old branch prematurely.
 #[tokio::test]
 async fn retirement_check_includes_pre_gate_executions_as_blockers() {

--- a/autumn-harvest/src/lib.rs
+++ b/autumn-harvest/src/lib.rs
@@ -77,6 +77,8 @@ pub mod types;
 pub mod update;
 #[cfg(feature = "db")]
 pub mod version_usage;
+#[cfg(feature = "db")]
+pub mod version_gate_retirement;
 
 #[cfg(feature = "db")]
 #[doc(hidden)]

--- a/autumn-harvest/src/lib.rs
+++ b/autumn-harvest/src/lib.rs
@@ -76,9 +76,9 @@ pub mod testing;
 pub mod types;
 pub mod update;
 #[cfg(feature = "db")]
-pub mod version_usage;
-#[cfg(feature = "db")]
 pub mod version_gate_retirement;
+#[cfg(feature = "db")]
+pub mod version_usage;
 
 #[cfg(feature = "db")]
 #[doc(hidden)]

--- a/autumn-harvest/src/version_gate_retirement.rs
+++ b/autumn-harvest/src/version_gate_retirement.rs
@@ -36,12 +36,20 @@ pub struct RetirementCheckFilters {
 /// A row exists for each `(workflow_name, recorded_version, shard_id)` triple
 /// where `recorded_version < min_safe_version`.
 ///
-/// When a non-identity [`PayloadCodec`] is configured, the `details` field of a
-/// `MarkerRecorded` event is stored as a codec envelope object rather than a bare
-/// integer.  Those rows cannot be decoded in SQL, so they are included
-/// conservatively with `recorded_version = 0` — always below any meaningful
-/// `min_safe_version`.  Operators should treat `recorded_version == 0` as
-/// *version unknown (opaque codec envelope)* and investigate before retiring.
+/// **`recorded_version = 0` sentinel** — used in two conservative cases where
+/// the true version cannot be determined from stored events alone:
+///
+/// 1. *Codec-envelope details* — when a non-identity [`PayloadCodec`] is
+///    configured, the `MarkerRecorded.details` field is stored as an opaque
+///    envelope object rather than a bare integer.
+/// 2. *Pre-gate executions* — executions that began before the version gate was
+///    inserted carry no `MarkerRecorded` event for the gate at all.  When they
+///    replay through the newly-inserted call to `ctx.version()` they receive
+///    `min` without writing a marker, so their effective version is unknown.
+///    Only surfaced when [`RetirementCheckFilters::workflow_name`] is set.
+///
+/// Operators must treat `recorded_version == 0` as "version unknown — investigate
+/// before retiring the old branch."
 #[derive(Debug, Clone, Eq, PartialEq, Serialize)]
 pub struct RetirementCheckShardRow {
     pub workflow_name: String,
@@ -133,6 +141,50 @@ WITH version_markers AS (
           )
       )
       AND ($5::INT4 IS NULL OR w.shard_id = $5::INT4)
+    UNION ALL
+    -- Pre-gate executions: workflow_name rows that have NO MarkerRecorded event
+    -- for this change id.  When they replay through the newly-inserted gate they
+    -- receive `min` without writing a marker, so their effective version is
+    -- unknown.  Included conservatively as recorded_version = 0.
+    --
+    -- Only emitted when workflow_name is provided ($3 IS NOT NULL) to avoid a
+    -- full-table scan across every workflow in the shard.
+    SELECT
+        w.id            AS workflow_exec_id,
+        w.workflow_name AS workflow_name,
+        w.state         AS state,
+        w.started_at    AS started_at,
+        w.shard_id      AS shard_id,
+        substring($1 FROM 9)::TEXT AS change_id,
+        0::BIGINT       AS recorded_version
+    FROM harvest_workflow_executions w
+    WHERE $3::TEXT IS NOT NULL
+      AND w.workflow_name = $3::TEXT
+      AND (
+          $4::TEXT = 'all'
+          OR (
+              $4::TEXT = 'active'
+              AND w.state NOT IN (
+                  'COMPLETED', 'FAILED', 'CANCELLED',
+                  'TIMED_OUT', 'CONTINUED_AS_NEW', 'TERMINATED'
+              )
+          )
+          OR (
+              $4::TEXT = 'terminal'
+              AND w.state IN (
+                  'COMPLETED', 'FAILED', 'CANCELLED',
+                  'TIMED_OUT', 'CONTINUED_AS_NEW', 'TERMINATED'
+              )
+          )
+      )
+      AND ($5::INT4 IS NULL OR w.shard_id = $5::INT4)
+      AND NOT EXISTS (
+          SELECT 1
+          FROM harvest_events e2
+          WHERE e2.workflow_exec_id = w.id
+            AND e2.event_type = 'MarkerRecorded'
+            AND e2.event_data #>> '{data,name}' = $1
+      )
 )
 SELECT
     workflow_name::TEXT AS workflow_name,
@@ -181,8 +233,14 @@ ORDER BY workflow_name, change_id, recorded_version, shard_id
 ///
 /// Returns one row per `(workflow_name, recorded_version, shard_id)` triple
 /// where `recorded_version < filters.min_safe_version`.  An empty `Vec`
-/// signals that no old-version markers exist on this shard under the given
-/// filters — a safe result when combined with a fully-inspected shard set.
+/// signals that no old-version markers (and no pre-gate executions, when
+/// `workflow_name` is set) exist on this shard — a safe result when combined
+/// with a fully-inspected shard set.
+///
+/// When [`RetirementCheckFilters::workflow_name`] is provided, the query also
+/// includes active executions for that workflow that carry **no** `MarkerRecorded`
+/// event for the given `change_id` (pre-gate executions).  Those rows appear
+/// with `recorded_version = 0`; see [`RetirementCheckShardRow`] for details.
 ///
 /// # Errors
 ///
@@ -294,6 +352,18 @@ mod tests {
         assert!(
             RETIREMENT_CHECK_SQL.contains("_harvest_codec_envelope"),
             "SQL must detect codec-envelope details to avoid false-safe reports"
+        );
+    }
+
+    #[test]
+    fn sql_contains_pre_gate_not_exists_branch() {
+        // Verify that the UNION ALL anti-join for pre-gate executions is present.
+        // Without it, executions that started before a version gate was inserted
+        // (and therefore have no MarkerRecorded event) are invisible to the check,
+        // causing a false-safe result.
+        assert!(
+            RETIREMENT_CHECK_SQL.contains("NOT EXISTS"),
+            "SQL must include pre-gate anti-join to catch executions with no marker"
         );
     }
 }

--- a/autumn-harvest/src/version_gate_retirement.rs
+++ b/autumn-harvest/src/version_gate_retirement.rs
@@ -35,6 +35,13 @@ pub struct RetirementCheckFilters {
 ///
 /// A row exists for each `(workflow_name, recorded_version, shard_id)` triple
 /// where `recorded_version < min_safe_version`.
+///
+/// When a non-identity [`PayloadCodec`] is configured, the `details` field of a
+/// `MarkerRecorded` event is stored as a codec envelope object rather than a bare
+/// integer.  Those rows cannot be decoded in SQL, so they are included
+/// conservatively with `recorded_version = 0` — always below any meaningful
+/// `min_safe_version`.  Operators should treat `recorded_version == 0` as
+/// *version unknown (opaque codec envelope)* and investigate before retiring.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize)]
 pub struct RetirementCheckShardRow {
     pub workflow_name: String,
@@ -84,15 +91,29 @@ WITH version_markers AS (
         w.started_at,
         w.shard_id,
         substring(e.event_data #>> '{data,name}' FROM 9) AS change_id,
-        (e.event_data #>> '{data,details}')::BIGINT AS recorded_version
+        CASE
+            WHEN e.event_data #>> '{data,details,_harvest_codec_envelope}' IS NOT NULL
+            THEN 0
+            ELSE (e.event_data #>> '{data,details}')::BIGINT
+        END AS recorded_version
     FROM harvest_events e
     INNER JOIN harvest_workflow_executions w
         ON w.id = e.workflow_exec_id
     WHERE e.event_type = 'MarkerRecorded'
       AND e.event_data #>> '{data,name}' = $1
-      AND e.event_data #>> '{data,details}' ~ '^[0-9]{1,19}$'
-      AND (e.event_data #>> '{data,details}')::NUMERIC <= 4294967295
-      AND (e.event_data #>> '{data,details}')::BIGINT < $2
+      AND (
+          -- Plain numeric details: must be a valid u32 below the safe threshold.
+          (
+              e.event_data #>> '{data,details}' ~ '^[0-9]{1,19}$'
+              AND (e.event_data #>> '{data,details}')::NUMERIC <= 4294967295
+              AND (e.event_data #>> '{data,details}')::BIGINT < $2
+          )
+          OR
+          -- Codec-envelope details: version is opaque; include conservatively
+          -- (mapped to recorded_version = 0 above) so they are never silently
+          -- excluded from the blocker set.
+          e.event_data #>> '{data,details,_harvest_codec_envelope}' IS NOT NULL
+      )
       AND ($3::TEXT IS NULL OR w.workflow_name = $3::TEXT)
       AND (
           $4::TEXT = 'all'
@@ -192,10 +213,8 @@ pub async fn load_retirement_check(
                     row.recorded_version
                 ))
             })?;
-            let sample_active_execution_ids =
-                parse_sample_ids(&row.sample_active_execution_ids).map_err(|e| {
-                    HarvestError::Database(format!("failed to parse sample ids: {e}"))
-                })?;
+            let sample_active_execution_ids = parse_sample_ids(&row.sample_active_execution_ids)
+                .map_err(|e| HarvestError::Database(format!("failed to parse sample ids: {e}")))?;
             Ok(RetirementCheckShardRow {
                 workflow_name: row.workflow_name,
                 change_id: row.change_id,
@@ -212,8 +231,7 @@ pub async fn load_retirement_check(
 }
 
 fn parse_sample_ids(json_text: &str) -> Result<Vec<Uuid>, String> {
-    let value: serde_json::Value =
-        serde_json::from_str(json_text).map_err(|e| e.to_string())?;
+    let value: serde_json::Value = serde_json::from_str(json_text).map_err(|e| e.to_string())?;
     let arr = value
         .as_array()
         .ok_or_else(|| "expected JSON array".to_string())?;
@@ -266,5 +284,16 @@ mod tests {
             shard_id: None,
         };
         assert_eq!(filters.state_group.as_str(), "all");
+    }
+
+    #[test]
+    fn sql_contains_codec_envelope_branch() {
+        // Verify that the SQL guard against opaque codec-envelope details is
+        // present so that non-identity PayloadCodec deployments are never
+        // silently excluded from the blocker set.
+        assert!(
+            RETIREMENT_CHECK_SQL.contains("_harvest_codec_envelope"),
+            "SQL must detect codec-envelope details to avoid false-safe reports"
+        );
     }
 }

--- a/autumn-harvest/src/version_gate_retirement.rs
+++ b/autumn-harvest/src/version_gate_retirement.rs
@@ -211,6 +211,7 @@ SELECT
                 SELECT vm2.workflow_exec_id::TEXT AS eid
                 FROM version_markers vm2
                 WHERE vm2.workflow_name = vm.workflow_name
+                  AND vm2.change_id = vm.change_id
                   AND vm2.recorded_version = vm.recorded_version
                   AND vm2.shard_id = vm.shard_id
                   AND vm2.state NOT IN (

--- a/autumn-harvest/src/version_gate_retirement.rs
+++ b/autumn-harvest/src/version_gate_retirement.rs
@@ -1,0 +1,270 @@
+//! Read-only retirement-check query for recorded workflow version-gate markers.
+//!
+//! Answers "is change id X safe to retire below version N?" by scanning
+//! `harvest_events` for `MarkerRecorded` rows whose recorded version is below the
+//! caller-supplied `min_safe_version` threshold and joining back to
+//! `harvest_workflow_executions` for execution state and start timestamp.
+
+use chrono::{DateTime, Utc};
+use diesel::sql_types::{BigInt, Integer, Nullable, Text, Timestamptz};
+use diesel_async::AsyncPgConnection;
+use diesel_async::RunQueryDsl;
+use serde::Serialize;
+use uuid::Uuid;
+
+use crate::error::{HarvestError, HarvestResult, database_error};
+use crate::version_usage::VersionExecutionStateGroup;
+
+/// Filters applied when reading retirement-check data from one shard.
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub struct RetirementCheckFilters {
+    /// Limit results to this workflow name.
+    pub workflow_name: Option<String>,
+    /// Change id to inspect (maps to `MarkerRecorded` name `"version:{change_id}"`).
+    pub change_id: String,
+    /// Executions whose recorded version is **below** this value are considered
+    /// to be taking the old (to-be-retired) branch.
+    pub min_safe_version: u32,
+    /// Which execution states to include.
+    pub state_group: VersionExecutionStateGroup,
+    /// Restrict to a single shard.
+    pub shard_id: Option<i32>,
+}
+
+/// One grouped retirement-check row read from a single database shard.
+///
+/// A row exists for each `(workflow_name, recorded_version, shard_id)` triple
+/// where `recorded_version < min_safe_version`.
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+pub struct RetirementCheckShardRow {
+    pub workflow_name: String,
+    pub change_id: String,
+    pub recorded_version: u32,
+    pub active_executions: i64,
+    pub terminal_executions: i64,
+    pub oldest_blocker_started_at: DateTime<Utc>,
+    pub newest_blocker_started_at: DateTime<Utc>,
+    /// Up to 10 active (non-terminal) execution IDs for manual investigation.
+    pub sample_active_execution_ids: Vec<Uuid>,
+    pub shard_id: i32,
+}
+
+#[derive(Debug, diesel::QueryableByName)]
+struct RetirementCheckSqlRow {
+    #[diesel(sql_type = Text)]
+    workflow_name: String,
+    #[diesel(sql_type = Text)]
+    change_id: String,
+    #[diesel(sql_type = BigInt)]
+    recorded_version: i64,
+    #[diesel(sql_type = BigInt)]
+    active_executions: i64,
+    #[diesel(sql_type = BigInt)]
+    terminal_executions: i64,
+    #[diesel(sql_type = Timestamptz)]
+    oldest_blocker_started_at: DateTime<Utc>,
+    #[diesel(sql_type = Timestamptz)]
+    newest_blocker_started_at: DateTime<Utc>,
+    /// JSON array of UUID strings, e.g. `["uuid1","uuid2"]`.
+    #[diesel(sql_type = Text)]
+    sample_active_execution_ids: String,
+    #[diesel(sql_type = Integer)]
+    shard_id: i32,
+}
+
+/// Maximum number of sample blocker IDs returned per row.
+const SAMPLE_BLOCKER_LIMIT: i64 = 10;
+
+const RETIREMENT_CHECK_SQL: &str = r"
+WITH version_markers AS (
+    SELECT DISTINCT
+        w.id AS workflow_exec_id,
+        w.workflow_name,
+        w.state,
+        w.started_at,
+        w.shard_id,
+        substring(e.event_data #>> '{data,name}' FROM 9) AS change_id,
+        (e.event_data #>> '{data,details}')::BIGINT AS recorded_version
+    FROM harvest_events e
+    INNER JOIN harvest_workflow_executions w
+        ON w.id = e.workflow_exec_id
+    WHERE e.event_type = 'MarkerRecorded'
+      AND e.event_data #>> '{data,name}' = $1
+      AND e.event_data #>> '{data,details}' ~ '^[0-9]{1,19}$'
+      AND (e.event_data #>> '{data,details}')::NUMERIC <= 4294967295
+      AND (e.event_data #>> '{data,details}')::BIGINT < $2
+      AND ($3::TEXT IS NULL OR w.workflow_name = $3::TEXT)
+      AND (
+          $4::TEXT = 'all'
+          OR (
+              $4::TEXT = 'active'
+              AND w.state NOT IN (
+                  'COMPLETED', 'FAILED', 'CANCELLED',
+                  'TIMED_OUT', 'CONTINUED_AS_NEW', 'TERMINATED'
+              )
+          )
+          OR (
+              $4::TEXT = 'terminal'
+              AND w.state IN (
+                  'COMPLETED', 'FAILED', 'CANCELLED',
+                  'TIMED_OUT', 'CONTINUED_AS_NEW', 'TERMINATED'
+              )
+          )
+      )
+      AND ($5::INT4 IS NULL OR w.shard_id = $5::INT4)
+)
+SELECT
+    workflow_name::TEXT AS workflow_name,
+    change_id::TEXT AS change_id,
+    recorded_version::BIGINT AS recorded_version,
+    COUNT(*) FILTER (
+        WHERE state NOT IN (
+            'COMPLETED', 'FAILED', 'CANCELLED',
+            'TIMED_OUT', 'CONTINUED_AS_NEW', 'TERMINATED'
+        )
+    )::BIGINT AS active_executions,
+    COUNT(*) FILTER (
+        WHERE state IN (
+            'COMPLETED', 'FAILED', 'CANCELLED',
+            'TIMED_OUT', 'CONTINUED_AS_NEW', 'TERMINATED'
+        )
+    )::BIGINT AS terminal_executions,
+    MIN(started_at) AS oldest_blocker_started_at,
+    MAX(started_at) AS newest_blocker_started_at,
+    COALESCE(
+        (
+            SELECT json_agg(eid)
+            FROM (
+                SELECT vm2.workflow_exec_id::TEXT AS eid
+                FROM version_markers vm2
+                WHERE vm2.workflow_name = vm.workflow_name
+                  AND vm2.recorded_version = vm.recorded_version
+                  AND vm2.shard_id = vm.shard_id
+                  AND vm2.state NOT IN (
+                      'COMPLETED', 'FAILED', 'CANCELLED',
+                      'TIMED_OUT', 'CONTINUED_AS_NEW', 'TERMINATED'
+                  )
+                ORDER BY vm2.started_at
+                LIMIT $6
+            ) sub
+        )::TEXT,
+        '[]'
+    ) AS sample_active_execution_ids,
+    shard_id::INT4 AS shard_id
+FROM version_markers vm
+GROUP BY workflow_name, change_id, recorded_version, shard_id
+ORDER BY workflow_name, change_id, recorded_version, shard_id
+";
+
+/// Load retirement-check rows from a single shard without mutating state.
+///
+/// Returns one row per `(workflow_name, recorded_version, shard_id)` triple
+/// where `recorded_version < filters.min_safe_version`.  An empty `Vec`
+/// signals that no old-version markers exist on this shard under the given
+/// filters — a safe result when combined with a fully-inspected shard set.
+///
+/// # Errors
+///
+/// Returns [`HarvestError::Database`] if the query fails.
+pub async fn load_retirement_check(
+    conn: &mut AsyncPgConnection,
+    filters: &RetirementCheckFilters,
+) -> HarvestResult<Vec<RetirementCheckShardRow>> {
+    let marker_name = format!("version:{}", filters.change_id);
+    let min_safe_version = i64::from(filters.min_safe_version);
+    let version_filter = min_safe_version;
+    let rows = diesel::sql_query(RETIREMENT_CHECK_SQL)
+        .bind::<Text, _>(marker_name)
+        .bind::<BigInt, _>(version_filter)
+        .bind::<Nullable<Text>, _>(filters.workflow_name.as_deref())
+        .bind::<Text, _>(filters.state_group.as_str())
+        .bind::<Nullable<Integer>, _>(filters.shard_id)
+        .bind::<BigInt, _>(SAMPLE_BLOCKER_LIMIT)
+        .load::<RetirementCheckSqlRow>(conn)
+        .await
+        .map_err(database_error)?;
+
+    rows.into_iter()
+        .map(|row| {
+            let recorded_version = u32::try_from(row.recorded_version).map_err(|_| {
+                HarvestError::Database(format!(
+                    "recorded version {} is outside u32 range",
+                    row.recorded_version
+                ))
+            })?;
+            let sample_active_execution_ids =
+                parse_sample_ids(&row.sample_active_execution_ids).map_err(|e| {
+                    HarvestError::Database(format!("failed to parse sample ids: {e}"))
+                })?;
+            Ok(RetirementCheckShardRow {
+                workflow_name: row.workflow_name,
+                change_id: row.change_id,
+                recorded_version,
+                active_executions: row.active_executions,
+                terminal_executions: row.terminal_executions,
+                oldest_blocker_started_at: row.oldest_blocker_started_at,
+                newest_blocker_started_at: row.newest_blocker_started_at,
+                sample_active_execution_ids,
+                shard_id: row.shard_id,
+            })
+        })
+        .collect()
+}
+
+fn parse_sample_ids(json_text: &str) -> Result<Vec<Uuid>, String> {
+    let value: serde_json::Value =
+        serde_json::from_str(json_text).map_err(|e| e.to_string())?;
+    let arr = value
+        .as_array()
+        .ok_or_else(|| "expected JSON array".to_string())?;
+    arr.iter()
+        .map(|v| {
+            v.as_str()
+                .ok_or_else(|| "expected string element".to_string())
+                .and_then(|s| Uuid::parse_str(s).map_err(|e| e.to_string()))
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parse_sample_ids_handles_empty_array() {
+        let ids = parse_sample_ids("[]").expect("empty array is valid");
+        assert!(ids.is_empty());
+    }
+
+    #[test]
+    fn parse_sample_ids_parses_uuid_strings() {
+        let uuid = Uuid::new_v4();
+        let json = format!("[\"{uuid}\"]");
+        let ids = parse_sample_ids(&json).expect("array of one UUID");
+        assert_eq!(ids, vec![uuid]);
+    }
+
+    #[test]
+    fn parse_sample_ids_rejects_non_uuid() {
+        let result = parse_sample_ids("[\"not-a-uuid\"]");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn parse_sample_ids_rejects_non_array() {
+        let result = parse_sample_ids("\"single-string\"");
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn retirement_check_filters_default_state_group() {
+        let filters = RetirementCheckFilters {
+            workflow_name: None,
+            change_id: "my_change".to_string(),
+            min_safe_version: 2,
+            state_group: VersionExecutionStateGroup::All,
+            shard_id: None,
+        };
+        assert_eq!(filters.state_group.as_str(), "all");
+    }
+}

--- a/docs/runbooks/version-gate-retirement.md
+++ b/docs/runbooks/version-gate-retirement.md
@@ -1,0 +1,244 @@
+# Version-Gate Retirement Playbook
+
+This runbook explains how to safely evolve `#[workflow]` code that uses
+`ctx.version(...)` gates, and how to prove that an old branch can be deleted
+without breaking any in-flight execution.
+
+---
+
+## Background
+
+`ctx.version(change_id, min, max)` records a `MarkerRecorded` event the first
+time a live execution crosses it and replays the recorded version on every
+subsequent replay cycle.  The engine uses the recorded version to decide which
+code branch to follow, so removing a branch while executions with the old
+recorded version still exist causes a non-determinism error and moves those
+executions to the dead-letter queue.
+
+---
+
+## Lifecycle
+
+### 1 — Add a version gate
+
+Wrap the new behaviour in a version branch:
+
+```rust
+#[workflow]
+async fn billing_checkout(ctx: &WorkflowContext, ...) -> Result<(), String> {
+    let v = ctx.version("billing_v2_tax", 1, 2);
+    if v >= 2 {
+        // New tax calculation logic
+        ctx.execute_activity(compute_new_tax, ...).await?;
+    } else {
+        // Old logic kept alive for in-flight v1 executions
+        ctx.execute_activity(compute_old_tax, ...).await?;
+    }
+    // ...
+}
+```
+
+Rules:
+- Always increment `max` when adding new behaviour.
+- Keep `min` at the lowest version that can still replay correctly.
+- Never decrease `min` or `max` of an existing gate — that changes replay
+  semantics for stored events.
+
+### 2 — Deploy new code
+
+Deploy the updated binary.  New executions receive `max` (the new version).
+In-flight executions from before the deploy continue to replay with their
+recorded version.
+
+### 3 — Run replay fixtures
+
+After deploying, verify that existing recorded histories are still
+deterministic:
+
+```bash
+cargo test -p my-app --test replay_tests
+```
+
+or with `WorkflowReplayer` in a staging environment pointed at real histories:
+
+```bash
+harvest workflow get <exec_id> | jq .events > fixtures/billing_v1.json
+cargo test --features testing -- replayer
+```
+
+### 4 — Wait for old executions to drain
+
+Old-version executions must complete (or be cancelled/terminated) before the
+old branch can be removed.  Monitor progress with the version-gate usage report:
+
+```bash
+# Show all observed versions for this change id
+harvest version-usage --change-id billing_v2_tax
+
+# Monitor only active (non-terminal) executions
+harvest version-usage --change-id billing_v2_tax --state-group active
+```
+
+### 5 — Run the retirement check
+
+When you believe all old executions have drained, run the retirement check to
+confirm it is safe to delete the old branch.  The check inspects every shard
+and returns `safe_to_retire: true` only when **zero active** (non-terminal)
+executions carry a version below the threshold across **all inspected shards**.
+
+```bash
+# Table output (default) — useful for manual review
+harvest version-gate-retirement \
+    --change-id billing_v2_tax \
+    --min-safe-version 2
+
+# JSON output — for scripts or CI pipelines
+harvest --output json version-gate-retirement \
+    --change-id billing_v2_tax \
+    --min-safe-version 2
+
+# CI gate — exits non-zero while any blocker or unavailable shard remains
+harvest version-gate-retirement \
+    --change-id billing_v2_tax \
+    --min-safe-version 2 \
+    --check
+```
+
+The check also accepts `--workflow-name` and `--shard-id` to narrow scope, and
+`--state-group active` to ignore terminal history rows if your release policy
+only cares about live blockers.
+
+#### Interpreting the report
+
+| `status`      | `safe_to_retire` | Meaning |
+|---------------|-----------------|---------|
+| `safe`        | `true`          | All shards inspected; no active old-version executions. Safe to remove the old branch. |
+| `blocked`     | `false`         | At least one active execution still carries a version below the threshold. Wait and retry. |
+| `partial`     | `false`         | Some shards could not be inspected. Investigate the named unavailable shards before proceeding. |
+| `unavailable` | `false`         | No shard could be reached. Check shard connectivity before proceeding. |
+
+The `blockers` array in the response includes:
+- `workflow_name`, `recorded_version`, `active_executions`, `terminal_executions`
+- `oldest_blocker_started_at` / `newest_blocker_started_at` and their age in seconds
+- `sample_active_execution_ids` — up to 10 execution UUIDs for investigation
+
+A workflow with **no recorded version gates** returns `status: "safe"` and an
+empty `blockers` array — not a 404 or error.
+
+#### Example: blocked report
+
+```json
+{
+  "status": "blocked",
+  "safe_to_retire": false,
+  "observed_at": "2026-05-07T14:30:00Z",
+  "filters": {
+    "change_id": "billing_v2_tax",
+    "min_safe_version": 2,
+    "state_group": "all"
+  },
+  "blockers": [{
+    "workflow_name": "billing_checkout",
+    "change_id": "billing_v2_tax",
+    "recorded_version": 1,
+    "active_executions": 3,
+    "terminal_executions": 142,
+    "oldest_blocker_age_secs": 14400,
+    "newest_blocker_age_secs": 60,
+    "sample_active_execution_ids": [
+      "018f1a2b-3c4d-7e8f-9a0b-1c2d3e4f5a6b"
+    ],
+    "shard_coverage": {
+      "inspected_shards": [0, 1],
+      "matched_shards": [0],
+      "unavailable_shards": []
+    }
+  }],
+  "shards": [
+    { "shard_id": 0, "status": "inspected", "matched_groups": 1 },
+    { "shard_id": 1, "status": "inspected", "matched_groups": 0 }
+  ]
+}
+```
+
+Investigate the sample execution IDs:
+
+```bash
+harvest workflow get 018f1a2b-3c4d-7e8f-9a0b-1c2d3e4f5a6b
+```
+
+If executions are genuinely stuck (no worker coverage, heartbeat timed out),
+consider cancelling or terminating them:
+
+```bash
+harvest workflow cancel 018f1a2b-3c4d-7e8f-9a0b-1c2d3e4f5a6b \
+    --reason "version-gate drain before retirement of billing_v2_tax<2"
+```
+
+### 6 — Remove the old branch and run replay again
+
+Once `status: "safe"`, remove the old branch:
+
+```rust
+#[workflow]
+async fn billing_checkout(ctx: &WorkflowContext, ...) -> Result<(), String> {
+    // Version gate still present but old branch removed.
+    // min is updated to 2 so the gate always returns 2 for new executions.
+    ctx.version("billing_v2_tax", 2, 2);
+    ctx.execute_activity(compute_new_tax, ...).await?;
+    // ...
+}
+```
+
+Re-run replay fixtures to confirm no determinism regressions, then remove the
+gate entirely in a subsequent deploy once all histories have rolled past it.
+
+---
+
+## API reference
+
+`GET /admin/version-gates/retirement-check`
+
+| Parameter         | Type     | Required | Description |
+|-------------------|----------|----------|-------------|
+| `change_id`       | `string` | Yes      | Version-gate change id to inspect. |
+| `min_safe_version`| `u32`    | Yes      | Versions strictly below this are considered old. |
+| `workflow_name`   | `string` | No       | Narrow to one workflow name. |
+| `state_group`     | `string` | No       | `all` (default), `active`, or `terminal`. |
+| `shard_id`        | `i32`    | No       | Restrict to one shard. |
+
+---
+
+## Multi-shard deployments
+
+When a shard is unreachable, the report returns `status: "partial"` and names
+the unavailable shard in `shards[].status = "unavailable"`.  The CLI `--check`
+flag treats `partial` as a failure (exit code 1) because safety cannot be
+proven without inspecting all shards.
+
+Restore shard connectivity before retiring the branch.  You can narrow scope
+to a specific healthy shard with `--shard-id` while investigating, but the
+final retirement gate should cover all shards.
+
+---
+
+## CI integration example
+
+```yaml
+# .github/workflows/deploy.yml
+- name: Wait for version-gate to drain
+  run: |
+    for i in $(seq 1 30); do
+      harvest --output json version-gate-retirement \
+        --change-id billing_v2_tax \
+        --min-safe-version 2 \
+        --check && exit 0
+      echo "Still blocked — waiting 60s"
+      sleep 60
+    done
+    echo "Timed out waiting for version-gate drain"
+    exit 1
+  env:
+    HARVEST_URL: ${{ vars.HARVEST_URL }}
+    HARVEST_TOKEN: ${{ secrets.HARVEST_TOKEN }}
+```


### PR DESCRIPTION
Adds a read-only retirement-check surface that answers "is change id X
safe to retire below version N?" across all configured shards.

Red/green/refactor TDD order:
  - Red: unit tests in core (parse_sample_ids, filter defaults), plugin
    (safe/blocked/partial/unavailable status, cross-shard aggregation),
    CLI (request building, exit codes, table rendering, check flag), and
    integration test stubs requiring testcontainers.
  - Green: implement core `version_gate_retirement::load_retirement_check`
    (SQL via `diesel::sql_query`, sample blocker IDs via correlated
    subquery), plugin `build_retirement_check_report` (shard fan-out,
    BTreeMap accumulation, age calculation), API handler at
    `GET /admin/version-gates/retirement-check`, and CLI
    `version-gate-retirement` command with `--check` gate.
  - Refactor: remove unused `Deserialize` import, confirm zero clippy
    warnings across all three crates.

New files:
  - autumn-harvest/src/version_gate_retirement.rs
  - autumn-harvest-plugin/src/version_gate_retirement.rs
  - autumn-harvest-plugin/tests/retirement_check_integration.rs
  - docs/runbooks/version-gate-retirement.md

No new WorkflowEvent variants. No event rewriting. No macro changes.
No DB migrations required.

https://claude.ai/code/session_01CiExuZ66cBwLyd4vpk1hKK