### PR TITLE
feat(det_check): add deterministic workflow guardrails (issue #172)

### DIFF
--- a/autumn-harvest/src/det_check.rs
+++ b/autumn-harvest/src/det_check.rs
@@ -471,9 +471,25 @@ fn strip_line_comment(line: &str) -> &str {
     line_comment_start(line).map_or(line, |pos| &line[..pos])
 }
 
+/// Returns the byte position immediately after the closing `*/` of a block
+/// comment, scanning from `start` (the position right after the opening `/*`).
+/// Returns `line.len()` if the comment is not closed on this line.
+/// Nested block comments are not supported.
+fn block_comment_end(line: &str, start: usize) -> usize {
+    let bytes = line.as_bytes();
+    let mut pos = start;
+    while pos < bytes.len() {
+        if bytes[pos] == b'*' && pos + 1 < bytes.len() && bytes[pos + 1] == b'/' {
+            return pos + 2;
+        }
+        pos += 1;
+    }
+    line.len()
+}
+
 /// Updates `depth` for braces in code, ignoring braces inside simple Rust
-/// string/character literals and line comments. Returns the byte position of
-/// the closing brace that returns the depth to zero, if present.
+/// string/character literals, line comments, and block comments. Returns the
+/// byte position of the closing brace that returns the depth to zero, if present.
 fn scan_braces_outside_literals(line: &str, depth: &mut u32) -> Option<usize> {
     let mut pos = 0;
 
@@ -493,6 +509,9 @@ fn scan_braces_outside_literals(line: &str, depth: &mut u32) -> Option<usize> {
                 pos = char_literal_end(line, pos).unwrap_or(next_pos);
             }
             '/' if line[next_pos..].starts_with('/') => break,
+            '/' if line[next_pos..].starts_with('*') => {
+                pos = block_comment_end(line, next_pos + 1);
+            }
             '{' => {
                 *depth = depth.saturating_add(1);
                 pos = next_pos;
@@ -512,7 +531,7 @@ fn scan_braces_outside_literals(line: &str, depth: &mut u32) -> Option<usize> {
 }
 
 /// Returns the byte position of the first `//` outside simple Rust
-/// string/character literals.
+/// string/character literals and block comments.
 fn line_comment_start(line: &str) -> Option<usize> {
     let mut pos = 0;
 
@@ -532,6 +551,9 @@ fn line_comment_start(line: &str) -> Option<usize> {
                 pos = char_literal_end(line, pos).unwrap_or(next_pos);
             }
             '/' if line[next_pos..].starts_with('/') => return Some(pos),
+            '/' if line[next_pos..].starts_with('*') => {
+                pos = block_comment_end(line, next_pos + 1);
+            }
             _ => pos = next_pos,
         }
     }
@@ -679,6 +701,9 @@ fn strip_unparseable_content(line: &str) -> String {
         match ch {
             '"' => pos = normal_string_end(code, pos),
             '\'' => pos = char_literal_end(code, pos).unwrap_or(next_pos),
+            '/' if code[next_pos..].starts_with('*') => {
+                pos = block_comment_end(code, next_pos + 1);
+            }
             _ => {
                 result.push(ch);
                 pos = next_pos;
@@ -810,6 +835,25 @@ mod tests {
                 r#"let _ = SystemTime::now(); // harvest-suppress: DET001 "safe""#
             ),
             Some("safe".to_string())
+        );
+    }
+
+    #[test]
+    fn strip_unparseable_content_removes_block_comments() {
+        // Block comment content is stripped.
+        assert_eq!(
+            strip_unparseable_content("let x = /* std::fs::read */ 5;"),
+            "let x =  5;"
+        );
+        // Block comment with `}` inside must not confuse callers.
+        assert_eq!(
+            strip_unparseable_content("foo() /* } */ .bar()"),
+            "foo()  .bar()"
+        );
+        // `/* // */` must not trick line_comment_start into discarding real code.
+        assert_eq!(
+            strip_unparseable_content("/* // */ let x = 1;"),
+            " let x = 1;"
         );
     }
 

--- a/autumn-harvest/src/det_check.rs
+++ b/autumn-harvest/src/det_check.rs
@@ -258,8 +258,8 @@ pub fn check_source(source: &str, file: &str) -> DetCheckReport {
     let mut report = DetCheckReport::default();
     let lines: Vec<&str> = source.lines().collect();
 
-    for (wf_name, body_start, body_lines) in extract_workflow_bodies(&lines) {
-        report.merge(check_body(&wf_name, body_start, &body_lines, file));
+    for (wf_name, body) in extract_workflow_bodies(&lines) {
+        report.merge(check_body(&wf_name, &body, file));
     }
 
     report
@@ -300,10 +300,10 @@ fn collect_rs_files(dir: &Path, report: &mut DetCheckReport) -> std::io::Result<
 
 // ── Workflow body extraction ───────────────────────────────────────────────────
 
-/// Returns `(workflow_name, body_start_1indexed, body_lines)` for every
-/// `#[workflow]`-annotated `async fn` in the source.  `#[activity]` bodies are
-/// not returned.
-fn extract_workflow_bodies<'a>(lines: &[&'a str]) -> Vec<(String, usize, Vec<&'a str>)> {
+/// Returns `(workflow_name, body_lines)` for every `#[workflow]`-annotated
+/// `async fn` in the source.  Each body line carries its 1-indexed line number.
+/// `#[activity]` bodies are not returned.
+fn extract_workflow_bodies<'a>(lines: &[&'a str]) -> Vec<(String, Vec<(u32, &'a str)>)> {
     let mut result = Vec::new();
     let mut i = 0;
 
@@ -354,34 +354,39 @@ fn extract_workflow_bodies<'a>(lines: &[&'a str]) -> Vec<(String, usize, Vec<&'a
             continue;
         }
 
-        // Body starts on the line immediately after the opening brace.
-        // brace_line is 0-indexed; first body line is 0-indexed brace_line+1,
-        // which is 1-indexed brace_line+2.
-        let body_start_1indexed = brace_line + 2;
-        j = brace_line + 1;
-
-        // Collect body lines until the matching closing brace (depth → 0).
+        // Start collecting from brace_line itself so that code on the same line
+        // as `{` is included (e.g. single-line `fn wf() { expr }`).
+        let brace_pos = lines[brace_line].find('{').unwrap_or(0);
         let mut depth = 1u32;
-        let mut body: Vec<&'a str> = Vec::new();
+        let mut body: Vec<(u32, &'a str)> = Vec::new(); // (1-indexed line, text)
+
+        j = brace_line;
+        let mut on_brace_line = true;
 
         while j < lines.len() && depth > 0 {
-            let line = lines[j];
-            let closing_brace_pos = scan_braces_outside_literals(line, &mut depth);
+            // On the opening-brace line only scan content after the `{`.
+            let line: &'a str = if on_brace_line {
+                on_brace_line = false;
+                &lines[j][brace_pos + 1..]
+            } else {
+                lines[j]
+            };
+            let line_num = u32::try_from(j + 1).unwrap_or(u32::MAX);
 
-            if let Some(pos) = closing_brace_pos {
+            if let Some(pos) = scan_braces_outside_literals(line, &mut depth) {
                 // Include any code on the closing-brace line that precedes the `}`
                 let before = &line[..pos];
                 if !before.trim().is_empty() {
-                    body.push(before);
+                    body.push((line_num, before));
                 }
-            } else {
-                body.push(line);
+            } else if !line.trim().is_empty() {
+                body.push((line_num, line));
             }
 
             j += 1;
         }
 
-        result.push((name, body_start_1indexed, body));
+        result.push((name, body));
         i = j;
     }
 
@@ -406,21 +411,15 @@ fn extract_fn_name(line: &str) -> Option<String> {
 
 // ── Body checker ──────────────────────────────────────────────────────────────
 
-fn check_body(
-    wf_name: &str,
-    body_start_1indexed: usize,
-    body_lines: &[&str],
-    file: &str,
-) -> DetCheckReport {
+fn check_body(wf_name: &str, body_lines: &[(u32, &str)], file: &str) -> DetCheckReport {
     let mut report = DetCheckReport::default();
 
-    for (idx, &line) in body_lines.iter().enumerate() {
-        let source_line = u32::try_from(body_start_1indexed + idx).unwrap_or(u32::MAX);
-
-        // The code portion of the line (before any `//` comment).
-        let code_part = strip_line_comment(line);
-        // Previous body line (used for preceding suppression comments).
-        let prev_line = if idx > 0 { body_lines[idx - 1] } else { "" };
+    for (idx, &(source_line, line)) in body_lines.iter().enumerate() {
+        // Code portion with string literals and line comments stripped to
+        // prevent false positives from patterns appearing in string data or comments.
+        let code_part = strip_unparseable_content(line);
+        // Previous body line — checked for a preceding suppression comment.
+        let prev_line = if idx > 0 { body_lines[idx - 1].1 } else { "" };
 
         'rules: for rule in RULES {
             for &pattern in rule.patterns {
@@ -461,6 +460,8 @@ fn check_body(
 
     report
 }
+
+// ── Lexer helpers ─────────────────────────────────────────────────────────────
 
 /// Returns the portion of `line` that precedes the first `//` (if any).
 /// This avoids flagging patterns that appear only inside comments.
@@ -655,6 +656,37 @@ fn raw_string_end(line: &str, start: usize) -> Option<usize> {
     Some(line.len())
 }
 
+/// Returns a copy of `line` with string literal and char literal content removed
+/// and everything from the first `//` comment stripped.
+/// This prevents pattern matches inside string data or comments.
+fn strip_unparseable_content(line: &str) -> String {
+    let code = strip_line_comment(line);
+    let mut result = String::with_capacity(code.len());
+    let mut pos = 0;
+
+    while pos < code.len() {
+        if let Some(end) = raw_string_end(code, pos) {
+            pos = end;
+            continue;
+        }
+
+        let Some((ch, next_pos)) = next_char(code, pos) else {
+            break;
+        };
+
+        match ch {
+            '"' => pos = normal_string_end(code, pos),
+            '\'' => pos = char_literal_end(code, pos).unwrap_or(next_pos),
+            _ => {
+                result.push(ch);
+                pos = next_pos;
+            }
+        }
+    }
+
+    result
+}
+
 /// Returns the suppression reason if either `line` or `prev_line` contains a
 /// valid `// harvest-suppress: RULE_ID "reason"` comment for `rule_id`.
 fn find_suppression(rule_id: &str, line: &str, prev_line: &str) -> Option<String> {
@@ -663,6 +695,8 @@ fn find_suppression(rule_id: &str, line: &str, prev_line: &str) -> Option<String
 }
 
 /// Parses `// harvest-suppress: RULE_ID "reason string"` from a line.
+/// The marker may appear anywhere in the line (supports both standalone comment
+/// lines and trailing inline comments such as `let x = foo(); // harvest-suppress: …`).
 /// Returns the reason string if valid and non-empty, `None` otherwise.
 fn parse_suppression_comment(rule_id: &str, line: &str) -> Option<String> {
     let comment_start = line_comment_start(line)?;
@@ -670,7 +704,6 @@ fn parse_suppression_comment(rule_id: &str, line: &str) -> Option<String> {
     let rest = rest.strip_prefix("harvest-suppress:")?;
     let rest = rest.trim_start();
     let rest = rest.strip_prefix(rule_id)?.trim_start();
-    // Require a quoted reason string.
     let inner = rest.strip_prefix('"')?;
     let end = inner.find('"')?;
     let reason = &inner[..end];
@@ -737,10 +770,35 @@ mod tests {
     }
 
     #[test]
-    fn strip_line_comment_removes_trailing_comment() {
-        assert_eq!(strip_line_comment("let x = 1; // comment"), "let x = 1; ");
-        assert_eq!(strip_line_comment("let x = 1;"), "let x = 1;");
-        assert_eq!(strip_line_comment("// full comment"), "");
+    fn strip_unparseable_content_removes_comments_and_strings() {
+        assert_eq!(
+            strip_unparseable_content("let x = 1; // comment"),
+            "let x = 1; "
+        );
+        assert_eq!(strip_unparseable_content("let x = 1;"), "let x = 1;");
+        assert_eq!(strip_unparseable_content("// full comment"), "");
+        // String literal content is silently removed.
+        assert_eq!(
+            strip_unparseable_content(r#"let s = "std::fs::read";"#),
+            "let s = ;"
+        );
+        // Escaped quote inside string does not prematurely close it.
+        assert_eq!(
+            strip_unparseable_content(r#"let s = "say \"hi\"";"#),
+            "let s = ;"
+        );
+    }
+
+    #[test]
+    fn parse_suppression_comment_handles_inline_trailing_comment() {
+        // Same-line trailing suppression comment.
+        assert_eq!(
+            parse_suppression_comment(
+                "DET001",
+                r#"let _ = SystemTime::now(); // harvest-suppress: DET001 "safe""#
+            ),
+            Some("safe".to_string())
+        );
     }
 
     #[test]

--- a/autumn-harvest/src/det_check.rs
+++ b/autumn-harvest/src/det_check.rs
@@ -366,29 +366,13 @@ fn extract_workflow_bodies<'a>(lines: &[&'a str]) -> Vec<(String, usize, Vec<&'a
 
         while j < lines.len() && depth > 0 {
             let line = lines[j];
-            let mut closed_here = false;
+            let closing_brace_pos = scan_braces_outside_literals(line, &mut depth);
 
-            for ch in line.chars() {
-                match ch {
-                    '{' => depth += 1,
-                    '}' => {
-                        depth = depth.saturating_sub(1);
-                        if depth == 0 {
-                            closed_here = true;
-                            break;
-                        }
-                    }
-                    _ => {}
-                }
-            }
-
-            if closed_here {
+            if let Some(pos) = closing_brace_pos {
                 // Include any code on the closing-brace line that precedes the `}`
-                if let Some(pos) = line.rfind('}') {
-                    let before = &line[..pos];
-                    if !before.trim().is_empty() {
-                        body.push(before);
-                    }
+                let before = &line[..pos];
+                if !before.trim().is_empty() {
+                    body.push(before);
                 }
             } else {
                 body.push(line);
@@ -481,7 +465,194 @@ fn check_body(
 /// Returns the portion of `line` that precedes the first `//` (if any).
 /// This avoids flagging patterns that appear only inside comments.
 fn strip_line_comment(line: &str) -> &str {
-    line.find("//").map_or(line, |pos| &line[..pos])
+    line_comment_start(line).map_or(line, |pos| &line[..pos])
+}
+
+/// Updates `depth` for braces in code, ignoring braces inside simple Rust
+/// string/character literals and line comments. Returns the byte position of
+/// the closing brace that returns the depth to zero, if present.
+fn scan_braces_outside_literals(line: &str, depth: &mut u32) -> Option<usize> {
+    let mut pos = 0;
+
+    while pos < line.len() {
+        if let Some(end) = raw_string_end(line, pos) {
+            pos = end;
+            continue;
+        }
+
+        let Some((ch, next_pos)) = next_char(line, pos) else {
+            break;
+        };
+
+        match ch {
+            '"' => pos = normal_string_end(line, pos),
+            '\'' => {
+                pos = char_literal_end(line, pos).unwrap_or(next_pos);
+            }
+            '/' if line[next_pos..].starts_with('/') => break,
+            '{' => {
+                *depth = depth.saturating_add(1);
+                pos = next_pos;
+            }
+            '}' => {
+                *depth = depth.saturating_sub(1);
+                if *depth == 0 {
+                    return Some(pos);
+                }
+                pos = next_pos;
+            }
+            _ => pos = next_pos,
+        }
+    }
+
+    None
+}
+
+/// Returns the byte position of the first `//` outside simple Rust
+/// string/character literals.
+fn line_comment_start(line: &str) -> Option<usize> {
+    let mut pos = 0;
+
+    while pos < line.len() {
+        if let Some(end) = raw_string_end(line, pos) {
+            pos = end;
+            continue;
+        }
+
+        let Some((ch, next_pos)) = next_char(line, pos) else {
+            break;
+        };
+
+        match ch {
+            '"' => pos = normal_string_end(line, pos),
+            '\'' => {
+                pos = char_literal_end(line, pos).unwrap_or(next_pos);
+            }
+            '/' if line[next_pos..].starts_with('/') => return Some(pos),
+            _ => pos = next_pos,
+        }
+    }
+
+    None
+}
+
+fn next_char(line: &str, pos: usize) -> Option<(char, usize)> {
+    let ch = line[pos..].chars().next()?;
+    Some((ch, pos + ch.len_utf8()))
+}
+
+fn normal_string_end(line: &str, start: usize) -> usize {
+    let mut pos = start + 1;
+    let mut escaped = false;
+
+    while pos < line.len() {
+        let Some((ch, next_pos)) = next_char(line, pos) else {
+            break;
+        };
+
+        if escaped {
+            escaped = false;
+        } else if ch == '\\' {
+            escaped = true;
+        } else if ch == '"' {
+            return next_pos;
+        }
+
+        pos = next_pos;
+    }
+
+    line.len()
+}
+
+fn char_literal_end(line: &str, start: usize) -> Option<usize> {
+    let content_start = start + 1;
+    let (first, first_end) = next_char(line, content_start)?;
+
+    if is_lifetime_start(first) {
+        let ident_end = consume_lifetime_ident(line, first_end);
+        if !line[ident_end..].starts_with('\'') {
+            return None;
+        }
+    }
+
+    let mut pos = content_start;
+    let mut escaped = false;
+
+    while pos < line.len() {
+        let (ch, next_pos) = next_char(line, pos)?;
+
+        if escaped {
+            escaped = false;
+        } else if ch == '\\' {
+            escaped = true;
+        } else if ch == '\'' && pos != content_start {
+            return Some(next_pos);
+        }
+
+        pos = next_pos;
+    }
+
+    None
+}
+
+const fn is_lifetime_start(ch: char) -> bool {
+    ch == '_' || ch.is_ascii_alphabetic()
+}
+
+const fn is_lifetime_continue(ch: char) -> bool {
+    ch == '_' || ch.is_ascii_alphanumeric()
+}
+
+fn consume_lifetime_ident(line: &str, mut pos: usize) -> usize {
+    while pos < line.len() {
+        let Some((ch, next_pos)) = next_char(line, pos) else {
+            break;
+        };
+        if !is_lifetime_continue(ch) {
+            break;
+        }
+        pos = next_pos;
+    }
+    pos
+}
+
+fn raw_string_end(line: &str, start: usize) -> Option<usize> {
+    let bytes = line.as_bytes();
+    let mut pos = start;
+
+    match bytes.get(pos).copied()? {
+        b'r' => pos += 1,
+        b'b' | b'c' if bytes.get(pos + 1).copied() == Some(b'r') => pos += 2,
+        _ => return None,
+    }
+
+    let hash_start = pos;
+    while bytes.get(pos).copied() == Some(b'#') {
+        pos += 1;
+    }
+    if bytes.get(pos).copied() != Some(b'"') {
+        return None;
+    }
+
+    let hashes = pos - hash_start;
+    pos += 1;
+
+    while pos < bytes.len() {
+        if bytes[pos] == b'"' {
+            let marker_start = pos + 1;
+            let marker_end = marker_start + hashes;
+            if marker_end <= bytes.len()
+                && bytes[marker_start..marker_end]
+                    .iter()
+                    .all(|&byte| byte == b'#')
+            {
+                return Some(marker_end);
+            }
+        }
+        pos += 1;
+    }
+
+    Some(line.len())
 }
 
 /// Returns the suppression reason if either `line` or `prev_line` contains a
@@ -494,8 +665,8 @@ fn find_suppression(rule_id: &str, line: &str, prev_line: &str) -> Option<String
 /// Parses `// harvest-suppress: RULE_ID "reason string"` from a line.
 /// Returns the reason string if valid and non-empty, `None` otherwise.
 fn parse_suppression_comment(rule_id: &str, line: &str) -> Option<String> {
-    let trimmed = line.trim();
-    let rest = trimmed.strip_prefix("//")?.trim_start();
+    let comment_start = line_comment_start(line)?;
+    let rest = line[comment_start + 2..].trim_start();
     let rest = rest.strip_prefix("harvest-suppress:")?;
     let rest = rest.trim_start();
     let rest = rest.strip_prefix(rule_id)?.trim_start();

--- a/autumn-harvest/src/det_check.rs
+++ b/autumn-harvest/src/det_check.rs
@@ -157,9 +157,11 @@ const RULES: &[Rule] = &[
             "Uuid::new_v4(",
             "Uuid::new_v7(",
             "Uuid::new_v1(",
+            "Uuid::now_v7(",
             "uuid::Uuid::new_v4",
             "uuid::Uuid::new_v7",
             "uuid::Uuid::new_v1",
+            "uuid::Uuid::now_v7",
         ],
         message: "Ad-hoc UUID generation inside a workflow function is non-deterministic. \
                   A new random UUID is produced on every replay, breaking event correlation.",
@@ -689,9 +691,19 @@ fn strip_unparseable_content(line: &str) -> String {
 
 /// Returns the suppression reason if either `line` or `prev_line` contains a
 /// valid `// harvest-suppress: RULE_ID "reason"` comment for `rule_id`.
+///
+/// `prev_line` is only eligible when it is a *standalone* comment line
+/// (no code before `//`). A trailing inline comment on `prev_line` is
+/// scoped to that line only and must not suppress violations on the next line.
 fn find_suppression(rule_id: &str, line: &str, prev_line: &str) -> Option<String> {
-    parse_suppression_comment(rule_id, prev_line)
-        .or_else(|| parse_suppression_comment(rule_id, line))
+    let prev_is_standalone =
+        line_comment_start(prev_line).is_some_and(|pos| prev_line[..pos].trim().is_empty());
+    if prev_is_standalone {
+        parse_suppression_comment(rule_id, prev_line)
+    } else {
+        None
+    }
+    .or_else(|| parse_suppression_comment(rule_id, line))
 }
 
 /// Parses `// harvest-suppress: RULE_ID "reason string"` from a line.

--- a/autumn-harvest/src/det_check.rs
+++ b/autumn-harvest/src/det_check.rs
@@ -1,0 +1,588 @@
+//! Deterministic workflow guardrails.
+//!
+//! Statically analyses Rust source files for common non-determinism patterns that
+//! break Harvest's deterministic replay contract inside `#[workflow]` functions.
+//!
+//! # Rule catalog
+//!
+//! | ID     | Severity | Pattern family                                 |
+//! |--------|----------|------------------------------------------------|
+//! | DET001 | Error    | Wall-clock time reads                          |
+//! | DET002 | Error    | Random number generation                       |
+//! | DET003 | Error    | Ad-hoc UUID generation                         |
+//! | DET004 | Error    | Environment variable / argument reads          |
+//! | DET005 | Warning  | Process-global state reads                     |
+//! | DET006 | Error    | Direct sleep / timer primitives                |
+//! | DET007 | Error    | Background task spawning                       |
+//! | DET008 | Error    | Direct network / filesystem I/O               |
+//!
+//! # Suppression
+//!
+//! Place a `// harvest-suppress: RULE_ID "reason"` comment on the line
+//! **immediately preceding** the flagged expression (or on the same line).
+//! The reason string is required and must be non-empty.
+//!
+//! ```rust,ignore
+//! // harvest-suppress: DET001 "timestamp comes from the signal payload"
+//! let recorded_at = std::time::SystemTime::now();
+//! ```
+//!
+//! Suppressions are always reported in [`DetCheckReport::suppressions`] so they
+//! remain auditable in machine-readable output.
+
+use std::path::Path;
+
+// ── Public types ─────────────────────────────────────────────────────────────
+
+/// Severity of a determinism finding.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DetSeverity {
+    /// Breaks replay determinism; counted as a hard blocker by [`DetCheckReport::has_hard_blockers`].
+    Error,
+    /// May break determinism in edge cases; reported but does not fail CI by default.
+    Warning,
+}
+
+/// Source location reported in a finding.
+#[derive(Debug, Clone)]
+pub struct DetLocation {
+    /// Path (or label) of the file being analysed, as passed to [`check_source`].
+    pub file: String,
+    /// 1-indexed line number within that file.
+    pub line: u32,
+}
+
+/// A single determinism violation found in a workflow function body.
+#[derive(Debug, Clone)]
+pub struct DetFinding {
+    /// Stable rule identifier (e.g. `"DET001"`).
+    pub rule_id: &'static str,
+    /// How serious the violation is.
+    pub severity: DetSeverity,
+    /// Name of the `#[workflow]` function where the violation was found.
+    pub workflow_name: Option<String>,
+    /// Source location, when available.
+    pub location: Option<DetLocation>,
+    /// Human-readable description of the violation.
+    pub message: String,
+    /// A deterministic Harvest-shaped alternative.
+    pub alternative: &'static str,
+}
+
+/// An active suppression comment found in the source.
+#[derive(Debug, Clone)]
+pub struct DetSuppression {
+    /// The rule ID that was suppressed.
+    pub rule_id: String,
+    /// The required reason string from the comment.
+    pub reason: String,
+    /// Where the suppressed expression (not the comment) was located.
+    pub location: DetLocation,
+}
+
+/// The result of checking one or more source files.
+#[derive(Debug, Default)]
+pub struct DetCheckReport {
+    /// Violations that were *not* suppressed.
+    pub findings: Vec<DetFinding>,
+    /// Suppressions that were applied (always reported for auditability).
+    pub suppressions: Vec<DetSuppression>,
+}
+
+impl DetCheckReport {
+    /// Returns `true` if any unsuppressed [`DetSeverity::Error`] finding is present.
+    /// Warnings alone do not constitute a hard blocker.
+    #[must_use]
+    pub fn has_hard_blockers(&self) -> bool {
+        self.findings
+            .iter()
+            .any(|f| matches!(f.severity, DetSeverity::Error))
+    }
+
+    fn merge(&mut self, other: Self) {
+        self.findings.extend(other.findings);
+        self.suppressions.extend(other.suppressions);
+    }
+}
+
+// ── Rule catalog ──────────────────────────────────────────────────────────────
+
+struct Rule {
+    id: &'static str,
+    severity: DetSeverity,
+    patterns: &'static [&'static str],
+    message: &'static str,
+    alternative: &'static str,
+}
+
+const RULES: &[Rule] = &[
+    Rule {
+        id: "DET001",
+        severity: DetSeverity::Error,
+        patterns: &[
+            "SystemTime::now()",
+            "Instant::now()",
+            "Utc::now()",
+            "Local::now()",
+            "chrono::Utc::now",
+            "chrono::Local::now",
+            "OffsetDateTime::now_utc()",
+        ],
+        message: "Wall-clock time read inside a workflow function breaks replay determinism. \
+                  Each replay may observe a different instant, causing non-deterministic branching.",
+        alternative: "Use `ctx.timer(id, secs)` for durable waits. To capture an exact timestamp, \
+                      record it inside an activity and return it to the workflow, or pass it as \
+                      workflow input.",
+    },
+    Rule {
+        id: "DET002",
+        severity: DetSeverity::Error,
+        patterns: &[
+            "rand::random",
+            "rand::thread_rng(",
+            "thread_rng(",
+            "SmallRng::from_entropy",
+            "StdRng::from_entropy",
+            "rand::rngs::OsRng",
+        ],
+        message: "Random number generation inside a workflow function is non-deterministic. \
+                  The RNG state differs on each replay, producing different values.",
+        alternative: "Generate random values inside an activity and return them to the workflow. \
+                      Use `ctx.random_uuid(label)` for durable, replay-safe UUIDs.",
+    },
+    Rule {
+        id: "DET003",
+        severity: DetSeverity::Error,
+        patterns: &[
+            "Uuid::new_v4(",
+            "Uuid::new_v7(",
+            "Uuid::new_v1(",
+            "uuid::Uuid::new_v4",
+            "uuid::Uuid::new_v7",
+            "uuid::Uuid::new_v1",
+        ],
+        message: "Ad-hoc UUID generation inside a workflow function is non-deterministic. \
+                  A new random UUID is produced on every replay, breaking event correlation.",
+        alternative: "Use `ctx.random_uuid(label)` which records the UUID in the event history \
+                      and replays the same value deterministically.",
+    },
+    Rule {
+        id: "DET004",
+        severity: DetSeverity::Error,
+        patterns: &[
+            "std::env::var(",
+            "env::var(",
+            "std::env::args(",
+            "env::args(",
+            "std::env::vars(",
+            "env::vars(",
+        ],
+        message: "Environment variable / argument reads inside a workflow function are \
+                  non-deterministic: values can differ across workers and across replays.",
+        alternative: "Pass configuration as workflow input, inject it via `ctx.state::<T>()`, \
+                      or read it inside an activity.",
+    },
+    Rule {
+        id: "DET005",
+        severity: DetSeverity::Warning,
+        patterns: &["std::process::id(", "process::id("],
+        message: "Process-global state read inside a workflow function may differ across \
+                  replays running on different worker processes.",
+        alternative: "Avoid reading process-global state from workflow code. Pass values as \
+                      input or use `ctx.state::<T>()` for injected dependencies.",
+    },
+    Rule {
+        id: "DET006",
+        severity: DetSeverity::Error,
+        patterns: &[
+            "tokio::time::sleep(",
+            "time::sleep(",
+            "std::thread::sleep(",
+            "thread::sleep(",
+        ],
+        message: "Direct sleep / timer primitive inside a workflow function is non-durable and \
+                  breaks replay: the sleep re-executes on every replay rather than being \
+                  skipped after the first completion.",
+        alternative: "Use `ctx.timer(id, secs)` for durable, replay-safe waits that resume \
+                      correctly after a worker crash or restart.",
+    },
+    Rule {
+        id: "DET007",
+        severity: DetSeverity::Error,
+        patterns: &[
+            "tokio::spawn(",
+            "tokio::task::spawn(",
+            "task::spawn(",
+            "std::thread::spawn(",
+            "thread::spawn(",
+            "tokio::task::spawn_blocking(",
+            "task::spawn_blocking(",
+        ],
+        message: "Background task spawning inside a workflow function is invisible to the replay \
+                  engine. The spawned task's side effects cannot be replayed deterministically.",
+        alternative: "Run concurrent work via parallel activity execution using `futures::join!` \
+                      with multiple `ctx.execute_activity_raw` calls. Blocking I/O belongs inside \
+                      an activity.",
+    },
+    Rule {
+        id: "DET008",
+        severity: DetSeverity::Error,
+        patterns: &[
+            "std::fs::",
+            "tokio::fs::",
+            "File::open(",
+            "File::create(",
+            "reqwest::",
+            "hyper::",
+            "std::net::TcpStream",
+            "TcpStream::connect(",
+            "UdpSocket::bind(",
+        ],
+        message: "Direct network / filesystem I/O inside a workflow function is non-deterministic. \
+                  The response or file contents may change between the original execution and \
+                  subsequent replays.",
+        alternative: "Move all I/O into activities. Activities are the durable side-effect boundary \
+                      in Harvest; their results are recorded in the event history and replayed \
+                      without re-executing the I/O.",
+    },
+];
+
+// ── Public entry points ───────────────────────────────────────────────────────
+
+/// Check Rust source code text for determinism violations inside `#[workflow]` functions.
+///
+/// `file` is used only for source-location reporting; no file is read.
+/// The function always returns a report; it never panics on malformed input.
+#[must_use]
+pub fn check_source(source: &str, file: &str) -> DetCheckReport {
+    let mut report = DetCheckReport::default();
+    let lines: Vec<&str> = source.lines().collect();
+
+    for (wf_name, body_start, body_lines) in extract_workflow_bodies(&lines) {
+        report.merge(check_body(&wf_name, body_start, &body_lines, file));
+    }
+
+    report
+}
+
+/// Check a single `.rs` file for determinism violations.
+///
+/// # Errors
+/// Returns an error if the file cannot be read.
+pub fn check_file(path: &Path) -> std::io::Result<DetCheckReport> {
+    let source = std::fs::read_to_string(path)?;
+    let file = path.to_string_lossy();
+    Ok(check_source(&source, &file))
+}
+
+/// Recursively check all `.rs` files under `dir` for determinism violations.
+///
+/// # Errors
+/// Returns an error if the directory cannot be read or any file read fails.
+pub fn check_dir(dir: &Path) -> std::io::Result<DetCheckReport> {
+    let mut report = DetCheckReport::default();
+    collect_rs_files(dir, &mut report)?;
+    Ok(report)
+}
+
+fn collect_rs_files(dir: &Path, report: &mut DetCheckReport) -> std::io::Result<()> {
+    for entry in std::fs::read_dir(dir)? {
+        let entry = entry?;
+        let path = entry.path();
+        if path.is_dir() {
+            collect_rs_files(&path, report)?;
+        } else if path.extension().is_some_and(|e| e == "rs") {
+            report.merge(check_file(&path)?);
+        }
+    }
+    Ok(())
+}
+
+// ── Workflow body extraction ───────────────────────────────────────────────────
+
+/// Returns `(workflow_name, body_start_1indexed, body_lines)` for every
+/// `#[workflow]`-annotated `async fn` in the source.  `#[activity]` bodies are
+/// not returned.
+fn extract_workflow_bodies<'a>(lines: &[&'a str]) -> Vec<(String, usize, Vec<&'a str>)> {
+    let mut result = Vec::new();
+    let mut i = 0;
+
+    while i < lines.len() {
+        let trimmed = lines[i].trim();
+
+        if !is_workflow_attr(trimmed) {
+            i += 1;
+            continue;
+        }
+
+        // Found `#[workflow]` — skip forward past any intermediate attributes / doc comments
+        i += 1;
+        while i < lines.len() {
+            let t = lines[i].trim();
+            if t.starts_with("//") || t.starts_with("#[") || t.is_empty() {
+                i += 1;
+            } else {
+                break;
+            }
+        }
+
+        if i >= lines.len() {
+            break;
+        }
+
+        // Extract function name from `(pub)? async fn NAME`
+        let fn_line = lines[i].trim();
+        let Some(name) = extract_fn_name(fn_line) else {
+            i += 1;
+            continue;
+        };
+
+        // Scan forward to find the opening `{` of the function body.
+        // The signature may span multiple lines.
+        let mut j = i;
+        let brace_line = loop {
+            if lines[j].contains('{') {
+                break j;
+            }
+            j += 1;
+            if j >= lines.len() {
+                break usize::MAX; // sentinel: not found
+            }
+        };
+        if brace_line == usize::MAX {
+            i += 1;
+            continue;
+        }
+
+        // Body starts on the line immediately after the opening brace.
+        // brace_line is 0-indexed; first body line is 0-indexed brace_line+1,
+        // which is 1-indexed brace_line+2.
+        let body_start_1indexed = brace_line + 2;
+        j = brace_line + 1;
+
+        // Collect body lines until the matching closing brace (depth → 0).
+        let mut depth = 1u32;
+        let mut body: Vec<&'a str> = Vec::new();
+
+        while j < lines.len() && depth > 0 {
+            let line = lines[j];
+            let mut closed_here = false;
+
+            for ch in line.chars() {
+                match ch {
+                    '{' => depth += 1,
+                    '}' => {
+                        depth = depth.saturating_sub(1);
+                        if depth == 0 {
+                            closed_here = true;
+                            break;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+
+            if closed_here {
+                // Include any code on the closing-brace line that precedes the `}`
+                if let Some(pos) = line.rfind('}') {
+                    let before = &line[..pos];
+                    if !before.trim().is_empty() {
+                        body.push(before);
+                    }
+                }
+            } else {
+                body.push(line);
+            }
+
+            j += 1;
+        }
+
+        result.push((name, body_start_1indexed, body));
+        i = j;
+    }
+
+    result
+}
+
+/// Returns `true` for `#[workflow]` and `#[workflow(...)]` attribute lines.
+fn is_workflow_attr(s: &str) -> bool {
+    s == "#[workflow]" || s.starts_with("#[workflow(") || s.starts_with("#[workflow ]")
+}
+
+/// Extracts the function name from a line like `pub async fn my_wf(`.
+fn extract_fn_name(line: &str) -> Option<String> {
+    let pos = line.find("fn ")?;
+    let after = &line[pos + 3..];
+    let name: String = after
+        .chars()
+        .take_while(|c| c.is_alphanumeric() || *c == '_')
+        .collect();
+    if name.is_empty() { None } else { Some(name) }
+}
+
+// ── Body checker ──────────────────────────────────────────────────────────────
+
+fn check_body(
+    wf_name: &str,
+    body_start_1indexed: usize,
+    body_lines: &[&str],
+    file: &str,
+) -> DetCheckReport {
+    let mut report = DetCheckReport::default();
+
+    for (idx, &line) in body_lines.iter().enumerate() {
+        let source_line = u32::try_from(body_start_1indexed + idx).unwrap_or(u32::MAX);
+
+        // The code portion of the line (before any `//` comment).
+        let code_part = strip_line_comment(line);
+        // Previous body line (used for preceding suppression comments).
+        let prev_line = if idx > 0 { body_lines[idx - 1] } else { "" };
+
+        'rules: for rule in RULES {
+            for &pattern in rule.patterns {
+                if !code_part.contains(pattern) {
+                    continue;
+                }
+
+                // Pattern matched — check for a suppression comment.
+                if let Some(reason) = find_suppression(rule.id, line, prev_line) {
+                    report.suppressions.push(DetSuppression {
+                        rule_id: rule.id.to_string(),
+                        reason,
+                        location: DetLocation {
+                            file: file.to_string(),
+                            line: source_line,
+                        },
+                    });
+                } else {
+                    report.findings.push(DetFinding {
+                        rule_id: rule.id,
+                        severity: rule.severity.clone(),
+                        workflow_name: Some(wf_name.to_string()),
+                        location: Some(DetLocation {
+                            file: file.to_string(),
+                            line: source_line,
+                        }),
+                        message: format!(
+                            "[{}] {} (matched pattern: `{}`)",
+                            rule.id, rule.message, pattern
+                        ),
+                        alternative: rule.alternative,
+                    });
+                }
+                continue 'rules; // one finding per rule per line
+            }
+        }
+    }
+
+    report
+}
+
+/// Returns the portion of `line` that precedes the first `//` (if any).
+/// This avoids flagging patterns that appear only inside comments.
+fn strip_line_comment(line: &str) -> &str {
+    line.find("//").map_or(line, |pos| &line[..pos])
+}
+
+/// Returns the suppression reason if either `line` or `prev_line` contains a
+/// valid `// harvest-suppress: RULE_ID "reason"` comment for `rule_id`.
+fn find_suppression(rule_id: &str, line: &str, prev_line: &str) -> Option<String> {
+    parse_suppression_comment(rule_id, prev_line)
+        .or_else(|| parse_suppression_comment(rule_id, line))
+}
+
+/// Parses `// harvest-suppress: RULE_ID "reason string"` from a line.
+/// Returns the reason string if valid and non-empty, `None` otherwise.
+fn parse_suppression_comment(rule_id: &str, line: &str) -> Option<String> {
+    let trimmed = line.trim();
+    let rest = trimmed.strip_prefix("//")?.trim_start();
+    let rest = rest.strip_prefix("harvest-suppress:")?;
+    let rest = rest.trim_start();
+    let rest = rest.strip_prefix(rule_id)?.trim_start();
+    // Require a quoted reason string.
+    let inner = rest.strip_prefix('"')?;
+    let end = inner.find('"')?;
+    let reason = &inner[..end];
+    if reason.is_empty() {
+        None
+    } else {
+        Some(reason.to_string())
+    }
+}
+
+// ── Module-level unit tests ───────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn is_workflow_attr_matches_bare_and_parameterised() {
+        assert!(is_workflow_attr("#[workflow]"));
+        assert!(is_workflow_attr("#[workflow()]"));
+        assert!(!is_workflow_attr("#[activity]"));
+        assert!(!is_workflow_attr("#[derive(Debug)]"));
+        assert!(!is_workflow_attr("// #[workflow]"));
+    }
+
+    #[test]
+    fn extract_fn_name_handles_visibility_and_async() {
+        assert_eq!(
+            extract_fn_name("async fn my_wf("),
+            Some("my_wf".to_string())
+        );
+        assert_eq!(
+            extract_fn_name("pub async fn billing("),
+            Some("billing".to_string())
+        );
+        assert_eq!(
+            extract_fn_name("pub(crate) async fn inner("),
+            Some("inner".to_string())
+        );
+        assert_eq!(extract_fn_name("let x = 1;"), None);
+    }
+
+    #[test]
+    fn parse_suppression_comment_requires_quoted_reason() {
+        assert_eq!(
+            parse_suppression_comment("DET001", "// harvest-suppress: DET001 \"safe here\""),
+            Some("safe here".to_string())
+        );
+        // No reason → None
+        assert_eq!(
+            parse_suppression_comment("DET001", "// harvest-suppress: DET001"),
+            None
+        );
+        // Empty reason → None
+        assert_eq!(
+            parse_suppression_comment("DET001", "// harvest-suppress: DET001 \"\""),
+            None
+        );
+        // Wrong rule → None
+        assert_eq!(
+            parse_suppression_comment("DET002", "// harvest-suppress: DET001 \"reason\""),
+            None
+        );
+    }
+
+    #[test]
+    fn strip_line_comment_removes_trailing_comment() {
+        assert_eq!(strip_line_comment("let x = 1; // comment"), "let x = 1; ");
+        assert_eq!(strip_line_comment("let x = 1;"), "let x = 1;");
+        assert_eq!(strip_line_comment("// full comment"), "");
+    }
+
+    #[test]
+    fn check_source_empty_source_produces_no_findings() {
+        let report = check_source("", "empty.rs");
+        assert!(report.findings.is_empty());
+        assert!(report.suppressions.is_empty());
+    }
+
+    #[test]
+    fn check_source_no_workflow_annotation_produces_no_findings() {
+        let src = "async fn foo() { let _ = std::time::SystemTime::now(); }\n";
+        let report = check_source(src, "test.rs");
+        assert!(report.findings.is_empty());
+    }
+}

--- a/autumn-harvest/src/lib.rs
+++ b/autumn-harvest/src/lib.rs
@@ -36,6 +36,8 @@ pub mod dag_linter;
 pub mod dag_profiler;
 #[cfg(any(test, feature = "testing"))]
 pub mod dag_simulator;
+/// Deterministic workflow guardrails: static source-level check for replay-breaking patterns.
+pub mod det_check;
 pub mod diagnostic;
 pub mod error;
 pub mod event;
@@ -137,6 +139,10 @@ pub use dag_linter::{
 pub use dag_profiler::{DagProfile, DagProfiler, ProfilerEvent, ProfilerEventKind};
 #[cfg(any(test, feature = "testing"))]
 pub use dag_simulator::{DagSimulator, DagSimulatorResult};
+pub use det_check::{
+    DetCheckReport, DetFinding, DetLocation, DetSeverity, DetSuppression, check_dir, check_file,
+    check_source,
+};
 pub use diagnostic::{DiagnosticReport, SimulatorResultExt};
 pub use error::{HarvestError, HarvestResult, TimeoutType};
 pub use event::WorkflowEvent;

--- a/autumn-harvest/tests/det_check_tests.rs
+++ b/autumn-harvest/tests/det_check_tests.rs
@@ -631,10 +631,8 @@ fn string_literal_not_flagged_as_violation() {
 #[test]
 fn same_line_suppression_works() {
     // Suppression comment placed on the SAME line as the violation (trailing comment).
-    let src = format!(
-        "#[workflow]\nasync fn test_wf(ctx: &WorkflowContext) -> Result<(), String> {{\n    let _t = std::time::SystemTime::now(); // harvest-suppress: DET001 \"same-line reason\"\n    Ok(())\n}}\n"
-    );
-    let report = check_source(&src, "test.rs");
+    let src = "#[workflow]\nasync fn test_wf(ctx: &WorkflowContext) -> Result<(), String> {\n    let _t = std::time::SystemTime::now(); // harvest-suppress: DET001 \"same-line reason\"\n    Ok(())\n}\n";
+    let report = check_source(src, "test.rs");
     assert!(
         !report.has_hard_blockers(),
         "same-line suppression must suppress the finding"

--- a/autumn-harvest/tests/det_check_tests.rs
+++ b/autumn-harvest/tests/det_check_tests.rs
@@ -125,6 +125,16 @@ fn det003_flags_uuid_new_v7() {
 }
 
 #[test]
+fn det003_flags_uuid_now_v7() {
+    let src = wf("let _id = Uuid::now_v7();");
+    let report = check_source(&src, "test.rs");
+    assert!(
+        report.findings.iter().any(|f| f.rule_id == "DET003"),
+        "Uuid::now_v7() uses current system time and must be flagged as DET003"
+    );
+}
+
+#[test]
 fn det003_is_hard_blocker() {
     let src = wf("let _id = uuid::Uuid::new_v4();");
     let report = check_source(&src, "test.rs");
@@ -640,6 +650,24 @@ fn same_line_suppression_works() {
     assert!(
         !report.suppressions.is_empty(),
         "same-line suppression must appear in report.suppressions"
+    );
+}
+
+#[test]
+fn inline_suppression_does_not_carry_to_next_line() {
+    // A trailing `// harvest-suppress:` on line N must NOT suppress a violation
+    // on line N+1 — it is scoped to the same line only.
+    let src = wf(
+        "let _a = std::time::SystemTime::now(); // harvest-suppress: DET001 \"first\"\n    let _b = std::time::SystemTime::now();",
+    );
+    let report = check_source(&src, "test.rs");
+    assert!(
+        report.has_hard_blockers(),
+        "second SystemTime::now() on the next line must still be a hard blocker"
+    );
+    assert!(
+        !report.suppressions.is_empty(),
+        "the first line's inline suppression must still be recorded"
     );
 }
 

--- a/autumn-harvest/tests/det_check_tests.rs
+++ b/autumn-harvest/tests/det_check_tests.rs
@@ -1,0 +1,621 @@
+//! Red-phase tests for `det_check` — deterministic workflow guardrails.
+//!
+//! These tests drive the design and must all pass after the green phase.
+//! Run with:
+//!   cargo test -p autumn-harvest --test det_check_tests --no-default-features
+
+use autumn_harvest::det_check::{DetSeverity, check_source};
+
+// ── helpers ────────────────────────────────────────────────────────────────
+
+/// Wrap an expression in a minimal `#[workflow]` function body.
+fn wf(body: &str) -> String {
+    format!(
+        "#[workflow]\nasync fn test_wf(ctx: &WorkflowContext) -> Result<(), String> {{\n    {body}\n    Ok(())\n}}\n"
+    )
+}
+
+/// Wrap an expression in a `#[activity]` function body (must NOT be flagged).
+fn act(body: &str) -> String {
+    format!(
+        "#[activity(start_to_close = \"30s\")]\nasync fn test_act(_ctx: &ActivityContext) -> Result<(), String> {{\n    {body}\n    Ok(())\n}}\n"
+    )
+}
+
+// ── DET001: wall-clock time ────────────────────────────────────────────────
+
+#[test]
+fn det001_flags_system_time_now() {
+    let src = wf("let _t = std::time::SystemTime::now();");
+    let report = check_source(&src, "test.rs");
+    assert!(
+        report.findings.iter().any(|f| f.rule_id == "DET001"),
+        "expected DET001 finding, got: {report:?}"
+    );
+}
+
+#[test]
+fn det001_flags_instant_now() {
+    let src = wf("let _t = std::time::Instant::now();");
+    let report = check_source(&src, "test.rs");
+    assert!(report.findings.iter().any(|f| f.rule_id == "DET001"));
+}
+
+#[test]
+fn det001_flags_chrono_utc_now() {
+    let src = wf("let _t = chrono::Utc::now();");
+    let report = check_source(&src, "test.rs");
+    assert!(report.findings.iter().any(|f| f.rule_id == "DET001"));
+}
+
+#[test]
+fn det001_flags_chrono_local_now() {
+    let src = wf("let _t = chrono::Local::now();");
+    let report = check_source(&src, "test.rs");
+    assert!(report.findings.iter().any(|f| f.rule_id == "DET001"));
+}
+
+#[test]
+fn det001_is_hard_blocker() {
+    let src = wf("let _t = std::time::SystemTime::now();");
+    let report = check_source(&src, "test.rs");
+    let finding = report
+        .findings
+        .iter()
+        .find(|f| f.rule_id == "DET001")
+        .unwrap();
+    assert!(
+        matches!(finding.severity, DetSeverity::Error),
+        "DET001 must be Error severity"
+    );
+}
+
+// ── DET002: randomness ─────────────────────────────────────────────────────
+
+#[test]
+fn det002_flags_rand_random() {
+    let src = wf("let _n: u64 = rand::random();");
+    let report = check_source(&src, "test.rs");
+    assert!(report.findings.iter().any(|f| f.rule_id == "DET002"));
+}
+
+#[test]
+fn det002_flags_thread_rng() {
+    let src = wf("let _rng = rand::thread_rng();");
+    let report = check_source(&src, "test.rs");
+    assert!(report.findings.iter().any(|f| f.rule_id == "DET002"));
+}
+
+#[test]
+fn det002_flags_os_rng() {
+    let src = wf("let _rng = rand::rngs::OsRng;");
+    let report = check_source(&src, "test.rs");
+    assert!(report.findings.iter().any(|f| f.rule_id == "DET002"));
+}
+
+#[test]
+fn det002_is_hard_blocker() {
+    let src = wf("let _n: u64 = rand::random();");
+    let report = check_source(&src, "test.rs");
+    let finding = report
+        .findings
+        .iter()
+        .find(|f| f.rule_id == "DET002")
+        .unwrap();
+    assert!(matches!(finding.severity, DetSeverity::Error));
+}
+
+// ── DET003: UUID generation ────────────────────────────────────────────────
+
+#[test]
+fn det003_flags_uuid_new_v4() {
+    let src = wf("let _id = uuid::Uuid::new_v4();");
+    let report = check_source(&src, "test.rs");
+    assert!(
+        report.findings.iter().any(|f| f.rule_id == "DET003"),
+        "expected DET003, got: {report:?}"
+    );
+}
+
+#[test]
+fn det003_flags_uuid_new_v7() {
+    let src = wf("let _id = Uuid::new_v7(ts);");
+    let report = check_source(&src, "test.rs");
+    assert!(report.findings.iter().any(|f| f.rule_id == "DET003"));
+}
+
+#[test]
+fn det003_is_hard_blocker() {
+    let src = wf("let _id = uuid::Uuid::new_v4();");
+    let report = check_source(&src, "test.rs");
+    let finding = report
+        .findings
+        .iter()
+        .find(|f| f.rule_id == "DET003")
+        .unwrap();
+    assert!(matches!(finding.severity, DetSeverity::Error));
+}
+
+// ── DET004: environment reads ──────────────────────────────────────────────
+
+#[test]
+fn det004_flags_env_var() {
+    let src = wf("let _v = std::env::var(\"KEY\").unwrap();");
+    let report = check_source(&src, "test.rs");
+    assert!(report.findings.iter().any(|f| f.rule_id == "DET004"));
+}
+
+#[test]
+fn det004_flags_env_var_shorthand() {
+    let src = wf("let _v = env::var(\"KEY\").unwrap();");
+    let report = check_source(&src, "test.rs");
+    assert!(report.findings.iter().any(|f| f.rule_id == "DET004"));
+}
+
+#[test]
+fn det004_flags_env_args() {
+    let src = wf("let _a = std::env::args().collect::<Vec<_>>();");
+    let report = check_source(&src, "test.rs");
+    assert!(report.findings.iter().any(|f| f.rule_id == "DET004"));
+}
+
+#[test]
+fn det004_is_hard_blocker() {
+    let src = wf("let _v = std::env::var(\"KEY\").unwrap();");
+    let report = check_source(&src, "test.rs");
+    let finding = report
+        .findings
+        .iter()
+        .find(|f| f.rule_id == "DET004")
+        .unwrap();
+    assert!(matches!(finding.severity, DetSeverity::Error));
+}
+
+// ── DET005: process-state reads ────────────────────────────────────────────
+
+#[test]
+fn det005_flags_process_id() {
+    let src = wf("let _pid = std::process::id();");
+    let report = check_source(&src, "test.rs");
+    assert!(report.findings.iter().any(|f| f.rule_id == "DET005"));
+}
+
+#[test]
+fn det005_is_warning_not_error() {
+    let src = wf("let _pid = std::process::id();");
+    let report = check_source(&src, "test.rs");
+    let finding = report
+        .findings
+        .iter()
+        .find(|f| f.rule_id == "DET005")
+        .unwrap();
+    assert!(
+        matches!(finding.severity, DetSeverity::Warning),
+        "DET005 should be Warning severity, not Error"
+    );
+}
+
+// ── DET006: direct sleep ───────────────────────────────────────────────────
+
+#[test]
+fn det006_flags_tokio_sleep() {
+    let src = wf("tokio::time::sleep(std::time::Duration::from_secs(1)).await;");
+    let report = check_source(&src, "test.rs");
+    assert!(
+        report.findings.iter().any(|f| f.rule_id == "DET006"),
+        "expected DET006 finding, got: {report:?}"
+    );
+}
+
+#[test]
+fn det006_flags_thread_sleep() {
+    let src = wf("std::thread::sleep(std::time::Duration::from_secs(1));");
+    let report = check_source(&src, "test.rs");
+    assert!(report.findings.iter().any(|f| f.rule_id == "DET006"));
+}
+
+#[test]
+fn det006_is_hard_blocker() {
+    let src = wf("tokio::time::sleep(std::time::Duration::from_secs(1)).await;");
+    let report = check_source(&src, "test.rs");
+    let finding = report
+        .findings
+        .iter()
+        .find(|f| f.rule_id == "DET006")
+        .unwrap();
+    assert!(matches!(finding.severity, DetSeverity::Error));
+}
+
+// ── DET007: background task spawning ──────────────────────────────────────
+
+#[test]
+fn det007_flags_tokio_spawn() {
+    let src = wf("tokio::spawn(async { println!(\"oops\"); });");
+    let report = check_source(&src, "test.rs");
+    assert!(
+        report.findings.iter().any(|f| f.rule_id == "DET007"),
+        "expected DET007 finding, got: {report:?}"
+    );
+}
+
+#[test]
+fn det007_flags_thread_spawn() {
+    let src = wf("std::thread::spawn(|| println!(\"oops\"));");
+    let report = check_source(&src, "test.rs");
+    assert!(report.findings.iter().any(|f| f.rule_id == "DET007"));
+}
+
+#[test]
+fn det007_flags_spawn_blocking() {
+    let src = wf("tokio::task::spawn_blocking(|| heavy_work()).await.unwrap();");
+    let report = check_source(&src, "test.rs");
+    assert!(report.findings.iter().any(|f| f.rule_id == "DET007"));
+}
+
+#[test]
+fn det007_is_hard_blocker() {
+    let src = wf("tokio::spawn(async { });");
+    let report = check_source(&src, "test.rs");
+    let finding = report
+        .findings
+        .iter()
+        .find(|f| f.rule_id == "DET007")
+        .unwrap();
+    assert!(matches!(finding.severity, DetSeverity::Error));
+}
+
+// ── DET008: direct I/O ────────────────────────────────────────────────────
+
+#[test]
+fn det008_flags_std_fs_read() {
+    let src = wf("let _data = std::fs::read(\"/etc/passwd\").unwrap();");
+    let report = check_source(&src, "test.rs");
+    assert!(
+        report.findings.iter().any(|f| f.rule_id == "DET008"),
+        "expected DET008 finding, got: {report:?}"
+    );
+}
+
+#[test]
+fn det008_flags_std_fs_write() {
+    let src = wf("std::fs::write(\"/tmp/out\", b\"data\").unwrap();");
+    let report = check_source(&src, "test.rs");
+    assert!(report.findings.iter().any(|f| f.rule_id == "DET008"));
+}
+
+#[test]
+fn det008_flags_file_open() {
+    let src = wf("let _f = std::fs::File::open(\"/etc/hosts\").unwrap();");
+    let report = check_source(&src, "test.rs");
+    assert!(report.findings.iter().any(|f| f.rule_id == "DET008"));
+}
+
+#[test]
+fn det008_flags_reqwest() {
+    let src = wf("let _resp = reqwest::get(\"http://example.com\").await.unwrap();");
+    let report = check_source(&src, "test.rs");
+    assert!(report.findings.iter().any(|f| f.rule_id == "DET008"));
+}
+
+#[test]
+fn det008_flags_tcp_stream() {
+    let src = wf("let _conn = std::net::TcpStream::connect(\"127.0.0.1:8080\").unwrap();");
+    let report = check_source(&src, "test.rs");
+    assert!(report.findings.iter().any(|f| f.rule_id == "DET008"));
+}
+
+#[test]
+fn det008_is_hard_blocker() {
+    let src = wf("let _data = std::fs::read(\"/etc/passwd\").unwrap();");
+    let report = check_source(&src, "test.rs");
+    let finding = report
+        .findings
+        .iter()
+        .find(|f| f.rule_id == "DET008")
+        .unwrap();
+    assert!(matches!(finding.severity, DetSeverity::Error));
+}
+
+// ── clean code produces no findings ───────────────────────────────────────
+
+#[test]
+fn clean_workflow_has_no_findings() {
+    let src = wf(r#"
+    let result = ctx.execute_activity_raw("my_act", serde_json::json!({}), "default").await?;
+    ctx.timer("pause", 30).await?;
+"#);
+    let report = check_source(&src, "test.rs");
+    assert!(
+        report.findings.is_empty(),
+        "clean workflow should have no findings, got: {report:?}"
+    );
+}
+
+#[test]
+fn activity_bodies_are_not_flagged() {
+    // Direct I/O is fine inside an activity — the checker must NOT flag it
+    let src = act("let _data = std::fs::read(\"/tmp/data\").unwrap();");
+    let report = check_source(&src, "test.rs");
+    assert!(
+        report.findings.is_empty(),
+        "activity bodies must not be flagged, got: {report:?}"
+    );
+}
+
+#[test]
+fn non_annotated_functions_are_not_flagged() {
+    let src = "async fn helper() { let _ = std::time::SystemTime::now(); }\n";
+    let report = check_source(src, "test.rs");
+    assert!(
+        report.findings.is_empty(),
+        "non-workflow functions must not be flagged, got: {report:?}"
+    );
+}
+
+// ── finding metadata ───────────────────────────────────────────────────────
+
+#[test]
+fn finding_carries_workflow_name() {
+    let src = wf("let _t = std::time::SystemTime::now();");
+    let report = check_source(&src, "test.rs");
+    let finding = report
+        .findings
+        .iter()
+        .find(|f| f.rule_id == "DET001")
+        .unwrap();
+    assert_eq!(
+        finding.workflow_name.as_deref(),
+        Some("test_wf"),
+        "finding must carry the workflow function name"
+    );
+}
+
+#[test]
+fn finding_carries_source_location() {
+    let src = wf("let _t = std::time::SystemTime::now();");
+    let report = check_source(&src, "test.rs");
+    let finding = report
+        .findings
+        .iter()
+        .find(|f| f.rule_id == "DET001")
+        .unwrap();
+    let loc = finding
+        .location
+        .as_ref()
+        .expect("finding must have a source location");
+    assert_eq!(loc.file, "test.rs");
+    assert!(loc.line > 0, "line must be non-zero");
+}
+
+#[test]
+fn finding_carries_alternative() {
+    let src = wf("let _t = std::time::SystemTime::now();");
+    let report = check_source(&src, "test.rs");
+    let finding = report
+        .findings
+        .iter()
+        .find(|f| f.rule_id == "DET001")
+        .unwrap();
+    assert!(
+        !finding.alternative.is_empty(),
+        "finding must carry a non-empty alternative suggestion"
+    );
+}
+
+#[test]
+fn finding_carries_message() {
+    let src = wf("let _t = std::time::SystemTime::now();");
+    let report = check_source(&src, "test.rs");
+    let finding = report
+        .findings
+        .iter()
+        .find(|f| f.rule_id == "DET001")
+        .unwrap();
+    assert!(!finding.message.is_empty());
+}
+
+// ── report aggregation ─────────────────────────────────────────────────────
+
+#[test]
+fn report_has_hard_blockers_when_error_findings_exist() {
+    let src = wf("let _t = std::time::SystemTime::now();");
+    let report = check_source(&src, "test.rs");
+    assert!(report.has_hard_blockers());
+}
+
+#[test]
+fn report_passes_when_only_warnings_exist() {
+    let src = wf("let _pid = std::process::id();");
+    let report = check_source(&src, "test.rs");
+    // DET005 is a Warning, not an Error, so it must not be a hard blocker
+    assert!(
+        !report.has_hard_blockers(),
+        "warnings alone must not block CI"
+    );
+}
+
+#[test]
+fn report_passes_for_clean_workflow() {
+    let src = wf("ctx.timer(\"t\", 10).await?;");
+    let report = check_source(&src, "test.rs");
+    assert!(!report.has_hard_blockers());
+}
+
+// ── suppression mechanism ──────────────────────────────────────────────────
+
+#[test]
+fn suppressed_finding_is_not_a_hard_blocker() {
+    let src = format!(
+        "#[workflow]\nasync fn test_wf(ctx: &WorkflowContext) -> Result<(), String> {{\n    // harvest-suppress: DET001 \"recorded in signal payload\"\n    let _t = std::time::SystemTime::now();\n    Ok(())\n}}\n"
+    );
+    let report = check_source(&src, "test.rs");
+    assert!(
+        !report.has_hard_blockers(),
+        "suppressed DET001 must not be a hard blocker"
+    );
+}
+
+#[test]
+fn suppression_requires_reason_string() {
+    // Suppression without a quoted reason is not valid and does NOT suppress
+    let src = format!(
+        "#[workflow]\nasync fn test_wf(ctx: &WorkflowContext) -> Result<(), String> {{\n    // harvest-suppress: DET001\n    let _t = std::time::SystemTime::now();\n    Ok(())\n}}\n"
+    );
+    let report = check_source(&src, "test.rs");
+    assert!(
+        report.has_hard_blockers(),
+        "suppression without a reason must not suppress the finding"
+    );
+}
+
+#[test]
+fn suppression_is_reported_in_output() {
+    let src = format!(
+        "#[workflow]\nasync fn test_wf(ctx: &WorkflowContext) -> Result<(), String> {{\n    // harvest-suppress: DET001 \"recorded in signal payload\"\n    let _t = std::time::SystemTime::now();\n    Ok(())\n}}\n"
+    );
+    let report = check_source(&src, "test.rs");
+    assert!(
+        !report.suppressions.is_empty(),
+        "active suppressions must appear in report output"
+    );
+    assert_eq!(report.suppressions[0].rule_id, "DET001");
+    assert!(!report.suppressions[0].reason.is_empty());
+}
+
+#[test]
+fn suppression_only_applies_to_its_rule_id() {
+    // Suppress DET001 but DET003 is also present — DET003 must still block
+    let src = format!(
+        "#[workflow]\nasync fn test_wf(ctx: &WorkflowContext) -> Result<(), String> {{\n    // harvest-suppress: DET001 \"known safe\"\n    let _t = std::time::SystemTime::now();\n    let _id = uuid::Uuid::new_v4();\n    Ok(())\n}}\n"
+    );
+    let report = check_source(&src, "test.rs");
+    assert!(
+        report.has_hard_blockers(),
+        "DET003 is not suppressed and must still block"
+    );
+}
+
+// ── multiple violations ────────────────────────────────────────────────────
+
+#[test]
+fn multiple_violations_are_all_reported() {
+    let src = wf(r#"
+    let _t = std::time::SystemTime::now();
+    let _n: u64 = rand::random();
+    let _id = uuid::Uuid::new_v4();
+"#);
+    let report = check_source(&src, "test.rs");
+    let rule_ids: Vec<&str> = report.findings.iter().map(|f| f.rule_id).collect();
+    assert!(rule_ids.contains(&"DET001"), "DET001 must be reported");
+    assert!(rule_ids.contains(&"DET002"), "DET002 must be reported");
+    assert!(rule_ids.contains(&"DET003"), "DET003 must be reported");
+}
+
+// ── examples pass with zero hard blockers ─────────────────────────────────
+
+#[test]
+fn quickstart_example_has_no_hard_blockers() {
+    let src = include_str!("../../examples/quickstart/src/main.rs");
+    let report = check_source(src, "examples/quickstart/src/main.rs");
+    assert!(
+        !report.has_hard_blockers(),
+        "quickstart example must pass with zero hard blockers, findings: {report:?}"
+    );
+}
+
+#[test]
+fn standalone_runner_workflows_have_no_hard_blockers() {
+    let src = include_str!("../../examples/standalone-runner/src/workflows.rs");
+    let report = check_source(src, "examples/standalone-runner/src/workflows.rs");
+    assert!(
+        !report.has_hard_blockers(),
+        "standalone-runner workflows must pass with zero hard blockers, findings: {report:?}"
+    );
+}
+
+#[test]
+fn billing_example_workflows_have_no_hard_blockers() {
+    let src = include_str!("../../examples/billing-autumn-web/src/workflows.rs");
+    let report = check_source(src, "examples/billing-autumn-web/src/workflows.rs");
+    assert!(
+        !report.has_hard_blockers(),
+        "billing example workflows must pass with zero hard blockers, findings: {report:?}"
+    );
+}
+
+// ── regression fixtures ────────────────────────────────────────────────────
+// These fixtures each embed exactly one violation of the target rule.
+// They serve as regression tests: if the rule is removed or its ID changes,
+// these fail, proving the catalog is complete.
+
+#[test]
+fn regression_det001_wall_clock() {
+    let report = check_source(
+        "#[workflow]\nasync fn wf(ctx: &WorkflowContext) -> Result<(), String> {\n    let _ = chrono::Utc::now();\n    Ok(())\n}\n",
+        "fixtures/det001.rs",
+    );
+    assert!(report.findings.iter().any(|f| f.rule_id == "DET001"));
+}
+
+#[test]
+fn regression_det002_randomness() {
+    let report = check_source(
+        "#[workflow]\nasync fn wf(ctx: &WorkflowContext) -> Result<(), String> {\n    let _ = rand::random::<u64>();\n    Ok(())\n}\n",
+        "fixtures/det002.rs",
+    );
+    assert!(report.findings.iter().any(|f| f.rule_id == "DET002"));
+}
+
+#[test]
+fn regression_det003_uuid() {
+    let report = check_source(
+        "#[workflow]\nasync fn wf(ctx: &WorkflowContext) -> Result<(), String> {\n    let _ = Uuid::new_v4();\n    Ok(())\n}\n",
+        "fixtures/det003.rs",
+    );
+    assert!(report.findings.iter().any(|f| f.rule_id == "DET003"));
+}
+
+#[test]
+fn regression_det004_env_read() {
+    let report = check_source(
+        "#[workflow]\nasync fn wf(ctx: &WorkflowContext) -> Result<(), String> {\n    let _ = std::env::var(\"X\");\n    Ok(())\n}\n",
+        "fixtures/det004.rs",
+    );
+    assert!(report.findings.iter().any(|f| f.rule_id == "DET004"));
+}
+
+#[test]
+fn regression_det005_process_read() {
+    let report = check_source(
+        "#[workflow]\nasync fn wf(ctx: &WorkflowContext) -> Result<(), String> {\n    let _ = std::process::id();\n    Ok(())\n}\n",
+        "fixtures/det005.rs",
+    );
+    assert!(report.findings.iter().any(|f| f.rule_id == "DET005"));
+}
+
+#[test]
+fn regression_det006_direct_sleep() {
+    let report = check_source(
+        "#[workflow]\nasync fn wf(ctx: &WorkflowContext) -> Result<(), String> {\n    tokio::time::sleep(std::time::Duration::from_secs(1)).await;\n    Ok(())\n}\n",
+        "fixtures/det006.rs",
+    );
+    assert!(report.findings.iter().any(|f| f.rule_id == "DET006"));
+}
+
+#[test]
+fn regression_det007_task_spawn() {
+    let report = check_source(
+        "#[workflow]\nasync fn wf(ctx: &WorkflowContext) -> Result<(), String> {\n    tokio::spawn(async {});\n    Ok(())\n}\n",
+        "fixtures/det007.rs",
+    );
+    assert!(report.findings.iter().any(|f| f.rule_id == "DET007"));
+}
+
+#[test]
+fn regression_det008_direct_io() {
+    let report = check_source(
+        "#[workflow]\nasync fn wf(ctx: &WorkflowContext) -> Result<(), String> {\n    let _ = std::fs::read(\"/tmp/x\");\n    Ok(())\n}\n",
+        "fixtures/det008.rs",
+    );
+    assert!(report.findings.iter().any(|f| f.rule_id == "DET008"));
+}

--- a/autumn-harvest/tests/det_check_tests.rs
+++ b/autumn-harvest/tests/det_check_tests.rs
@@ -600,6 +600,51 @@ fn billing_example_workflows_have_no_hard_blockers() {
     );
 }
 
+// ── single-line workflow body ──────────────────────────────────────────────
+
+#[test]
+fn single_line_workflow_body_is_scanned() {
+    // Compact single-line form: `fn wf() { stmt }` — body after `{` must be checked.
+    let src = "#[workflow]\nasync fn wf(ctx: &WorkflowContext) -> Result<(), String> { let _ = std::time::SystemTime::now(); Ok(()) }\n";
+    let report = check_source(src, "test.rs");
+    assert!(
+        report.findings.iter().any(|f| f.rule_id == "DET001"),
+        "single-line workflow body must be scanned, got: {report:?}"
+    );
+}
+
+// ── string literal false-positive guard ───────────────────────────────────
+
+#[test]
+fn string_literal_not_flagged_as_violation() {
+    // A string value that happens to contain a rule pattern must not cause a finding.
+    let src = wf(r#"let msg = "std::fs::read is documented here";"#);
+    let report = check_source(&src, "test.rs");
+    assert!(
+        !report.has_hard_blockers(),
+        "pattern inside string literal must not cause a hard blocker, got: {report:?}"
+    );
+}
+
+// ── same-line suppression ──────────────────────────────────────────────────
+
+#[test]
+fn same_line_suppression_works() {
+    // Suppression comment placed on the SAME line as the violation (trailing comment).
+    let src = format!(
+        "#[workflow]\nasync fn test_wf(ctx: &WorkflowContext) -> Result<(), String> {{\n    let _t = std::time::SystemTime::now(); // harvest-suppress: DET001 \"same-line reason\"\n    Ok(())\n}}\n"
+    );
+    let report = check_source(&src, "test.rs");
+    assert!(
+        !report.has_hard_blockers(),
+        "same-line suppression must suppress the finding"
+    );
+    assert!(
+        !report.suppressions.is_empty(),
+        "same-line suppression must appear in report.suppressions"
+    );
+}
+
 // ── regression fixtures ────────────────────────────────────────────────────
 // These fixtures each embed exactly one violation of the target rule.
 // They serve as regression tests: if the rule is removed or its ID changes,

--- a/autumn-harvest/tests/det_check_tests.rs
+++ b/autumn-harvest/tests/det_check_tests.rs
@@ -671,6 +671,30 @@ fn inline_suppression_does_not_carry_to_next_line() {
     );
 }
 
+// ── block comment handling ────────────────────────────────────────────────
+
+#[test]
+fn block_comment_brace_does_not_end_body_early() {
+    // A `}` inside `/* */` must not terminate workflow body extraction early.
+    let src = wf("let x = /* } */ 5;\n    let _ = std::time::SystemTime::now();");
+    let report = check_source(&src, "test.rs");
+    assert!(
+        report.has_hard_blockers(),
+        "violation after a block-comment `}}` must still be flagged"
+    );
+}
+
+#[test]
+fn block_comment_pattern_is_not_flagged() {
+    // A DET pattern inside `/* */` must not produce a finding.
+    let src = wf("let x = /* std::fs::read */ 5;");
+    let report = check_source(&src, "test.rs");
+    assert!(
+        !report.has_hard_blockers(),
+        "DET pattern inside block comment must not be flagged"
+    );
+}
+
 // ── regression fixtures ────────────────────────────────────────────────────
 // These fixtures each embed exactly one violation of the target rule.
 // They serve as regression tests: if the rule is removed or its ID changes,

--- a/autumn-harvest/tests/det_check_tests.rs
+++ b/autumn-harvest/tests/det_check_tests.rs
@@ -2,7 +2,7 @@
 //!
 //! These tests drive the design and must all pass after the green phase.
 //! Run with:
-//!   cargo test -p autumn-harvest --test det_check_tests --no-default-features
+//!   cargo test -p autumn-harvest --test `det_check_tests` --no-default-features
 
 use autumn_harvest::det_check::{DetSeverity, check_source};
 
@@ -352,6 +352,24 @@ fn non_annotated_functions_are_not_flagged() {
     );
 }
 
+#[test]
+fn workflow_body_extraction_ignores_braces_inside_string_and_char_literals() {
+    let src = r#"
+#[workflow]
+async fn test_wf(ctx: &WorkflowContext) -> Result<(), String> {
+    let _string_marker = "}";
+    let _char_marker = '}';
+    let _t = std::time::SystemTime::now();
+    Ok(())
+}
+"#;
+    let report = check_source(src, "test.rs");
+    assert!(
+        report.findings.iter().any(|f| f.rule_id == "DET001"),
+        "literal braces must not truncate workflow body scanning, got: {report:?}"
+    );
+}
+
 // ── finding metadata ───────────────────────────────────────────────────────
 
 #[test]
@@ -445,10 +463,15 @@ fn report_passes_for_clean_workflow() {
 
 #[test]
 fn suppressed_finding_is_not_a_hard_blocker() {
-    let src = format!(
-        "#[workflow]\nasync fn test_wf(ctx: &WorkflowContext) -> Result<(), String> {{\n    // harvest-suppress: DET001 \"recorded in signal payload\"\n    let _t = std::time::SystemTime::now();\n    Ok(())\n}}\n"
-    );
-    let report = check_source(&src, "test.rs");
+    let src = r#"
+#[workflow]
+async fn test_wf(ctx: &WorkflowContext) -> Result<(), String> {
+    // harvest-suppress: DET001 "recorded in signal payload"
+    let _t = std::time::SystemTime::now();
+    Ok(())
+}
+"#;
+    let report = check_source(src, "test.rs");
     assert!(
         !report.has_hard_blockers(),
         "suppressed DET001 must not be a hard blocker"
@@ -456,12 +479,35 @@ fn suppressed_finding_is_not_a_hard_blocker() {
 }
 
 #[test]
+fn same_line_suppression_is_not_a_hard_blocker() {
+    let src = r#"
+#[workflow]
+async fn test_wf(ctx: &WorkflowContext) -> Result<(), String> {
+    let _t = std::time::SystemTime::now(); // harvest-suppress: DET001 "recorded in signal payload"
+    Ok(())
+}
+"#;
+    let report = check_source(src, "test.rs");
+    assert!(
+        !report.has_hard_blockers(),
+        "same-line harvest-suppress comment must suppress DET001, got: {report:?}"
+    );
+    assert_eq!(report.suppressions.len(), 1);
+    assert_eq!(report.suppressions[0].rule_id, "DET001");
+}
+
+#[test]
 fn suppression_requires_reason_string() {
     // Suppression without a quoted reason is not valid and does NOT suppress
-    let src = format!(
-        "#[workflow]\nasync fn test_wf(ctx: &WorkflowContext) -> Result<(), String> {{\n    // harvest-suppress: DET001\n    let _t = std::time::SystemTime::now();\n    Ok(())\n}}\n"
-    );
-    let report = check_source(&src, "test.rs");
+    let src = r"
+#[workflow]
+async fn test_wf(ctx: &WorkflowContext) -> Result<(), String> {
+    // harvest-suppress: DET001
+    let _t = std::time::SystemTime::now();
+    Ok(())
+}
+";
+    let report = check_source(src, "test.rs");
     assert!(
         report.has_hard_blockers(),
         "suppression without a reason must not suppress the finding"
@@ -470,10 +516,15 @@ fn suppression_requires_reason_string() {
 
 #[test]
 fn suppression_is_reported_in_output() {
-    let src = format!(
-        "#[workflow]\nasync fn test_wf(ctx: &WorkflowContext) -> Result<(), String> {{\n    // harvest-suppress: DET001 \"recorded in signal payload\"\n    let _t = std::time::SystemTime::now();\n    Ok(())\n}}\n"
-    );
-    let report = check_source(&src, "test.rs");
+    let src = r#"
+#[workflow]
+async fn test_wf(ctx: &WorkflowContext) -> Result<(), String> {
+    // harvest-suppress: DET001 "recorded in signal payload"
+    let _t = std::time::SystemTime::now();
+    Ok(())
+}
+"#;
+    let report = check_source(src, "test.rs");
     assert!(
         !report.suppressions.is_empty(),
         "active suppressions must appear in report output"
@@ -485,10 +536,16 @@ fn suppression_is_reported_in_output() {
 #[test]
 fn suppression_only_applies_to_its_rule_id() {
     // Suppress DET001 but DET003 is also present — DET003 must still block
-    let src = format!(
-        "#[workflow]\nasync fn test_wf(ctx: &WorkflowContext) -> Result<(), String> {{\n    // harvest-suppress: DET001 \"known safe\"\n    let _t = std::time::SystemTime::now();\n    let _id = uuid::Uuid::new_v4();\n    Ok(())\n}}\n"
-    );
-    let report = check_source(&src, "test.rs");
+    let src = r#"
+#[workflow]
+async fn test_wf(ctx: &WorkflowContext) -> Result<(), String> {
+    // harvest-suppress: DET001 "known safe"
+    let _t = std::time::SystemTime::now();
+    let _id = uuid::Uuid::new_v4();
+    Ok(())
+}
+"#;
+    let report = check_source(src, "test.rs");
     assert!(
         report.has_hard_blockers(),
         "DET003 is not suppressed and must still block"
@@ -499,11 +556,11 @@ fn suppression_only_applies_to_its_rule_id() {
 
 #[test]
 fn multiple_violations_are_all_reported() {
-    let src = wf(r#"
+    let src = wf(r"
     let _t = std::time::SystemTime::now();
     let _n: u64 = rand::random();
     let _id = uuid::Uuid::new_v4();
-"#);
+");
     let report = check_source(&src, "test.rs");
     let rule_ids: Vec<&str> = report.findings.iter().map(|f| f.rule_id).collect();
     assert!(rule_ids.contains(&"DET001"), "DET001 must be reported");


### PR DESCRIPTION
Implements a source-level determinism checker for `#[workflow]` functions
via TDD (red → green → refactor). The checker (`det_check` module) scans
Rust source text for eight rule families that break Harvest's deterministic
replay contract:

  DET001 Error  Wall-clock time reads (SystemTime::now, Utc::now, …)
  DET002 Error  Random number generation (rand::random, thread_rng, …)
  DET003 Error  Ad-hoc UUID generation (Uuid::new_v4, new_v7, …)
  DET004 Error  Environment / argument reads (std::env::var, env::args)
  DET005 Warn   Process-global state reads (std::process::id)
  DET006 Error  Direct sleep/timer primitives (tokio::time::sleep, …)
  DET007 Error  Background task spawning (tokio::spawn, thread::spawn, …)
  DET008 Error  Direct network/filesystem I/O (std::fs, reqwest, …)

Key design points:
- Only `#[workflow]`-annotated fn bodies are scanned; `#[activity]` bodies
  and un-annotated functions are ignored.
- Each finding carries a stable rule ID, severity, workflow name, source
  location (file + line), human-readable message, and a Harvest-shaped
  alternative.
- Hard blockers (Error severity) are reported via `DetCheckReport::has_hard_blockers`.
  Warnings alone do not block CI.
- False-positive escape hatch: `// harvest-suppress: DET001 "reason"` on
  the preceding or same line suppresses a finding. A non-empty reason
  string is required. All suppressions are reported in
  `DetCheckReport::suppressions` for auditability.
- No new WorkflowEvent variants, no migration, no macro-path changes.
- No new crate dependencies; implemented with std text analysis only.

Public API added to `autumn_harvest`:
  `check_source(source, file) -> DetCheckReport`
  `check_file(path) -> io::Result<DetCheckReport>`
  `check_dir(dir) -> io::Result<DetCheckReport>`
  `DetCheckReport`, `DetFinding`, `DetLocation`, `DetSeverity`, `DetSuppression`

Test coverage (57 tests in `tests/det_check_tests.rs`):
- One positive and one severity test per rule (DET001-DET008)
- Regression fixture per rule (catches rule-id renames / removal)
- Activity bodies not flagged, un-annotated fns not flagged
- Clean workflow produces no findings
- Finding carries workflow name, source location, alternative, message
- Suppression: suppressed → not a hard blocker, requires reason, reported
  in output, rule-scoped (suppressing DET001 leaves DET003 active)
- All three workspace examples (quickstart, standalone-runner,
  billing-autumn-web) pass with zero hard blockers

https://claude.ai/code/session_01NNa4GmnNNkwTu2ft2ghuxR