### PR TITLE
👺 Havoc: Re-entrant Deadlocks in Update Registry

### DIFF
--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -1707,18 +1707,23 @@ impl WorkflowContext {
     ///
     /// Panics if the internal update registry mutex is poisoned.
     pub fn validate_update(&self, name: &str, input: &Value) -> HarvestResult<()> {
-        let registry = self
-            .update_registry
-            .lock()
-            .expect("update_registry lock poisoned");
-        // Check existence structurally so validator errors are never confused
-        // with a missing handler, regardless of the error message text.
-        if !registry.contains(name) {
-            return Err(HarvestError::UpdateHandlerNotFound(name.to_string()));
+        let validator_opt = {
+            let registry = self
+                .update_registry
+                .lock()
+                .expect("update_registry lock poisoned");
+            // Check existence structurally so validator errors are never confused
+            // with a missing handler, regardless of the error message text.
+            if !registry.contains(name) {
+                return Err(HarvestError::UpdateHandlerNotFound(name.to_string()));
+            }
+            registry.get_validator(name)
+        };
+
+        if let Some(validator) = validator_opt {
+            validator(input).map_err(|reason| HarvestError::UpdateRejected { reason })?;
         }
-        registry
-            .validate(name, input)
-            .map_err(|reason| HarvestError::UpdateRejected { reason })
+        Ok(())
     }
 
     /// Execute an already-admitted update by `update_id`.
@@ -1763,16 +1768,16 @@ impl WorkflowContext {
         }
 
         // Live path: invoke the registered handler.
-        let future = {
+        let handler_opt = {
             let registry = self
                 .update_registry
                 .lock()
                 .expect("update_registry lock poisoned");
-            registry.invoke(name, input)
+            registry.get_handler(name)
         };
 
-        let result = match future {
-            Some(fut) => fut.await,
+        let result = match handler_opt {
+            Some(handler) => handler(input).await,
             None => Err(format!("update handler '{name}' not found")),
         };
 

--- a/autumn-harvest/src/update.rs
+++ b/autumn-harvest/src/update.rs
@@ -67,29 +67,15 @@ impl UpdateRegistry {
         self.entries.contains_key(name)
     }
 
-    /// Run the validator for `name` against `input`.
-    ///
-    /// # Errors
-    ///
-    /// - Returns `Err("update handler 'name' not found")` if `name` is unknown.
-    /// - Returns `Err(reason)` if the validator rejects.
-    pub fn validate(&self, name: &str, input: &Value) -> Result<(), String> {
-        let entry = self
-            .entries
-            .get(name)
-            .ok_or_else(|| format!("update handler '{name}' not found"))?;
-
-        if let Some(validator) = &entry.validator {
-            validator(input)?;
-        }
-        Ok(())
+    /// Returns the validator for `name`, if registered and present.
+    #[must_use]
+    pub fn get_validator(&self, name: &str) -> Option<BoxUpdateValidator> {
+        self.entries.get(name).and_then(|e| e.validator.clone())
     }
 
-    /// Invoke the handler for `name` with `input`.
-    ///
-    /// Returns `None` if `name` is not registered.
+    /// Returns the handler for `name`, if registered.
     #[must_use]
-    pub fn invoke(&self, name: &str, input: Value) -> Option<UpdateHandlerFuture> {
-        self.entries.get(name).map(|e| (e.handler)(input))
+    pub fn get_handler(&self, name: &str) -> Option<BoxUpdateHandler> {
+        self.entries.get(name).map(|e| e.handler.clone())
     }
 }

--- a/autumn-harvest/src/update.rs
+++ b/autumn-harvest/src/update.rs
@@ -67,6 +67,32 @@ impl UpdateRegistry {
         self.entries.contains_key(name)
     }
 
+    /// Run the validator for `name` against `input`.
+    ///
+    /// # Errors
+    ///
+    /// - Returns `Err("update handler 'name' not found")` if `name` is unknown.
+    /// - Returns `Err(reason)` if the validator rejects.
+    pub fn validate(&self, name: &str, input: &Value) -> Result<(), String> {
+        let entry = self
+            .entries
+            .get(name)
+            .ok_or_else(|| format!("update handler '{name}' not found"))?;
+
+        if let Some(validator) = &entry.validator {
+            validator(input)?;
+        }
+        Ok(())
+    }
+
+    /// Invoke the handler for `name` with `input`.
+    ///
+    /// Returns `None` if `name` is not registered.
+    #[must_use]
+    pub fn invoke(&self, name: &str, input: Value) -> Option<UpdateHandlerFuture> {
+        self.entries.get(name).map(|e| (e.handler)(input))
+    }
+
     /// Returns the validator for `name`, if registered and present.
     #[must_use]
     pub fn get_validator(&self, name: &str) -> Option<BoxUpdateValidator> {

--- a/autumn-harvest/tests/havoc_reentrancy.rs
+++ b/autumn-harvest/tests/havoc_reentrancy.rs
@@ -1,0 +1,86 @@
+use autumn_harvest::WorkflowEvent;
+use autumn_harvest::context::WorkflowContext;
+use autumn_harvest::types::ExecutionId;
+use autumn_harvest::types::UpdateId;
+use serde_json::Value;
+use std::sync::Arc;
+use uuid::Uuid;
+
+#[test]
+fn test_update_validate_deadlock() {
+    let events = vec![WorkflowEvent::WorkflowStarted {
+        input: Value::Null,
+        timestamp: chrono::Utc::now(),
+    }];
+    let ctx = Arc::new(WorkflowContext::for_replay(
+        ExecutionId::from_uuid(Uuid::new_v4()),
+        events,
+    ));
+
+    let ctx_clone = ctx.clone();
+
+    // Validator that tries to register another update, causing a deadlock
+    let validator = move |_: &Value| {
+        // Attempt to register another update, which will try to lock update_registry
+        ctx_clone
+            .register_update_handler_no_validator("another_update", |input| async { Ok(input) });
+        Ok(())
+    };
+
+    ctx.register_update_handler("my_update", validator, |input| async { Ok(input) });
+
+    let (tx, rx) = std::sync::mpsc::channel();
+    let ctx_run = ctx;
+    std::thread::spawn(move || {
+        let result = ctx_run.validate_update("my_update", &Value::Null);
+        tx.send(result).unwrap();
+    });
+
+    match rx.recv_timeout(std::time::Duration::from_secs(2)) {
+        Ok(res) => println!("Validation finished: {res:?}"),
+        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+            panic!("Deadlock!");
+        }
+        Err(e) => panic!("Thread error: {e:?}"),
+    }
+}
+
+#[tokio::test]
+async fn test_update_handler_deadlock() {
+    let events = vec![WorkflowEvent::WorkflowStarted {
+        input: Value::Null,
+        timestamp: chrono::Utc::now(),
+    }];
+    let ctx = Arc::new(WorkflowContext::for_replay(
+        ExecutionId::from_uuid(Uuid::new_v4()),
+        events,
+    ));
+
+    let ctx_clone = ctx.clone();
+
+    // Register update handler that tries to register another update handler in the outer closure
+    ctx.register_update_handler_no_validator("my_update", move |input| {
+        ctx_clone.register_update_handler_no_validator("another_update", |i| async { Ok(i) });
+        async { Ok(input) }
+    });
+
+    let (tx, rx) = std::sync::mpsc::channel();
+    let ctx_run = ctx;
+    std::thread::spawn(move || {
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        rt.block_on(async {
+            let result = ctx_run
+                .execute_admitted_update(UpdateId::new(), "my_update", Value::Null)
+                .await;
+            tx.send(result).unwrap();
+        });
+    });
+
+    match rx.recv_timeout(std::time::Duration::from_secs(2)) {
+        Ok(res) => println!("Execution finished: {res:?}"),
+        Err(std::sync::mpsc::RecvTimeoutError::Timeout) => {
+            panic!("Deadlock!");
+        }
+        Err(e) => panic!("Thread error: {e:?}"),
+    }
+}


### PR DESCRIPTION
🧨 **The Trigger:** A user registers a closure for an update handler or validator that internally registers another update handler (or performs any operation trying to lock `update_registry`).
📉 **The Stack Trace:** Standard `Deadlock!` panic resulting from attempting to acquire a `std::sync::Mutex` that the thread already holds. 
🧪 **Reproduction:** Run `cargo test --test havoc_reentrancy`. The tests specifically craft closures that register a second update handler, forcing a re-entrant lock acquisition. Before this patch, the tests timed out and panicked. Now they pass.
😈 **Comment:** "You assumed developers would never call context functions from inside context handlers. You were wrong."

---
*PR created automatically by Jules for task [11544041846884803432](https://jules.google.com/task/11544041846884803432) started by @madmax983*