### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -287,7 +287,7 @@ impl HarvestApiState {
 
     /// Mark whether the Harvest management API is mounted behind auth.
     ///
-    /// This reports the boundary provided via [`HarvestPlugin::api_with_auth`]
+    /// This reports the boundary provided via [`crate::plugin::HarvestPlugin::api_with_auth`]
     /// or an equivalent standalone integration. It does not implement RBAC.
     ///
     /// # Panics

--- a/autumn-harvest/src/audit.rs
+++ b/autumn-harvest/src/audit.rs
@@ -16,7 +16,7 @@
 //!
 //! Health checks, all list/get/query routes, worker heartbeats, activity
 //! heartbeats, read-only UI page loads, worker fleet reads, and the audit
-//! list endpoint itself. See [`EXCLUDED_ROUTES`] for the full list.
+//! list endpoint itself. See [`crate::audit::EXCLUDED_ROUTES`] for the full list.
 
 use chrono::{DateTime, Utc};
 use diesel::ExpressionMethods;
@@ -277,7 +277,7 @@ impl Default for AuditFilters {
 ///
 /// # Errors
 ///
-/// Returns [`HarvestError::Database`] if the insert fails.
+/// Returns [`crate::error::HarvestError::Database`] if the insert fails.
 pub async fn insert_audit(
     conn: &mut AsyncPgConnection,
     record: &NewAuditRecord<'_>,
@@ -297,7 +297,7 @@ pub async fn insert_audit(
 ///
 /// # Errors
 ///
-/// Returns [`HarvestError::Database`] if the query fails.
+/// Returns [`crate::error::HarvestError::Database`] if the query fails.
 pub async fn list_audit(
     conn: &mut AsyncPgConnection,
     filters: &AuditFilters,
@@ -345,7 +345,7 @@ pub async fn list_audit(
 ///
 /// # Errors
 ///
-/// Returns [`HarvestError::Database`] if the delete fails.
+/// Returns [`crate::error::HarvestError::Database`] if the delete fails.
 pub async fn purge_old_audit_records(
     conn: &mut AsyncPgConnection,
     retention_days: i64,

--- a/autumn-harvest/src/error.rs
+++ b/autumn-harvest/src/error.rs
@@ -168,7 +168,7 @@ pub enum HarvestError {
 
     /// A search attribute key or value violated a documented constraint.
     ///
-    /// Returned by [`WorkflowContext::upsert_search_attrs`] when:
+    /// Returned by [`crate::context::WorkflowContext::upsert_search_attrs`] when:
     /// - The key is empty or longer than 64 characters.
     /// - The key contains characters outside `[a-zA-Z0-9_-]`.
     /// - The key is engine-reserved (`exec_id`, `workflow_name`, `shard_id`,

--- a/autumn-harvest/src/version_gate_retirement.rs
+++ b/autumn-harvest/src/version_gate_retirement.rs
@@ -39,7 +39,7 @@ pub struct RetirementCheckFilters {
 /// **`recorded_version = 0` sentinel** — used in two conservative cases where
 /// the true version cannot be determined from stored events alone:
 ///
-/// 1. *Codec-envelope details* — when a non-identity [`PayloadCodec`] is
+/// 1. *Codec-envelope details* — when a non-identity [`crate::payload_codec::PayloadCodec`] is
 ///    configured, the `MarkerRecorded.details` field is stored as an opaque
 ///    envelope object rather than a bare integer.
 /// 2. *Pre-gate executions* — executions that began before the version gate was


### PR DESCRIPTION
🎻 **Bard: [documentation update]**

📖 **Chapter:** The Audit, Error, and Plugin APIs.
🔦 **Insight:** Several `cargo doc` generation warnings were firing due to unresolved intra-doc links, leaving developers with unclickable references in the generated HTML. I've updated the links across `audit.rs`, `error.rs`, `version_gate_retirement.rs`, and `api.rs` to use fully qualified `crate::...` paths.
🧪 **Example:** N/A (Internal link resolution fix).
🖼️ **Preview:** N/A

---
*PR created automatically by Jules for task [12741210034428080841](https://jules.google.com/task/12741210034428080841) started by @madmax983*