### PR TITLE
⚡ Bolt: [performance improvement] Preallocate targets vector in batch ops

### DIFF
--- a/autumn-harvest/src/batch.rs
+++ b/autumn-harvest/src/batch.rs
@@ -655,7 +655,11 @@ mod db {
         };
 
         // Walk every shard, collect targets, dispatch with bounded fan-out.
-        let mut all_targets: Vec<ExecutionId> = Vec::new();
+        // Bolt: Pre-calculate total shards to hint the initial capacity of `all_targets`.
+        // While we don't know exactly how many executions exist on each shard,
+        // pre-allocating an estimated batch size prevents continuous reallocations
+        // when concatenating results from 256 default shards.
+        let mut all_targets: Vec<ExecutionId> = Vec::with_capacity(pool.iter_shards().count() * 10);
         for (_, shard_pool) in pool.iter_shards() {
             let mut conn = shard_pool
                 .get()


### PR DESCRIPTION
💡 What: Pre-allocate the `all_targets` vector in `batch.rs` with an estimated capacity using `Vec::with_capacity(pool.iter_shards().count() * 10)` instead of `Vec::new()`.
🎯 Why: The `all_targets` vector gathers execution targets by looping over all shards (default 256). By default, `Vec::new()` creates an empty vector, leading to continuous reallocations and memory copying as `append()` is called inside the loop.
📊 Impact: Reduces heap reallocations during batch processing by providing an initial capacity estimate, reducing memory fragmentation and overhead.
🔬 Measurement: Run a batch target resolution query against a populated database and profile memory allocations or `cargo bench` if available for batch operations.

---
*PR created automatically by Jules for task [18148147835472063956](https://jules.google.com/task/18148147835472063956) started by @madmax983*