### PR TITLE
👺 Havoc: Fix Re-Entrancy Deadlock in validate_update

### DIFF
--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -1707,18 +1707,22 @@ impl WorkflowContext {
     ///
     /// Panics if the internal update registry mutex is poisoned.
     pub fn validate_update(&self, name: &str, input: &Value) -> HarvestResult<()> {
-        let registry = self
-            .update_registry
-            .lock()
-            .expect("update_registry lock poisoned");
-        // Check existence structurally so validator errors are never confused
-        // with a missing handler, regardless of the error message text.
-        if !registry.contains(name) {
-            return Err(HarvestError::UpdateHandlerNotFound(name.to_string()));
+        let validator_opt = {
+            let registry = self
+                .update_registry
+                .lock()
+                .expect("update_registry lock poisoned");
+
+            registry.get_validator(name)
+        };
+
+        match validator_opt {
+            Some(Some(validator)) => {
+                validator(input).map_err(|reason| HarvestError::UpdateRejected { reason })
+            }
+            Some(None) => Ok(()), // Registered but no validator
+            None => Err(HarvestError::UpdateHandlerNotFound(name.to_string())),
         }
-        registry
-            .validate(name, input)
-            .map_err(|reason| HarvestError::UpdateRejected { reason })
     }
 
     /// Execute an already-admitted update by `update_id`.
@@ -3903,5 +3907,40 @@ mod tests {
             ctx.drain_commands().is_empty(),
             "empty patch emits no command"
         );
+    }
+
+    #[test]
+    fn validate_update_does_not_deadlock_on_reentrant_call() {
+        // Havoc: verify that validate_update drops its lock before invoking the validator
+        let ctx = Arc::new(WorkflowContext::new_test());
+
+        let ctx_clone = Arc::clone(&ctx);
+        ctx.register_update_handler(
+            "test_deadlock",
+            move |_| {
+                // Re-entrant call! This will deadlock if the lock is still held.
+                let _ = ctx_clone.validate_update("another_update", &Value::Null);
+                Ok(())
+            },
+            |_| async { Ok(Value::Null) },
+        );
+
+        ctx.register_update_handler(
+            "another_update",
+            |_| Ok(()),
+            |_| async { Ok(Value::Null) },
+        );
+
+        // Run validation in a thread with a short timeout to catch the deadlock
+        let (tx, rx) = std::sync::mpsc::channel();
+        let ctx_run = Arc::clone(&ctx);
+
+        std::thread::spawn(move || {
+            let _ = ctx_run.validate_update("test_deadlock", &Value::Null);
+            tx.send(()).unwrap();
+        });
+
+        rx.recv_timeout(std::time::Duration::from_millis(500))
+            .expect("validate_update deadlocked!");
     }
 }

--- a/autumn-harvest/src/update.rs
+++ b/autumn-harvest/src/update.rs
@@ -85,6 +85,16 @@ impl UpdateRegistry {
         Ok(())
     }
 
+    /// Retrieve the validator for `name`.
+    ///
+    /// Returns `None` if `name` is not registered.
+    /// Returns `Some(None)` if `name` is registered but has no validator.
+    /// Returns `Some(Some(validator))` if `name` is registered and has a validator.
+    #[must_use]
+    pub fn get_validator(&self, name: &str) -> Option<Option<BoxUpdateValidator>> {
+        self.entries.get(name).map(|e| e.validator.clone())
+    }
+
     /// Invoke the handler for `name` with `input`.
     ///
     /// Returns `None` if `name` is not registered.


### PR DESCRIPTION
👺 **Havoc** PR: Resolving a system-halting deadlock vulnerability.

🧨 **The Trigger**
A malicious or poorly-written user update validator function calling back into `WorkflowContext` APIs (like `validate_update` or `register_update_handler`) while inside the validator callback. Because `validate_update` previously held the `update_registry` lock while executing the callback, a re-entrant call would permanently deadlock the thread.

📉 **The Stack Trace**
```
thread 'context::tests::validate_update_does_not_deadlock_on_reentrant_call' panicked at autumn-harvest/src/context.rs:3940:14:
validate_update deadlocked!: Timeout
```

🧪 **Reproduction**
Run `cargo test -p autumn-harvest validate_update_does_not_deadlock`. The provided test now passes instantly but would previously hang indefinitely until the harness timeout fired.

😈 **Comment**
You assumed the lock was safe because you were only doing "validation." You were wrong. User code executes inside your walls. Drop the guards *before* you give them the keys.

---
*PR created automatically by Jules for task [9156757950951868484](https://jules.google.com/task/9156757950951868484) started by @madmax983*