### PR TITLE
🌟 Nova: Export DAG Profiles to Mermaid Gantt

### DIFF
--- a/autumn-harvest/src/dag_gantt.rs
+++ b/autumn-harvest/src/dag_gantt.rs
@@ -1,0 +1,105 @@
+#[cfg(feature = "testing")]
+use crate::dag_profiler::{DagProfile, ProfilerEventKind};
+use std::fmt::Write;
+
+/// Exports a `DagProfile` to a Mermaid.js Gantt chart.
+///
+/// # Examples
+///
+/// ```rust
+/// use autumn_harvest::dag::DagBuilder;
+/// use autumn_harvest::dag_profiler::DagProfiler;
+/// use autumn_harvest::dag_gantt::export_mermaid_gantt;
+/// use std::time::Duration;
+///
+/// fn my_activity() {}
+/// fn my_other_activity() {}
+///
+/// let mut builder = DagBuilder::new();
+/// let a = builder.activity(my_activity);
+/// let b = builder.activity(my_other_activity).upstream(&a);
+/// let dag = builder.build().unwrap();
+///
+/// let profile = DagProfiler::new(dag)
+///     .mock_duration("my_activity", Duration::from_secs(2))
+///     .mock_duration("my_other_activity", Duration::from_secs(3))
+///     .profile();
+///
+/// let mermaid = export_mermaid_gantt(&profile).unwrap();
+/// assert!(mermaid.contains("gantt"));
+/// assert!(mermaid.contains("my_activity"));
+/// ```
+///
+/// # Errors
+/// Returns `std::fmt::Error` if string formatting fails.
+#[cfg(feature = "testing")]
+pub fn export_mermaid_gantt(profile: &DagProfile) -> Result<String, std::fmt::Error> {
+    let mut out = String::new();
+    writeln!(out, "gantt")?;
+    writeln!(out, "    title DAG Execution Profile")?;
+    writeln!(out, "    dateFormat  s")?;
+    writeln!(out, "    axisFormat  %S")?;
+    writeln!(out)?;
+    writeln!(out, "    section Tasks")?;
+
+    // We need to match starts and ends.
+    // The timeline is chronologically sorted.
+    let mut starts = std::collections::HashMap::new();
+
+    for event in &profile.timeline {
+        match &event.kind {
+            ProfilerEventKind::TaskStarted(idx, name) => {
+                starts.insert(*idx, (name.clone(), event.time.as_secs()));
+            }
+            ProfilerEventKind::TaskCompleted(idx, _name) => {
+                if let Some((name, start_secs)) = starts.remove(idx) {
+                    let end_secs = event.time.as_secs();
+                    let duration = end_secs.saturating_sub(start_secs);
+                    // format: Task Name : t1, 0s, 5s
+                    writeln!(out, "    {name} : t{idx}, {start_secs}s, {duration}s")?;
+                }
+            }
+        }
+    }
+
+    Ok(out)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dag::DagBuilder;
+    use crate::dag_profiler::DagProfiler;
+    use std::time::Duration;
+
+    fn act_a() {}
+    fn act_b() {}
+
+    #[test]
+    #[cfg(feature = "testing")]
+    fn test_export_mermaid_gantt() {
+        let mut builder = DagBuilder::new();
+        let a = builder.activity(act_a);
+        let _b = builder.activity(act_b).upstream(&a);
+        let dag = builder.build().unwrap();
+
+        let profile = DagProfiler::new(dag)
+            .mock_duration("act_a", Duration::from_secs(2))
+            .mock_duration("act_b", Duration::from_secs(3))
+            .profile();
+
+        let gantt = export_mermaid_gantt(&profile).unwrap();
+
+        let expected = "\
+gantt
+    title DAG Execution Profile
+    dateFormat  s
+    axisFormat  %S
+
+    section Tasks
+    act_a : t0, 0s, 2s
+    act_b : t1, 2s, 3s
+";
+        assert_eq!(gantt, expected);
+    }
+}

--- a/autumn-harvest/src/lib.rs
+++ b/autumn-harvest/src/lib.rs
@@ -28,6 +28,9 @@ pub mod critical_path;
 pub mod dag;
 /// Export format types for Directed Acyclic Graphs (DAGs) representing workflows.
 pub mod dag_export;
+/// Export DAG profiles to Mermaid Gantt charts.
+#[cfg(feature = "testing")]
+pub mod dag_gantt;
 pub mod dag_linter;
 #[cfg(feature = "testing")]
 pub mod dag_profiler;
@@ -126,6 +129,8 @@ pub use context::{ActivityContext, WorkflowCommand, WorkflowContext};
 pub use critical_path::{CriticalPathAnalyzer, CriticalPathResult};
 pub use dag::{DagBuildError, DagBuilder, DagDefinition, DagTask, DagTaskRef};
 pub use dag_export::{export_dot, export_mermaid};
+#[cfg(feature = "testing")]
+pub use dag_gantt::export_mermaid_gantt;
 pub use dag_linter::{
     DagLinter, DagRule, DagWarning, ExcessiveParallelismRule, MissingRetryPolicyRule,
     MissingTimeoutRule,


### PR DESCRIPTION
💡 **The Spark:** We have a powerful `DagProfiler` that calculates simulated execution timelines for DAGs based on expected task durations. Currently, these profiles are just raw structs. What if we could visualize the critical path and concurrency bottlenecks directly?

🚀 **The Feature:** Implemented `dag_gantt.rs`, which provides an `export_mermaid_gantt` function. It takes a `DagProfile` (generated by the existing `DagProfiler`) and converts the chronological `timeline` events into a clean Mermaid.js Gantt chart format.

🔮 **The Potential:** This enables developers to instantly generate visual timelines of their complex DAG workflows, making it trivial to spot slow activities, massive parallel fan-outs, and the true critical path before ever running the code in production.

⚠️ **Risk:** Extremely low. The feature is completely additive, isolated to its own `dag_gantt` module, and fully gated behind the existing `#[cfg(feature = "testing")]` flag. It has no impact on core orchestration logic or database operations.

---
*PR created automatically by Jules for task [10655319952280938788](https://jules.google.com/task/10655319952280938788) started by @madmax983*