### PR TITLE
⚡ Bolt: Remove intermediate Vec allocation in suspended_workflow_error

### DIFF
--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -275,11 +275,17 @@ fn suspended_workflow_error(commands: &[WorkflowCommand]) -> String {
             .to_string();
     }
 
-    let command_names = commands
-        .iter()
-        .map(workflow_command_name)
-        .collect::<Vec<_>>()
-        .join(", ");
+    // ⚡ Bolt: Construct the comma-separated string directly without collecting
+    // into an intermediate `Vec`. This eliminates a heap allocation and reduces
+    // memory overhead on this error path.
+    let command_names = commands.iter().fold(String::new(), |mut acc, cmd| {
+        if !acc.is_empty() {
+            acc.push_str(", ");
+        }
+        acc.push_str(workflow_command_name(cmd));
+        acc
+    });
+
     format!(
         "workflow task suspended with unsupported commands ({command_names}); this command set is not implemented yet"
     )


### PR DESCRIPTION
💡 **What**: Refactored the string construction in `suspended_workflow_error` to use `fold` with `String::push_str` instead of collecting into an intermediate `Vec<_>` and calling `join(", ")`.
🎯 **Why**: The previous implementation allocated an intermediate `Vec` on the heap unnecessarily just to join string slices. By accumulating directly into a `String`, we achieve the same result with zero intermediate vector allocations.
📊 **Impact**: Eliminates one `Vec` heap allocation per invocation on the workflow suspension error path.
🔬 **Measurement**: Verify by running `cargo test -p autumn-harvest worker::tests` and observing that `suspended_workflow_error` behaves identically without the extra allocation overhead. Evaluated via `cargo clippy --all-targets --all-features -- -D warnings`.

---
*PR created automatically by Jules for task [3089290406037476262](https://jules.google.com/task/3089290406037476262) started by @madmax983*