### PR TITLE
feat: add remote worker drain controls (issue #170)

### DIFF
--- a/autumn-harvest-cli/src/lib.rs
+++ b/autumn-harvest-cli/src/lib.rs
@@ -1170,10 +1170,9 @@ pub async fn run_cli(cli: Cli) -> Result<(), CliError> {
 fn history_output_file(cli: &Cli) -> Option<&Path> {
     match &cli.command {
         Commands::History {
-            command: HistoryCommand::Export { output_file, .. },
-        }
-        | Commands::History {
-            command: HistoryCommand::ExportBatch { output_file, .. },
+            command:
+                HistoryCommand::Export { output_file, .. }
+                | HistoryCommand::ExportBatch { output_file, .. },
         } => output_file.as_deref(),
         _ => None,
     }

--- a/autumn-harvest-cli/src/lib.rs
+++ b/autumn-harvest-cli/src/lib.rs
@@ -211,6 +211,15 @@ pub enum CliError {
     /// Retirement check found active old-version executions or an unavailable shard.
     #[error("version-gate retirement check failed")]
     RetirementCheckGate,
+
+    /// `--wait` timed out before the worker reached `Stopped`.
+    #[error("timed out waiting for worker '{worker_id}' to stop (last status: {last_status})")]
+    DrainWaitTimeout {
+        /// Worker ID that did not reach `Stopped`.
+        worker_id: String,
+        /// Last observed lifecycle status.
+        last_status: String,
+    },
 }
 
 impl CliError {
@@ -863,6 +872,13 @@ enum WorkerCommand {
         /// When omitted the server uses its configured shutdown timeout.
         #[arg(long)]
         deadline: Option<String>,
+        /// Block until the worker reaches `Stopped` or the deadline elapses.
+        /// Polls `GET /workers/{id}` every 2 s; exits 1 on timeout.
+        #[arg(long)]
+        wait: bool,
+        /// Maximum seconds to wait when `--wait` is set (default: 120).
+        #[arg(long, default_value = "120")]
+        wait_timeout_secs: u64,
     },
     /// Preview which workers would be targeted by a drain, without draining them.
     #[command(name = "drain-preview")]
@@ -1002,6 +1018,20 @@ pub async fn run_cli(cli: Cli) -> Result<(), CliError> {
         return tui::run_tui(&cli).await;
     }
 
+    // --wait mode: issue drain then poll until Stopped or timeout.
+    if let Commands::Worker {
+        command:
+            WorkerCommand::Drain {
+                worker_id,
+                wait: true,
+                wait_timeout_secs,
+                ..
+            },
+    } = &cli.command
+    {
+        return run_worker_drain_wait(&cli, worker_id, *wait_timeout_secs).await;
+    }
+
     let response = execute(&cli).await?;
     let rendered = render_response(&cli, &response)?;
     println!("{rendered}");
@@ -1080,6 +1110,59 @@ pub async fn execute(cli: &Cli) -> Result<Value, CliError> {
     }
 
     serde_json::from_str(&body).map_err(CliError::ParseResponse)
+}
+
+/// Issue drain then poll `GET /workers/{id}` until status reaches `Stopped`
+/// or `wait_timeout_secs` elapses. Prints each poll result as it arrives.
+async fn run_worker_drain_wait(
+    cli: &Cli,
+    worker_id: &str,
+    wait_timeout_secs: u64,
+) -> Result<(), CliError> {
+    // Kick off the drain.
+    let response = execute(cli).await?;
+    let rendered = render_response(cli, &response)?;
+    println!("{rendered}");
+
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(wait_timeout_secs);
+    let poll_interval = std::time::Duration::from_secs(2);
+
+    loop {
+        tokio::time::sleep(poll_interval).await;
+
+        let poll_cli = Cli {
+            base_url: cli.base_url.clone(),
+            token: cli.token.clone(),
+            actor: cli.actor.clone(),
+            request_id: cli.request_id.clone(),
+            output: cli.output,
+            command: Commands::Worker {
+                command: WorkerCommand::Get {
+                    worker_id: worker_id.to_string(),
+                },
+            },
+        };
+        let worker_value = execute(&poll_cli).await?;
+        let status = worker_value
+            .get("status")
+            .and_then(Value::as_str)
+            .unwrap_or("Unknown")
+            .to_string();
+
+        let rendered = render_response(cli, &worker_value)?;
+        println!("{rendered}");
+
+        if status == "Stopped" {
+            return Ok(());
+        }
+
+        if std::time::Instant::now() >= deadline {
+            return Err(CliError::DrainWaitTimeout {
+                worker_id: worker_id.to_string(),
+                last_status: status,
+            });
+        }
+    }
 }
 
 /// Render a successful response.
@@ -2483,6 +2566,8 @@ fn worker_request(command: &WorkerCommand) -> ApiRequest {
         WorkerCommand::Drain {
             worker_id,
             deadline,
+            wait: _,
+            wait_timeout_secs: _,
         } => {
             let mut body = Map::new();
             if let Some(d) = deadline {
@@ -3689,6 +3774,68 @@ mod reuse_policy_tests {
         let req = parse(&["worker", "health"]).api_request().unwrap();
         assert_eq!(req.method, ApiMethod::Get);
         assert_eq!(req.path, "/workers/health");
+    }
+
+    // -- Drain wait mode (AC #6) --
+
+    #[test]
+    fn worker_drain_with_wait_flag_still_builds_drain_post_request() {
+        let req = parse(&["worker", "drain", "w-abc", "--wait"])
+            .api_request()
+            .unwrap();
+        assert_eq!(req.method, ApiMethod::Post);
+        assert_eq!(req.path, "/workers/w-abc/drain");
+    }
+
+    #[test]
+    fn worker_drain_wait_and_deadline_are_independent_flags() {
+        let req = parse(&[
+            "worker",
+            "drain",
+            "w-abc",
+            "--wait",
+            "--deadline",
+            "2026-05-09T12:00:00Z",
+        ])
+        .api_request()
+        .unwrap();
+        let body = req.body.as_ref().unwrap();
+        assert_eq!(
+            body["deadline_at"].as_str().unwrap(),
+            "2026-05-09T12:00:00Z"
+        );
+    }
+
+    #[test]
+    fn worker_drain_wait_timeout_secs_default_is_120() {
+        let cli = parse(&["worker", "drain", "w-abc", "--wait"]);
+        if let Commands::Worker {
+            command:
+                WorkerCommand::Drain {
+                    wait,
+                    wait_timeout_secs,
+                    ..
+                },
+        } = &cli.command
+        {
+            assert!(*wait);
+            assert_eq!(*wait_timeout_secs, 120);
+        } else {
+            panic!("expected Worker::Drain command");
+        }
+    }
+
+    #[test]
+    fn worker_drain_without_wait_flag_wait_is_false() {
+        let cli = parse(&["worker", "drain", "w-abc"]);
+        if let Commands::Worker {
+            command: WorkerCommand::Drain { wait, .. },
+        } = &cli.command
+        {
+            assert!(!*wait);
+        } else {
+            panic!("expected Worker::Drain command");
+        }
     }
 
     #[test]

--- a/autumn-harvest-cli/src/lib.rs
+++ b/autumn-harvest-cli/src/lib.rs
@@ -336,6 +336,12 @@ enum Commands {
     },
     /// Open the TUI dashboard to monitor workflows.
     Tui,
+    /// Inspect and drain worker fleet (issue #170).
+    #[command(alias = "workers")]
+    Worker {
+        #[command(subcommand)]
+        command: WorkerCommand,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -841,6 +847,66 @@ enum DeadLetterCommand {
     },
 }
 
+/// Subcommands for `harvest worker` (issue #170).
+#[derive(Debug, Subcommand)]
+enum WorkerCommand {
+    /// Request a graceful drain for a specific worker.
+    ///
+    /// Sets the worker status to `Draining` so it stops accepting new tasks.
+    /// The worker itself will complete in-flight tasks and then transition to
+    /// `Stopped`. Use `--wait` to block until the worker reaches a terminal
+    /// state before the deadline.
+    Drain {
+        /// Worker ID to drain.
+        worker_id: String,
+        /// Drain-by deadline (RFC 3339, e.g. `2026-05-09T12:00:00Z`).
+        /// When omitted the server uses its configured shutdown timeout.
+        #[arg(long)]
+        deadline: Option<String>,
+    },
+    /// Preview which workers would be targeted by a drain, without draining them.
+    #[command(name = "drain-preview")]
+    DrainPreview {
+        /// Filter by task queue name.
+        #[arg(long)]
+        queue: Option<String>,
+        /// Filter by shard id.
+        #[arg(long)]
+        shard_id: Option<i32>,
+        /// Filter by lifecycle status (`Active`, `Draining`, `Stopped`).
+        #[arg(long)]
+        status: Option<String>,
+        /// Maximum number of workers to return [1–500].
+        #[arg(long, value_parser = clap::value_parser!(i64).range(1..=500))]
+        limit: Option<i64>,
+    },
+    /// List registered workers.
+    List {
+        /// Filter by task queue name.
+        #[arg(long)]
+        queue: Option<String>,
+        /// Filter by shard id.
+        #[arg(long)]
+        shard_id: Option<i32>,
+        /// Filter by lifecycle status (`Active`, `Draining`, `Stopped`).
+        #[arg(long)]
+        status: Option<String>,
+        /// Filter by health (`healthy` or `stale`).
+        #[arg(long)]
+        health: Option<String>,
+        /// Maximum number of workers to return [1–500].
+        #[arg(long, value_parser = clap::value_parser!(i64).range(1..=500))]
+        limit: Option<i64>,
+    },
+    /// Show details for a single worker.
+    Get {
+        /// Worker ID.
+        worker_id: String,
+    },
+    /// Show aggregated fleet health statistics.
+    Health,
+}
+
 impl Cli {
     /// Build the management API request represented by these CLI arguments.
     ///
@@ -862,6 +928,7 @@ impl Cli {
             Commands::Concurrency { command } => Ok(concurrency_request(command)),
             Commands::Batch { command } => batch_request(command),
             Commands::Audit { command } => Ok(audit_request(command)),
+            Commands::Worker { command } => Ok(worker_request(command)),
             Commands::VersionUsage {
                 workflow_name,
                 change_id,
@@ -2411,6 +2478,90 @@ fn build_bulk_dlq_body(
     Value::Object(body)
 }
 
+fn worker_request(command: &WorkerCommand) -> ApiRequest {
+    match command {
+        WorkerCommand::Drain {
+            worker_id,
+            deadline,
+        } => {
+            let mut body = Map::new();
+            if let Some(d) = deadline {
+                body.insert("deadline_at".to_string(), json!(d));
+            }
+            ApiRequest::post(
+                format!("/workers/{}/drain", path_segment(worker_id)),
+                Some(Value::Object(body)),
+            )
+        }
+        WorkerCommand::DrainPreview {
+            queue,
+            shard_id,
+            status,
+            limit,
+        } => {
+            let mut params: Vec<(&'static str, String)> = Vec::new();
+            if let Some(q) = queue {
+                params.push(("queue", q.clone()));
+            }
+            if let Some(s) = shard_id {
+                params.push(("shard_id", s.to_string()));
+            }
+            if let Some(s) = status {
+                params.push(("status", s.clone()));
+            }
+            if let Some(l) = limit {
+                params.push(("limit", l.to_string()));
+            }
+            if params.is_empty() {
+                return ApiRequest::get("/workers/drain-preview");
+            }
+            let qs = params
+                .iter()
+                .map(|(k, v)| format!("{k}={}", query_encode(v)))
+                .collect::<Vec<_>>()
+                .join("&");
+            ApiRequest::get(format!("/workers/drain-preview?{qs}"))
+        }
+        WorkerCommand::List {
+            queue,
+            shard_id,
+            status,
+            health,
+            limit,
+        } => {
+            let mut params: Vec<(&'static str, String)> = Vec::new();
+            if let Some(q) = queue {
+                params.push(("queue", q.clone()));
+            }
+            if let Some(s) = shard_id {
+                params.push(("shard_id", s.to_string()));
+            }
+            if let Some(s) = status {
+                params.push(("status", s.clone()));
+            }
+            if let Some(h) = health {
+                params.push(("health", h.clone()));
+            }
+            if let Some(l) = limit {
+                params.push(("limit", l.to_string()));
+            }
+            if params.is_empty() {
+                return ApiRequest::get("/workers");
+            }
+            let qs = params
+                .iter()
+                .map(|(k, v)| format!("{k}={}", query_encode(v)))
+                .collect::<Vec<_>>()
+                .join("&");
+            ApiRequest::get(format!("/workers?{qs}"))
+        }
+        WorkerCommand::Get { worker_id } => {
+            ApiRequest::get(format!("/workers/{}", path_segment(worker_id)))
+        }
+        WorkerCommand::Health => ApiRequest::get("/workers/health"),
+    }
+}
+
 fn parse_json_source(
     inline: Option<&str>,
     file: Option<&Path>,
@@ -3429,6 +3580,115 @@ mod reuse_policy_tests {
 
         assert!(rendered.trim_start().starts_with('{'));
         assert!(rendered.contains("\"safe_to_retire\":true"));
+    }
+
+    // -- Worker subcommand (issue #170) --
+
+    #[test]
+    fn worker_drain_builds_post_request() {
+        let req = parse(&["worker", "drain", "w-abc"]).api_request().unwrap();
+        assert_eq!(req.method, ApiMethod::Post);
+        assert_eq!(req.path, "/workers/w-abc/drain");
+        assert!(req.body.is_some());
+    }
+
+    #[test]
+    fn worker_drain_without_deadline_sends_empty_body() {
+        let req = parse(&["worker", "drain", "w-abc"]).api_request().unwrap();
+        let body = req.body.as_ref().unwrap();
+        assert!(body.get("deadline_at").is_none());
+    }
+
+    #[test]
+    fn worker_drain_with_deadline_includes_deadline_in_body() {
+        let req = parse(&[
+            "worker",
+            "drain",
+            "w-abc",
+            "--deadline",
+            "2026-05-09T12:00:00Z",
+        ])
+        .api_request()
+        .unwrap();
+        let body = req.body.as_ref().unwrap();
+        assert_eq!(
+            body["deadline_at"].as_str().unwrap(),
+            "2026-05-09T12:00:00Z"
+        );
+    }
+
+    #[test]
+    fn worker_drain_preview_builds_get_request() {
+        let req = parse(&["worker", "drain-preview"]).api_request().unwrap();
+        assert_eq!(req.method, ApiMethod::Get);
+        assert_eq!(req.path, "/workers/drain-preview");
+        assert!(req.body.is_none());
+    }
+
+    #[test]
+    fn worker_drain_preview_with_queue_filter_sends_param() {
+        let req = parse(&["worker", "drain-preview", "--queue", "email-workers"])
+            .api_request()
+            .unwrap();
+        assert_eq!(req.method, ApiMethod::Get);
+        assert!(
+            req.path.contains("queue=email-workers"),
+            "path: {}",
+            req.path
+        );
+    }
+
+    #[test]
+    fn worker_drain_preview_with_shard_filter_sends_param() {
+        let req = parse(&["worker", "drain-preview", "--shard-id", "2"])
+            .api_request()
+            .unwrap();
+        assert!(req.path.contains("shard_id=2"), "path: {}", req.path);
+    }
+
+    #[test]
+    fn worker_drain_preview_with_status_filter_sends_param() {
+        let req = parse(&["worker", "drain-preview", "--status", "Active"])
+            .api_request()
+            .unwrap();
+        assert!(req.path.contains("status=Active"), "path: {}", req.path);
+    }
+
+    #[test]
+    fn worker_list_builds_get_request() {
+        let req = parse(&["worker", "list"]).api_request().unwrap();
+        assert_eq!(req.method, ApiMethod::Get);
+        assert_eq!(req.path, "/workers");
+    }
+
+    #[test]
+    fn worker_list_with_status_filter_sends_param() {
+        let req = parse(&["worker", "list", "--status", "Draining"])
+            .api_request()
+            .unwrap();
+        assert!(req.path.contains("status=Draining"), "path: {}", req.path);
+    }
+
+    #[test]
+    fn worker_list_with_queue_filter_sends_param() {
+        let req = parse(&["worker", "list", "--queue", "default"])
+            .api_request()
+            .unwrap();
+        assert!(req.path.contains("queue=default"), "path: {}", req.path);
+    }
+
+    #[test]
+    fn worker_get_builds_get_request() {
+        let req = parse(&["worker", "get", "w-xyz"]).api_request().unwrap();
+        assert_eq!(req.method, ApiMethod::Get);
+        assert_eq!(req.path, "/workers/w-xyz");
+    }
+
+    #[test]
+    fn worker_health_builds_get_request() {
+        let req = parse(&["worker", "health"]).api_request().unwrap();
+        assert_eq!(req.method, ApiMethod::Get);
+        assert_eq!(req.path, "/workers/health");
     }
 
     #[test]

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -5424,6 +5424,7 @@ struct DrainWorkerRequest {
     deadline_at: Option<String>,
 }
 
+#[allow(clippy::too_many_lines)]
 async fn request_drain_handler(
     Extension(api_state): Extension<HarvestApiState>,
     headers: axum::http::HeaderMap,
@@ -5434,20 +5435,23 @@ async fn request_drain_handler(
     let stale_threshold = api_state.worker_stale_threshold();
     let pool = api_state.storage_pool().map_err(map_error)?;
 
-    let deadline_at = if let Some(raw) = &request.deadline_at {
+    // Track whether the deadline is operator-supplied so we can avoid
+    // shortening an existing window when re-draining without --deadline.
+    let (deadline_at, deadline_is_explicit) = if let Some(raw) = &request.deadline_at {
         let dt = chrono::DateTime::parse_from_rfc3339(raw).map_err(|_| {
             AutumnError::bad_request_msg(format!(
                 "invalid deadline_at '{raw}'; expected RFC 3339 (e.g. 2026-05-09T12:00:00Z)"
             ))
         })?;
-        Some(dt.with_timezone(&chrono::Utc))
+        (Some(dt.with_timezone(&chrono::Utc)), true)
     } else {
         // Compute a default deadline from the configured worker shutdown timeout so
         // operators always get a finite drain window even when they omit the field.
         let timeout = api_state.worker_shutdown_timeout();
-        chrono::Duration::from_std(timeout)
+        let computed = chrono::Duration::from_std(timeout)
             .ok()
-            .map(|d| chrono::Utc::now() + d)
+            .map(|d| chrono::Utc::now() + d);
+        (computed, false)
     };
 
     // Search every shard for the worker — workers are registered on exactly
@@ -5460,9 +5464,15 @@ async fn request_drain_handler(
             continue;
         };
 
-        let mut response = request_drain(&mut conn, &worker_id, deadline_at, stale_threshold)
-            .await
-            .map_err(map_error)?;
+        let mut response = request_drain(
+            &mut conn,
+            &worker_id,
+            deadline_at,
+            deadline_is_explicit,
+            stale_threshold,
+        )
+        .await
+        .map_err(map_error)?;
 
         if response.outcome == autumn_harvest::workers::DrainOutcome::NotFound {
             continue;

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -5483,7 +5483,9 @@ async fn request_drain_handler(
             error_summary: None,
             shard_id: Some(shard_id.as_i32()),
         };
-        let _ = audit::insert_audit(&mut conn, &ar).await;
+        audit::insert_audit(&mut conn, &ar)
+            .await
+            .map_err(map_error)?;
 
         return Ok(Json(response));
     }

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -5524,6 +5524,29 @@ async fn request_drain_handler(
         }));
     }
 
+    // All shards reachable but the worker ID was absent on every one.
+    // Write an audit record on any available shard so that
+    // `harvest audit list --operation worker.drain --target-id <id>`
+    // shows the attempted drain even for a 404 response.
+    'audit: for (_shard_id, shard_pool) in pool.iter_shards() {
+        if let Ok(mut conn) = acquire_conn(shard_pool).await {
+            let ar = NewAuditRecord {
+                actor: &actor,
+                source: &source,
+                operation: OP_WORKER_DRAIN,
+                target_type: TARGET_WORKER,
+                target_id: Some(worker_id.as_str()),
+                route_or_command: "POST /workers/{worker_id}/drain",
+                request_id: request_id.as_deref(),
+                idempotency_key: None,
+                status: STATUS_FAILED,
+                error_summary: Some("worker not found"),
+                shard_id: None,
+            };
+            let _ = audit::insert_audit(&mut conn, &ar).await;
+            break 'audit;
+        }
+    }
     Err(AutumnError::not_found_msg(format!("worker '{worker_id}'")))
 }
 

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -28,10 +28,10 @@ use autumn_harvest::audit::{
     self, AuditFilters, HEADER_ACTOR, HEADER_REQUEST_ID, HEADER_SOURCE, OP_BATCH_SUBMIT,
     OP_DAG_PATCH, OP_DAG_TRIGGER, OP_DLQ_DISCARD_BULK, OP_DLQ_REPLAY, OP_DLQ_REPLAY_BULK,
     OP_EXTERNAL_ACTIVITY_COMPLETE, OP_EXTERNAL_ACTIVITY_FAIL, OP_RETENTION_RUN_NOW,
-    OP_SCHEDULE_CREATE, OP_SCHEDULE_DELETE, OP_SCHEDULE_PAUSE, OP_SCHEDULE_RESUME,
+    OP_SCHEDULE_CREATE, OP_SCHEDULE_DELETE, OP_SCHEDULE_PAUSE, OP_SCHEDULE_RESUME, OP_WORKER_DRAIN,
     OP_WORKFLOW_CANCEL, OP_WORKFLOW_RESET, OP_WORKFLOW_SIGNAL, OP_WORKFLOW_START, SOURCE_API,
     STATUS_FAILED, STATUS_SUCCEEDED, TARGET_BATCH, TARGET_DAG, TARGET_DEAD_LETTER,
-    TARGET_EXTERNAL_ACTIVITY, TARGET_RETENTION, TARGET_SCHEDULE, TARGET_WORKFLOW,
+    TARGET_EXTERNAL_ACTIVITY, TARGET_RETENTION, TARGET_SCHEDULE, TARGET_WORKER, TARGET_WORKFLOW,
 };
 use autumn_harvest::batch::{
     self, BatchAction, BatchExecutorConfig, BatchFilter, BatchJobStatus, BatchJobView,
@@ -67,8 +67,8 @@ use autumn_harvest::types::{
 };
 use autumn_harvest::worker::{DbPool, HandlerRegistry};
 use autumn_harvest::workers::{
-    FleetHealth, WorkerFilters, WorkerRow, fleet_health, get_worker, list_workers,
-    parse_worker_filters,
+    DrainPreviewItem, DrainResponse, FleetHealth, WorkerFilters, WorkerRow, drain_preview,
+    fleet_health, get_worker, list_workers, parse_worker_filters, request_drain,
 };
 use autumn_harvest::{HistoryMatch, HistoryMatcher, WorkflowEvent};
 use autumn_harvest::{
@@ -945,12 +945,15 @@ pub fn harvest_api_router(api_state: HarvestApiState) -> Router<AppState> {
             "/activities/external/{token}/heartbeat",
             post(heartbeat_external_activity),
         )
-        // Worker fleet observability (issue #100).
-        // /workers/health must be registered before /workers/{worker_id} so axum
-        // does not treat the literal "health" segment as a worker_id capture.
+        // Worker fleet observability (issue #100) + remote drain (issue #170).
+        // Static paths (/workers/health, /workers/drain-preview) must be
+        // registered before /workers/{worker_id} so axum does not capture the
+        // literal segments as the worker_id path parameter.
         .route("/workers/health", get(workers_health))
+        .route("/workers/drain-preview", get(drain_preview_handler))
         .route("/workers", get(list_workers_handler))
         .route("/workers/{worker_id}", get(get_worker_handler))
+        .route("/workers/{worker_id}/drain", post(request_drain_handler))
         // Batch operations (issue #102): operator-facing fleet-wide cancel /
         // terminate / signal so an incident commander does not have to script
         // a one-off loop over GET /workflows.
@@ -4830,6 +4833,101 @@ async fn workers_health(
 /// Parse worker query-string parameters, mapping errors to `400 Bad Request`.
 fn parse_worker_filters_api(pairs: &[(String, String)]) -> Result<WorkerFilters, AutumnError> {
     parse_worker_filters(pairs).map_err(AutumnError::bad_request_msg)
+}
+
+// ---------------------------------------------------------------------------
+// Remote drain controls (issue #170)
+// ---------------------------------------------------------------------------
+
+/// Request body for `POST /workers/{worker_id}/drain`.
+#[derive(Debug, Deserialize)]
+struct DrainWorkerRequest {
+    /// Optional ISO 8601 deadline by which the worker must have drained.
+    /// When absent the server uses its configured worker shutdown timeout.
+    #[serde(default)]
+    deadline_at: Option<String>,
+}
+
+async fn request_drain_handler(
+    Extension(api_state): Extension<HarvestApiState>,
+    headers: axum::http::HeaderMap,
+    Path(worker_id): Path<String>,
+    Json(request): Json<DrainWorkerRequest>,
+) -> Result<Json<DrainResponse>, AutumnError> {
+    let (actor, source, request_id) = audit_context(&headers, &api_state);
+    let stale_threshold = api_state.worker_stale_threshold();
+    let pool = api_state.storage_pool().map_err(map_error)?;
+
+    let deadline_at = if let Some(raw) = &request.deadline_at {
+        let dt = chrono::DateTime::parse_from_rfc3339(raw).map_err(|_| {
+            AutumnError::bad_request_msg(format!(
+                "invalid deadline_at '{raw}'; expected RFC 3339 (e.g. 2026-05-09T12:00:00Z)"
+            ))
+        })?;
+        Some(dt.with_timezone(&chrono::Utc))
+    } else {
+        None
+    };
+
+    // Search every shard for the worker — workers are registered on exactly
+    // one shard, so the first hit wins.
+    for (shard_id, shard_pool) in pool.iter_shards() {
+        let mut conn = acquire_conn(shard_pool).await?;
+
+        let response = request_drain(&mut conn, &worker_id, deadline_at, stale_threshold)
+            .await
+            .map_err(map_error)?;
+
+        if response.outcome == autumn_harvest::workers::DrainOutcome::NotFound {
+            continue;
+        }
+
+        let ar = NewAuditRecord {
+            actor: &actor,
+            source: &source,
+            operation: OP_WORKER_DRAIN,
+            target_type: TARGET_WORKER,
+            target_id: Some(worker_id.as_str()),
+            route_or_command: "POST /workers/{worker_id}/drain",
+            request_id: request_id.as_deref(),
+            idempotency_key: None,
+            status: STATUS_SUCCEEDED,
+            error_summary: None,
+            shard_id: Some(shard_id.as_i32()),
+        };
+        let _ = audit::insert_audit(&mut conn, &ar).await;
+
+        return Ok(Json(response));
+    }
+
+    Err(AutumnError::not_found_msg(format!("worker '{worker_id}'")))
+}
+
+async fn drain_preview_handler(
+    Extension(api_state): Extension<HarvestApiState>,
+    Query(pairs): Query<Vec<(String, String)>>,
+) -> Result<Json<Vec<DrainPreviewItem>>, AutumnError> {
+    let filters = parse_worker_filters_api(&pairs)?;
+    let stale_threshold = api_state.worker_stale_threshold();
+    let pool = api_state.storage_pool().map_err(map_error)?;
+
+    let per_shard_filters = WorkerFilters {
+        limit: i64::MAX,
+        ..filters.clone()
+    };
+
+    let mut results: Vec<DrainPreviewItem> = Vec::new();
+    for (_shard, shard_pool) in pool.iter_shards() {
+        let mut conn = acquire_conn(shard_pool).await?;
+        let mut items = drain_preview(&mut conn, &per_shard_filters, stale_threshold)
+            .await
+            .map_err(map_error)?;
+        results.append(&mut items);
+    }
+
+    results.sort_by(|a, b| a.worker_id.cmp(&b.worker_id));
+    results.truncate(usize::try_from(filters.limit).unwrap_or(usize::MAX));
+    Ok(Json(results))
 }
 
 // ---------------------------------------------------------------------------

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -5362,7 +5362,12 @@ async fn get_worker_handler(
     let pool = api_state.storage_pool().map_err(map_error)?;
 
     for (_shard, shard_pool) in pool.iter_shards() {
-        let mut conn = acquire_conn(shard_pool).await?;
+        // Skip unavailable shards rather than returning 500; the worker may
+        // live on a reachable shard even when others are down, and the --wait
+        // poll loop must not abort just because an unrelated shard is offline.
+        let Ok(mut conn) = acquire_conn(shard_pool).await else {
+            continue;
+        };
         if let Some(row) = get_worker(&mut conn, &worker_id, stale_threshold)
             .await
             .map_err(map_error)?

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -192,6 +192,9 @@ pub struct HarvestApiState {
     admin_auth_boundary: Arc<Mutex<bool>>,
     /// When enabled, `/health` returns 503 until writable shards are ready.
     health_requires_shard_readiness: Arc<Mutex<bool>>,
+    /// Default drain deadline offset used when `POST /workers/{id}/drain` omits `deadline_at`.
+    /// Set from `WorkerConfig::shutdown_timeout` at startup; defaults to 30 s.
+    worker_shutdown_timeout: Arc<Mutex<std::time::Duration>>,
 }
 
 impl Default for HarvestApiState {
@@ -205,6 +208,7 @@ impl Default for HarvestApiState {
             deployment_profile: Arc::new(Mutex::new("unknown".to_string())),
             admin_auth_boundary: Arc::new(Mutex::new(false)),
             health_requires_shard_readiness: Arc::new(Mutex::new(false)),
+            worker_shutdown_timeout: Arc::new(Mutex::new(std::time::Duration::from_secs(30))),
         }
     }
 }
@@ -343,6 +347,27 @@ impl HarvestApiState {
     fn health_requires_shard_readiness(&self) -> bool {
         *self
             .health_requires_shard_readiness
+            .lock()
+            .expect("harvest api state lock poisoned")
+    }
+
+    /// Override the default deadline applied when `POST /workers/{id}/drain` does not
+    /// supply a `deadline_at`. Defaults to 30 s (the `WorkerConfig::shutdown_timeout`
+    /// default). Set this at startup from the actual `WorkerConfig`.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal mutex is poisoned.
+    pub fn set_worker_shutdown_timeout(&self, timeout: std::time::Duration) {
+        *self
+            .worker_shutdown_timeout
+            .lock()
+            .expect("harvest api state lock poisoned") = timeout;
+    }
+
+    pub(crate) fn worker_shutdown_timeout(&self) -> std::time::Duration {
+        *self
+            .worker_shutdown_timeout
             .lock()
             .expect("harvest api state lock poisoned")
     }
@@ -4866,21 +4891,33 @@ async fn request_drain_handler(
         })?;
         Some(dt.with_timezone(&chrono::Utc))
     } else {
-        None
+        // Compute a default deadline from the configured worker shutdown timeout so
+        // operators always get a finite drain window even when they omit the field.
+        let timeout = api_state.worker_shutdown_timeout();
+        chrono::Duration::from_std(timeout)
+            .ok()
+            .map(|d| chrono::Utc::now() + d)
     };
 
     // Search every shard for the worker — workers are registered on exactly
-    // one shard, so the first hit wins.
+    // one shard, so the first hit wins. Connection failures on individual shards
+    // are recorded as unavailable rather than aborting the whole request (AC #8).
+    let mut unavailable_shards: Vec<i32> = Vec::new();
     for (shard_id, shard_pool) in pool.iter_shards() {
-        let mut conn = acquire_conn(shard_pool).await?;
+        let Ok(mut conn) = acquire_conn(shard_pool).await else {
+            unavailable_shards.push(shard_id.as_i32());
+            continue;
+        };
 
-        let response = request_drain(&mut conn, &worker_id, deadline_at, stale_threshold)
+        let mut response = request_drain(&mut conn, &worker_id, deadline_at, stale_threshold)
             .await
             .map_err(map_error)?;
 
         if response.outcome == autumn_harvest::workers::DrainOutcome::NotFound {
             continue;
         }
+
+        response.unavailable_shards = std::mem::take(&mut unavailable_shards);
 
         let ar = NewAuditRecord {
             actor: &actor,
@@ -4898,6 +4935,19 @@ async fn request_drain_handler(
         let _ = audit::insert_audit(&mut conn, &ar).await;
 
         return Ok(Json(response));
+    }
+
+    // Worker not found on any reachable shard. If some shards were unavailable
+    // the worker may live there — return a degraded 200 rather than 404.
+    if !unavailable_shards.is_empty() {
+        return Ok(Json(DrainResponse {
+            worker_id: worker_id.clone(),
+            outcome: autumn_harvest::workers::DrainOutcome::NotFound,
+            in_flight_count: 0,
+            drain_deadline_at: None,
+            shard_ids: vec![],
+            unavailable_shards,
+        }));
     }
 
     Err(AutumnError::not_found_msg(format!("worker '{worker_id}'")))
@@ -5520,6 +5570,27 @@ mod tests {
         assert_eq!(
             state.worker_stale_threshold(),
             std::time::Duration::from_secs(20)
+        );
+    }
+
+    // -- Drain: AC #2 -- default deadline from shutdown timeout
+
+    #[test]
+    fn harvest_api_state_shutdown_timeout_defaults_to_30s() {
+        let state = HarvestApiState::new();
+        assert_eq!(
+            state.worker_shutdown_timeout(),
+            std::time::Duration::from_secs(30)
+        );
+    }
+
+    #[test]
+    fn harvest_api_state_shutdown_timeout_can_be_overridden() {
+        let state = HarvestApiState::new();
+        state.set_worker_shutdown_timeout(std::time::Duration::from_secs(60));
+        assert_eq!(
+            state.worker_shutdown_timeout(),
+            std::time::Duration::from_secs(60)
         );
     }
 }

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -5490,7 +5490,30 @@ async fn request_drain_handler(
 
     // Worker not found on any reachable shard. If some shards were unavailable
     // the worker may live there — return a degraded 200 rather than 404.
+    // Write an audit record on any reachable shard so the attempt is traceable
+    // even when the owning shard is down.
     if !unavailable_shards.is_empty() {
+        'audit: for (_shard_id, shard_pool) in pool.iter_shards() {
+            if let Ok(mut conn) = acquire_conn(shard_pool).await {
+                let ar = NewAuditRecord {
+                    actor: &actor,
+                    source: &source,
+                    operation: OP_WORKER_DRAIN,
+                    target_type: TARGET_WORKER,
+                    target_id: Some(worker_id.as_str()),
+                    route_or_command: "POST /workers/{worker_id}/drain",
+                    request_id: request_id.as_deref(),
+                    idempotency_key: None,
+                    status: STATUS_FAILED,
+                    error_summary: Some(
+                        "degraded: worker not found on reachable shards; may exist on unavailable shard",
+                    ),
+                    shard_id: None,
+                };
+                let _ = audit::insert_audit(&mut conn, &ar).await;
+                break 'audit;
+            }
+        }
         return Ok(Json(DrainResponse {
             worker_id: worker_id.clone(),
             outcome: autumn_harvest::workers::DrainOutcome::NotFound,

--- a/autumn-harvest-plugin/src/plugin.rs
+++ b/autumn-harvest-plugin/src/plugin.rs
@@ -255,6 +255,9 @@ fn start_harvest_runtime(
     // Derive the API stale threshold from the worker heartbeat interval so that
     // /workers correctly classifies workers under non-default configurations.
     api_state.set_worker_stale_threshold(built.worker_config().worker_heartbeat_interval * 2);
+    // Mirror the configured shutdown timeout so drain requests can compute a
+    // sensible default deadline without the caller having to supply one.
+    api_state.set_worker_shutdown_timeout(built.worker_config().shutdown_timeout);
 
     // Apply the api_state audit retention override only when explicitly set,
     // so that builder-level retention config is not silently clobbered.

--- a/autumn-harvest-plugin/tests/ui_integration.rs
+++ b/autumn-harvest-plugin/tests/ui_integration.rs
@@ -45,6 +45,10 @@ const INIT_SQL: &str = concat!(
     "\n",
     include_str!("../../autumn-harvest/migrations/20260501000000_harvest_workers/up.sql"),
     "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260508010000_harvest_workers_drain_deadline/up.sql"
+    ),
+    "\n",
     include_str!("../../autumn-harvest/migrations/20260505000000_harvest_heartbeat_details/up.sql"),
     "\n",
     include_str!("../../autumn-harvest/migrations/20260506000000_harvest_audit_log/up.sql"),

--- a/autumn-harvest/migrations/20260508010000_harvest_workers_drain_deadline/down.sql
+++ b/autumn-harvest/migrations/20260508010000_harvest_workers_drain_deadline/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE harvest_workers
+    DROP COLUMN drain_deadline_at;

--- a/autumn-harvest/migrations/20260508010000_harvest_workers_drain_deadline/up.sql
+++ b/autumn-harvest/migrations/20260508010000_harvest_workers_drain_deadline/up.sql
@@ -1,0 +1,2 @@
+ALTER TABLE harvest_workers
+    ADD COLUMN drain_deadline_at TIMESTAMPTZ;

--- a/autumn-harvest/src/audit.rs
+++ b/autumn-harvest/src/audit.rs
@@ -49,6 +49,7 @@ pub const OP_BATCH_SUBMIT: &str = "batch.submit";
 pub const OP_RETENTION_RUN_NOW: &str = "retention.run_now";
 pub const OP_EXTERNAL_ACTIVITY_COMPLETE: &str = "external_activity.complete";
 pub const OP_EXTERNAL_ACTIVITY_FAIL: &str = "external_activity.fail";
+pub const OP_WORKER_DRAIN: &str = "worker.drain";
 
 // ── Target type constants ─────────────────────────────────────────────────────
 
@@ -59,6 +60,7 @@ pub const TARGET_DEAD_LETTER: &str = "dead_letter";
 pub const TARGET_BATCH: &str = "batch";
 pub const TARGET_RETENTION: &str = "retention";
 pub const TARGET_EXTERNAL_ACTIVITY: &str = "external_activity";
+pub const TARGET_WORKER: &str = "worker";
 
 // ── Status constants ──────────────────────────────────────────────────────────
 
@@ -119,6 +121,7 @@ pub const AUDITED_OPERATIONS: &[&str] = &[
     OP_RETENTION_RUN_NOW,
     OP_EXTERNAL_ACTIVITY_COMPLETE,
     OP_EXTERNAL_ACTIVITY_FAIL,
+    OP_WORKER_DRAIN,
 ];
 
 /// Routes explicitly excluded from audit.
@@ -148,6 +151,7 @@ pub const EXCLUDED_ROUTES: &[&str] = &[
     "GET /workers",
     "GET /workers/health",
     "GET /workers/{worker_id}",
+    "GET /workers/drain-preview",
     "GET /batch-operations",
     "GET /batch-operations/{id}",
     // The audit list endpoint itself is read-only.
@@ -216,10 +220,12 @@ pub const ALL_MUTATION_ROUTES: &[(&str, Option<&str>)] = &[
         Some(OP_EXTERNAL_ACTIVITY_FAIL),
     ),
     ("POST /activities/external/{token}/heartbeat", None),
-    // Worker fleet (read-only)
+    // Worker fleet
     ("GET /workers/health", None),
     ("GET /workers", None),
     ("GET /workers/{worker_id}", None),
+    ("GET /workers/drain-preview", None),
+    ("POST /workers/{worker_id}/drain", Some(OP_WORKER_DRAIN)),
     // Batch operations
     ("GET /batch-operations", None),
     ("POST /batch-operations", Some(OP_BATCH_SUBMIT)),

--- a/autumn-harvest/src/models.rs
+++ b/autumn-harvest/src/models.rs
@@ -391,6 +391,8 @@ pub struct HarvestWorker {
     pub version: Option<String>,
     /// Lifecycle status: `Active`, `Draining`, or `Stopped`.
     pub status: String,
+    /// When set, the deadline by which this worker must have finished draining.
+    pub drain_deadline_at: Option<DateTime<Utc>>,
 }
 
 /// Insert struct for registering a new worker process.

--- a/autumn-harvest/src/schema.rs
+++ b/autumn-harvest/src/schema.rs
@@ -193,6 +193,7 @@ diesel::table! {
         host -> Text,
         version -> Nullable<Text>,
         status -> Text,
+        drain_deadline_at -> Nullable<Timestamptz>,
     }
 }
 

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -2990,10 +2990,11 @@ pub struct Worker {
     activity_semaphore: Arc<Semaphore>,
     /// Cancellation token for graceful shutdown.
     shutdown: CancellationToken,
-    /// Set by the heartbeat task when a remote drain is detected; holds the
-    /// remaining time until the operator-supplied `drain_deadline_at` so that
-    /// `drain_in_flight` honours it instead of the static `shutdown_timeout`.
-    remote_drain_deadline: Arc<Mutex<Option<Duration>>>,
+    /// Set (and refreshed on every heartbeat) by the heartbeat task while the
+    /// worker is draining.  Holds the absolute deadline from the operator's
+    /// `drain_deadline_at` so that `drain_in_flight` can honour an extended
+    /// window even after it has already started waiting.
+    remote_drain_deadline: Arc<Mutex<Option<std::time::Instant>>>,
 }
 
 impl Worker {
@@ -3416,27 +3417,35 @@ impl Worker {
         });
     }
 
-    /// Wait for all in-flight tasks to finish (or timeout).
+    /// Wait for all in-flight tasks to finish (or the drain deadline expires).
     ///
     /// We wait until all semaphore permits are available again, meaning all
     /// spawned tasks have completed and dropped their permits.
     ///
-    /// When a remote drain set a deadline via `remote_drain_deadline`, we use
-    /// the remaining time from that deadline as the timeout.  This ensures that
-    /// a longer operator-supplied window is actually honoured rather than being
-    /// capped by the static `shutdown_timeout` (P2-B fix).
+    /// The deadline is read from `remote_drain_deadline` (set by the heartbeat
+    /// task) rather than being snapshotted once.  The heartbeat task refreshes
+    /// that cell on every tick while draining, so an operator-extended deadline
+    /// (via a second POST .../drain with a later `deadline_at`) is picked up
+    /// here without restarting the worker.
     async fn drain_in_flight(&self) {
         let total_permits =
             self.config.max_concurrent_workflows + self.config.max_concurrent_activities;
 
-        // Prefer the deadline received from the remote drain request; fall back
-        // to the statically-configured shutdown_timeout for local shutdowns.
-        let timeout = self
-            .remote_drain_deadline
-            .lock()
-            .ok()
-            .and_then(|g| *g)
-            .unwrap_or(self.config.shutdown_timeout);
+        // Returns the current deadline as a tokio Instant, falling back to the
+        // statically-configured shutdown_timeout for local (non-remote) shutdowns.
+        let snapshot_deadline = || -> tokio::time::Instant {
+            self.remote_drain_deadline
+                .lock()
+                .ok()
+                .and_then(|g| *g)
+                .map_or_else(
+                    || tokio::time::Instant::now() + self.config.shutdown_timeout,
+                    tokio::time::Instant::from_std,
+                )
+        };
+
+        let sleep = tokio::time::sleep_until(snapshot_deadline());
+        tokio::pin!(sleep);
 
         let drain = async {
             // Try to acquire ALL permits — when we can, all in-flight tasks are done.
@@ -3457,13 +3466,31 @@ impl Worker {
                 )
                 .await;
         };
+        tokio::pin!(drain);
 
-        if tokio::time::timeout(timeout, drain).await.is_err() {
-            tracing::warn!(
-                worker_id = %self.config.worker_id,
-                total_permits,
-                "shutdown timeout elapsed — some tasks may still be running"
-            );
+        // Poll for a refreshed deadline once per second so an extended window
+        // updates the sleep timer without requiring a worker restart.
+        let mut check = tokio::time::interval_at(
+            tokio::time::Instant::now() + Duration::from_secs(1),
+            Duration::from_secs(1),
+        );
+
+        loop {
+            tokio::select! {
+                biased;
+                () = &mut drain => return,
+                () = &mut sleep => {
+                    tracing::warn!(
+                        worker_id = %self.config.worker_id,
+                        total_permits,
+                        "shutdown timeout elapsed — some tasks may still be running"
+                    );
+                    return;
+                }
+                _ = check.tick() => {
+                    sleep.as_mut().reset(snapshot_deadline());
+                }
+            }
         }
     }
 

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -3431,17 +3431,18 @@ impl Worker {
         let total_permits =
             self.config.max_concurrent_workflows + self.config.max_concurrent_activities;
 
-        // Returns the current deadline as a tokio Instant, falling back to the
-        // statically-configured shutdown_timeout for local (non-remote) shutdowns.
+        // Fixed fallback for local (non-remote) shutdowns: computed once so that
+        // the 1-second tick in the loop cannot keep sliding it forward.
+        let local_deadline = tokio::time::Instant::now() + self.config.shutdown_timeout;
+
+        // Returns the current deadline: remote (refreshable) when set, otherwise
+        // the fixed local_deadline computed above.
         let snapshot_deadline = || -> tokio::time::Instant {
             self.remote_drain_deadline
                 .lock()
                 .ok()
                 .and_then(|g| *g)
-                .map_or_else(
-                    || tokio::time::Instant::now() + self.config.shutdown_timeout,
-                    tokio::time::Instant::from_std,
-                )
+                .map_or(local_deadline, tokio::time::Instant::from_std)
         };
 
         let sleep = tokio::time::sleep_until(snapshot_deadline());

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -3149,6 +3149,7 @@ impl Worker {
             self.config.max_concurrent_activities,
             self.config.worker_heartbeat_interval,
             heartbeat_cancel.clone(),
+            self.shutdown.clone(),
         );
 
         while !self.shutdown.is_cancelled() {

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -12,7 +12,7 @@
 
 use std::any::{Any, TypeId};
 use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use diesel::{ExpressionMethods, OptionalExtension, QueryDsl, SelectableHelper};
@@ -2990,6 +2990,10 @@ pub struct Worker {
     activity_semaphore: Arc<Semaphore>,
     /// Cancellation token for graceful shutdown.
     shutdown: CancellationToken,
+    /// Set by the heartbeat task when a remote drain is detected; holds the
+    /// remaining time until the operator-supplied `drain_deadline_at` so that
+    /// `drain_in_flight` honours it instead of the static `shutdown_timeout`.
+    remote_drain_deadline: Arc<Mutex<Option<Duration>>>,
 }
 
 impl Worker {
@@ -3010,6 +3014,7 @@ impl Worker {
             workflow_semaphore,
             activity_semaphore,
             shutdown: CancellationToken::new(),
+            remote_drain_deadline: Arc::new(Mutex::new(None)),
         })
     }
 
@@ -3150,6 +3155,7 @@ impl Worker {
             self.config.worker_heartbeat_interval,
             heartbeat_cancel.clone(),
             self.shutdown.clone(),
+            Arc::clone(&self.remote_drain_deadline),
         );
 
         while !self.shutdown.is_cancelled() {
@@ -3414,9 +3420,23 @@ impl Worker {
     ///
     /// We wait until all semaphore permits are available again, meaning all
     /// spawned tasks have completed and dropped their permits.
+    ///
+    /// When a remote drain set a deadline via `remote_drain_deadline`, we use
+    /// the remaining time from that deadline as the timeout.  This ensures that
+    /// a longer operator-supplied window is actually honoured rather than being
+    /// capped by the static `shutdown_timeout` (P2-B fix).
     async fn drain_in_flight(&self) {
         let total_permits =
             self.config.max_concurrent_workflows + self.config.max_concurrent_activities;
+
+        // Prefer the deadline received from the remote drain request; fall back
+        // to the statically-configured shutdown_timeout for local shutdowns.
+        let timeout = self
+            .remote_drain_deadline
+            .lock()
+            .ok()
+            .and_then(|g| *g)
+            .unwrap_or(self.config.shutdown_timeout);
 
         let drain = async {
             // Try to acquire ALL permits — when we can, all in-flight tasks are done.
@@ -3438,10 +3458,7 @@ impl Worker {
                 .await;
         };
 
-        if tokio::time::timeout(self.config.shutdown_timeout, drain)
-            .await
-            .is_err()
-        {
+        if tokio::time::timeout(timeout, drain).await.is_err() {
             tracing::warn!(
                 worker_id = %self.config.worker_id,
                 total_permits,

--- a/autumn-harvest/src/workers.rs
+++ b/autumn-harvest/src/workers.rs
@@ -857,9 +857,10 @@ pub fn spawn_worker_heartbeat(
     interval: Duration,
     cancel: CancellationToken,
     worker_shutdown: CancellationToken,
-    // Populated when a remote drain is detected: remaining time until the
-    // operator-supplied drain_deadline_at so drain_in_flight can honour it.
-    remote_drain_deadline: Arc<Mutex<Option<Duration>>>,
+    // Populated when a remote drain is detected: absolute Instant of the
+    // operator-supplied drain_deadline_at, refreshed on every heartbeat tick
+    // so that extended deadlines are picked up by drain_in_flight.
+    remote_drain_deadline: Arc<Mutex<Option<std::time::Instant>>>,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
         loop {
@@ -897,36 +898,40 @@ pub fn spawn_worker_heartbeat(
                             }
                         }
                         Ok(_) => {
-                            // Heartbeat succeeded; check whether a remote drain
-                            // request has changed this worker's status to Draining.
-                            // Cancel the worker's poll-loop shutdown token (not the
-                            // heartbeat token) so the poll loop stops accepting new
-                            // work within the next heartbeat interval while heartbeats
-                            // continue until the worker is fully stopped (P1).
-                            if !worker_shutdown.is_cancelled() {
+                            if worker_shutdown.is_cancelled() {
+                                // Already draining — refresh the stored deadline on
+                                // every heartbeat so an operator-extended window (via
+                                // a second POST .../drain with a later deadline_at)
+                                // is picked up by drain_in_flight without restarting
+                                // the worker.
+                                sync_drain_deadline(
+                                    &mut conn,
+                                    &registration.worker_id,
+                                    &remote_drain_deadline,
+                                )
+                                .await;
+                            } else {
+                                // Heartbeat succeeded; check whether a remote drain
+                                // request has changed this worker's status to Draining.
+                                // Cancel the worker's poll-loop shutdown token (not the
+                                // heartbeat token) so the poll loop stops accepting new
+                                // work within the next heartbeat interval while heartbeats
+                                // continue until the worker is fully stopped (P1).
                                 match read_worker_status(&mut conn, &registration.worker_id).await {
                                     Ok(Some(ref s)) if s == WorkerStatus::Draining.as_str() => {
                                         tracing::info!(
                                             worker_id = %registration.worker_id,
                                             "remote drain detected; triggering graceful shutdown"
                                         );
-                                        // Read the operator-supplied deadline so
-                                        // drain_in_flight can honour it instead of
-                                        // the static shutdown_timeout (P2-B).
-                                        if let Ok(Some(deadline)) = read_worker_drain_deadline(
+                                        // Store the operator-supplied deadline as an
+                                        // absolute Instant so drain_in_flight can
+                                        // honour it (P2-B).
+                                        sync_drain_deadline(
                                             &mut conn,
                                             &registration.worker_id,
+                                            &remote_drain_deadline,
                                         )
-                                        .await
-                                        {
-                                            let remaining = deadline
-                                                .signed_duration_since(Utc::now())
-                                                .to_std()
-                                                .unwrap_or(Duration::ZERO);
-                                            if let Ok(mut guard) = remote_drain_deadline.lock() {
-                                                *guard = Some(remaining);
-                                            }
-                                        }
+                                        .await;
                                         worker_shutdown.cancel();
                                     }
                                     _ => {}
@@ -952,6 +957,27 @@ pub fn spawn_worker_heartbeat(
             }
         }
     })
+}
+
+/// Fetch `drain_deadline_at` from the DB and write it as an absolute
+/// `std::time::Instant` into the shared cell used by `drain_in_flight`.
+/// Called both on first drain detection and on every subsequent heartbeat
+/// tick while the worker is draining, so that an operator-extended deadline
+/// is reflected without a restart.
+async fn sync_drain_deadline(
+    conn: &mut AsyncPgConnection,
+    worker_id: &str,
+    cell: &Mutex<Option<std::time::Instant>>,
+) {
+    if let Ok(Some(deadline)) = read_worker_drain_deadline(conn, worker_id).await {
+        let remaining = deadline
+            .signed_duration_since(Utc::now())
+            .to_std()
+            .unwrap_or(Duration::ZERO);
+        if let Ok(mut guard) = cell.lock() {
+            *guard = Some(std::time::Instant::now() + remaining);
+        }
+    }
 }
 
 /// Compute the number of tasks currently in flight from semaphore permits.

--- a/autumn-harvest/src/workers.rs
+++ b/autumn-harvest/src/workers.rs
@@ -740,15 +740,33 @@ pub async fn request_drain(
         .unwrap_or_default();
 
     // Persist the Draining transition (and deadline) for accepted / stale drains.
+    // The UPDATE is guarded by `status != 'Stopped'` so a concurrent self-shutdown
+    // that already wrote Stopped is not overwritten (P2).
     if outcome.is_accepted() {
-        diesel::update(harvest_workers::table.find(worker_id))
-            .set((
-                harvest_workers::status.eq(WorkerStatus::Draining.as_str()),
-                harvest_workers::drain_deadline_at.eq(deadline_at),
-            ))
-            .execute(conn)
-            .await
-            .map_err(crate::error::database_error)?;
+        let rows = diesel::update(
+            harvest_workers::table
+                .find(worker_id)
+                .filter(harvest_workers::status.ne(WorkerStatus::Stopped.as_str())),
+        )
+        .set((
+            harvest_workers::status.eq(WorkerStatus::Draining.as_str()),
+            harvest_workers::drain_deadline_at.eq(deadline_at),
+        ))
+        .execute(conn)
+        .await
+        .map_err(crate::error::database_error)?;
+
+        if rows == 0 {
+            // Worker self-stopped between our read and this update; report as stopped.
+            return Ok(DrainResponse {
+                worker_id: worker_id.to_string(),
+                outcome: DrainOutcome::AlreadyStopped,
+                in_flight_count: worker.in_flight_count,
+                drain_deadline_at: None,
+                shard_ids,
+                unavailable_shards: vec![],
+            });
+        }
     }
 
     Ok(DrainResponse {
@@ -798,6 +816,7 @@ pub fn spawn_worker_heartbeat(
     act_max: usize,
     interval: Duration,
     cancel: CancellationToken,
+    worker_shutdown: CancellationToken,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
         loop {
@@ -836,18 +855,19 @@ pub fn spawn_worker_heartbeat(
                         }
                         Ok(_) => {
                             // Heartbeat succeeded; check whether a remote drain
-                            // request has changed this worker's status to
-                            // Draining. If so, trigger local graceful shutdown
-                            // so the poll loop stops accepting new work within
-                            // the next heartbeat interval.
-                            if !cancel.is_cancelled() {
+                            // request has changed this worker's status to Draining.
+                            // Cancel the worker's poll-loop shutdown token (not the
+                            // heartbeat token) so the poll loop stops accepting new
+                            // work within the next heartbeat interval while heartbeats
+                            // continue until the worker is fully stopped (P1).
+                            if !worker_shutdown.is_cancelled() {
                                 match read_worker_status(&mut conn, &registration.worker_id).await {
                                     Ok(Some(ref s)) if s == WorkerStatus::Draining.as_str() => {
                                         tracing::info!(
                                             worker_id = %registration.worker_id,
                                             "remote drain detected; triggering graceful shutdown"
                                         );
-                                        cancel.cancel();
+                                        worker_shutdown.cancel();
                                     }
                                     _ => {}
                                 }

--- a/autumn-harvest/src/workers.rs
+++ b/autumn-harvest/src/workers.rs
@@ -596,6 +596,10 @@ pub struct DrainResponse {
     pub drain_deadline_at: Option<DateTime<Utc>>,
     /// Shard IDs this worker was serving at drain time.
     pub shard_ids: Vec<i32>,
+    /// Shards that could not be contacted during this request.
+    /// When non-empty the result is **degraded**: the worker may exist on an
+    /// unavailable shard and operators should verify before re-routing traffic.
+    pub unavailable_shards: Vec<i32>,
 }
 
 /// One entry in a dry-run drain preview — what *would* be drained.
@@ -711,6 +715,7 @@ pub async fn request_drain(
             in_flight_count: 0,
             drain_deadline_at: None,
             shard_ids: vec![],
+            unavailable_shards: vec![],
         });
     };
 
@@ -752,6 +757,7 @@ pub async fn request_drain(
         in_flight_count: worker.in_flight_count,
         drain_deadline_at: deadline_at,
         shard_ids,
+        unavailable_shards: vec![],
     })
 }
 
@@ -1243,6 +1249,7 @@ mod tests {
             in_flight_count: 3,
             drain_deadline_at: Some(Utc::now()),
             shard_ids: vec![0, 1],
+            unavailable_shards: vec![],
         };
         let json = serde_json::to_value(&resp).unwrap();
         assert!(json.get("worker_id").is_some(), "missing worker_id");
@@ -1256,6 +1263,10 @@ mod tests {
             "missing drain_deadline_at"
         );
         assert!(json.get("shard_ids").is_some(), "missing shard_ids");
+        assert!(
+            json.get("unavailable_shards").is_some(),
+            "missing unavailable_shards"
+        );
     }
 
     #[test]
@@ -1266,10 +1277,29 @@ mod tests {
             in_flight_count: 0,
             drain_deadline_at: None,
             shard_ids: vec![],
+            unavailable_shards: vec![],
         };
         let json = serde_json::to_value(&resp).unwrap();
         assert!(json["drain_deadline_at"].is_null());
         assert_eq!(json["shard_ids"].as_array().unwrap().len(), 0);
+        assert_eq!(json["unavailable_shards"].as_array().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn drain_response_with_unavailable_shards_serializes() {
+        let resp = DrainResponse {
+            worker_id: "w-abc".to_string(),
+            outcome: DrainOutcome::NotFound,
+            in_flight_count: 0,
+            drain_deadline_at: None,
+            shard_ids: vec![],
+            unavailable_shards: vec![2, 3],
+        };
+        let json = serde_json::to_value(&resp).unwrap();
+        let shards = json["unavailable_shards"].as_array().unwrap();
+        assert_eq!(shards.len(), 2);
+        assert_eq!(shards[0].as_i64().unwrap(), 2);
+        assert_eq!(shards[1].as_i64().unwrap(), 3);
     }
 
     // -- preview_item_from_row --

--- a/autumn-harvest/src/workers.rs
+++ b/autumn-harvest/src/workers.rs
@@ -799,7 +799,20 @@ pub async fn drain_preview(
     filters: &WorkerFilters,
     stale_threshold: Duration,
 ) -> HarvestResult<Vec<DrainPreviewItem>> {
-    let rows = list_workers(conn, filters, stale_threshold).await?;
+    // Default to Active-only so the preview shows workers that *would* be newly
+    // drained. Callers that want Draining or Stopped workers must pass an explicit
+    // status filter.
+    let active_filters;
+    let effective = if filters.status.is_none() {
+        active_filters = WorkerFilters {
+            status: Some(WorkerStatus::Active.as_str().to_string()),
+            ..filters.clone()
+        };
+        &active_filters
+    } else {
+        filters
+    };
+    let rows = list_workers(conn, effective, stale_threshold).await?;
     Ok(rows.iter().map(preview_item_from_row).collect())
 }
 
@@ -1331,6 +1344,20 @@ mod tests {
     }
 
     #[test]
+    #[test]
+    fn drain_preview_defaults_status_to_active_when_unset() {
+        // Verify the documented default: callers that omit status see only Active.
+        // We can't run a DB query in a unit test, but we can verify the filter
+        // construction by inspecting the effective filters value.
+        let filters = WorkerFilters::new();
+        assert!(
+            filters.status.is_none(),
+            "WorkerFilters::new() must leave status unset so drain_preview can override it"
+        );
+        // drain_preview sets status = Active when None; the DB-level assertion
+        // lives in the integration test suite.
+    }
+
     fn drain_outcome_already_draining_is_not_accepted() {
         // AlreadyDraining must NOT be treated as accepted (status transition),
         // but the deadline refresh path covers it separately.

--- a/autumn-harvest/src/workers.rs
+++ b/autumn-harvest/src/workers.rs
@@ -739,9 +739,9 @@ pub async fn request_drain(
         })
         .unwrap_or_default();
 
-    // Persist the Draining transition (and deadline) for accepted / stale drains.
+    // Persist the status transition and deadline for new drains (Accepted / StaleWorker).
     // The UPDATE is guarded by `status != 'Stopped'` so a concurrent self-shutdown
-    // that already wrote Stopped is not overwritten (P2).
+    // that already wrote Stopped is not overwritten.
     if outcome.is_accepted() {
         let rows = diesel::update(
             harvest_workers::table
@@ -767,6 +767,14 @@ pub async fn request_drain(
                 unavailable_shards: vec![],
             });
         }
+    } else if outcome == DrainOutcome::AlreadyDraining {
+        // Worker is already Draining — only refresh the deadline so operators
+        // can extend or correct it without re-triggering the status transition.
+        diesel::update(harvest_workers::table.find(worker_id))
+            .set(harvest_workers::drain_deadline_at.eq(deadline_at))
+            .execute(conn)
+            .await
+            .map_err(crate::error::database_error)?;
     }
 
     Ok(DrainResponse {
@@ -1320,6 +1328,15 @@ mod tests {
         assert_eq!(shards.len(), 2);
         assert_eq!(shards[0].as_i64().unwrap(), 2);
         assert_eq!(shards[1].as_i64().unwrap(), 3);
+    }
+
+    #[test]
+    fn drain_outcome_already_draining_is_not_accepted() {
+        // AlreadyDraining must NOT be treated as accepted (status transition),
+        // but the deadline refresh path covers it separately.
+        assert!(!DrainOutcome::AlreadyDraining.is_accepted());
+        assert!(DrainOutcome::Accepted.is_accepted());
+        assert!(DrainOutcome::StaleWorker.is_accepted());
     }
 
     // -- preview_item_from_row --

--- a/autumn-harvest/src/workers.rs
+++ b/autumn-harvest/src/workers.rs
@@ -1344,7 +1344,6 @@ mod tests {
     }
 
     #[test]
-    #[test]
     fn drain_preview_defaults_status_to_active_when_unset() {
         // Verify the documented default: callers that omit status see only Active.
         // We can't run a DB query in a unit test, but we can verify the filter
@@ -1358,6 +1357,7 @@ mod tests {
         // lives in the integration test suite.
     }
 
+    #[test]
     fn drain_outcome_already_draining_is_not_accepted() {
         // AlreadyDraining must NOT be treated as accepted (status transition),
         // but the deadline refresh path covers it separately.

--- a/autumn-harvest/src/workers.rs
+++ b/autumn-harvest/src/workers.rs
@@ -7,7 +7,7 @@
 //! The API layer queries this table (per-shard) to surface fleet status to
 //! operators via the management HTTP routes.
 
-use std::sync::Arc;
+use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use chrono::{DateTime, Utc};
@@ -677,6 +677,25 @@ pub async fn read_worker_status(
     Ok(status)
 }
 
+/// Read the `drain_deadline_at` timestamp for a worker, if it exists.
+///
+/// # Errors
+///
+/// Returns [`HarvestError`] on database failure.
+pub async fn read_worker_drain_deadline(
+    conn: &mut AsyncPgConnection,
+    worker_id: &str,
+) -> HarvestResult<Option<DateTime<Utc>>> {
+    let row: Option<Option<DateTime<Utc>>> = harvest_workers::table
+        .find(worker_id)
+        .select(harvest_workers::drain_deadline_at)
+        .first(conn)
+        .await
+        .optional()
+        .map_err(crate::error::database_error)?;
+    Ok(row.flatten())
+}
+
 /// Request a graceful drain for the worker identified by `worker_id`.
 ///
 /// The function classifies the current worker state and, if appropriate,
@@ -838,6 +857,9 @@ pub fn spawn_worker_heartbeat(
     interval: Duration,
     cancel: CancellationToken,
     worker_shutdown: CancellationToken,
+    // Populated when a remote drain is detected: remaining time until the
+    // operator-supplied drain_deadline_at so drain_in_flight can honour it.
+    remote_drain_deadline: Arc<Mutex<Option<Duration>>>,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
         loop {
@@ -888,6 +910,23 @@ pub fn spawn_worker_heartbeat(
                                             worker_id = %registration.worker_id,
                                             "remote drain detected; triggering graceful shutdown"
                                         );
+                                        // Read the operator-supplied deadline so
+                                        // drain_in_flight can honour it instead of
+                                        // the static shutdown_timeout (P2-B).
+                                        if let Ok(Some(deadline)) = read_worker_drain_deadline(
+                                            &mut conn,
+                                            &registration.worker_id,
+                                        )
+                                        .await
+                                        {
+                                            let remaining = deadline
+                                                .signed_duration_since(Utc::now())
+                                                .to_std()
+                                                .unwrap_or(Duration::ZERO);
+                                            if let Ok(mut guard) = remote_drain_deadline.lock() {
+                                                *guard = Some(remaining);
+                                            }
+                                        }
                                         worker_shutdown.cancel();
                                     }
                                     _ => {}

--- a/autumn-harvest/src/workers.rs
+++ b/autumn-harvest/src/workers.rs
@@ -717,6 +717,9 @@ pub async fn request_drain(
     conn: &mut AsyncPgConnection,
     worker_id: &str,
     deadline_at: Option<DateTime<Utc>>,
+    // true = operator supplied an explicit value; false = computed default.
+    // AlreadyDraining only refreshes the stored deadline for explicit values.
+    deadline_is_explicit: bool,
     stale_threshold: Duration,
 ) -> HarvestResult<DrainResponse> {
     let row = harvest_workers::table
@@ -786,21 +789,31 @@ pub async fn request_drain(
                 unavailable_shards: vec![],
             });
         }
-    } else if outcome == DrainOutcome::AlreadyDraining {
-        // Worker is already Draining — only refresh the deadline so operators
-        // can extend or correct it without re-triggering the status transition.
+    } else if outcome == DrainOutcome::AlreadyDraining && deadline_is_explicit {
+        // Worker is already Draining and the caller supplied an explicit deadline
+        // — refresh it so operators can extend or correct the window without
+        // re-triggering the status transition.
         diesel::update(harvest_workers::table.find(worker_id))
             .set(harvest_workers::drain_deadline_at.eq(deadline_at))
             .execute(conn)
             .await
             .map_err(crate::error::database_error)?;
     }
+    // AlreadyDraining + !deadline_is_explicit: preserve the stored deadline.
+
+    // Echo whichever deadline is now in effect: the parameter for new drains
+    // or explicit refreshes; the pre-existing row value when preserving.
+    let effective_deadline = if outcome == DrainOutcome::AlreadyDraining && !deadline_is_explicit {
+        worker.drain_deadline_at
+    } else {
+        deadline_at
+    };
 
     Ok(DrainResponse {
         worker_id: worker_id.to_string(),
         outcome,
         in_flight_count: worker.in_flight_count,
-        drain_deadline_at: deadline_at,
+        drain_deadline_at: effective_deadline,
         shard_ids,
         unavailable_shards: vec![],
     })

--- a/autumn-harvest/src/workers.rs
+++ b/autumn-harvest/src/workers.rs
@@ -554,6 +554,224 @@ pub struct FleetHealth {
 }
 
 // ---------------------------------------------------------------------------
+// Drain controls (issue #170)
+// ---------------------------------------------------------------------------
+
+/// Machine-readable outcome of a remote worker drain request.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum DrainOutcome {
+    /// Drain accepted; the worker status has been set to `Draining`.
+    Accepted,
+    /// The worker was already in the `Draining` state.
+    AlreadyDraining,
+    /// The worker is already in the `Stopped` state and will not accept new work.
+    AlreadyStopped,
+    /// The worker's last heartbeat is older than the stale threshold; the drain
+    /// was accepted but the worker may already be dead.
+    StaleWorker,
+    /// No worker with that ID exists in the fleet table.
+    NotFound,
+}
+
+impl DrainOutcome {
+    /// Returns `true` when the drain was recorded (accepted or stale-but-drained).
+    #[must_use]
+    pub const fn is_accepted(self) -> bool {
+        matches!(self, Self::Accepted | Self::StaleWorker)
+    }
+}
+
+/// Response returned by `POST /workers/{worker_id}/drain`.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct DrainResponse {
+    /// The worker that was targeted by the drain request.
+    pub worker_id: String,
+    /// Machine-readable outcome.
+    pub outcome: DrainOutcome,
+    /// Tasks in flight at the moment the drain was requested.
+    pub in_flight_count: i32,
+    /// When this worker must have finished draining (echoed from the request or
+    /// derived from the configured shutdown timeout).
+    pub drain_deadline_at: Option<DateTime<Utc>>,
+    /// Shard IDs this worker was serving at drain time.
+    pub shard_ids: Vec<i32>,
+}
+
+/// One entry in a dry-run drain preview — what *would* be drained.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct DrainPreviewItem {
+    /// Worker ID.
+    pub worker_id: String,
+    /// Current lifecycle status.
+    pub status: String,
+    /// Current health classification.
+    pub health: WorkerHealth,
+    /// Tasks currently in flight.
+    pub in_flight_count: i32,
+    /// Task queues this worker is polling.
+    pub queues: Vec<String>,
+    /// Shard IDs this worker serves.
+    pub shard_ids: Vec<i32>,
+}
+
+/// Convert a `WorkerRow` into a `DrainPreviewItem`.
+///
+/// Pure function — no DB access; used by both the API handler and unit tests.
+#[must_use]
+pub fn preview_item_from_row(row: &WorkerRow) -> DrainPreviewItem {
+    let queues = row
+        .worker
+        .queues
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let shard_ids = row
+        .worker
+        .shard_assignments
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_i64().and_then(|n| i32::try_from(n).ok()))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    DrainPreviewItem {
+        worker_id: row.worker.worker_id.clone(),
+        status: row.worker.status.clone(),
+        health: row.health,
+        in_flight_count: row.worker.in_flight_count,
+        queues,
+        shard_ids,
+    }
+}
+
+/// Read the current lifecycle status of a worker without modifying it.
+///
+/// Returns `None` when the worker row does not exist.
+///
+/// # Errors
+///
+/// Returns [`HarvestError`] on database failure.
+pub async fn read_worker_status(
+    conn: &mut AsyncPgConnection,
+    worker_id: &str,
+) -> HarvestResult<Option<String>> {
+    let status = harvest_workers::table
+        .find(worker_id)
+        .select(harvest_workers::status)
+        .first::<String>(conn)
+        .await
+        .optional()
+        .map_err(crate::error::database_error)?;
+    Ok(status)
+}
+
+/// Request a graceful drain for the worker identified by `worker_id`.
+///
+/// The function classifies the current worker state and, if appropriate,
+/// transitions it to `Draining` and records `drain_deadline_at`.
+/// It never touches workflow-event history.
+///
+/// | Outcome          | Condition                                            |
+/// |------------------|------------------------------------------------------|
+/// | `accepted`       | Worker is `Active` and healthy                       |
+/// | `stale_worker`   | Worker is `Active` but past the stale threshold      |
+/// | `already_draining` | Worker is already `Draining`                       |
+/// | `already_stopped`  | Worker is already `Stopped`                        |
+/// | `not_found`        | No row with that `worker_id`                       |
+///
+/// # Errors
+///
+/// Returns [`HarvestError`] on database failure.
+pub async fn request_drain(
+    conn: &mut AsyncPgConnection,
+    worker_id: &str,
+    deadline_at: Option<DateTime<Utc>>,
+    stale_threshold: Duration,
+) -> HarvestResult<DrainResponse> {
+    let row = harvest_workers::table
+        .find(worker_id)
+        .select(HarvestWorker::as_select())
+        .first::<HarvestWorker>(conn)
+        .await
+        .optional()
+        .map_err(crate::error::database_error)?;
+
+    let Some(worker) = row else {
+        return Ok(DrainResponse {
+            worker_id: worker_id.to_string(),
+            outcome: DrainOutcome::NotFound,
+            in_flight_count: 0,
+            drain_deadline_at: None,
+            shard_ids: vec![],
+        });
+    };
+
+    let health = WorkerHealth::classify(worker.last_heartbeat_at, stale_threshold);
+    let current_status = WorkerStatus::from_str(&worker.status);
+
+    let outcome = match current_status {
+        Some(WorkerStatus::Draining) => DrainOutcome::AlreadyDraining,
+        Some(WorkerStatus::Stopped) => DrainOutcome::AlreadyStopped,
+        _ if health == WorkerHealth::Stale => DrainOutcome::StaleWorker,
+        _ => DrainOutcome::Accepted,
+    };
+
+    let shard_ids: Vec<i32> = worker
+        .shard_assignments
+        .as_array()
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_i64().and_then(|n| i32::try_from(n).ok()))
+                .collect()
+        })
+        .unwrap_or_default();
+
+    // Persist the Draining transition (and deadline) for accepted / stale drains.
+    if outcome.is_accepted() {
+        diesel::update(harvest_workers::table.find(worker_id))
+            .set((
+                harvest_workers::status.eq(WorkerStatus::Draining.as_str()),
+                harvest_workers::drain_deadline_at.eq(deadline_at),
+            ))
+            .execute(conn)
+            .await
+            .map_err(crate::error::database_error)?;
+    }
+
+    Ok(DrainResponse {
+        worker_id: worker_id.to_string(),
+        outcome,
+        in_flight_count: worker.in_flight_count,
+        drain_deadline_at: deadline_at,
+        shard_ids,
+    })
+}
+
+/// Return a preview of which workers would be drained for the given filters.
+///
+/// This is the dry-run surface: it never mutates any row.
+///
+/// # Errors
+///
+/// Returns [`HarvestError`] on database failure.
+pub async fn drain_preview(
+    conn: &mut AsyncPgConnection,
+    filters: &WorkerFilters,
+    stale_threshold: Duration,
+) -> HarvestResult<Vec<DrainPreviewItem>> {
+    let rows = list_workers(conn, filters, stale_threshold).await?;
+    Ok(rows.iter().map(preview_item_from_row).collect())
+}
+
+// ---------------------------------------------------------------------------
 // Background heartbeat task
 // ---------------------------------------------------------------------------
 
@@ -610,7 +828,25 @@ pub fn spawn_worker_heartbeat(
                                 );
                             }
                         }
-                        Ok(_) => {}
+                        Ok(_) => {
+                            // Heartbeat succeeded; check whether a remote drain
+                            // request has changed this worker's status to
+                            // Draining. If so, trigger local graceful shutdown
+                            // so the poll loop stops accepting new work within
+                            // the next heartbeat interval.
+                            if !cancel.is_cancelled() {
+                                match read_worker_status(&mut conn, &registration.worker_id).await {
+                                    Ok(Some(ref s)) if s == WorkerStatus::Draining.as_str() => {
+                                        tracing::info!(
+                                            worker_id = %registration.worker_id,
+                                            "remote drain detected; triggering graceful shutdown"
+                                        );
+                                        cancel.cancel();
+                                    }
+                                    _ => {}
+                                }
+                            }
+                        }
                         Err(error) => {
                             tracing::warn!(
                                 worker_id = %registration.worker_id,
@@ -857,6 +1093,7 @@ mod tests {
                 host: "localhost".to_string(),
                 version: None,
                 status: "Active".to_string(),
+                drain_deadline_at: None,
             },
             health: WorkerHealth::Healthy,
             active_task_ids: vec![],
@@ -922,6 +1159,7 @@ mod tests {
                 host: "localhost".to_string(),
                 version: None,
                 status: "Active".to_string(),
+                drain_deadline_at: None,
             },
             health: WorkerHealth::Healthy,
             active_task_ids,
@@ -948,6 +1186,148 @@ mod tests {
             .expect("active_task_ids should be array");
         assert_eq!(ids.len(), 1);
         assert_eq!(ids[0].as_str().unwrap(), tid.to_string());
+    }
+
+    // -- DrainOutcome --
+
+    #[test]
+    fn drain_outcome_serializes_to_snake_case() {
+        let cases = [
+            (DrainOutcome::Accepted, "accepted"),
+            (DrainOutcome::AlreadyDraining, "already_draining"),
+            (DrainOutcome::AlreadyStopped, "already_stopped"),
+            (DrainOutcome::StaleWorker, "stale_worker"),
+            (DrainOutcome::NotFound, "not_found"),
+        ];
+        for (outcome, expected) in cases {
+            let json = serde_json::to_value(outcome).unwrap();
+            assert_eq!(
+                json.as_str().unwrap(),
+                expected,
+                "wrong serialization for {outcome:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn drain_outcome_is_accepted_only_for_accepted_and_stale() {
+        assert!(DrainOutcome::Accepted.is_accepted());
+        assert!(DrainOutcome::StaleWorker.is_accepted());
+        assert!(!DrainOutcome::AlreadyDraining.is_accepted());
+        assert!(!DrainOutcome::AlreadyStopped.is_accepted());
+        assert!(!DrainOutcome::NotFound.is_accepted());
+    }
+
+    #[test]
+    fn drain_outcome_round_trips_via_json() {
+        for outcome in [
+            DrainOutcome::Accepted,
+            DrainOutcome::AlreadyDraining,
+            DrainOutcome::AlreadyStopped,
+            DrainOutcome::StaleWorker,
+            DrainOutcome::NotFound,
+        ] {
+            let encoded = serde_json::to_string(&outcome).unwrap();
+            let decoded: DrainOutcome = serde_json::from_str(&encoded).unwrap();
+            assert_eq!(decoded, outcome, "round-trip failed for {outcome:?}");
+        }
+    }
+
+    // -- DrainResponse --
+
+    #[test]
+    fn drain_response_serializes_all_required_fields() {
+        let resp = DrainResponse {
+            worker_id: "w-abc".to_string(),
+            outcome: DrainOutcome::Accepted,
+            in_flight_count: 3,
+            drain_deadline_at: Some(Utc::now()),
+            shard_ids: vec![0, 1],
+        };
+        let json = serde_json::to_value(&resp).unwrap();
+        assert!(json.get("worker_id").is_some(), "missing worker_id");
+        assert!(json.get("outcome").is_some(), "missing outcome");
+        assert!(
+            json.get("in_flight_count").is_some(),
+            "missing in_flight_count"
+        );
+        assert!(
+            json.get("drain_deadline_at").is_some(),
+            "missing drain_deadline_at"
+        );
+        assert!(json.get("shard_ids").is_some(), "missing shard_ids");
+    }
+
+    #[test]
+    fn drain_response_null_deadline_serializes() {
+        let resp = DrainResponse {
+            worker_id: "w-abc".to_string(),
+            outcome: DrainOutcome::NotFound,
+            in_flight_count: 0,
+            drain_deadline_at: None,
+            shard_ids: vec![],
+        };
+        let json = serde_json::to_value(&resp).unwrap();
+        assert!(json["drain_deadline_at"].is_null());
+        assert_eq!(json["shard_ids"].as_array().unwrap().len(), 0);
+    }
+
+    // -- preview_item_from_row --
+
+    fn make_worker_row_full(
+        worker_id: &str,
+        status: &str,
+        in_flight: i32,
+        queues: &[&str],
+        shards: &[i32],
+    ) -> WorkerRow {
+        WorkerRow {
+            worker: HarvestWorker {
+                worker_id: worker_id.to_string(),
+                started_at: Utc::now(),
+                last_heartbeat_at: Utc::now(),
+                queues: serde_json::json!(queues),
+                shard_assignments: serde_json::json!(shards),
+                max_concurrency: 10,
+                in_flight_count: in_flight,
+                host: "localhost".to_string(),
+                version: None,
+                status: status.to_string(),
+                drain_deadline_at: None,
+            },
+            health: WorkerHealth::Healthy,
+            active_task_ids: vec![],
+        }
+    }
+
+    #[test]
+    fn preview_item_from_row_captures_all_fields() {
+        let row = make_worker_row_full("w-1", "Active", 5, &["default", "email"], &[0, 1]);
+        let item = preview_item_from_row(&row);
+        assert_eq!(item.worker_id, "w-1");
+        assert_eq!(item.status, "Active");
+        assert_eq!(item.in_flight_count, 5);
+        assert_eq!(item.queues, vec!["default", "email"]);
+        assert_eq!(item.shard_ids, vec![0, 1]);
+        assert_eq!(item.health, WorkerHealth::Healthy);
+    }
+
+    #[test]
+    fn preview_item_from_row_handles_empty_queues_and_shards() {
+        let row = make_worker_row_full("w-2", "Draining", 0, &[], &[]);
+        let item = preview_item_from_row(&row);
+        assert!(item.queues.is_empty());
+        assert!(item.shard_ids.is_empty());
+    }
+
+    #[test]
+    fn preview_item_serializes_to_json() {
+        let row = make_worker_row_full("w-3", "Active", 2, &["default"], &[0]);
+        let item = preview_item_from_row(&row);
+        let json = serde_json::to_value(&item).unwrap();
+        assert_eq!(json["worker_id"].as_str().unwrap(), "w-3");
+        assert_eq!(json["status"].as_str().unwrap(), "Active");
+        assert_eq!(json["in_flight_count"].as_i64().unwrap(), 2);
     }
 
     // -- compute_in_flight --

--- a/autumn-harvest/tests/integration_e2e.rs
+++ b/autumn-harvest/tests/integration_e2e.rs
@@ -4691,9 +4691,15 @@ async fn drain_accepted_sets_status_to_draining() {
     // layer, not request_drain itself. The integration test verifies the DB
     // round-trip for a caller-supplied deadline.
     let deadline = Utc::now() + chrono::Duration::minutes(1);
-    let resp = request_drain(&mut conn, "w-drain-1", Some(deadline), stale_threshold)
-        .await
-        .unwrap();
+    let resp = request_drain(
+        &mut conn,
+        "w-drain-1",
+        Some(deadline),
+        true,
+        stale_threshold,
+    )
+    .await
+    .unwrap();
 
     assert_eq!(
         resp.outcome,
@@ -4732,6 +4738,7 @@ async fn drain_already_draining_on_second_call() {
         &mut conn,
         "w-drain-2",
         Some(first_deadline),
+        true,
         stale_threshold,
     )
     .await
@@ -4740,9 +4747,15 @@ async fn drain_already_draining_on_second_call() {
     // Re-drain with a new deadline — should return AlreadyDraining and
     // persist the updated deadline (operators extending a drain window).
     let new_deadline = Utc::now() + chrono::Duration::minutes(5);
-    let resp2 = request_drain(&mut conn, "w-drain-2", Some(new_deadline), stale_threshold)
-        .await
-        .unwrap();
+    let resp2 = request_drain(
+        &mut conn,
+        "w-drain-2",
+        Some(new_deadline),
+        true,
+        stale_threshold,
+    )
+    .await
+    .unwrap();
 
     assert_eq!(
         resp2.outcome,
@@ -4771,7 +4784,7 @@ async fn drain_already_stopped_after_transition() {
         .await
         .unwrap();
 
-    let resp = request_drain(&mut conn, "w-drain-3", None, stale_threshold)
+    let resp = request_drain(&mut conn, "w-drain-3", None, false, stale_threshold)
         .await
         .unwrap();
 
@@ -4789,7 +4802,7 @@ async fn drain_not_found_for_unknown_worker() {
     let (mut conn, _container) = setup_test_db().await;
     let stale_threshold = Duration::from_secs(10);
 
-    let resp = request_drain(&mut conn, "w-does-not-exist", None, stale_threshold)
+    let resp = request_drain(&mut conn, "w-does-not-exist", None, false, stale_threshold)
         .await
         .unwrap();
 
@@ -4824,6 +4837,7 @@ async fn drain_with_explicit_deadline_is_stored() {
         &mut conn,
         "w-drain-deadline",
         Some(explicit_deadline),
+        true,
         stale_threshold,
     )
     .await

--- a/autumn-harvest/tests/integration_e2e.rs
+++ b/autumn-harvest/tests/integration_e2e.rs
@@ -4727,11 +4727,15 @@ async fn drain_already_draining_on_second_call() {
     .await
     .unwrap();
 
-    request_drain(&mut conn, "w-drain-2", None, stale_threshold)
+    let first_deadline = Utc::now() + chrono::Duration::minutes(1);
+    request_drain(&mut conn, "w-drain-2", Some(first_deadline), stale_threshold)
         .await
         .unwrap();
 
-    let resp2 = request_drain(&mut conn, "w-drain-2", None, stale_threshold)
+    // Re-drain with a new deadline — should return AlreadyDraining and
+    // persist the updated deadline (operators extending a drain window).
+    let new_deadline = Utc::now() + chrono::Duration::minutes(5);
+    let resp2 = request_drain(&mut conn, "w-drain-2", Some(new_deadline), stale_threshold)
         .await
         .unwrap();
 
@@ -4740,6 +4744,10 @@ async fn drain_already_draining_on_second_call() {
         DrainOutcome::AlreadyDraining,
         "second drain on already-draining worker must return AlreadyDraining"
     );
+    // Deadline must reflect the refreshed value, not the original.
+    let stored = resp2.drain_deadline_at.expect("deadline must be echoed");
+    let diff = (stored - new_deadline).num_seconds().abs();
+    assert!(diff <= 2, "refreshed deadline differs by {diff}s");
 }
 
 #[tokio::test]

--- a/autumn-harvest/tests/integration_e2e.rs
+++ b/autumn-harvest/tests/integration_e2e.rs
@@ -71,6 +71,10 @@ const INIT_SQL: &str = concat!(
     include_str!("../migrations/20260508000000_harvest_external_task_updated_at/up.sql"),
     "\n",
     include_str!("../migrations/20260506000000_harvest_audit_log/up.sql"),
+    "\n",
+    include_str!("../migrations/20260501000000_harvest_workers/up.sql"),
+    "\n",
+    include_str!("../migrations/20260508010000_harvest_workers_drain_deadline/up.sql"),
 );
 
 /// The minimal "legacy" migration set used by the upgrade-path regression
@@ -4658,4 +4662,193 @@ fn workflow_schedule_builder_rejects_unregistered_workflow() {
         ),
         "expected UnknownWorkflowSchedule error, got: {result:?}"
     );
+}
+
+// ---------------------------------------------------------------------------
+// Worker drain controls (issue #170)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn drain_accepted_sets_status_to_draining() {
+    use autumn_harvest::workers::{DrainOutcome, register_worker, request_drain};
+
+    let (mut conn, _container) = setup_test_db().await;
+    let stale_threshold = Duration::from_secs(10);
+
+    register_worker(
+        &mut conn,
+        "w-drain-1",
+        &["default".to_string()],
+        &[0],
+        4,
+        "test-host",
+        None,
+    )
+    .await
+    .unwrap();
+
+    let resp = request_drain(&mut conn, "w-drain-1", None, stale_threshold)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.outcome,
+        DrainOutcome::Accepted,
+        "first drain must be Accepted"
+    );
+    assert!(
+        resp.drain_deadline_at.is_some(),
+        "drain_deadline_at must be set when none supplied"
+    );
+    assert_eq!(resp.worker_id, "w-drain-1");
+    assert!(resp.unavailable_shards.is_empty());
+}
+
+#[tokio::test]
+async fn drain_already_draining_on_second_call() {
+    use autumn_harvest::workers::{DrainOutcome, register_worker, request_drain};
+
+    let (mut conn, _container) = setup_test_db().await;
+    let stale_threshold = Duration::from_secs(10);
+
+    register_worker(
+        &mut conn,
+        "w-drain-2",
+        &["default".to_string()],
+        &[],
+        2,
+        "test-host",
+        None,
+    )
+    .await
+    .unwrap();
+
+    request_drain(&mut conn, "w-drain-2", None, stale_threshold)
+        .await
+        .unwrap();
+
+    let resp2 = request_drain(&mut conn, "w-drain-2", None, stale_threshold)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp2.outcome,
+        DrainOutcome::AlreadyDraining,
+        "second drain on already-draining worker must return AlreadyDraining"
+    );
+}
+
+#[tokio::test]
+async fn drain_already_stopped_after_transition() {
+    use autumn_harvest::workers::{
+        DrainOutcome, WorkerStatus, register_worker, request_drain, transition_status,
+    };
+
+    let (mut conn, _container) = setup_test_db().await;
+    let stale_threshold = Duration::from_secs(10);
+
+    register_worker(&mut conn, "w-drain-3", &[], &[], 1, "test-host", None)
+        .await
+        .unwrap();
+    transition_status(&mut conn, "w-drain-3", WorkerStatus::Stopped)
+        .await
+        .unwrap();
+
+    let resp = request_drain(&mut conn, "w-drain-3", None, stale_threshold)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.outcome,
+        DrainOutcome::AlreadyStopped,
+        "draining a stopped worker must return AlreadyStopped"
+    );
+}
+
+#[tokio::test]
+async fn drain_not_found_for_unknown_worker() {
+    use autumn_harvest::workers::request_drain;
+
+    let (mut conn, _container) = setup_test_db().await;
+    let stale_threshold = Duration::from_secs(10);
+
+    let resp = request_drain(&mut conn, "w-does-not-exist", None, stale_threshold)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        resp.outcome,
+        autumn_harvest::workers::DrainOutcome::NotFound,
+        "unknown worker must return NotFound"
+    );
+}
+
+#[tokio::test]
+async fn drain_with_explicit_deadline_is_stored() {
+    use autumn_harvest::workers::{DrainOutcome, register_worker, request_drain};
+
+    let (mut conn, _container) = setup_test_db().await;
+    let stale_threshold = Duration::from_secs(10);
+
+    register_worker(
+        &mut conn,
+        "w-drain-deadline",
+        &[],
+        &[],
+        1,
+        "test-host",
+        None,
+    )
+    .await
+    .unwrap();
+
+    let explicit_deadline = Utc::now() + chrono::Duration::minutes(5);
+    let resp = request_drain(
+        &mut conn,
+        "w-drain-deadline",
+        Some(explicit_deadline),
+        stale_threshold,
+    )
+    .await
+    .unwrap();
+
+    assert_eq!(resp.outcome, DrainOutcome::Accepted);
+    let stored = resp.drain_deadline_at.expect("deadline must be set");
+    let diff = (stored - explicit_deadline).num_seconds().abs();
+    assert!(diff <= 2, "stored deadline differs by {diff}s");
+}
+
+#[tokio::test]
+async fn drain_preview_returns_active_workers() {
+    use autumn_harvest::workers::{WorkerFilters, drain_preview, register_worker};
+
+    let (mut conn, _container) = setup_test_db().await;
+    let stale_threshold = Duration::from_secs(10);
+
+    for i in 0..3_u8 {
+        register_worker(
+            &mut conn,
+            &format!("w-preview-{i}"),
+            &["default".to_string()],
+            &[],
+            4,
+            "test-host",
+            None,
+        )
+        .await
+        .unwrap();
+    }
+
+    let filters = WorkerFilters {
+        queue: Some("default".to_string()),
+        ..WorkerFilters::default()
+    };
+    let items = drain_preview(&mut conn, &filters, stale_threshold)
+        .await
+        .unwrap();
+
+    assert_eq!(items.len(), 3, "drain-preview should return all 3 workers");
+    for item in &items {
+        assert_eq!(item.status, "Active");
+    }
 }

--- a/autumn-harvest/tests/integration_e2e.rs
+++ b/autumn-harvest/tests/integration_e2e.rs
@@ -4728,9 +4728,14 @@ async fn drain_already_draining_on_second_call() {
     .unwrap();
 
     let first_deadline = Utc::now() + chrono::Duration::minutes(1);
-    request_drain(&mut conn, "w-drain-2", Some(first_deadline), stale_threshold)
-        .await
-        .unwrap();
+    request_drain(
+        &mut conn,
+        "w-drain-2",
+        Some(first_deadline),
+        stale_threshold,
+    )
+    .await
+    .unwrap();
 
     // Re-drain with a new deadline — should return AlreadyDraining and
     // persist the updated deadline (operators extending a drain window).

--- a/autumn-harvest/tests/metrics_integration.rs
+++ b/autumn-harvest/tests/metrics_integration.rs
@@ -59,6 +59,8 @@ const INIT_SQL: &str = concat!(
     include_str!("../migrations/20260508000000_harvest_external_task_updated_at/up.sql"),
     "\n",
     include_str!("../migrations/20260501000000_harvest_workers/up.sql"),
+    "\n",
+    include_str!("../migrations/20260508010000_harvest_workers_drain_deadline/up.sql"),
 );
 
 // ---------------------------------------------------------------------------

--- a/docs/runbooks/safe-deploy.md
+++ b/docs/runbooks/safe-deploy.md
@@ -1,0 +1,152 @@
+# Runbook: Safe Worker Drain Before a Deploy
+
+Use the Harvest drain controls to quiesce one or more workers gracefully before
+deploying a new version or taking a host out of rotation. This avoids dropped
+in-flight tasks and mid-execution interruptions without needing SSH or raw
+process signals.
+
+**When to use:** rolling deploys, host maintenance, canary rollbacks, scheduled
+scale-in events.
+
+**When _not_ to use:** emergency kills — use SIGKILL directly and let Harvest's
+retry/timeout logic recover the in-flight tasks.
+
+---
+
+## Step 1 — Identify the target worker(s)
+
+List all active workers to find the candidates:
+
+```bash
+harvest worker list --status Active
+```
+
+Filter by queue or shard when operating a large fleet:
+
+```bash
+harvest worker list --queue email-workers --shard-id 0
+```
+
+Key fields in the response:
+- `worker_id` — the string passed to `--drain` below.
+- `in_flight_count` — tasks currently executing on this worker.
+- `status` — `Active`, `Draining`, or `Stopped`.
+- `health` — `healthy` (heartbeat recent) or `stale` (heartbeat expired).
+
+---
+
+## Step 2 — Dry-run with drain-preview
+
+Before draining, confirm which workers would be affected:
+
+```bash
+harvest worker drain-preview --queue email-workers
+```
+
+`drain-preview` is read-only and never changes any state. The response lists
+every matching active worker with its current `in_flight_count`.
+
+---
+
+## Step 3 — Request the drain
+
+Drain a specific worker:
+
+```bash
+harvest worker drain <worker-id>
+```
+
+The server sets the worker's status to `Draining`. The worker will finish its
+current tasks and then transition to `Stopped` within one heartbeat interval
+(default: 5 s) after quiescing.
+
+To specify an explicit deadline (RFC 3339):
+
+```bash
+harvest worker drain <worker-id> --deadline 2026-05-09T14:30:00Z
+```
+
+When `--deadline` is omitted the server uses the configured
+`WorkerConfig::shutdown_timeout` (default 30 s from the current time).
+
+### Drain outcome codes
+
+| `outcome`         | Meaning                                                     |
+|-------------------|-------------------------------------------------------------|
+| `accepted`        | Drain requested; worker will quiesce and stop.              |
+| `already_draining`| Worker is already draining; deadline was refreshed.         |
+| `already_stopped` | Worker has already stopped; no action taken.                |
+| `stale_worker`    | Worker heartbeat is stale; drain was written but the process may already be gone. |
+| `not_found`       | Worker ID not found on any shard.                           |
+
+---
+
+## Step 4 — Wait for the worker to stop
+
+### Option A — CLI wait mode (recommended)
+
+The `--wait` flag blocks until the worker reaches `Stopped` or the timeout
+expires, polling every 2 s:
+
+```bash
+harvest worker drain <worker-id> --wait --wait-timeout-secs 120
+```
+
+Exits 0 when the worker stops, exits 1 on timeout.
+
+### Option B — Manual polling
+
+```bash
+watch -n 2 'harvest worker get <worker-id> | jq .status'
+```
+
+Wait until `"status": "Stopped"` appears.
+
+### Option C — Management API
+
+```http
+GET /workers/<worker-id>
+```
+
+Poll until `status == "Stopped"`.
+
+---
+
+## Step 5 — Terminate the process
+
+Once the worker is `Stopped` you can safely send SIGTERM (or SIGKILL) to the
+process, redeploy the binary, or decommission the host. No in-flight tasks will
+be lost.
+
+---
+
+## Degraded mode: unavailable shards
+
+When a shard is temporarily unreachable the drain response includes
+`unavailable_shards: [<id>, ...]` and an `outcome` of `not_found`. The worker
+_may_ live on an unavailable shard. Retry the drain once the shard recovers, or
+use `GET /admin/shards/health` to investigate.
+
+---
+
+## Drain audit trail
+
+Every `POST /workers/{id}/drain` call is recorded in the audit log:
+
+```bash
+harvest audit list --operation worker.drain --target-id <worker-id>
+```
+
+Audit fields include `actor`, `occurred_at`, `status` (`succeeded` / `failed`),
+and `request_id`.
+
+---
+
+## Common mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Terminating the process before `Stopped` | Poll with `--wait` or `worker get` until status is `Stopped` |
+| Forgetting `--deadline` on a slow worker | The default deadline is `shutdown_timeout` (30 s); set a longer deadline for workers with large in-flight batches |
+| Draining the wrong shard | Use `--shard-id` with `drain-preview` to scope the preview first |
+| Ignoring `unavailable_shards` in the response | The worker may be on an unreachable shard; retry after shard recovers |


### PR DESCRIPTION
Implements the full operator surface for quiescing workers through the
management API and CLI without SSH or raw process signals.

**Schema (additive migration)**
- `harvest_workers.drain_deadline_at TIMESTAMPTZ` — stores the operator-
  supplied or server-derived deadline echoed back in the drain response.

**workers.rs**
- `DrainOutcome` enum (`accepted`, `already_draining`, `already_stopped`,
  `stale_worker`, `not_found`) with snake_case JSON serialization.
- `DrainResponse` — echoes `worker_id`, `outcome`, `in_flight_count`,
  `drain_deadline_at`, and `shard_ids`.
- `DrainPreviewItem` — read-only projection for the dry-run surface.
- `preview_item_from_row` — pure converter used by both the handler and tests.
- `read_worker_status` — lightweight DB read for heartbeat-driven remote drain detection.
- `request_drain` — classifies the worker state, transitions to `Draining`
  if appropriate, and records the deadline atomically.
- `drain_preview` — dry-run listing built on `list_workers`.
- `spawn_worker_heartbeat` — now reads back the DB status after each
  successful write; calls `cancel.cancel()` when a remote drain is detected
  so the worker stops accepting new tasks within two heartbeat intervals.

**api.rs (plugin)**
- `POST /workers/{worker_id}/drain` — calls `request_drain`, emits an
  audit record under `OP_WORKER_DRAIN`, searches all shards for the worker.
- `GET /workers/drain-preview` — returns the dry-run worker list.
- Static paths registered before `{worker_id}` capture to avoid routing
  collisions.

**audit.rs**
- `OP_WORKER_DRAIN = "worker.drain"`, `TARGET_WORKER = "worker"`.
- Both new routes declared in `ALL_MUTATION_ROUTES`; drain-preview added
  to `EXCLUDED_ROUTES`; coverage guard tests remain green.

**CLI (lib.rs)**
- `WorkerCommand` subcommand group: `drain`, `drain-preview`, `list`,
  `get`, `health` (alias: `workers`).
- `harvest worker drain <id> [--deadline <RFC3339>]`
- `harvest worker drain-preview [--queue] [--shard-id] [--status] [--limit]`
- `harvest worker list [--queue] [--shard-id] [--status] [--health] [--limit]`
- `harvest worker get <id>`
- `harvest worker health`

**Tests (TDD red → green → refactor)**
- Red phase: drain outcome, response, preview-item serialization tests
  added to workers.rs before implementation; CLI tests added that panicked
  on parse until the subcommand was wired up.
- Green phase: implementation makes all new and existing tests pass.
- Refactor: `cargo fmt` + `cargo clippy -D warnings` clean.

Closes #170

https://claude.ai/code/session_01RQ131UQ9y4usEXNK82RMfw