### PR TITLE
🔒 Warden: Fix event ID overflow with checked math

### DIFF
--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -1072,7 +1072,11 @@ async fn persist_update_result_commands(
     }
 
     store::append_events(conn, exec_id, &events, *next_event_id).await?;
-    *next_event_id = next_event_id.saturating_add(i32::try_from(events.len()).unwrap_or(i32::MAX));
+    *next_event_id = next_event_id
+        .checked_add(i32::try_from(events.len()).unwrap_or(i32::MAX))
+        .ok_or_else(|| {
+            crate::error::HarvestError::Database("Event ID overflow".to_string())
+        })?;
     Ok(())
 }
 

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -1071,12 +1071,14 @@ async fn persist_update_result_commands(
         return Ok(());
     }
 
-    store::append_events(conn, exec_id, &events, *next_event_id).await?;
-    *next_event_id = next_event_id
+    let advanced_event_id = next_event_id
         .checked_add(i32::try_from(events.len()).unwrap_or(i32::MAX))
         .ok_or_else(|| {
             crate::error::HarvestError::Database("Event ID overflow".to_string())
         })?;
+
+    store::append_events(conn, exec_id, &events, *next_event_id).await?;
+    *next_event_id = advanced_event_id;
     Ok(())
 }
 

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -1073,9 +1073,7 @@ async fn persist_update_result_commands(
 
     let advanced_event_id = next_event_id
         .checked_add(i32::try_from(events.len()).unwrap_or(i32::MAX))
-        .ok_or_else(|| {
-            crate::error::HarvestError::Database("Event ID overflow".to_string())
-        })?;
+        .ok_or_else(|| crate::error::HarvestError::Database("Event ID overflow".to_string()))?;
 
     store::append_events(conn, exec_id, &events, *next_event_id).await?;
     *next_event_id = advanced_event_id;


### PR DESCRIPTION
🦠 **Threat**: Integer overflow when incrementing `next_event_id` in `autumn-harvest/src/worker.rs`. The code used `saturating_add`, which silently masked overflows by pinning the value to `i32::MAX`, leading to primary key collisions, event ID reuse, or subsequent panics on DB interactions.

🛡️ **Defense**: Switched from `saturating_add` to `checked_add` and mapped the resulting `None` case directly to an explicit `crate::error::HarvestError::Database("Event ID overflow".to_string())`. This ensures safe failure ("Parse, don't validate").

💥 **Severity**: Moderate to High - Could cause workflow corruption, database constraint violations, and difficult-to-debug logic failures when an execution contains an exceptionally large number of events.

🧪 **Verification**: Ran `cargo audit` to confirm no malicious dependencies or CVEs exist. Validated the defense via the existing `test_havoc_event_id_overflow` test harness, ensuring the system predictably errors without crashing. Also ran `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test` and code review passed.

---
*PR created automatically by Jules for task [6307902760737299170](https://jules.google.com/task/6307902760737299170) started by @madmax983*