### PR TITLE
feat: expose operator external activity handoffs

### DIFF
--- a/autumn-harvest-cli/src/lib.rs
+++ b/autumn-harvest-cli/src/lib.rs
@@ -240,6 +240,16 @@ enum Commands {
         #[command(subcommand)]
         command: WorkflowCommand,
     },
+    /// Inspect and resolve external activity handoffs.
+    #[command(
+        alias = "handoffs",
+        alias = "external-handoff",
+        alias = "external-handoffs"
+    )]
+    Handoff {
+        #[command(subcommand)]
+        command: HandoffCommand,
+    },
     /// Manage DAG schedules and runs.
     Dag {
         #[command(subcommand)]
@@ -541,6 +551,107 @@ enum WorkflowCommand {
 }
 
 #[derive(Debug, Subcommand)]
+enum HandoffCommand {
+    /// List external activity handoffs.
+    List {
+        /// Filter by handoff state. Repeat the flag or pass a comma-separated list.
+        #[arg(long, value_delimiter = ',')]
+        state: Vec<String>,
+        /// Filter by registered workflow name.
+        #[arg(long)]
+        workflow_name: Option<String>,
+        /// Filter by workflow execution ID.
+        #[arg(long)]
+        execution_id: Option<String>,
+        /// Filter by registered activity name.
+        #[arg(long)]
+        activity_name: Option<String>,
+        /// Filter by external activity token.
+        #[arg(long)]
+        token: Option<String>,
+        /// Restrict inspection to one shard.
+        #[arg(long)]
+        shard_id: Option<i32>,
+        /// Return handoffs due before this RFC3339 timestamp.
+        #[arg(long)]
+        due_before: Option<String>,
+        /// Return handoffs last updated before this RFC3339 timestamp.
+        #[arg(long)]
+        updated_before: Option<String>,
+        /// Maximum number of rows to return.
+        #[arg(long, value_parser = clap::value_parser!(i64).range(1..=500))]
+        limit: Option<i64>,
+        /// Print the raw JSON API payload instead of a human table.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Inspect one external activity handoff by token.
+    #[command(alias = "get")]
+    Inspect {
+        /// External activity token.
+        token: String,
+        /// Print the raw JSON API payload instead of a human table.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Complete an external activity handoff by token.
+    Complete {
+        /// External activity token.
+        token: String,
+        /// JSON value to send as the activity output.
+        #[arg(long, conflicts_with = "output_file")]
+        output_json: Option<String>,
+        /// File containing JSON output. Use `-` for stdin.
+        #[arg(long, value_name = "PATH", conflicts_with = "output_json")]
+        output_file: Option<PathBuf>,
+        /// Full JSON request body. Use this to send `{ "output": ... }` directly.
+        #[arg(long, conflicts_with = "request_file")]
+        request_json: Option<String>,
+        /// File containing the full JSON request body. Use `-` for stdin.
+        #[arg(long, value_name = "PATH", conflicts_with = "request_json")]
+        request_file: Option<PathBuf>,
+    },
+    /// Fail an external activity handoff by token.
+    Fail {
+        /// External activity token.
+        token: String,
+        /// String error to record on the external activity.
+        #[arg(long)]
+        error: Option<String>,
+        /// JSON error details, compacted into the recorded error string.
+        #[arg(long, conflicts_with = "error_file")]
+        error_json: Option<String>,
+        /// File containing JSON error details. Use `-` for stdin.
+        #[arg(long, value_name = "PATH", conflicts_with = "error_json")]
+        error_file: Option<PathBuf>,
+        /// Full JSON request body. Use this to send `{ "error": "...", "retryable": false }`.
+        #[arg(long, conflicts_with = "request_file")]
+        request_json: Option<String>,
+        /// File containing the full JSON request body. Use `-` for stdin.
+        #[arg(long, value_name = "PATH", conflicts_with = "request_json")]
+        request_file: Option<PathBuf>,
+        /// Mark the external failure as retryable for workflow replay.
+        #[arg(long)]
+        retryable: bool,
+    },
+    /// Heartbeat an external activity handoff and optionally extend its deadline.
+    #[command(alias = "extend")]
+    Heartbeat {
+        /// External activity token.
+        token: String,
+        /// Seconds to extend the deadline from now.
+        #[arg(long)]
+        extend_by_secs: Option<u64>,
+        /// Full JSON request body. Use this to send `{ "extend_by_secs": 3600 }`.
+        #[arg(long, conflicts_with = "request_file")]
+        request_json: Option<String>,
+        /// File containing the full JSON request body. Use `-` for stdin.
+        #[arg(long, value_name = "PATH", conflicts_with = "request_json")]
+        request_file: Option<PathBuf>,
+    },
+}
+
+#[derive(Debug, Subcommand)]
 enum DagCommand {
     /// List DAG schedules.
     List,
@@ -743,6 +854,7 @@ impl Cli {
             Commands::Preflight => Ok(ApiRequest::get("/admin/preflight")),
             Commands::Shard { command } => Ok(shard_request(command)),
             Commands::Workflow { command } => workflow_request(command),
+            Commands::Handoff { command } => handoff_request(command),
             Commands::Dag { command } => dag_request(command),
             Commands::Schedule { command } => schedule_request(command),
             Commands::Dlq { command } => Ok(dead_letter_request(command)),
@@ -927,6 +1039,9 @@ fn render_response(cli: &Cli, value: &Value) -> Result<String, CliError> {
     if workflow_children_wants_table(cli) {
         return Ok(format_workflow_children_table(value));
     }
+    if handoff_wants_table(cli) {
+        return Ok(format_handoff_table(value));
+    }
     if audit_list_wants_table(cli) {
         return Ok(format_audit_table(value));
     }
@@ -937,7 +1052,7 @@ fn render_response(cli: &Cli, value: &Value) -> Result<String, CliError> {
         return Ok(format_retirement_check_table(value));
     }
 
-    let output = if workflow_children_wants_raw_json(cli) {
+    let output = if workflow_children_wants_raw_json(cli) || handoff_wants_raw_json(cli) {
         OutputFormat::Json
     } else {
         cli.output
@@ -1250,6 +1365,143 @@ const fn workflow_children_wants_raw_json(cli: &Cli) -> bool {
             command: WorkflowCommand::Children { json: true, .. }
         }
     )
+}
+
+fn handoff_wants_table(cli: &Cli) -> bool {
+    matches!(
+        &cli.command,
+        Commands::Handoff {
+            command:
+                HandoffCommand::List { json: false, .. }
+                    | HandoffCommand::Inspect { json: false, .. }
+        } if cli.output == OutputFormat::PrettyJson
+    )
+}
+
+const fn handoff_wants_raw_json(cli: &Cli) -> bool {
+    matches!(
+        &cli.command,
+        Commands::Handoff {
+            command: HandoffCommand::List { json: true, .. }
+                | HandoffCommand::Inspect { json: true, .. }
+        }
+    )
+}
+
+fn format_handoff_table(value: &Value) -> String {
+    let (status, items, coverage) =
+        if let Some(items) = value.get("items").and_then(Value::as_array) {
+            (
+                value
+                    .get("status")
+                    .and_then(Value::as_str)
+                    .unwrap_or("unknown"),
+                items.clone(),
+                value.get("shard_coverage"),
+            )
+        } else if let Some(item) = value.get("item") {
+            (
+                value
+                    .get("status")
+                    .and_then(Value::as_str)
+                    .unwrap_or("unknown"),
+                vec![item.clone()],
+                value.get("shard_coverage"),
+            )
+        } else {
+            return "No external handoffs found.".to_string();
+        };
+
+    if items.is_empty() {
+        return format!("status: {status}\nNo external handoffs found.");
+    }
+
+    let mut rows = Vec::with_capacity(items.len() + 1);
+    rows.push(vec![
+        "STATE".to_string(),
+        "DEADLINE".to_string(),
+        "UPDATED".to_string(),
+        "WORKFLOW".to_string(),
+        "EXEC ID".to_string(),
+        "ACTIVITY".to_string(),
+        "SHARD".to_string(),
+        "TOKEN".to_string(),
+    ]);
+    for item in items {
+        rows.push(vec![
+            cell_str(item.get("state")),
+            cell_str(item.get("deadline_at")),
+            cell_str(item.get("updated_at")),
+            cell_str(
+                item.get("workflow")
+                    .and_then(|workflow| workflow.get("workflow_name")),
+            ),
+            cell_str(
+                item.get("workflow")
+                    .and_then(|workflow| workflow.get("execution_id")),
+            ),
+            cell_str(
+                item.get("activity")
+                    .and_then(|activity| activity.get("activity_name")),
+            ),
+            cell_number(
+                item.get("workflow")
+                    .and_then(|workflow| workflow.get("shard_id")),
+            ),
+            cell_str(item.get("token")),
+        ]);
+    }
+
+    let widths = (0..rows[0].len())
+        .map(|col| rows.iter().map(|row| row[col].len()).max().unwrap_or(0))
+        .collect::<Vec<_>>();
+    let table = rows
+        .iter()
+        .map(|row| {
+            row.iter()
+                .enumerate()
+                .map(|(col, cell)| format!("{cell:<width$}", width = widths[col]))
+                .collect::<Vec<_>>()
+                .join("  ")
+                .trim_end()
+                .to_string()
+        })
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    let coverage = coverage.map_or_else(String::new, handoff_coverage_summary);
+    if coverage.is_empty() {
+        format!("status: {status}\n\n{table}")
+    } else {
+        format!("status: {status}\n{coverage}\n\n{table}")
+    }
+}
+
+fn handoff_coverage_summary(value: &Value) -> String {
+    let unavailable = value
+        .get("unavailable_shards")
+        .and_then(Value::as_array)
+        .map_or_else(String::new, |shards| {
+            if shards.is_empty() {
+                return String::new();
+            }
+            let cells = shards
+                .iter()
+                .map(|shard| {
+                    let id = cell_number(shard.get("shard_id"));
+                    let reason = cell_str(shard.get("reason"));
+                    format!("{id}:{reason}")
+                })
+                .collect::<Vec<_>>()
+                .join(",");
+            format!("unavailable_shards: {cells}")
+        });
+    let inspected = shard_array_cell(value, "inspected_shards");
+    if unavailable.is_empty() {
+        format!("inspected_shards: {inspected}")
+    } else {
+        format!("inspected_shards: {inspected}\n{unavailable}")
+    }
 }
 
 fn format_workflow_children_table(value: &Value) -> String {
@@ -1749,6 +2001,152 @@ fn workflow_request(command: &WorkflowCommand) -> Result<ApiRequest, CliError> {
     }
 }
 
+fn handoff_request(command: &HandoffCommand) -> Result<ApiRequest, CliError> {
+    match command {
+        HandoffCommand::List {
+            state,
+            workflow_name,
+            execution_id,
+            activity_name,
+            token,
+            shard_id,
+            due_before,
+            updated_before,
+            limit,
+            json: _,
+        } => Ok(ApiRequest::get(build_handoff_list_path(
+            state,
+            workflow_name.as_deref(),
+            execution_id.as_deref(),
+            activity_name.as_deref(),
+            token.as_deref(),
+            *shard_id,
+            due_before.as_deref(),
+            updated_before.as_deref(),
+            *limit,
+        ))),
+        HandoffCommand::Inspect { token, json: _ } => Ok(ApiRequest::get(format!(
+            "/admin/external-handoffs/{}",
+            path_segment(token)
+        ))),
+        HandoffCommand::Complete {
+            token,
+            output_json,
+            output_file,
+            request_json,
+            request_file,
+        } => complete_handoff_request(
+            token,
+            output_json.as_deref(),
+            output_file.as_deref(),
+            request_json.as_deref(),
+            request_file.as_deref(),
+        ),
+        HandoffCommand::Fail {
+            token,
+            error,
+            error_json,
+            error_file,
+            request_json,
+            request_file,
+            retryable,
+        } => fail_handoff_request(
+            token,
+            error.as_deref(),
+            error_json.as_deref(),
+            error_file.as_deref(),
+            request_json.as_deref(),
+            request_file.as_deref(),
+            *retryable,
+        ),
+        HandoffCommand::Heartbeat {
+            token,
+            extend_by_secs,
+            request_json,
+            request_file,
+        } => heartbeat_handoff_request(
+            token,
+            *extend_by_secs,
+            request_json.as_deref(),
+            request_file.as_deref(),
+        ),
+    }
+}
+
+fn complete_handoff_request(
+    token: &str,
+    output_json: Option<&str>,
+    output_file: Option<&Path>,
+    request_json: Option<&str>,
+    request_file: Option<&Path>,
+) -> Result<ApiRequest, CliError> {
+    let request_body = parse_json_source(request_json, request_file, "handoff complete request")?;
+    let body = if let Some(request_body) = request_body {
+        request_body
+    } else {
+        let output = parse_json_source(output_json, output_file, "handoff completion output")?
+            .unwrap_or(Value::Null);
+        json!({ "output": output })
+    };
+    Ok(ApiRequest::post(
+        format!("/activities/external/{}/complete", path_segment(token)),
+        Some(body),
+    ))
+}
+
+fn fail_handoff_request(
+    token: &str,
+    error: Option<&str>,
+    error_json: Option<&str>,
+    error_file: Option<&Path>,
+    request_json: Option<&str>,
+    request_file: Option<&Path>,
+    retryable: bool,
+) -> Result<ApiRequest, CliError> {
+    let request = parse_json_source(request_json, request_file, "handoff fail request")?;
+    let body = if let Some(request) = request {
+        request
+    } else {
+        let error_value = parse_json_source(error_json, error_file, "handoff error")?;
+        let error = error_value.map_or_else(
+            || error.unwrap_or("external handoff failed").to_string(),
+            stringify_handoff_error,
+        );
+        json!({ "error": error, "retryable": retryable })
+    };
+    Ok(ApiRequest::post(
+        format!("/activities/external/{}/fail", path_segment(token)),
+        Some(body),
+    ))
+}
+
+fn stringify_handoff_error(value: Value) -> String {
+    match value {
+        Value::String(raw) => raw,
+        other => serde_json::to_string(&other).unwrap_or_else(|_| other.to_string()),
+    }
+}
+
+fn heartbeat_handoff_request(
+    token: &str,
+    extend_by_secs: Option<u64>,
+    request_json: Option<&str>,
+    request_file: Option<&Path>,
+) -> Result<ApiRequest, CliError> {
+    let body = parse_json_source(request_json, request_file, "handoff heartbeat request")?
+        .unwrap_or_else(|| {
+            let mut body = Map::new();
+            if let Some(secs) = extend_by_secs {
+                body.insert("extend_by_secs".to_string(), json!(secs));
+            }
+            Value::Object(body)
+        });
+    Ok(ApiRequest::post(
+        format!("/activities/external/{}/heartbeat", path_segment(token)),
+        Some(body),
+    ))
+}
+
 fn dag_request(command: &DagCommand) -> Result<ApiRequest, CliError> {
     match command {
         DagCommand::List => Ok(ApiRequest::get("/dags")),
@@ -2082,6 +2480,58 @@ fn path_with_limit(base: &str, limit: Option<(&str, i64)>) -> String {
         .collect::<Vec<_>>()
         .join("&");
     format!("{base}?{query}")
+}
+
+#[allow(clippy::too_many_arguments)]
+fn build_handoff_list_path(
+    states: &[String],
+    workflow_name: Option<&str>,
+    execution_id: Option<&str>,
+    activity_name: Option<&str>,
+    token: Option<&str>,
+    shard_id: Option<i32>,
+    due_before: Option<&str>,
+    updated_before: Option<&str>,
+    limit: Option<i64>,
+) -> String {
+    let mut params: Vec<(&'static str, String)> = Vec::new();
+    if !states.is_empty() {
+        params.push(("state", states.join(",")));
+    }
+    if let Some(value) = workflow_name {
+        params.push(("workflow_name", value.to_string()));
+    }
+    if let Some(value) = execution_id {
+        params.push(("execution_id", value.to_string()));
+    }
+    if let Some(value) = activity_name {
+        params.push(("activity_name", value.to_string()));
+    }
+    if let Some(value) = token {
+        params.push(("token", value.to_string()));
+    }
+    if let Some(value) = shard_id {
+        params.push(("shard_id", value.to_string()));
+    }
+    if let Some(value) = due_before {
+        params.push(("due_before", value.to_string()));
+    }
+    if let Some(value) = updated_before {
+        params.push(("updated_before", value.to_string()));
+    }
+    if let Some(value) = limit {
+        params.push(("limit", value.to_string()));
+    }
+
+    if params.is_empty() {
+        return "/admin/external-handoffs".to_string();
+    }
+    let query = params
+        .iter()
+        .map(|(key, value)| format!("{key}={}", query_encode(value)))
+        .collect::<Vec<_>>()
+        .join("&");
+    format!("/admin/external-handoffs?{query}")
 }
 
 fn build_workflow_list_path(
@@ -2458,6 +2908,65 @@ mod reuse_policy_tests {
         let rendered = render_response(&cli, &payload).expect("json output should render");
 
         assert_eq!(rendered, r#"{"items":[],"next_cursor":null}"#);
+    }
+
+    #[test]
+    fn handoff_list_default_output_renders_human_table() {
+        let cli = parse(&["handoff", "list"]);
+        let payload = json!({
+            "status": "ok",
+            "shard_coverage": {
+                "inspected_shards": [0],
+                "matched_shards": [0],
+                "unavailable_shards": []
+            },
+            "items": [{
+                "token": "11111111-1111-4111-8111-111111111111",
+                "workflow": {
+                    "execution_id": "00000000-0000-0000-0000-000000000001",
+                    "workflow_id": "invoice-42",
+                    "workflow_name": "billing_checkout",
+                    "shard_id": 0
+                },
+                "activity": {
+                    "activity_id": "22222222-2222-4222-8222-222222222222",
+                    "activity_name": "manager_approval"
+                },
+                "state": "PENDING",
+                "created_at": "2026-05-08T11:00:00Z",
+                "updated_at": "2026-05-08T11:05:00Z",
+                "deadline_at": "2026-05-08T12:00:00Z"
+            }]
+        });
+
+        let rendered = render_response(&cli, &payload).expect("table output should render");
+
+        assert!(rendered.contains("status: ok"));
+        assert!(rendered.contains("STATE"));
+        assert!(rendered.contains("manager_approval"));
+        assert!(rendered.contains("11111111-1111-4111-8111-111111111111"));
+        assert!(!rendered.trim_start().starts_with('{'));
+    }
+
+    #[test]
+    fn handoff_json_flag_renders_raw_payload() {
+        let cli = parse(&["handoff", "list", "--json"]);
+        let payload = json!({
+            "status": "ok",
+            "items": [],
+            "shard_coverage": {
+                "inspected_shards": [0],
+                "matched_shards": [],
+                "unavailable_shards": []
+            }
+        });
+
+        let rendered = render_response(&cli, &payload).expect("json output should render");
+
+        assert_eq!(
+            rendered,
+            r#"{"items":[],"shard_coverage":{"inspected_shards":[0],"matched_shards":[],"unavailable_shards":[]},"status":"ok"}"#
+        );
     }
 
     #[test]

--- a/autumn-harvest-cli/tests/request_mapping.rs
+++ b/autumn-harvest-cli/tests/request_mapping.rs
@@ -265,6 +265,136 @@ fn workflow_children_maps_to_management_api_request() {
 }
 
 #[test]
+fn handoff_list_maps_filters_to_management_api_request() {
+    let cli = Cli::try_parse_from([
+        "harvest",
+        "handoff",
+        "list",
+        "--state",
+        "PENDING,FAILED",
+        "--workflow-name",
+        "billing_checkout",
+        "--execution-id",
+        "00000000-0000-0000-0000-000000000001",
+        "--activity-name",
+        "manager_approval",
+        "--token",
+        "11111111-1111-4111-8111-111111111111",
+        "--shard-id",
+        "2",
+        "--due-before",
+        "2026-05-08T12:00:00Z",
+        "--updated-before",
+        "2026-05-08T13:00:00Z",
+        "--limit",
+        "25",
+    ])
+    .expect("handoff list args should parse");
+    let request = cli
+        .api_request()
+        .expect("handoff list request should build");
+
+    assert_eq!(request.method, ApiMethod::Get);
+    assert_eq!(
+        request.path,
+        "/admin/external-handoffs?state=PENDING,FAILED&workflow_name=billing_checkout\
+         &execution_id=00000000-0000-0000-0000-000000000001&activity_name=manager_approval\
+         &token=11111111-1111-4111-8111-111111111111&shard_id=2\
+         &due_before=2026-05-08T12:00:00Z&updated_before=2026-05-08T13:00:00Z&limit=25"
+    );
+    assert_eq!(request.body, None);
+}
+
+#[test]
+fn handoff_inspect_maps_to_detail_request() {
+    let cli = Cli::try_parse_from([
+        "harvest",
+        "handoff",
+        "inspect",
+        "11111111-1111-4111-8111-111111111111",
+    ])
+    .expect("handoff inspect args should parse");
+    let request = cli
+        .api_request()
+        .expect("handoff inspect request should build");
+
+    assert_eq!(request.method, ApiMethod::Get);
+    assert_eq!(
+        request.path,
+        "/admin/external-handoffs/11111111-1111-4111-8111-111111111111"
+    );
+    assert_eq!(request.body, None);
+}
+
+#[test]
+fn handoff_mutations_map_to_token_completion_routes() {
+    let complete = Cli::try_parse_from([
+        "harvest",
+        "handoff",
+        "complete",
+        "11111111-1111-4111-8111-111111111111",
+        "--output-json",
+        r#"{"approved":true}"#,
+    ])
+    .expect("handoff complete args should parse");
+    let complete_request = complete
+        .api_request()
+        .expect("complete request should build");
+    assert_eq!(complete_request.method, ApiMethod::Post);
+    assert_eq!(
+        complete_request.path,
+        "/activities/external/11111111-1111-4111-8111-111111111111/complete"
+    );
+    assert_eq!(
+        complete_request.body,
+        Some(json!({ "output": { "approved": true } }))
+    );
+
+    let fail = Cli::try_parse_from([
+        "harvest",
+        "handoff",
+        "fail",
+        "11111111-1111-4111-8111-111111111111",
+        "--error",
+        "manager rejected",
+        "--retryable",
+    ])
+    .expect("handoff fail args should parse");
+    let fail_request = fail.api_request().expect("fail request should build");
+    assert_eq!(fail_request.method, ApiMethod::Post);
+    assert_eq!(
+        fail_request.path,
+        "/activities/external/11111111-1111-4111-8111-111111111111/fail"
+    );
+    assert_eq!(
+        fail_request.body,
+        Some(json!({ "error": "manager rejected", "retryable": true }))
+    );
+
+    let heartbeat = Cli::try_parse_from([
+        "harvest",
+        "handoff",
+        "heartbeat",
+        "11111111-1111-4111-8111-111111111111",
+        "--extend-by-secs",
+        "3600",
+    ])
+    .expect("handoff heartbeat args should parse");
+    let heartbeat_request = heartbeat
+        .api_request()
+        .expect("heartbeat request should build");
+    assert_eq!(heartbeat_request.method, ApiMethod::Post);
+    assert_eq!(
+        heartbeat_request.path,
+        "/activities/external/11111111-1111-4111-8111-111111111111/heartbeat"
+    );
+    assert_eq!(
+        heartbeat_request.body,
+        Some(json!({ "extend_by_secs": 3600 }))
+    );
+}
+
+#[test]
 fn workflow_list_rejects_search_attr_without_equals() {
     let list = Cli::try_parse_from(["harvest", "workflow", "list", "--search-attr", "tenant"])
         .expect("malformed search-attr args should still parse at clap level");

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -55,8 +55,8 @@ use autumn_harvest::scheduler::{
     DagCatalog, RegisteredDag, SchedulerMonitor, SchedulerSnapshot, trigger_dag,
 };
 use autumn_harvest::schema::{
-    harvest_dag_runs, harvest_events, harvest_external_tasks, harvest_schedules, harvest_signals,
-    harvest_task_queue, harvest_timers, harvest_workflow_executions,
+    harvest_dag_runs, harvest_events, harvest_schedules, harvest_signals, harvest_task_queue,
+    harvest_timers, harvest_workflow_executions,
 };
 use autumn_harvest::shard::ShardRouter;
 use autumn_harvest::signal;
@@ -460,6 +460,7 @@ struct WorkflowDetailsResponse {
     parent_id: Option<uuid::Uuid>,
     execution: WorkflowExecution,
     history: Vec<Value>,
+    external_handoffs: Vec<ExternalHandoffResponse>,
 }
 
 #[derive(Debug, Serialize)]
@@ -470,6 +471,7 @@ struct WorkflowStackResponse {
     state: String,
     is_terminal: bool,
     pending_activities: Vec<PendingActivity>,
+    pending_external_handoffs: Vec<ExternalHandoffResponse>,
     pending_local_activities: Vec<PendingLocalActivity>,
     pending_timers: Vec<PendingTimer>,
     pending_signals: Vec<PendingSignal>,
@@ -536,6 +538,71 @@ struct PendingChildWorkflow {
     child_exec_id: String,
     child_workflow_name: String,
     state: String,
+}
+
+#[derive(Debug, Serialize)]
+struct ExternalHandoffListResponse {
+    status: String,
+    items: Vec<ExternalHandoffResponse>,
+    shard_coverage: ExternalHandoffShardCoverage,
+}
+
+#[derive(Debug, Serialize)]
+struct ExternalHandoffDetailResponse {
+    status: String,
+    item: ExternalHandoffResponse,
+    shard_coverage: ExternalHandoffShardCoverage,
+}
+
+#[derive(Debug, Serialize, Clone)]
+struct ExternalHandoffShardCoverage {
+    #[serde(rename = "inspected_shards")]
+    inspected: Vec<i32>,
+    #[serde(rename = "matched_shards")]
+    matched: Vec<i32>,
+    #[serde(rename = "unavailable_shards")]
+    unavailable: Vec<UnavailableShard>,
+}
+
+#[derive(Debug, Serialize, Clone)]
+struct UnavailableShard {
+    shard_id: i32,
+    reason: String,
+}
+
+#[derive(Debug, Serialize)]
+struct ExternalHandoffResponse {
+    token: String,
+    workflow: ExternalHandoffWorkflow,
+    activity: ExternalHandoffActivity,
+    state: String,
+    created_at: chrono::DateTime<chrono::Utc>,
+    updated_at: chrono::DateTime<chrono::Utc>,
+    deadline_at: chrono::DateTime<chrono::Utc>,
+    complete_path: String,
+    fail_path: String,
+    heartbeat_path: String,
+    payloads: RedactedPayloadSummary,
+}
+
+#[derive(Debug, Serialize)]
+struct ExternalHandoffWorkflow {
+    execution_id: String,
+    workflow_id: String,
+    workflow_name: String,
+    shard_id: i32,
+}
+
+#[derive(Debug, Serialize)]
+struct ExternalHandoffActivity {
+    activity_id: String,
+    activity_name: String,
+}
+
+#[derive(Debug, Serialize)]
+struct RedactedPayloadSummary {
+    redacted: bool,
+    summary: &'static str,
 }
 
 fn is_terminal_state(state: &str) -> bool {
@@ -741,6 +808,8 @@ const MAX_WORKFLOW_LIMIT: i64 = 200;
 const DEFAULT_WORKFLOW_CHILDREN_LIMIT: usize = 50;
 const MAX_WORKFLOW_CHILDREN_LIMIT: usize = 500;
 const MAX_WORKFLOW_CHILDREN_DEPTH: u8 = 5;
+const DEFAULT_EXTERNAL_HANDOFF_LIMIT: i64 = 100;
+const MAX_EXTERNAL_HANDOFF_LIMIT: i64 = 500;
 
 #[derive(Debug, Default, Clone)]
 pub(crate) struct WorkflowFilters {
@@ -852,6 +921,11 @@ pub fn harvest_api_router(api_state: HarvestApiState) -> Router<AppState> {
         .route("/admin/retention", get(retention_status))
         .route("/admin/retention/run-now", post(retention_run_now))
         .route("/admin/concurrency", get(concurrency_status))
+        .route("/admin/external-handoffs", get(list_external_handoffs))
+        .route(
+            "/admin/external-handoffs/{token}",
+            get(get_external_handoff),
+        )
         // Schedule management (issue #91): unified list + workflow-schedule CRUD.
         .route("/admin/schedules", get(list_schedules))
         .route("/admin/schedules/workflow", post(create_workflow_schedule))
@@ -1368,11 +1442,24 @@ async fn get_workflow(
         .map(|event| serde_json::to_value(event).map_err(HarvestError::from))
         .collect::<HarvestResult<Vec<_>>>()
         .map_err(map_error)?;
+    let handoff_filters = external_task::ExternalHandoffFilters {
+        states: vec!["PENDING".to_string()],
+        execution_id: Some(exec_id),
+        limit: MAX_EXTERNAL_HANDOFF_LIMIT,
+        ..external_task::ExternalHandoffFilters::default()
+    };
+    let external_handoffs = external_task::list_external_handoffs(&mut conn, &handoff_filters)
+        .await
+        .map_err(map_error)?
+        .into_iter()
+        .map(ExternalHandoffResponse::from)
+        .collect();
 
     Ok(Json(WorkflowDetailsResponse {
         parent_id: execution.parent_id,
         execution,
         history: events,
+        external_handoffs,
     }))
 }
 
@@ -1663,6 +1750,295 @@ impl From<store::WorkflowChildRow> for WorkflowChildResponse {
     }
 }
 
+impl From<external_task::ExternalHandoffRow> for ExternalHandoffResponse {
+    fn from(row: external_task::ExternalHandoffRow) -> Self {
+        let token = row.token.to_string();
+        Self {
+            complete_path: format!("/activities/external/{token}/complete"),
+            fail_path: format!("/activities/external/{token}/fail"),
+            heartbeat_path: format!("/activities/external/{token}/heartbeat"),
+            token,
+            workflow: ExternalHandoffWorkflow {
+                execution_id: row.workflow_exec_id.to_string(),
+                workflow_id: row.workflow_id,
+                workflow_name: row.workflow_name,
+                shard_id: row.shard_id,
+            },
+            activity: ExternalHandoffActivity {
+                activity_id: row.activity_id.to_string(),
+                activity_name: row.activity_name,
+            },
+            state: row.state,
+            created_at: row.created_at,
+            updated_at: row.updated_at,
+            deadline_at: row.deadline_at,
+            payloads: RedactedPayloadSummary {
+                redacted: true,
+                summary: "raw workflow inputs, activity inputs, outputs, signals, and secrets are redacted",
+            },
+        }
+    }
+}
+
+async fn list_external_handoffs(
+    Extension(api_state): Extension<HarvestApiState>,
+    Query(pairs): Query<Vec<(String, String)>>,
+) -> Result<Json<ExternalHandoffListResponse>, AutumnError> {
+    let filters = parse_external_handoff_filters(&pairs)?;
+    let limit = filters.limit;
+    let (mut rows, coverage) = load_external_handoffs_from_shards(&api_state, &filters).await?;
+    sort_external_handoff_rows(&mut rows);
+    rows.truncate(usize::try_from(limit).unwrap_or(usize::MAX));
+    let status = external_handoff_status(&coverage);
+
+    Ok(Json(ExternalHandoffListResponse {
+        status,
+        items: rows
+            .into_iter()
+            .map(ExternalHandoffResponse::from)
+            .collect(),
+        shard_coverage: coverage,
+    }))
+}
+
+async fn get_external_handoff(
+    Extension(api_state): Extension<HarvestApiState>,
+    Path(token_str): Path<String>,
+) -> Result<Json<ExternalHandoffDetailResponse>, AutumnError> {
+    let token = parse_external_token(&token_str)?;
+    let filters = external_task::ExternalHandoffFilters {
+        token: Some(token),
+        limit: 1,
+        ..external_task::ExternalHandoffFilters::default()
+    };
+    let (mut rows, coverage) = load_external_handoffs_from_shards(&api_state, &filters).await?;
+    sort_external_handoff_rows(&mut rows);
+
+    let Some(row) = rows.into_iter().next() else {
+        if coverage.unavailable.is_empty() {
+            return Err(AutumnError::not_found_msg(format!(
+                "external handoff token {token}"
+            )));
+        }
+        return Err(AutumnError::service_unavailable_msg(format!(
+            "external handoff token {token} was not found on inspected shards; unavailable shards: {}",
+            unavailable_shards_summary(&coverage.unavailable)
+        )));
+    };
+
+    Ok(Json(ExternalHandoffDetailResponse {
+        status: external_handoff_status(&coverage),
+        item: ExternalHandoffResponse::from(row),
+        shard_coverage: coverage,
+    }))
+}
+
+fn parse_external_handoff_filters(
+    pairs: &[(String, String)],
+) -> Result<external_task::ExternalHandoffFilters, AutumnError> {
+    let mut limit_raw = None;
+    let mut filters =
+        external_task::ExternalHandoffFilters::default().with_limit(DEFAULT_EXTERNAL_HANDOFF_LIMIT);
+
+    for (key, value) in pairs {
+        match key.as_str() {
+            "state" => {
+                for raw in value.split(',') {
+                    let trimmed = raw.trim();
+                    if trimmed.is_empty() {
+                        continue;
+                    }
+                    let state = parse_external_handoff_state(trimmed)?;
+                    if !filters.states.contains(&state) {
+                        filters.states.push(state);
+                    }
+                }
+            }
+            "workflow_name" => {
+                let trimmed = value.trim();
+                if !trimmed.is_empty() {
+                    filters.workflow_name = Some(trimmed.to_string());
+                }
+            }
+            "execution_id" => {
+                filters.execution_id = Some(parse_execution_id(value)?);
+            }
+            "activity_name" => {
+                let trimmed = value.trim();
+                if !trimmed.is_empty() {
+                    filters.activity_name = Some(trimmed.to_string());
+                }
+            }
+            "token" => {
+                filters.token = Some(parse_external_token(value)?);
+            }
+            "shard_id" | "shard" => {
+                let shard_id = value.parse::<i32>().map_err(|_| {
+                    AutumnError::bad_request_msg(format!("invalid shard_id '{value}'"))
+                })?;
+                filters.shard_id = Some(shard_id);
+            }
+            "due_before" => {
+                filters.due_before = Some(parse_external_handoff_datetime(value, "due_before")?);
+            }
+            "updated_before" => {
+                filters.updated_before =
+                    Some(parse_external_handoff_datetime(value, "updated_before")?);
+            }
+            "limit" => {
+                let parsed = value.parse::<i64>().map_err(|_| {
+                    AutumnError::bad_request_msg(format!("invalid limit '{value}'"))
+                })?;
+                limit_raw = Some(parsed);
+            }
+            _ => {}
+        }
+    }
+
+    let limit = limit_raw
+        .unwrap_or(DEFAULT_EXTERNAL_HANDOFF_LIMIT)
+        .clamp(1, MAX_EXTERNAL_HANDOFF_LIMIT);
+    Ok(filters.with_limit(limit))
+}
+
+fn parse_external_handoff_state(raw: &str) -> Result<String, AutumnError> {
+    let normalized = raw
+        .chars()
+        .filter(|ch| *ch != '_' && *ch != '-')
+        .flat_map(char::to_lowercase)
+        .collect::<String>();
+    let state = match normalized.as_str() {
+        "pending" => "PENDING",
+        "completed" => "COMPLETED",
+        "failed" => "FAILED",
+        "timedout" => "TIMED_OUT",
+        "cancelled" | "canceled" => "CANCELLED",
+        _ => {
+            return Err(AutumnError::bad_request_msg(format!(
+                "unknown external handoff state '{raw}'; expected one of {:?}",
+                external_task::KNOWN_EXTERNAL_TASK_STATES
+            )));
+        }
+    };
+    Ok(state.to_string())
+}
+
+fn parse_external_handoff_datetime(
+    raw: &str,
+    label: &str,
+) -> Result<chrono::DateTime<chrono::Utc>, AutumnError> {
+    chrono::DateTime::parse_from_rfc3339(raw)
+        .map(|dt| dt.with_timezone(&chrono::Utc))
+        .map_err(|_| {
+            AutumnError::bad_request_msg(format!(
+                "invalid {label} '{raw}'; expected RFC 3339 format, e.g. 2026-05-08T00:00:00Z"
+            ))
+        })
+}
+
+async fn load_external_handoffs_from_shards(
+    api_state: &HarvestApiState,
+    filters: &external_task::ExternalHandoffFilters,
+) -> Result<
+    (
+        Vec<external_task::ExternalHandoffRow>,
+        ExternalHandoffShardCoverage,
+    ),
+    AutumnError,
+> {
+    let pool = api_state.storage_pool().map_err(map_error)?;
+    let mut rows = Vec::new();
+    let mut inspected_shards = Vec::new();
+    let mut matched_shards = Vec::new();
+    let mut unavailable_shards = Vec::new();
+    let mut matched_target = false;
+
+    for (shard, shard_pool) in pool.iter_shards() {
+        let shard_id = shard.as_i32();
+        if filters.shard_id.is_some_and(|target| target != shard_id) {
+            continue;
+        }
+        matched_target = true;
+
+        let mut conn = match acquire_conn(shard_pool).await {
+            Ok(conn) => conn,
+            Err(error) => {
+                unavailable_shards.push(UnavailableShard {
+                    shard_id,
+                    reason: error.to_string(),
+                });
+                continue;
+            }
+        };
+        inspected_shards.push(shard_id);
+
+        match external_task::list_external_handoffs(&mut conn, filters).await {
+            Ok(mut shard_rows) => {
+                if !shard_rows.is_empty() {
+                    matched_shards.push(shard_id);
+                }
+                rows.append(&mut shard_rows);
+            }
+            Err(error) => unavailable_shards.push(UnavailableShard {
+                shard_id,
+                reason: error.to_string(),
+            }),
+        }
+    }
+
+    if let Some(shard_id) = filters.shard_id
+        && !matched_target
+    {
+        unavailable_shards.push(UnavailableShard {
+            shard_id,
+            reason: "shard pool is not configured".to_string(),
+        });
+    }
+
+    inspected_shards.sort_unstable();
+    inspected_shards.dedup();
+    matched_shards.sort_unstable();
+    matched_shards.dedup();
+    unavailable_shards.sort_by_key(|shard| shard.shard_id);
+
+    Ok((
+        rows,
+        ExternalHandoffShardCoverage {
+            inspected: inspected_shards,
+            matched: matched_shards,
+            unavailable: unavailable_shards,
+        },
+    ))
+}
+
+fn sort_external_handoff_rows(rows: &mut [external_task::ExternalHandoffRow]) {
+    rows.sort_by(|left, right| {
+        left.deadline_at
+            .cmp(&right.deadline_at)
+            .then_with(|| right.updated_at.cmp(&left.updated_at))
+            .then_with(|| left.token.as_uuid().cmp(&right.token.as_uuid()))
+    });
+}
+
+fn external_handoff_status(coverage: &ExternalHandoffShardCoverage) -> String {
+    if coverage.unavailable.is_empty() {
+        "ok"
+    } else if coverage.inspected.is_empty() {
+        "unavailable"
+    } else {
+        "partial"
+    }
+    .to_string()
+}
+
+fn unavailable_shards_summary(shards: &[UnavailableShard]) -> String {
+    shards
+        .iter()
+        .map(|shard| format!("{} ({})", shard.shard_id, shard.reason))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
 #[allow(clippy::too_many_lines)]
 async fn get_workflow_stack(
     Extension(api_state): Extension<HarvestApiState>,
@@ -1690,6 +2066,7 @@ async fn get_workflow_stack(
             state: execution.state,
             is_terminal,
             pending_activities: Vec::new(),
+            pending_external_handoffs: Vec::new(),
             pending_local_activities: Vec::new(),
             pending_timers: Vec::new(),
             pending_signals: Vec::new(),
@@ -1728,29 +2105,36 @@ async fn get_workflow_stack(
                 .map(|(h, d)| h + d),
         })
         .collect::<Vec<_>>();
-    let external_pending = harvest_external_tasks::table
-        .filter(harvest_external_tasks::workflow_exec_id.eq(exec_uuid))
-        .filter(harvest_external_tasks::state.eq("PENDING"))
-        .select(autumn_harvest::models::ExternalTask::as_select())
-        .load::<autumn_harvest::models::ExternalTask>(&mut conn)
+    let handoff_filters = external_task::ExternalHandoffFilters {
+        states: vec!["PENDING".to_string()],
+        execution_id: Some(exec_id),
+        limit: MAX_EXTERNAL_HANDOFF_LIMIT,
+        ..external_task::ExternalHandoffFilters::default()
+    };
+    let external_handoff_rows = external_task::list_external_handoffs(&mut conn, &handoff_filters)
         .await
-        .map_err(database_error)?
-        .into_iter()
+        .map_err(map_error)?;
+    let external_pending = external_handoff_rows
+        .iter()
         .map(|task| PendingActivity {
             activity_exec_id: task.activity_id.to_string(),
-            activity_name: task.name,
-            queue: task.queue,
+            activity_name: task.activity_name.clone(),
+            queue: "external".to_string(),
             scheduled_at: task.created_at,
             attempt: 1,
             max_attempts: 1,
-            task_status: "PENDING".to_string(),
+            task_status: task.state.clone(),
             claimed_by_worker_id: None,
             last_heartbeat_at: None,
             next_retry_at: None,
             schedule_to_start_deadline: None,
-            start_to_close_deadline: Some(task.schedule_to_close_at),
+            start_to_close_deadline: Some(task.deadline_at),
             heartbeat_deadline: None,
         })
+        .collect::<Vec<_>>();
+    let pending_external_handoffs = external_handoff_rows
+        .into_iter()
+        .map(ExternalHandoffResponse::from)
         .collect::<Vec<_>>();
     let mut pending_activities = pending_activities;
     pending_activities.extend(external_pending);
@@ -1896,6 +2280,7 @@ async fn get_workflow_stack(
         state: execution.state,
         is_terminal,
         pending_activities,
+        pending_external_handoffs,
         pending_local_activities,
         pending_timers,
         pending_signals,
@@ -4073,6 +4458,8 @@ struct HeartbeatExternalActivityRequest {
 struct ExternalActivityAck {
     ok: bool,
     newly_resolved: bool,
+    status: String,
+    current_state: String,
 }
 
 async fn complete_external_activity(
@@ -4155,10 +4542,17 @@ async fn complete_external_activity(
         }
     }
 
-    let newly_resolved = complete_result?;
+    let (newly_resolved, current_state) = complete_result?;
     Ok(Json(ExternalActivityAck {
         ok: true,
         newly_resolved,
+        status: if newly_resolved {
+            "completed"
+        } else {
+            "already_terminal"
+        }
+        .to_string(),
+        current_state,
     }))
 }
 
@@ -4242,10 +4636,17 @@ async fn fail_external_activity(
         }
     }
 
-    let newly_resolved = fail_result?;
+    let (newly_resolved, current_state) = fail_result?;
     Ok(Json(ExternalActivityAck {
         ok: true,
         newly_resolved,
+        status: if newly_resolved {
+            "failed"
+        } else {
+            "already_terminal"
+        }
+        .to_string(),
+        current_state,
     }))
 }
 
@@ -4253,7 +4654,7 @@ async fn heartbeat_external_activity(
     Extension(api_state): Extension<HarvestApiState>,
     Path(token_str): Path<String>,
     Json(request): Json<HeartbeatExternalActivityRequest>,
-) -> Result<Json<BasicAck>, AutumnError> {
+) -> Result<Json<ExternalActivityAck>, AutumnError> {
     let token = parse_external_token(&token_str)?;
     let pool = api_state.storage_pool().map_err(map_error)?;
 
@@ -4263,6 +4664,14 @@ async fn heartbeat_external_activity(
             .await
             .map_err(map_error)?
         {
+            if task.state != "PENDING" {
+                return Ok(Json(ExternalActivityAck {
+                    ok: true,
+                    newly_resolved: false,
+                    status: "already_terminal".to_string(),
+                    current_state: task.state,
+                }));
+            }
             // Default to the original configured duration so that omitting
             // extend_by_secs resets the deadline by the same fixed window every
             // time, regardless of how many heartbeats have already fired.
@@ -4271,7 +4680,12 @@ async fn heartbeat_external_activity(
             external_task::extend_deadline(&mut conn, token, extend_by)
                 .await
                 .map_err(map_error)?;
-            return Ok(Json(BasicAck { ok: true }));
+            return Ok(Json(ExternalActivityAck {
+                ok: true,
+                newly_resolved: false,
+                status: "extended".to_string(),
+                current_state: "PENDING".to_string(),
+            }));
         }
     }
 
@@ -4287,12 +4701,12 @@ fn parse_external_token(raw: &str) -> Result<ExternalActivityToken, AutumnError>
 
 /// Scan all shards for the external task identified by `token`, then invoke
 /// `action` on the shard that owns it.  Returns `true` if the state transition
-/// happened, `false` if the token was already in a terminal state (idempotent).
+/// happened, plus the current durable handoff state.
 async fn resolve_external_on_shards<F>(
     api_state: &HarvestApiState,
     token: ExternalActivityToken,
     action: F,
-) -> Result<bool, AutumnError>
+) -> Result<(bool, String), AutumnError>
 where
     F: for<'c> Fn(
         &'c mut diesel_async::AsyncPgConnection,
@@ -4311,7 +4725,11 @@ where
             .is_some()
         {
             let result = action(&mut conn, token).await.map_err(map_error)?;
-            return Ok(result);
+            let current_state = external_task::find_by_token(&mut conn, token)
+                .await
+                .map_err(map_error)?
+                .map_or_else(|| "UNKNOWN".to_string(), |task| task.state);
+            return Ok((result, current_state));
         }
     }
 
@@ -4774,6 +5192,39 @@ mod tests {
         let err = parse_workflow_filters(&pairs(&[("limit", "abc")]))
             .expect_err("non-numeric limit must error");
         assert!(err.to_string().contains("invalid limit"));
+    }
+
+    #[test]
+    fn parse_external_handoff_filters_accepts_all_filters() {
+        let filters = parse_external_handoff_filters(&pairs(&[
+            ("state", "pending,failed"),
+            ("workflow_name", "billing_checkout"),
+            ("execution_id", "00000000-0000-0000-0000-000000000001"),
+            ("activity_name", "manager_approval"),
+            ("token", "11111111-1111-4111-8111-111111111111"),
+            ("shard_id", "2"),
+            ("due_before", "2026-05-08T12:00:00Z"),
+            ("updated_before", "2026-05-08T13:00:00Z"),
+            ("limit", "9001"),
+        ]))
+        .expect("handoff filters should parse");
+
+        assert_eq!(filters.states, vec!["PENDING", "FAILED"]);
+        assert_eq!(filters.workflow_name.as_deref(), Some("billing_checkout"));
+        assert!(filters.execution_id.is_some());
+        assert_eq!(filters.activity_name.as_deref(), Some("manager_approval"));
+        assert!(filters.token.is_some());
+        assert_eq!(filters.shard_id, Some(2));
+        assert!(filters.due_before.is_some());
+        assert!(filters.updated_before.is_some());
+        assert_eq!(filters.limit, MAX_EXTERNAL_HANDOFF_LIMIT);
+    }
+
+    #[test]
+    fn parse_external_handoff_filters_rejects_unknown_state() {
+        let err = parse_external_handoff_filters(&pairs(&[("state", "zombie")]))
+            .expect_err("unknown handoff state must error");
+        assert!(err.to_string().contains("unknown external handoff state"));
     }
 
     #[test]

--- a/autumn-harvest-plugin/tests/api_scheduler_integration.rs
+++ b/autumn-harvest-plugin/tests/api_scheduler_integration.rs
@@ -68,6 +68,10 @@ const INIT_SQL: &str = concat!(
     include_str!("../../autumn-harvest/migrations/20260430000001_harvest_external_tasks/up.sql"),
     "\n",
     include_str!(
+        "../../autumn-harvest/migrations/20260508000000_harvest_external_task_updated_at/up.sql"
+    ),
+    "\n",
+    include_str!(
         "../../autumn-harvest/migrations/20260504000000_harvest_workflow_parent_children/up.sql"
     ),
     "\n",

--- a/autumn-harvest-plugin/tests/batch_operations_integration.rs
+++ b/autumn-harvest-plugin/tests/batch_operations_integration.rs
@@ -52,6 +52,10 @@ const INIT_SQL: &str = concat!(
     "\n",
     include_str!("../../autumn-harvest/migrations/20260430000001_harvest_external_tasks/up.sql"),
     "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260508000000_harvest_external_task_updated_at/up.sql"
+    ),
+    "\n",
     include_str!("../../autumn-harvest/migrations/20260501010000_harvest_batch_jobs/up.sql"),
     "\n",
     include_str!(

--- a/autumn-harvest-plugin/tests/dlq_bulk_integration.rs
+++ b/autumn-harvest-plugin/tests/dlq_bulk_integration.rs
@@ -38,6 +38,10 @@ const INIT_SQL: &str = concat!(
     "\n",
     include_str!("../../autumn-harvest/migrations/20260430000001_harvest_external_tasks/up.sql"),
     "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260508000000_harvest_external_task_updated_at/up.sql"
+    ),
+    "\n",
     include_str!("../../autumn-harvest/migrations/20260505000000_harvest_heartbeat_details/up.sql"),
     "\n",
     include_str!("../../autumn-harvest/migrations/20260506000000_harvest_audit_log/up.sql"),

--- a/autumn-harvest-plugin/tests/external_handoffs_integration.rs
+++ b/autumn-harvest-plugin/tests/external_handoffs_integration.rs
@@ -1,0 +1,293 @@
+//! Operator-facing external activity handoff API coverage (issue #168).
+
+use std::sync::Arc;
+
+use autumn_harvest::models::NewWorkflowExecution;
+use autumn_harvest::policy::WorkflowSchedule;
+use autumn_harvest::scheduler::{DagCatalog, SchedulerMonitor};
+use autumn_harvest::shard::ShardRouter;
+use autumn_harvest::store;
+use autumn_harvest::types::{ActivityExecId, ExecutionId, ExternalActivityToken, ShardId};
+use autumn_harvest::worker::{DbPool, HandlerRegistry};
+use autumn_harvest::{WorkflowEvent, external_task};
+use autumn_harvest_plugin::HarvestDbPool;
+use autumn_harvest_plugin::api::{
+    HarvestApiRuntime, HarvestApiState, HarvestRetentionRuntime, harvest_api_router,
+};
+use autumn_web::reexports::axum;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use diesel::{ExpressionMethods, QueryDsl};
+use diesel_async::pooled_connection::AsyncDieselConnectionManager;
+use diesel_async::{AsyncConnection, AsyncPgConnection, RunQueryDsl};
+use serde_json::{Value, json};
+use testcontainers::ContainerAsync;
+use testcontainers_modules::postgres::Postgres;
+use testcontainers_modules::testcontainers::runners::AsyncRunner;
+use tower::ServiceExt;
+
+type HarvestApiApp = axum::Router;
+
+fn build_test_pool(database_url: &str) -> DbPool {
+    let manager = AsyncDieselConnectionManager::<AsyncPgConnection>::new(database_url);
+    deadpool::managed::Pool::builder(manager)
+        .max_size(4)
+        .build()
+        .expect("failed to build test pool")
+}
+
+async fn setup_database_url_with_migrations() -> (String, ContainerAsync<Postgres>) {
+    let container = Postgres::default()
+        .start()
+        .await
+        .expect("failed to start Postgres container");
+    let host = container
+        .get_host()
+        .await
+        .expect("failed to get container host");
+    let port = container
+        .get_host_port_ipv4(5432)
+        .await
+        .expect("failed to get container port");
+    let url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+    autumn_web::migrate::run_pending(&url, autumn_harvest::MIGRATIONS)
+        .expect("failed to run Harvest migrations");
+    (url, container)
+}
+
+fn build_api_app(pool: HarvestDbPool) -> HarvestApiApp {
+    let api_state = HarvestApiState::new();
+    api_state.install_storage_pool(pool);
+    api_state.install(HarvestApiRuntime::new(
+        Arc::new(HandlerRegistry::new(vec![], vec![])),
+        Arc::new(DagCatalog::default()),
+        Arc::new(Vec::<WorkflowSchedule>::new()),
+        None,
+        vec!["default".to_string()],
+        SchedulerMonitor::offline(),
+        HarvestRetentionRuntime::disabled(autumn_harvest::RetentionConfig::default()),
+        ShardRouter::single(),
+    ));
+    harvest_api_router(api_state).with_state(autumn_web::AppState::for_test())
+}
+
+async fn read_json_response(response: axum::response::Response) -> Value {
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("failed to read response body");
+    serde_json::from_slice(&body).expect("response must be JSON")
+}
+
+async fn get_json(app: &HarvestApiApp, uri: impl Into<String>) -> (StatusCode, Value) {
+    let uri = uri.into();
+    let response = app
+        .clone()
+        .oneshot(Request::builder().uri(&uri).body(Body::empty()).unwrap())
+        .await
+        .expect("GET request failed");
+    let status = response.status();
+    let json = read_json_response(response).await;
+    (status, json)
+}
+
+async fn post_json(
+    app: &HarvestApiApp,
+    uri: impl Into<String>,
+    body: Value,
+) -> (StatusCode, Value) {
+    let uri = uri.into();
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(&uri)
+                .header("content-type", "application/json")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .expect("POST request failed");
+    let status = response.status();
+    let json = read_json_response(response).await;
+    (status, json)
+}
+
+async fn seed_external_handoff(
+    database_url: &str,
+    workflow_name: &str,
+    workflow_id: &str,
+    activity_name: &str,
+) -> (ExecutionId, ActivityExecId, ExternalActivityToken) {
+    let exec_id = ExecutionId::new_for_shard(ShardId::new(0));
+    let activity_id = ActivityExecId::new();
+    let token = ExternalActivityToken::new();
+    let mut conn = <AsyncPgConnection as AsyncConnection>::establish(database_url)
+        .await
+        .expect("failed to connect to test database");
+
+    let execution = NewWorkflowExecution {
+        id: exec_id.as_uuid(),
+        workflow_name,
+        workflow_id,
+        run_id: uuid::Uuid::new_v4(),
+        shard_id: 0,
+        input: json!({ "raw": "not exposed in handoff list" }),
+        parent_id: None,
+        queue_name: "default",
+        execution_timeout: None,
+        memo: None,
+        search_attrs: None,
+    };
+    diesel::insert_into(autumn_harvest::schema::harvest_workflow_executions::table)
+        .values(&execution)
+        .execute(&mut conn)
+        .await
+        .expect("failed to insert workflow execution");
+
+    store::append_single_event(
+        &mut conn,
+        exec_id,
+        WorkflowEvent::ActivityAwaitingExternal {
+            activity_id,
+            name: activity_name.to_string(),
+            token,
+            input: json!({ "raw": "redacted" }),
+            queue: "approvals".to_string(),
+            schedule_to_close_secs: 3600,
+        },
+    )
+    .await
+    .expect("failed to append awaiting event");
+    external_task::record_external_task(
+        &mut conn,
+        exec_id,
+        token,
+        activity_id,
+        activity_name,
+        "approvals",
+        3600,
+    )
+    .await
+    .expect("failed to record external task");
+
+    (exec_id, activity_id, token)
+}
+
+async fn terminal_event_count(database_url: &str, exec_id: ExecutionId) -> i64 {
+    let mut conn = <AsyncPgConnection as AsyncConnection>::establish(database_url)
+        .await
+        .expect("failed to connect to test database");
+    autumn_harvest::schema::harvest_events::table
+        .filter(autumn_harvest::schema::harvest_events::workflow_exec_id.eq(exec_id.as_uuid()))
+        .filter(
+            autumn_harvest::schema::harvest_events::event_type.eq("ActivityCompletedExternally"),
+        )
+        .count()
+        .get_result(&mut conn)
+        .await
+        .expect("failed to count terminal events")
+}
+
+#[tokio::test]
+async fn pending_handoff_can_be_listed_completed_and_retried_idempotently() {
+    let (database_url, _container) = setup_database_url_with_migrations().await;
+    let app = build_api_app(HarvestDbPool::from(build_test_pool(&database_url)));
+    let (exec_id, activity_id, token) = seed_external_handoff(
+        &database_url,
+        "billing_checkout",
+        "invoice-42",
+        "manager_approval",
+    )
+    .await;
+
+    let (status, list) = get_json(&app, "/admin/external-handoffs?state=PENDING").await;
+    assert_eq!(status, StatusCode::OK, "{list}");
+    assert_eq!(list["status"], "ok");
+    assert_eq!(list["items"].as_array().expect("items array").len(), 1);
+    let item = &list["items"][0];
+    assert_eq!(item["token"], token.to_string());
+    assert_eq!(item["workflow"]["execution_id"], exec_id.to_string());
+    assert_eq!(item["workflow"]["workflow_name"], "billing_checkout");
+    assert_eq!(item["workflow"]["workflow_id"], "invoice-42");
+    assert_eq!(item["workflow"]["shard_id"], 0);
+    assert_eq!(item["activity"]["activity_id"], activity_id.to_string());
+    assert_eq!(item["activity"]["activity_name"], "manager_approval");
+    assert_eq!(item["state"], "PENDING");
+    assert!(item["created_at"].is_string());
+    assert!(item["updated_at"].is_string());
+    assert!(item["deadline_at"].is_string());
+    assert_eq!(item["payloads"]["redacted"], true);
+    assert!(
+        item.get("input").is_none(),
+        "raw payload must not be exposed"
+    );
+
+    let (status, detail) = get_json(&app, format!("/workflows/{exec_id}")).await;
+    assert_eq!(status, StatusCode::OK, "{detail}");
+    assert_eq!(detail["external_handoffs"][0]["token"], token.to_string());
+
+    let (status, ack) = post_json(
+        &app,
+        format!("/activities/external/{token}/complete"),
+        json!({ "output": { "approved": true } }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{ack}");
+    assert_eq!(ack["newly_resolved"], true);
+    assert_eq!(ack["status"], "completed");
+
+    let (status, pending) = get_json(&app, "/admin/external-handoffs?state=PENDING").await;
+    assert_eq!(status, StatusCode::OK, "{pending}");
+    assert!(pending["items"].as_array().expect("items array").is_empty());
+
+    let (status, completed) = get_json(&app, "/admin/external-handoffs?state=COMPLETED").await;
+    assert_eq!(status, StatusCode::OK, "{completed}");
+    assert_eq!(completed["items"][0]["state"], "COMPLETED");
+
+    let (status, retry_ack) = post_json(
+        &app,
+        format!("/activities/external/{token}/complete"),
+        json!({ "output": { "approved": true } }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{retry_ack}");
+    assert_eq!(retry_ack["newly_resolved"], false);
+    assert_eq!(retry_ack["status"], "already_terminal");
+    assert_eq!(retry_ack["current_state"], "COMPLETED");
+    assert_eq!(terminal_event_count(&database_url, exec_id).await, 1);
+}
+
+#[tokio::test]
+async fn failing_handoff_returns_terminal_state_for_retries() {
+    let (database_url, _container) = setup_database_url_with_migrations().await;
+    let app = build_api_app(HarvestDbPool::from(build_test_pool(&database_url)));
+    let (_exec_id, _activity_id, token) = seed_external_handoff(
+        &database_url,
+        "billing_checkout",
+        "invoice-43",
+        "webhook_wait",
+    )
+    .await;
+
+    let (status, ack) = post_json(
+        &app,
+        format!("/activities/external/{token}/fail"),
+        json!({ "error": "manager rejected", "retryable": false }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{ack}");
+    assert_eq!(ack["newly_resolved"], true);
+    assert_eq!(ack["status"], "failed");
+
+    let (status, retry_ack) = post_json(
+        &app,
+        format!("/activities/external/{token}/fail"),
+        json!({ "error": "manager rejected again", "retryable": false }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "{retry_ack}");
+    assert_eq!(retry_ack["newly_resolved"], false);
+    assert_eq!(retry_ack["status"], "already_terminal");
+    assert_eq!(retry_ack["current_state"], "FAILED");
+}

--- a/autumn-harvest-plugin/tests/telemetry_propagation_tests.rs
+++ b/autumn-harvest-plugin/tests/telemetry_propagation_tests.rs
@@ -54,6 +54,10 @@ const INIT_SQL: &str = concat!(
     "\n",
     include_str!("../../autumn-harvest/migrations/20260430000001_harvest_external_tasks/up.sql"),
     "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260508000000_harvest_external_task_updated_at/up.sql"
+    ),
+    "\n",
     include_str!("../../autumn-harvest/migrations/20260501000000_harvest_workers/up.sql"),
     "\n",
     include_str!("../../autumn-harvest/migrations/20260501010000_harvest_batch_jobs/up.sql"),

--- a/autumn-harvest-plugin/tests/workflow_reset_integration.rs
+++ b/autumn-harvest-plugin/tests/workflow_reset_integration.rs
@@ -53,6 +53,10 @@ const INIT_SQL: &str = concat!(
     "\n",
     include_str!("../../autumn-harvest/migrations/20260430000001_harvest_external_tasks/up.sql"),
     "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260508000000_harvest_external_task_updated_at/up.sql"
+    ),
+    "\n",
     include_str!("../../autumn-harvest/migrations/20260503000000_harvest_workflow_reset/up.sql"),
     "\n",
     include_str!("../../autumn-harvest/migrations/20260505000000_harvest_heartbeat_details/up.sql"),

--- a/autumn-harvest/migrations/20260508000000_harvest_external_task_updated_at/down.sql
+++ b/autumn-harvest/migrations/20260508000000_harvest_external_task_updated_at/down.sql
@@ -1,0 +1,6 @@
+DROP INDEX IF EXISTS idx_harvest_ext_activity_name;
+DROP INDEX IF EXISTS idx_harvest_ext_workflow_exec;
+DROP INDEX IF EXISTS idx_harvest_ext_state_updated;
+
+ALTER TABLE harvest_external_tasks
+    DROP COLUMN IF EXISTS updated_at;

--- a/autumn-harvest/migrations/20260508000000_harvest_external_task_updated_at/up.sql
+++ b/autumn-harvest/migrations/20260508000000_harvest_external_task_updated_at/up.sql
@@ -1,0 +1,11 @@
+ALTER TABLE harvest_external_tasks
+    ADD COLUMN updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+
+CREATE INDEX idx_harvest_ext_state_updated
+    ON harvest_external_tasks (state, updated_at DESC);
+
+CREATE INDEX idx_harvest_ext_workflow_exec
+    ON harvest_external_tasks (workflow_exec_id);
+
+CREATE INDEX idx_harvest_ext_activity_name
+    ON harvest_external_tasks (name);

--- a/autumn-harvest/src/external_task.rs
+++ b/autumn-harvest/src/external_task.rs
@@ -14,9 +14,112 @@ use scoped_futures::ScopedFutureExt;
 use crate::error::{HarvestError, HarvestResult, database_error};
 use crate::event::WorkflowEvent;
 use crate::models::{ExternalTask, NewExternalTask};
-use crate::schema::harvest_external_tasks;
+use crate::schema::{harvest_external_tasks, harvest_workflow_executions};
 use crate::store;
 use crate::types::{ActivityExecId, ExecutionId, ExternalActivityToken};
+
+/// External activity states persisted in `harvest_external_tasks`.
+pub const KNOWN_EXTERNAL_TASK_STATES: &[&str] =
+    &["PENDING", "COMPLETED", "FAILED", "TIMED_OUT", "CANCELLED"];
+
+/// Filters for operator-facing external activity handoff queries.
+#[derive(Debug, Clone)]
+pub struct ExternalHandoffFilters {
+    pub states: Vec<String>,
+    pub workflow_name: Option<String>,
+    pub execution_id: Option<ExecutionId>,
+    pub activity_name: Option<String>,
+    pub token: Option<ExternalActivityToken>,
+    pub shard_id: Option<i32>,
+    pub due_before: Option<chrono::DateTime<Utc>>,
+    pub updated_before: Option<chrono::DateTime<Utc>>,
+    pub limit: i64,
+}
+
+impl Default for ExternalHandoffFilters {
+    fn default() -> Self {
+        Self {
+            states: Vec::new(),
+            workflow_name: None,
+            execution_id: None,
+            activity_name: None,
+            token: None,
+            shard_id: None,
+            due_before: None,
+            updated_before: None,
+            limit: 100,
+        }
+    }
+}
+
+impl ExternalHandoffFilters {
+    #[must_use]
+    pub const fn with_limit(mut self, limit: i64) -> Self {
+        self.limit = limit;
+        self
+    }
+}
+
+/// Redacted, operator-facing external handoff row.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ExternalHandoffRow {
+    pub token: ExternalActivityToken,
+    pub workflow_exec_id: ExecutionId,
+    pub workflow_id: String,
+    pub workflow_name: String,
+    pub activity_id: ActivityExecId,
+    pub activity_name: String,
+    pub state: String,
+    pub created_at: chrono::DateTime<Utc>,
+    pub updated_at: chrono::DateTime<Utc>,
+    pub deadline_at: chrono::DateTime<Utc>,
+    pub shard_id: i32,
+}
+
+type ExternalHandoffProjection = (
+    uuid::Uuid,
+    uuid::Uuid,
+    String,
+    String,
+    uuid::Uuid,
+    String,
+    String,
+    chrono::DateTime<Utc>,
+    chrono::DateTime<Utc>,
+    chrono::DateTime<Utc>,
+    i32,
+);
+
+impl From<ExternalHandoffProjection> for ExternalHandoffRow {
+    fn from(row: ExternalHandoffProjection) -> Self {
+        let (
+            token,
+            workflow_exec_id,
+            workflow_id,
+            workflow_name,
+            activity_id,
+            activity_name,
+            state,
+            created_at,
+            updated_at,
+            deadline_at,
+            shard_id,
+        ) = row;
+        Self {
+            token: ExternalActivityToken::from_uuid(token),
+            workflow_exec_id: ExecutionId::from_uuid(workflow_exec_id),
+            workflow_id,
+            workflow_name,
+            activity_id: ActivityExecId::from_uuid(activity_id),
+            activity_name,
+            state,
+            created_at,
+            updated_at,
+            deadline_at,
+            shard_id,
+        }
+    }
+}
 
 /// Insert a new external-task row, linking `token` → `(exec_id, activity_id)`.
 ///
@@ -85,6 +188,94 @@ pub async fn find_by_token(
         .map_err(database_error)
 }
 
+/// List external activity handoffs for operator read surfaces.
+///
+/// Rows intentionally expose only task identity, token, state, and timing
+/// metadata. Raw workflow/activity payloads remain in event history and are
+/// not selected here.
+///
+/// # Errors
+///
+/// Returns [`HarvestError::Database`] if the query fails.
+pub async fn list_external_handoffs(
+    conn: &mut AsyncPgConnection,
+    filters: &ExternalHandoffFilters,
+) -> HarvestResult<Vec<ExternalHandoffRow>> {
+    let mut query = harvest_external_tasks::table
+        .inner_join(harvest_workflow_executions::table)
+        .select((
+            harvest_external_tasks::token,
+            harvest_external_tasks::workflow_exec_id,
+            harvest_workflow_executions::workflow_id,
+            harvest_workflow_executions::workflow_name,
+            harvest_external_tasks::activity_id,
+            harvest_external_tasks::name,
+            harvest_external_tasks::state,
+            harvest_external_tasks::created_at,
+            harvest_external_tasks::updated_at,
+            harvest_external_tasks::schedule_to_close_at,
+            harvest_workflow_executions::shard_id,
+        ))
+        .into_boxed::<diesel::pg::Pg>();
+
+    if !filters.states.is_empty() {
+        query = query.filter(harvest_external_tasks::state.eq_any(filters.states.clone()));
+    }
+    if let Some(workflow_name) = &filters.workflow_name {
+        query = query.filter(harvest_workflow_executions::workflow_name.eq(workflow_name));
+    }
+    if let Some(exec_id) = filters.execution_id {
+        query = query.filter(harvest_external_tasks::workflow_exec_id.eq(exec_id.as_uuid()));
+    }
+    if let Some(activity_name) = &filters.activity_name {
+        query = query.filter(harvest_external_tasks::name.eq(activity_name));
+    }
+    if let Some(token) = filters.token {
+        query = query.filter(harvest_external_tasks::token.eq(token.as_uuid()));
+    }
+    if let Some(shard_id) = filters.shard_id {
+        query = query.filter(harvest_workflow_executions::shard_id.eq(shard_id));
+    }
+    if let Some(due_before) = filters.due_before {
+        query = query.filter(harvest_external_tasks::schedule_to_close_at.le(due_before));
+    }
+    if let Some(updated_before) = filters.updated_before {
+        query = query.filter(harvest_external_tasks::updated_at.le(updated_before));
+    }
+
+    query
+        .order((
+            harvest_external_tasks::schedule_to_close_at.asc(),
+            harvest_external_tasks::updated_at.desc(),
+            harvest_external_tasks::token.asc(),
+        ))
+        .limit(filters.limit)
+        .load::<ExternalHandoffProjection>(conn)
+        .await
+        .map_err(database_error)
+        .map(|rows| rows.into_iter().map(ExternalHandoffRow::from).collect())
+}
+
+/// Look up one operator-facing external handoff by token.
+///
+/// # Errors
+///
+/// Returns [`HarvestError::Database`] if the query fails.
+pub async fn find_handoff_by_token(
+    conn: &mut AsyncPgConnection,
+    token: ExternalActivityToken,
+) -> HarvestResult<Option<ExternalHandoffRow>> {
+    let filters = ExternalHandoffFilters {
+        token: Some(token),
+        limit: 1,
+        ..ExternalHandoffFilters::default()
+    };
+    Ok(list_external_handoffs(conn, &filters)
+        .await?
+        .into_iter()
+        .next())
+}
+
 /// Look up an external task by its opaque token, acquiring a row-level lock.
 ///
 /// Like [`find_by_token`] but uses `FOR UPDATE`, serializing the caller
@@ -136,7 +327,10 @@ pub async fn complete_externally(
             let activity_id = ActivityExecId::from_uuid(task.activity_id);
 
             diesel::update(harvest_external_tasks::table.find(task.id))
-                .set(harvest_external_tasks::state.eq("COMPLETED"))
+                .set((
+                    harvest_external_tasks::state.eq("COMPLETED"),
+                    harvest_external_tasks::updated_at.eq(Utc::now()),
+                ))
                 .execute(conn)
                 .await
                 .map_err(database_error)?;
@@ -183,7 +377,10 @@ pub async fn fail_externally(
             let activity_id = ActivityExecId::from_uuid(task.activity_id);
 
             diesel::update(harvest_external_tasks::table.find(task.id))
-                .set(harvest_external_tasks::state.eq("FAILED"))
+                .set((
+                    harvest_external_tasks::state.eq("FAILED"),
+                    harvest_external_tasks::updated_at.eq(Utc::now()),
+                ))
                 .execute(conn)
                 .await
                 .map_err(database_error)?;
@@ -242,7 +439,10 @@ pub async fn extend_deadline(
             })?;
 
             diesel::update(harvest_external_tasks::table.find(task.id))
-                .set(harvest_external_tasks::schedule_to_close_at.eq(new_deadline))
+                .set((
+                    harvest_external_tasks::schedule_to_close_at.eq(new_deadline),
+                    harvest_external_tasks::updated_at.eq(Utc::now()),
+                ))
                 .execute(conn)
                 .await
                 .map_err(database_error)?;

--- a/autumn-harvest/src/models.rs
+++ b/autumn-harvest/src/models.rs
@@ -350,6 +350,7 @@ pub struct ExternalTask {
     pub schedule_to_close_at: DateTime<Utc>,
     pub schedule_to_close_secs: i64,
     pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
 }
 
 /// Insert struct for registering a new external activity task.

--- a/autumn-harvest/src/reset.rs
+++ b/autumn-harvest/src/reset.rs
@@ -818,7 +818,10 @@ async fn cancel_pending_external_tasks(
             .filter(harvest_external_tasks::workflow_exec_id.eq(exec_id.as_uuid()))
             .filter(harvest_external_tasks::state.eq("PENDING")),
     )
-    .set(harvest_external_tasks::state.eq("CANCELLED"))
+    .set((
+        harvest_external_tasks::state.eq("CANCELLED"),
+        harvest_external_tasks::updated_at.eq(chrono::Utc::now()),
+    ))
     .execute(conn)
     .await
     .map_err(database_error)

--- a/autumn-harvest/src/schema.rs
+++ b/autumn-harvest/src/schema.rs
@@ -175,6 +175,7 @@ diesel::table! {
         schedule_to_close_at -> Timestamptz,
         schedule_to_close_secs -> Int8,
         created_at -> Timestamptz,
+        updated_at -> Timestamptz,
     }
 }
 

--- a/autumn-harvest/src/timeout.rs
+++ b/autumn-harvest/src/timeout.rs
@@ -391,7 +391,10 @@ pub async fn enforce_external_task_timeouts(conn: &mut AsyncPgConnection) -> Har
                             .filter(harvest_external_tasks::state.eq("PENDING"))
                             .filter(harvest_external_tasks::schedule_to_close_at.lt(Utc::now())),
                     )
-                    .set(harvest_external_tasks::state.eq("TIMED_OUT"))
+                    .set((
+                        harvest_external_tasks::state.eq("TIMED_OUT"),
+                        harvest_external_tasks::updated_at.eq(Utc::now()),
+                    ))
                     .execute(conn)
                     .await
                     .map_err(crate::error::database_error)?;

--- a/autumn-harvest/tests/audit_tests.rs
+++ b/autumn-harvest/tests/audit_tests.rs
@@ -33,6 +33,8 @@ const INIT_SQL: &str = concat!(
     "\n",
     include_str!("../migrations/20260430000001_harvest_external_tasks/up.sql"),
     "\n",
+    include_str!("../migrations/20260508000000_harvest_external_task_updated_at/up.sql"),
+    "\n",
     include_str!("../migrations/20260501000000_harvest_workers/up.sql"),
     "\n",
     include_str!("../migrations/20260501010000_harvest_batch_jobs/up.sql"),

--- a/autumn-harvest/tests/havoc_tests.rs
+++ b/autumn-harvest/tests/havoc_tests.rs
@@ -1,6 +1,8 @@
+use autumn_harvest::policy::RetryPolicy;
 #[cfg(feature = "db")]
 use autumn_harvest::store::events_to_insert_rows_from;
-use autumn_harvest::{event::WorkflowEvent, policy::RetryPolicy, types::ExecutionId};
+#[cfg(feature = "db")]
+use autumn_harvest::{event::WorkflowEvent, types::ExecutionId};
 use std::time::Duration;
 
 #[cfg(feature = "db")]

--- a/autumn-harvest/tests/integration_e2e.rs
+++ b/autumn-harvest/tests/integration_e2e.rs
@@ -68,6 +68,8 @@ const INIT_SQL: &str = concat!(
     "\n",
     include_str!("../migrations/20260430000001_harvest_external_tasks/up.sql"),
     "\n",
+    include_str!("../migrations/20260508000000_harvest_external_task_updated_at/up.sql"),
+    "\n",
     include_str!("../migrations/20260506000000_harvest_audit_log/up.sql"),
 );
 

--- a/autumn-harvest/tests/metrics_integration.rs
+++ b/autumn-harvest/tests/metrics_integration.rs
@@ -56,6 +56,8 @@ const INIT_SQL: &str = concat!(
     "\n",
     include_str!("../migrations/20260430000001_harvest_external_tasks/up.sql"),
     "\n",
+    include_str!("../migrations/20260508000000_harvest_external_task_updated_at/up.sql"),
+    "\n",
     include_str!("../migrations/20260501000000_harvest_workers/up.sql"),
 );
 

--- a/autumn-harvest/tests/replayer_integration_tests.rs
+++ b/autumn-harvest/tests/replayer_integration_tests.rs
@@ -47,6 +47,8 @@ const INIT_SQL: &str = concat!(
     include_str!("../migrations/20260430000000_harvest_workflow_schedules/up.sql"),
     "\n",
     include_str!("../migrations/20260430000001_harvest_external_tasks/up.sql"),
+    "\n",
+    include_str!("../migrations/20260508000000_harvest_external_task_updated_at/up.sql"),
 );
 
 // ---------------------------------------------------------------------------

--- a/autumn-harvest/tests/telemetry_span_tests.rs
+++ b/autumn-harvest/tests/telemetry_span_tests.rs
@@ -58,6 +58,8 @@ const INIT_SQL: &str = concat!(
     "\n",
     include_str!("../migrations/20260430000001_harvest_external_tasks/up.sql"),
     "\n",
+    include_str!("../migrations/20260508000000_harvest_external_task_updated_at/up.sql"),
+    "\n",
     include_str!("../migrations/20260501000000_harvest_workers/up.sql"),
     "\n",
     include_str!("../migrations/20260501010000_harvest_batch_jobs/up.sql"),

--- a/docs/runbooks/external-activity-handoffs.md
+++ b/docs/runbooks/external-activity-handoffs.md
@@ -1,0 +1,136 @@
+# External Activity Handoff Runbook
+
+Use this when a workflow is waiting on `execute_activity_external`, such as a
+manager approval or webhook callback. Handoff list/detail responses expose
+identity, state, token, and timing metadata only; raw workflow inputs, activity
+inputs, outputs, signal bodies, and secrets stay redacted.
+
+## Find pending handoffs
+
+```bash
+harvest handoff list --state PENDING
+```
+
+Narrow the inbox during an incident:
+
+```bash
+harvest handoff list \
+  --state PENDING \
+  --workflow-name billing_checkout \
+  --activity-name manager_approval \
+  --due-before 2026-05-08T12:00:00Z \
+  --limit 50
+```
+
+For automation, use JSON:
+
+```bash
+harvest handoff list --state PENDING --output json
+```
+
+The API route is:
+
+```text
+GET /admin/external-handoffs?state=PENDING&workflow_name=billing_checkout
+```
+
+## Inspect one handoff
+
+```bash
+harvest handoff inspect <TOKEN>
+```
+
+API:
+
+```text
+GET /admin/external-handoffs/<TOKEN>
+```
+
+Workflow detail also embeds pending external handoffs:
+
+```bash
+harvest workflow get <EXECUTION_ID>
+harvest workflow stack <EXECUTION_ID>
+```
+
+## Complete a handoff
+
+Inline JSON output:
+
+```bash
+harvest handoff complete <TOKEN> --output-json '{"approved":true,"manager":"alice"}'
+```
+
+Output from a file:
+
+```bash
+harvest handoff complete <TOKEN> --output-file approval-result.json
+```
+
+Output from stdin:
+
+```bash
+printf '{"approved":true}' | harvest handoff complete <TOKEN> --output-file -
+```
+
+API:
+
+```text
+POST /activities/external/<TOKEN>/complete
+Content-Type: application/json
+
+{"output":{"approved":true}}
+```
+
+Successful first completion returns `status: "completed"` and
+`newly_resolved: true`. Repeating the same command is idempotent and returns
+`status: "already_terminal"` with the current terminal state.
+
+## Fail a handoff
+
+```bash
+harvest handoff fail <TOKEN> --error "manager rejected"
+```
+
+With structured error details compacted into the durable error string:
+
+```bash
+harvest handoff fail <TOKEN> --error-json '{"code":"rejected","reason":"budget"}'
+```
+
+API:
+
+```text
+POST /activities/external/<TOKEN>/fail
+Content-Type: application/json
+
+{"error":"manager rejected","retryable":false}
+```
+
+Repeated failures after the handoff is terminal are idempotent and return
+`status: "already_terminal"`.
+
+## Extend the deadline
+
+```bash
+harvest handoff heartbeat <TOKEN> --extend-by-secs 3600
+```
+
+API:
+
+```text
+POST /activities/external/<TOKEN>/heartbeat
+Content-Type: application/json
+
+{"extend_by_secs":3600}
+```
+
+Omitting `extend_by_secs` resets the deadline using the activity's original
+schedule-to-close window.
+
+## Shard coverage
+
+List responses include `shard_coverage`. If a shard cannot be inspected, the
+response status becomes `partial` and `unavailable_shards` names the shard and
+reason. Do not treat a partial response as proof that no matching handoff exists
+until the unavailable shard is repaired or explicitly excluded with `--shard-id`.


### PR DESCRIPTION
  Body:

  Add management API and CLI surfaces for external activity handoffs, including
  filtered list/detail endpoints, redacted handoff metadata, workflow detail/stack
  embedding, idempotent terminal retry responses, and shard coverage reporting.

  Add updated_at tracking/indexes for external tasks, integration coverage, and an
  operator runbook.