### PR TITLE
👺 Havoc: Prevent re-entrant deadlocks in workflow context registries

### DIFF
--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -1707,18 +1707,24 @@ impl WorkflowContext {
     ///
     /// Panics if the internal update registry mutex is poisoned.
     pub fn validate_update(&self, name: &str, input: &Value) -> HarvestResult<()> {
-        let registry = self
-            .update_registry
-            .lock()
-            .expect("update_registry lock poisoned");
-        // Check existence structurally so validator errors are never confused
-        // with a missing handler, regardless of the error message text.
-        if !registry.contains(name) {
-            return Err(HarvestError::UpdateHandlerNotFound(name.to_string()));
-        }
-        registry
-            .validate(name, input)
-            .map_err(|reason| HarvestError::UpdateRejected { reason })
+        // Drop the lock before executing the validator closure to prevent re-entrant deadlocks.
+        let validator = {
+            let registry = self
+                .update_registry
+                .lock()
+                .expect("update_registry lock poisoned");
+            // Check existence structurally so validator errors are never confused
+            // with a missing handler, regardless of the error message text.
+            if !registry.contains(name) {
+                return Err(HarvestError::UpdateHandlerNotFound(name.to_string()));
+            }
+            registry.get_validator(name)
+        };
+
+        validator.map_or_else(
+            || Ok(()),
+            |validator| validator(input).map_err(|reason| HarvestError::UpdateRejected { reason }),
+        )
     }
 
     /// Execute an already-admitted update by `update_id`.
@@ -1763,16 +1769,16 @@ impl WorkflowContext {
         }
 
         // Live path: invoke the registered handler.
-        let future = {
+        let handler = {
             let registry = self
                 .update_registry
                 .lock()
                 .expect("update_registry lock poisoned");
-            registry.invoke(name, input)
+            registry.get_handler(name)
         };
 
-        let result = match future {
-            Some(fut) => fut.await,
+        let result = match handler {
+            Some(h) => h(input).await,
             None => Err(format!("update handler '{name}' not found")),
         };
 

--- a/autumn-harvest/src/update.rs
+++ b/autumn-harvest/src/update.rs
@@ -92,4 +92,20 @@ impl UpdateRegistry {
     pub fn invoke(&self, name: &str, input: Value) -> Option<UpdateHandlerFuture> {
         self.entries.get(name).map(|e| (e.handler)(input))
     }
+
+    /// Get the validator for `name`.
+    ///
+    /// Returns `None` if `name` is not registered or has no validator.
+    #[must_use]
+    pub fn get_validator(&self, name: &str) -> Option<BoxUpdateValidator> {
+        self.entries.get(name).and_then(|e| e.validator.clone())
+    }
+
+    /// Get the handler for `name`.
+    ///
+    /// Returns `None` if `name` is not registered.
+    #[must_use]
+    pub fn get_handler(&self, name: &str) -> Option<BoxUpdateHandler> {
+        self.entries.get(name).map(|e| e.handler.clone())
+    }
 }

--- a/autumn-harvest/tests/havoc_tests.rs
+++ b/autumn-harvest/tests/havoc_tests.rs
@@ -93,8 +93,8 @@ async fn test_havoc_deadlock_in_query() {
 #[tokio::test]
 async fn test_havoc_deadlock_in_update_validation() {
     use autumn_harvest::context::WorkflowContext;
-    use std::sync::Arc;
     use serde_json::json;
+    use std::sync::Arc;
     use std::time::Duration;
 
     let ctx = Arc::new(WorkflowContext::new_test());
@@ -108,14 +108,10 @@ async fn test_havoc_deadlock_in_update_validation() {
             let _ = ctx_clone.validate_update("another", input);
             Ok(())
         },
-        |input| async move { Ok(input) }
+        |input| async move { Ok(input) },
     );
 
-    ctx.register_update_handler(
-        "another",
-        |_| Ok(()),
-        |input| async move { Ok(input) }
-    );
+    ctx.register_update_handler("another", |_| Ok(()), |input| async move { Ok(input) });
 
     let handle = tokio::spawn(async move {
         let _ = ctx.validate_update("test", &json!(1));
@@ -129,10 +125,10 @@ async fn test_havoc_deadlock_in_update_validation() {
 #[tokio::test]
 async fn test_havoc_deadlock_in_update_execution() {
     use autumn_harvest::context::WorkflowContext;
-    use std::sync::Arc;
-    use serde_json::json;
-    use std::time::Duration;
     use autumn_harvest::types::UpdateId;
+    use serde_json::json;
+    use std::sync::Arc;
+    use std::time::Duration;
 
     let ctx = Arc::new(WorkflowContext::new_test());
     let ctx_clone = ctx.clone();
@@ -143,20 +139,20 @@ async fn test_havoc_deadlock_in_update_execution() {
         move |input| {
             let ctx_inner = ctx_clone.clone();
             async move {
-                let _ = ctx_inner.execute_admitted_update(UpdateId::new(), "another", input.clone()).await;
+                let _ = ctx_inner
+                    .execute_admitted_update(UpdateId::new(), "another", input.clone())
+                    .await;
                 Ok(input)
             }
-        }
+        },
     );
 
-    ctx.register_update_handler(
-        "another",
-        |_| Ok(()),
-        |input| async move { Ok(input) }
-    );
+    ctx.register_update_handler("another", |_| Ok(()), |input| async move { Ok(input) });
 
     let handle = tokio::spawn(async move {
-        let _ = ctx.execute_admitted_update(UpdateId::new(), "test", json!(1)).await;
+        let _ = ctx
+            .execute_admitted_update(UpdateId::new(), "test", json!(1))
+            .await;
     });
 
     let res = tokio::time::timeout(Duration::from_millis(500), handle).await;

--- a/autumn-harvest/tests/havoc_tests.rs
+++ b/autumn-harvest/tests/havoc_tests.rs
@@ -60,3 +60,105 @@ fn test_havoc_external_task_duration_panic() {
     });
     assert!(res.is_ok());
 }
+
+#[cfg(feature = "testing")]
+#[tokio::test]
+async fn test_havoc_deadlock_in_query() {
+    use autumn_harvest::context::WorkflowContext;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    let ctx = Arc::new(WorkflowContext::new_test());
+
+    let ctx_clone = ctx.clone();
+
+    ctx.register_query("test", move || {
+        // This will attempt to lock `query_registry` while it is already locked
+        // by the outer `execute_query` call.
+        let _ = ctx_clone.execute_query("another");
+        serde_json::json!(1)
+    });
+
+    ctx.register_query("another", || serde_json::json!(2));
+
+    let handle = tokio::spawn(async move {
+        let _ = ctx.execute_query("test");
+    });
+
+    let res = tokio::time::timeout(Duration::from_millis(500), handle).await;
+    assert!(res.is_ok(), "Test should NOT timeout due to deadlock");
+}
+
+#[cfg(feature = "testing")]
+#[tokio::test]
+async fn test_havoc_deadlock_in_update_validation() {
+    use autumn_harvest::context::WorkflowContext;
+    use std::sync::Arc;
+    use serde_json::json;
+    use std::time::Duration;
+
+    let ctx = Arc::new(WorkflowContext::new_test());
+
+    let ctx_clone = ctx.clone();
+
+    ctx.register_update_handler(
+        "test",
+        move |input| {
+            // This will deadlock if validate_update holds the lock
+            let _ = ctx_clone.validate_update("another", input);
+            Ok(())
+        },
+        |input| async move { Ok(input) }
+    );
+
+    ctx.register_update_handler(
+        "another",
+        |_| Ok(()),
+        |input| async move { Ok(input) }
+    );
+
+    let handle = tokio::spawn(async move {
+        let _ = ctx.validate_update("test", &json!(1));
+    });
+
+    let res = tokio::time::timeout(Duration::from_millis(500), handle).await;
+    assert!(res.is_ok(), "Test should NOT timeout due to deadlock");
+}
+
+#[cfg(feature = "testing")]
+#[tokio::test]
+async fn test_havoc_deadlock_in_update_execution() {
+    use autumn_harvest::context::WorkflowContext;
+    use std::sync::Arc;
+    use serde_json::json;
+    use std::time::Duration;
+    use autumn_harvest::types::UpdateId;
+
+    let ctx = Arc::new(WorkflowContext::new_test());
+    let ctx_clone = ctx.clone();
+
+    ctx.register_update_handler(
+        "test",
+        |_| Ok(()),
+        move |input| {
+            let ctx_inner = ctx_clone.clone();
+            async move {
+                let _ = ctx_inner.execute_admitted_update(UpdateId::new(), "another", input.clone()).await;
+                Ok(input)
+            }
+        }
+    );
+
+    ctx.register_update_handler(
+        "another",
+        |_| Ok(()),
+        |input| async move { Ok(input) }
+    );
+
+    let handle = tokio::spawn(async move {
+        let _ = ctx.execute_admitted_update(UpdateId::new(), "test", json!(1)).await;
+    });
+
+    let res = tokio::time::timeout(Duration::from_millis(500), handle).await;
+    assert!(res.is_ok(), "Test should NOT timeout due to deadlock");
+}


### PR DESCRIPTION
🧨 **The Trigger:**
Calling `ctx.validate_update` or `ctx.execute_admitted_update` where the registered handler recursively calls back into the context while the internal `update_registry` Mutex is held.

📉 **The Stack Trace:**
N/A (Process simply blocks forever inside Tokio runtime due to synchronous deadlock on a poisoned Mutex).

🧪 **Reproduction:**
Run `cargo test -p autumn-harvest test_havoc_deadlock_in_update_validation --features testing`.

😈 **Comment:**
You assumed a user closure was safe to run within your `Mutex` critical path. They are not. If they call back into your registry, your system locks up completely. 

*Added proper testing harness to simulate this scenario and proved the deadlock. Refactored the core implementation of `validate_update` and `execute_admitted_update` to get the handler *then* execute it without holding the registry lock.*

---
*PR created automatically by Jules for task [9412282455200331993](https://jules.google.com/task/9412282455200331993) started by @madmax983*