### PR TITLE
🌟 Nova: Export DAG execution profile to Mermaid Gantt chart

### DIFF
--- a/autumn-harvest/src/dag_export.rs
+++ b/autumn-harvest/src/dag_export.rs
@@ -4,6 +4,11 @@
 //! and tool-compatible diagram formats such as Mermaid.js and Graphviz DOT.
 //! This is useful for debugging, documentation, and visualizing dependencies.
 use crate::dag::DagDefinition;
+#[cfg(feature = "testing")]
+use crate::dag_profiler::{DagProfile, ProfilerEventKind};
+#[cfg(feature = "testing")]
+use std::collections::HashMap;
+
 use std::fmt::Write;
 
 /// Exports the DAG definition to a Mermaid.js flowchart.
@@ -153,5 +158,100 @@ digraph DAG {
 }
 ";
         assert_eq!(dot, expected_dot);
+    }
+}
+
+/// Exports a DAG execution profile to a Mermaid.js Gantt chart.
+///
+/// # Examples
+///
+/// ```rust
+/// use std::time::Duration;
+/// use autumn_harvest::dag_profiler::{DagProfile, ProfilerEvent, ProfilerEventKind};
+/// use autumn_harvest::dag_export::export_mermaid_gantt;
+///
+/// let profile = DagProfile {
+///     total_duration: Duration::from_secs(5),
+///     peak_concurrency: 1,
+///     timeline: vec![
+///         ProfilerEvent { time: Duration::from_secs(0), kind: ProfilerEventKind::TaskStarted(0, "task_a".to_string()) },
+///         ProfilerEvent { time: Duration::from_secs(5), kind: ProfilerEventKind::TaskCompleted(0, "task_a".to_string()) },
+///     ]
+/// };
+///
+/// let gantt = export_mermaid_gantt(&profile).unwrap();
+/// assert!(gantt.contains("gantt"));
+/// assert!(gantt.contains("task_a"));
+/// ```
+///
+/// # Errors
+/// Returns `std::fmt::Error` if string formatting fails.
+#[cfg(feature = "testing")]
+pub fn export_mermaid_gantt(profile: &DagProfile) -> Result<String, std::fmt::Error> {
+    let mut out = String::new();
+    writeln!(out, "gantt")?;
+    writeln!(
+        out,
+        "    title DAG Execution Profile (Peak Concurrency: {})",
+        profile.peak_concurrency
+    )?;
+    writeln!(out, "    dateFormat X")?;
+    writeln!(out, "    axisFormat %M:%S")?;
+    writeln!(out, "    section Tasks")?;
+
+    let mut start_times = HashMap::new();
+
+    for event in &profile.timeline {
+        match &event.kind {
+            ProfilerEventKind::TaskStarted(id, _name) => {
+                start_times.insert(*id, event.time.as_secs());
+            }
+            ProfilerEventKind::TaskCompleted(id, name) => {
+                if let Some(start) = start_times.remove(id) {
+                    let end = event.time.as_secs();
+                    writeln!(out, "    {name} : {start}, {end}")?;
+                }
+            }
+        }
+    }
+
+    Ok(out)
+}
+
+#[cfg(test)]
+#[cfg(feature = "testing")]
+mod testing_tests {
+    use super::*;
+    use crate::dag_profiler::{DagProfile, ProfilerEvent, ProfilerEventKind};
+    use std::time::Duration;
+
+    #[test]
+    fn test_export_mermaid_gantt() {
+        let profile = DagProfile {
+            total_duration: Duration::from_secs(5),
+            peak_concurrency: 2,
+            timeline: vec![
+                ProfilerEvent {
+                    time: Duration::from_secs(0),
+                    kind: ProfilerEventKind::TaskStarted(0, "task_a".to_string()),
+                },
+                ProfilerEvent {
+                    time: Duration::from_secs(2),
+                    kind: ProfilerEventKind::TaskCompleted(0, "task_a".to_string()),
+                },
+                ProfilerEvent {
+                    time: Duration::from_secs(2),
+                    kind: ProfilerEventKind::TaskStarted(1, "task_b".to_string()),
+                },
+                ProfilerEvent {
+                    time: Duration::from_secs(5),
+                    kind: ProfilerEventKind::TaskCompleted(1, "task_b".to_string()),
+                },
+            ],
+        };
+
+        let gantt = export_mermaid_gantt(&profile).unwrap();
+        let expected = "gantt\n    title DAG Execution Profile (Peak Concurrency: 2)\n    dateFormat X\n    axisFormat %M:%S\n    section Tasks\n    task_a : 0, 2\n    task_b : 2, 5\n";
+        assert_eq!(gantt, expected);
     }
 }

--- a/autumn-harvest/src/lib.rs
+++ b/autumn-harvest/src/lib.rs
@@ -123,6 +123,8 @@ pub use cache::{CachedWorkflowState, WorkflowCache};
 pub use context::{ActivityContext, WorkflowCommand, WorkflowContext};
 pub use critical_path::{CriticalPathAnalyzer, CriticalPathResult};
 pub use dag::{DagBuildError, DagBuilder, DagDefinition, DagTask, DagTaskRef};
+#[cfg(feature = "testing")]
+pub use dag_export::export_mermaid_gantt;
 pub use dag_export::{export_dot, export_mermaid};
 pub use dag_linter::{
     DagLinter, DagRule, DagWarning, ExcessiveParallelismRule, MissingRetryPolicyRule,


### PR DESCRIPTION
💡 **The Spark:** We have a powerful `DagProfiler` that calculates simulated task execution start and end times, and a `dag_export` module that visualizes graphs in Mermaid.js, but we couldn't visualize the execution timeline itself.

🚀 **The Feature:** Implemented `export_mermaid_gantt` in `dag_export.rs`. This takes a `DagProfile` and maps its `timeline` events (`TaskStarted`, `TaskCompleted`) to a standard Mermaid.js Gantt chart. It visually represents parallel execution blocks and includes the calculated peak concurrency in the chart title!

🔮 **The Potential:** When testing complex, highly concurrent workflows using the simulator, developers can now render exactly how tasks will stagger or bottleneck in a time-based format natively supported by GitHub markdown and many modern documentation tools.

⚠️ **Risk:** Low. The feature is completely self-contained within `dag_export.rs`, relies on standard library string formatting, and is properly gated behind the `testing` feature to prevent bloat in production builds. It does not alter core DAG execution logic.

---
*PR created automatically by Jules for task [2660726416878147644](https://jules.google.com/task/2660726416878147644) started by @madmax983*