### PR TITLE
Add versioned management API contract and regression tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,36 @@ All notable changes to autumn-harvest will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Versioned management API contract** (`docs/api-contract.json`, issue #175):
+  machine-readable JSON describing every route's method, path, category,
+  `read_only` flag, request-body field schema, success/error responses,
+  pagination params, and idempotency semantics. Contract version `"1"`,
+  aligned with crate version `"0.2.0"`.
+- `management_api_request_fields()` in `autumn_harvest_plugin::api`: canonical
+  registry of request-body field names per mutating route. Compared against the
+  contract by the regression test suite; update both together when adding or
+  renaming fields.
+- Contract regression tests (`autumn-harvest-plugin/tests/contract_regression.rs`):
+  six tests assert route-set parity, required metadata fields, version/compat
+  metadata, structured `request_body` on all mutating routes, field-registry
+  parity, and read-only/method consistency.
+- CLI body-field coverage tests (`autumn-harvest-cli/tests/contract_coverage.rs`):
+  every CLI subcommand is exercised to confirm (a) it maps to a documented
+  contract route and (b) every key it sends in the request body is declared in
+  the contract's `fields` list.
+- Embedder guide `docs/api-contract-guide.md` with jq inspection recipes,
+  compatibility rules, client generation workflow, and developer update checklist.
+
+### Non-breaking
+
+This release adds documentation artefacts and test scaffolding only.  No route,
+event, or schema was removed or renamed.  Adding the contract is classified as
+non-breaking per the compatibility rules stated in `docs/api-contract.json`.
+
 ## [0.2.0] - 2026-04-27
 
 ### Added

--- a/autumn-harvest-cli/tests/contract_coverage.rs
+++ b/autumn-harvest-cli/tests/contract_coverage.rs
@@ -1,0 +1,440 @@
+/// CLI contract coverage tests.
+///
+/// Every CLI subcommand that calls the management API must map to a route that
+/// is documented in `docs/api-contract.json`.  If a CLI command maps to a path
+/// that is not in the contract, either the contract is incomplete or the CLI
+/// has drifted from the documented API surface.
+use autumn_harvest_cli::{ApiMethod, Cli};
+use clap::Parser;
+use std::collections::HashSet;
+
+const CONTRACT_JSON: &str = include_str!("../../docs/api-contract.json");
+
+/// Returns all `(METHOD, path-template)` pairs from the contract.
+fn contract_route_set() -> HashSet<(String, String)> {
+    let contract: serde_json::Value =
+        serde_json::from_str(CONTRACT_JSON).expect("docs/api-contract.json must be valid JSON");
+    contract["routes"]
+        .as_array()
+        .expect("contract.routes must be an array")
+        .iter()
+        .map(|r| {
+            (
+                r["method"].as_str().unwrap().to_string(),
+                r["path"].as_str().unwrap().to_string(),
+            )
+        })
+        .collect()
+}
+
+/// Returns the HTTP method string for an `ApiMethod`.
+fn method_str(m: &ApiMethod) -> &'static str {
+    match m {
+        ApiMethod::Get => "GET",
+        ApiMethod::Post => "POST",
+        ApiMethod::Patch => "PATCH",
+        ApiMethod::Delete => "DELETE",
+    }
+}
+
+/// Strips the query string from a path.
+fn bare_path(path: &str) -> &str {
+    path.split('?').next().unwrap_or(path)
+}
+
+/// Returns true if a concrete path (e.g. `/workflows/abc-123/cancel`) matches
+/// a contract path template (e.g. `/workflows/{id}/cancel`).
+fn path_matches_template(actual: &str, template: &str) -> bool {
+    let a: Vec<&str> = actual.trim_start_matches('/').split('/').collect();
+    let t: Vec<&str> = template.trim_start_matches('/').split('/').collect();
+    if a.len() != t.len() {
+        return false;
+    }
+    a.iter()
+        .zip(t.iter())
+        .all(|(seg, tmpl)| tmpl.starts_with('{') && tmpl.ends_with('}') || seg == tmpl)
+}
+
+/// Asserts that a CLI invocation produces an API request whose method and path
+/// are covered by the contract.
+#[track_caller]
+fn assert_covered(args: &[&str]) {
+    let all: Vec<&str> = std::iter::once("harvest").chain(args.iter().copied()).collect();
+    let cli = Cli::try_parse_from(&all)
+        .unwrap_or_else(|e| panic!("CLI args {args:?} should parse: {e}"));
+    let req = cli
+        .api_request()
+        .unwrap_or_else(|e| panic!("api_request() should succeed for {args:?}: {e}"));
+
+    let method = method_str(&req.method);
+    let path = bare_path(&req.path);
+    let routes = contract_route_set();
+
+    let found = routes
+        .iter()
+        .any(|(m, t)| m == method && path_matches_template(path, t));
+
+    assert!(
+        found,
+        "CLI command {args:?} maps to {method} {path} \
+         which is not covered by docs/api-contract.json"
+    );
+}
+
+// ── health / admin ────────────────────────────────────────────────────────────
+
+#[test]
+fn health_is_covered() {
+    assert_covered(&["health"]);
+}
+
+#[test]
+fn preflight_is_covered() {
+    assert_covered(&["preflight"]);
+}
+
+#[test]
+fn shard_health_is_covered() {
+    assert_covered(&["shard", "health"]);
+}
+
+#[test]
+fn version_usage_is_covered() {
+    assert_covered(&["version-usage"]);
+}
+
+#[test]
+fn version_gate_retirement_is_covered() {
+    assert_covered(&[
+        "version-gate-retirement",
+        "--change-id",
+        "my_gate",
+        "--min-safe-version",
+        "2",
+    ]);
+}
+
+// ── workflows ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn workflow_list_is_covered() {
+    assert_covered(&["workflow", "list"]);
+}
+
+#[test]
+fn workflow_get_is_covered() {
+    assert_covered(&["workflow", "get", "00000000-0000-0000-0000-000000000001"]);
+}
+
+#[test]
+fn workflow_stack_is_covered() {
+    assert_covered(&["workflow", "stack", "00000000-0000-0000-0000-000000000001"]);
+}
+
+#[test]
+fn workflow_children_is_covered() {
+    assert_covered(&[
+        "workflow",
+        "children",
+        "00000000-0000-0000-0000-000000000001",
+    ]);
+}
+
+#[test]
+fn workflow_start_is_covered() {
+    assert_covered(&["workflow", "start", "my_workflow"]);
+}
+
+#[test]
+fn workflow_cancel_is_covered() {
+    assert_covered(&[
+        "workflow",
+        "cancel",
+        "00000000-0000-0000-0000-000000000001",
+    ]);
+}
+
+#[test]
+fn workflow_reset_is_covered() {
+    assert_covered(&[
+        "workflow",
+        "reset",
+        "00000000-0000-0000-0000-000000000001",
+        "--to-event",
+        "50",
+        "--reason",
+        "bad deploy",
+    ]);
+}
+
+#[test]
+fn workflow_signal_is_covered() {
+    assert_covered(&[
+        "workflow",
+        "signal",
+        "00000000-0000-0000-0000-000000000001",
+        "my_signal",
+    ]);
+}
+
+#[test]
+fn workflow_query_is_covered() {
+    assert_covered(&[
+        "workflow",
+        "query",
+        "00000000-0000-0000-0000-000000000001",
+        "my_query",
+    ]);
+}
+
+#[test]
+fn workflow_update_is_covered() {
+    assert_covered(&[
+        "workflow",
+        "update",
+        "00000000-0000-0000-0000-000000000001",
+        "my_update",
+    ]);
+}
+
+#[test]
+fn workflow_update_result_is_covered() {
+    assert_covered(&[
+        "workflow",
+        "update-result",
+        "00000000-0000-0000-0000-000000000001",
+        "aaaaaaaa-bbbb-cccc-dddd-000000000002",
+    ]);
+}
+
+// ── history ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn history_export_single_is_covered() {
+    assert_covered(&[
+        "history",
+        "export",
+        "00000000-0000-0000-0000-000000000001",
+    ]);
+}
+
+#[test]
+fn history_export_batch_is_covered() {
+    assert_covered(&["history", "export-batch"]);
+}
+
+// ── external handoffs ─────────────────────────────────────────────────────────
+
+#[test]
+fn handoff_list_is_covered() {
+    assert_covered(&["handoff", "list"]);
+}
+
+#[test]
+fn handoff_inspect_is_covered() {
+    assert_covered(&[
+        "handoff",
+        "inspect",
+        "11111111-1111-4111-8111-111111111111",
+    ]);
+}
+
+#[test]
+fn handoff_complete_is_covered() {
+    assert_covered(&[
+        "handoff",
+        "complete",
+        "11111111-1111-4111-8111-111111111111",
+    ]);
+}
+
+#[test]
+fn handoff_fail_is_covered() {
+    assert_covered(&[
+        "handoff",
+        "fail",
+        "11111111-1111-4111-8111-111111111111",
+        "--error",
+        "rejected",
+    ]);
+}
+
+#[test]
+fn handoff_heartbeat_is_covered() {
+    assert_covered(&[
+        "handoff",
+        "heartbeat",
+        "11111111-1111-4111-8111-111111111111",
+    ]);
+}
+
+// ── DAGs ──────────────────────────────────────────────────────────────────────
+
+#[test]
+fn dag_list_is_covered() {
+    assert_covered(&["dag", "list"]);
+}
+
+#[test]
+fn dag_runs_is_covered() {
+    assert_covered(&["dag", "runs", "my_dag"]);
+}
+
+#[test]
+fn dag_trigger_is_covered() {
+    assert_covered(&["dag", "trigger", "my_dag"]);
+}
+
+#[test]
+fn dag_pause_is_covered() {
+    assert_covered(&["dag", "pause", "my_dag"]);
+}
+
+#[test]
+fn dag_unpause_is_covered() {
+    assert_covered(&["dag", "unpause", "my_dag"]);
+}
+
+// ── schedules ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn schedule_list_is_covered() {
+    assert_covered(&["schedule", "list"]);
+}
+
+#[test]
+fn schedule_create_workflow_is_covered() {
+    assert_covered(&[
+        "schedule",
+        "create-workflow",
+        "--name",
+        "nightly_job",
+        "--cron",
+        "0 0 * * *",
+    ]);
+}
+
+#[test]
+fn schedule_pause_is_covered() {
+    assert_covered(&[
+        "schedule",
+        "pause",
+        "00000000-0000-0000-0000-000000000001",
+    ]);
+}
+
+#[test]
+fn schedule_resume_is_covered() {
+    assert_covered(&[
+        "schedule",
+        "resume",
+        "00000000-0000-0000-0000-000000000001",
+    ]);
+}
+
+#[test]
+fn schedule_delete_is_covered() {
+    assert_covered(&[
+        "schedule",
+        "delete",
+        "00000000-0000-0000-0000-000000000001",
+    ]);
+}
+
+// ── retention ─────────────────────────────────────────────────────────────────
+
+#[test]
+fn retention_status_is_covered() {
+    assert_covered(&["retention", "status"]);
+}
+
+#[test]
+fn retention_run_now_is_covered() {
+    assert_covered(&["retention", "run-now"]);
+}
+
+// ── concurrency ───────────────────────────────────────────────────────────────
+
+#[test]
+fn concurrency_status_is_covered() {
+    assert_covered(&["concurrency"]);
+}
+
+// ── audit ─────────────────────────────────────────────────────────────────────
+
+#[test]
+fn audit_list_is_covered() {
+    assert_covered(&["audit", "list"]);
+}
+
+// ── batch operations ──────────────────────────────────────────────────────────
+
+#[test]
+fn batch_list_is_covered() {
+    assert_covered(&["batch", "list"]);
+}
+
+#[test]
+fn batch_get_is_covered() {
+    assert_covered(&["batch", "get", "00000000-0000-0000-0000-000000000001"]);
+}
+
+#[test]
+fn batch_submit_is_covered() {
+    assert_covered(&[
+        "batch",
+        "submit",
+        "Cancel",
+        "--filter-json",
+        r#"{"states":["RUNNING"]}"#,
+    ]);
+}
+
+// ── dead-letter queue ─────────────────────────────────────────────────────────
+
+#[test]
+fn dlq_list_is_covered() {
+    assert_covered(&["dlq", "list"]);
+}
+
+#[test]
+fn dlq_replay_single_is_covered() {
+    assert_covered(&["dlq", "replay", "00000000-0000-0000-0000-000000000001"]);
+}
+
+#[test]
+fn dlq_bulk_replay_is_covered() {
+    assert_covered(&["dlq", "bulk-replay"]);
+}
+
+#[test]
+fn dlq_bulk_discard_is_covered() {
+    assert_covered(&["dlq", "bulk-discard"]);
+}
+
+// ── workers ───────────────────────────────────────────────────────────────────
+
+#[test]
+fn worker_list_is_covered() {
+    assert_covered(&["worker", "list"]);
+}
+
+#[test]
+fn worker_get_is_covered() {
+    assert_covered(&["worker", "get", "worker-abc"]);
+}
+
+#[test]
+fn worker_health_is_covered() {
+    assert_covered(&["worker", "health"]);
+}
+
+#[test]
+fn worker_drain_preview_is_covered() {
+    assert_covered(&["worker", "drain-preview"]);
+}
+
+#[test]
+fn worker_drain_is_covered() {
+    assert_covered(&["worker", "drain", "worker-abc"]);
+}

--- a/autumn-harvest-cli/tests/contract_coverage.rs
+++ b/autumn-harvest-cli/tests/contract_coverage.rs
@@ -63,9 +63,11 @@ fn path_matches_template(actual: &str, template: &str) -> bool {
 /// are covered by the contract.
 #[track_caller]
 fn assert_covered(args: &[&str]) {
-    let all: Vec<&str> = std::iter::once("harvest").chain(args.iter().copied()).collect();
-    let cli = Cli::try_parse_from(&all)
-        .unwrap_or_else(|e| panic!("CLI args {args:?} should parse: {e}"));
+    let all: Vec<&str> = std::iter::once("harvest")
+        .chain(args.iter().copied())
+        .collect();
+    let cli =
+        Cli::try_parse_from(&all).unwrap_or_else(|e| panic!("CLI args {args:?} should parse: {e}"));
     let req = cli
         .api_request()
         .unwrap_or_else(|e| panic!("api_request() should succeed for {args:?}: {e}"));
@@ -133,9 +135,11 @@ fn contract_route_request_fields() -> HashMap<(String, String), Option<Vec<Strin
 /// Skips GET requests and `None` bodies.  Free-form routes are also skipped.
 #[track_caller]
 fn assert_body_fields_documented(args: &[&str]) {
-    let all: Vec<&str> = std::iter::once("harvest").chain(args.iter().copied()).collect();
-    let cli = Cli::try_parse_from(&all)
-        .unwrap_or_else(|e| panic!("CLI args {args:?} should parse: {e}"));
+    let all: Vec<&str> = std::iter::once("harvest")
+        .chain(args.iter().copied())
+        .collect();
+    let cli =
+        Cli::try_parse_from(&all).unwrap_or_else(|e| panic!("CLI args {args:?} should parse: {e}"));
     let req = cli
         .api_request()
         .unwrap_or_else(|e| panic!("api_request() should succeed for {args:?}: {e}"));
@@ -249,11 +253,7 @@ fn workflow_start_is_covered() {
 
 #[test]
 fn workflow_cancel_is_covered() {
-    assert_covered(&[
-        "workflow",
-        "cancel",
-        "00000000-0000-0000-0000-000000000001",
-    ]);
+    assert_covered(&["workflow", "cancel", "00000000-0000-0000-0000-000000000001"]);
 }
 
 #[test]
@@ -313,11 +313,7 @@ fn workflow_update_result_is_covered() {
 
 #[test]
 fn history_export_single_is_covered() {
-    assert_covered(&[
-        "history",
-        "export",
-        "00000000-0000-0000-0000-000000000001",
-    ]);
+    assert_covered(&["history", "export", "00000000-0000-0000-0000-000000000001"]);
 }
 
 #[test]
@@ -334,11 +330,7 @@ fn handoff_list_is_covered() {
 
 #[test]
 fn handoff_inspect_is_covered() {
-    assert_covered(&[
-        "handoff",
-        "inspect",
-        "11111111-1111-4111-8111-111111111111",
-    ]);
+    assert_covered(&["handoff", "inspect", "11111111-1111-4111-8111-111111111111"]);
 }
 
 #[test]
@@ -418,29 +410,17 @@ fn schedule_create_workflow_is_covered() {
 
 #[test]
 fn schedule_pause_is_covered() {
-    assert_covered(&[
-        "schedule",
-        "pause",
-        "00000000-0000-0000-0000-000000000001",
-    ]);
+    assert_covered(&["schedule", "pause", "00000000-0000-0000-0000-000000000001"]);
 }
 
 #[test]
 fn schedule_resume_is_covered() {
-    assert_covered(&[
-        "schedule",
-        "resume",
-        "00000000-0000-0000-0000-000000000001",
-    ]);
+    assert_covered(&["schedule", "resume", "00000000-0000-0000-0000-000000000001"]);
 }
 
 #[test]
 fn schedule_delete_is_covered() {
-    assert_covered(&[
-        "schedule",
-        "delete",
-        "00000000-0000-0000-0000-000000000001",
-    ]);
+    assert_covered(&["schedule", "delete", "00000000-0000-0000-0000-000000000001"]);
 }
 
 // ── retention ─────────────────────────────────────────────────────────────────

--- a/autumn-harvest-cli/tests/contract_coverage.rs
+++ b/autumn-harvest-cli/tests/contract_coverage.rs
@@ -4,9 +4,13 @@
 /// is documented in `docs/api-contract.json`.  If a CLI command maps to a path
 /// that is not in the contract, either the contract is incomplete or the CLI
 /// has drifted from the documented API surface.
+///
+/// The body-field tests additionally verify that every JSON key the CLI sends
+/// in a request body is listed in the contract's `request_body.fields` array,
+/// enforcing AC 4: "uses the documented request shape."
 use autumn_harvest_cli::{ApiMethod, Cli};
 use clap::Parser;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 const CONTRACT_JSON: &str = include_str!("../../docs/api-contract.json");
 
@@ -79,6 +83,104 @@ fn assert_covered(args: &[&str]) {
         "CLI command {args:?} maps to {method} {path} \
          which is not covered by docs/api-contract.json"
     );
+}
+
+// ── Body-field helpers (AC 4) ─────────────────────────────────────────────────
+
+/// Returns a map of (METHOD, path-template) → documented field names extracted
+/// from the contract's structured `request_body.fields` array.
+/// `None` means the body is free-form (no fixed schema).
+/// Panics if a mutating route is missing the required `fields` array.
+fn contract_route_request_fields() -> HashMap<(String, String), Option<Vec<String>>> {
+    let contract: serde_json::Value =
+        serde_json::from_str(CONTRACT_JSON).expect("api-contract.json must be valid JSON");
+    let mutating = ["POST", "PUT", "PATCH", "DELETE"];
+    let mut map: HashMap<(String, String), Option<Vec<String>>> = HashMap::new();
+
+    for route in contract["routes"].as_array().unwrap() {
+        let method = route["method"].as_str().unwrap().to_string();
+        let path = route["path"].as_str().unwrap().to_string();
+        if !mutating.contains(&method.as_str()) {
+            continue;
+        }
+        let rb = &route["request_body"];
+        assert!(
+            rb.is_object(),
+            "mutating route {method} {path} must have a 'request_body' object in the contract"
+        );
+        if rb["free_form"].as_bool().unwrap_or(false) {
+            map.insert((method, path), None);
+        } else {
+            let fields: Vec<String> = rb["fields"]
+                .as_array()
+                .unwrap_or_else(|| {
+                    panic!(
+                        "{method} {path}: contract request_body must have a 'fields' array \
+                         (set free_form:true for routes whose body is an opaque payload)"
+                    )
+                })
+                .iter()
+                .filter_map(|f| f["name"].as_str().map(|s| s.to_string()))
+                .collect();
+            map.insert((method, path), Some(fields));
+        }
+    }
+    map
+}
+
+/// Asserts that every JSON key the CLI sends in a request body is listed in
+/// the contract's `request_body.fields` for the matching route.
+/// Skips GET requests and `None` bodies.  Free-form routes are also skipped.
+#[track_caller]
+fn assert_body_fields_documented(args: &[&str]) {
+    let all: Vec<&str> = std::iter::once("harvest").chain(args.iter().copied()).collect();
+    let cli = Cli::try_parse_from(&all)
+        .unwrap_or_else(|e| panic!("CLI args {args:?} should parse: {e}"));
+    let req = cli
+        .api_request()
+        .unwrap_or_else(|e| panic!("api_request() should succeed for {args:?}: {e}"));
+
+    // GET requests never have a body — nothing to validate.
+    let method = method_str(&req.method);
+    if method == "GET" {
+        return;
+    }
+
+    let Some(body) = req.body else { return };
+    let Some(body_obj) = body.as_object() else {
+        return; // free-form non-object body — skip
+    };
+    if body_obj.is_empty() {
+        return; // empty body — nothing to validate
+    }
+
+    let path = bare_path(&req.path);
+    let fields_map = contract_route_request_fields();
+
+    // Find the matching contract entry by template matching.
+    let entry = fields_map
+        .iter()
+        .find(|((m, t), _)| m == method && path_matches_template(path, t));
+
+    let Some((_, field_spec)) = entry else {
+        // Route not in fields map — covered by the route-membership test.
+        return;
+    };
+
+    let Some(contract_fields) = field_spec else {
+        // Free-form body — no per-field validation possible.
+        return;
+    };
+
+    let documented: HashSet<&str> = contract_fields.iter().map(|s| s.as_str()).collect();
+    for key in body_obj.keys() {
+        assert!(
+            documented.contains(key.as_str()),
+            "CLI command {args:?} sends body field '{key}' for {method} {path} \
+             but '{key}' is not documented in docs/api-contract.json. \
+             Add it to request_body.fields and management_api_request_fields()."
+        );
+    }
 }
 
 // ── health / admin ────────────────────────────────────────────────────────────
@@ -437,4 +539,212 @@ fn worker_drain_preview_is_covered() {
 #[test]
 fn worker_drain_is_covered() {
     assert_covered(&["worker", "drain", "worker-abc"]);
+}
+
+// ── Body-field validation tests (AC 4) ───────────────────────────────────────
+//
+// For every mutating CLI command that sends a structured request body, verify
+// that each body field is listed in the contract's request_body.fields.
+
+#[test]
+fn workflow_start_body_fields_are_documented() {
+    assert_body_fields_documented(&[
+        "workflow",
+        "start",
+        "my_workflow",
+        "--workflow-id",
+        "wf-1",
+        "--queue",
+        "critical",
+        "--input-json",
+        r#"{"x":1}"#,
+        "--memo-json",
+        r#"{"note":"test"}"#,
+        "--search-attrs-json",
+        r#"{"tenant":"acme"}"#,
+        "--execution-timeout-secs",
+        "30",
+        "--reuse-policy",
+        "reject_duplicate",
+    ]);
+}
+
+#[test]
+fn workflow_cancel_body_fields_are_documented() {
+    assert_body_fields_documented(&[
+        "workflow",
+        "cancel",
+        "00000000-0000-0000-0000-000000000001",
+        "--reason",
+        "test",
+    ]);
+}
+
+#[test]
+fn workflow_reset_body_fields_are_documented() {
+    assert_body_fields_documented(&[
+        "workflow",
+        "reset",
+        "00000000-0000-0000-0000-000000000001",
+        "--to-event",
+        "50",
+        "--reason",
+        "bad deploy",
+        "--operator-id",
+        "ops",
+        "--signal-reapply",
+        "buffer",
+    ]);
+}
+
+#[test]
+fn workflow_update_body_fields_are_documented() {
+    assert_body_fields_documented(&[
+        "workflow",
+        "update",
+        "00000000-0000-0000-0000-000000000001",
+        "my_update",
+        "--input-json",
+        r#"{"approved":true}"#,
+    ]);
+}
+
+#[test]
+fn dag_trigger_body_fields_are_documented() {
+    assert_body_fields_documented(&[
+        "dag",
+        "trigger",
+        "my_dag",
+        "--conf-json",
+        r#"{"date":"2026-01-01"}"#,
+    ]);
+}
+
+#[test]
+fn dag_pause_body_fields_are_documented() {
+    assert_body_fields_documented(&["dag", "pause", "my_dag"]);
+}
+
+#[test]
+fn dag_unpause_body_fields_are_documented() {
+    assert_body_fields_documented(&["dag", "unpause", "my_dag"]);
+}
+
+#[test]
+fn dlq_bulk_replay_body_fields_are_documented() {
+    assert_body_fields_documented(&[
+        "dlq",
+        "bulk-replay",
+        "--activity-name",
+        "send_email",
+        "--workflow-name",
+        "billing",
+        "--failed-after",
+        "2026-01-01T00:00:00Z",
+        "--failed-before",
+        "2026-02-01T00:00:00Z",
+        "--limit",
+        "100",
+        "--dry-run",
+    ]);
+}
+
+#[test]
+fn dlq_bulk_discard_body_fields_are_documented() {
+    assert_body_fields_documented(&[
+        "dlq",
+        "bulk-discard",
+        "--activity-name",
+        "send_email",
+        "--dry-run",
+    ]);
+}
+
+#[test]
+fn handoff_complete_body_fields_are_documented() {
+    assert_body_fields_documented(&[
+        "handoff",
+        "complete",
+        "11111111-1111-4111-8111-111111111111",
+        "--output-json",
+        r#"{"approved":true}"#,
+    ]);
+}
+
+#[test]
+fn handoff_fail_body_fields_are_documented() {
+    assert_body_fields_documented(&[
+        "handoff",
+        "fail",
+        "11111111-1111-4111-8111-111111111111",
+        "--error",
+        "rejected",
+        "--retryable",
+    ]);
+}
+
+#[test]
+fn handoff_heartbeat_body_fields_are_documented() {
+    assert_body_fields_documented(&[
+        "handoff",
+        "heartbeat",
+        "11111111-1111-4111-8111-111111111111",
+        "--extend-by-secs",
+        "3600",
+    ]);
+}
+
+#[test]
+fn worker_drain_body_fields_are_documented() {
+    assert_body_fields_documented(&[
+        "worker",
+        "drain",
+        "worker-abc",
+        "--deadline",
+        "2026-06-01T12:00:00Z",
+    ]);
+}
+
+#[test]
+fn batch_submit_cancel_body_fields_are_documented() {
+    assert_body_fields_documented(&[
+        "batch",
+        "submit",
+        "Cancel",
+        "--filter-json",
+        r#"{"states":["RUNNING"]}"#,
+    ]);
+}
+
+#[test]
+fn batch_submit_signal_body_fields_are_documented() {
+    assert_body_fields_documented(&[
+        "batch",
+        "submit",
+        "Signal",
+        "--filter-json",
+        r#"{"states":["RUNNING"]}"#,
+        "--signal-name",
+        "my_signal",
+        "--signal-payload-json",
+        r#"{"key":"val"}"#,
+    ]);
+}
+
+#[test]
+fn schedule_create_workflow_body_fields_are_documented() {
+    assert_body_fields_documented(&[
+        "schedule",
+        "create-workflow",
+        "--name",
+        "nightly",
+        "--cron",
+        "0 0 * * *",
+        "--input-json",
+        r#"{"env":"prod"}"#,
+        "--max-active-runs",
+        "3",
+        "--catchup",
+        "--paused",
+    ]);
 }

--- a/autumn-harvest-cli/tests/contract_coverage.rs
+++ b/autumn-harvest-cli/tests/contract_coverage.rs
@@ -32,7 +32,7 @@ fn contract_route_set() -> HashSet<(String, String)> {
 }
 
 /// Returns the HTTP method string for an `ApiMethod`.
-fn method_str(m: &ApiMethod) -> &'static str {
+const fn method_str(m: ApiMethod) -> &'static str {
     match m {
         ApiMethod::Get => "GET",
         ApiMethod::Post => "POST",
@@ -72,7 +72,7 @@ fn assert_covered(args: &[&str]) {
         .api_request()
         .unwrap_or_else(|e| panic!("api_request() should succeed for {args:?}: {e}"));
 
-    let method = method_str(&req.method);
+    let method = method_str(req.method);
     let path = bare_path(&req.path);
     let routes = contract_route_set();
 
@@ -122,7 +122,7 @@ fn contract_route_request_fields() -> HashMap<(String, String), Option<Vec<Strin
                     )
                 })
                 .iter()
-                .filter_map(|f| f["name"].as_str().map(|s| s.to_string()))
+                .filter_map(|f| f["name"].as_str().map(ToString::to_string))
                 .collect();
             map.insert((method, path), Some(fields));
         }
@@ -145,7 +145,7 @@ fn assert_body_fields_documented(args: &[&str]) {
         .unwrap_or_else(|e| panic!("api_request() should succeed for {args:?}: {e}"));
 
     // GET requests never have a body — nothing to validate.
-    let method = method_str(&req.method);
+    let method = method_str(req.method);
     if method == "GET" {
         return;
     }
@@ -176,7 +176,7 @@ fn assert_body_fields_documented(args: &[&str]) {
         return;
     };
 
-    let documented: HashSet<&str> = contract_fields.iter().map(|s| s.as_str()).collect();
+    let documented: HashSet<&str> = contract_fields.iter().map(String::as_str).collect();
     for key in body_obj.keys() {
         assert!(
             documented.contains(key.as_str()),

--- a/autumn-harvest-cli/tests/contract_coverage.rs
+++ b/autumn-harvest-cli/tests/contract_coverage.rs
@@ -357,7 +357,7 @@ fn retention_run_now_is_covered() {
 
 #[test]
 fn concurrency_status_is_covered() {
-    assert_covered(&["concurrency"]);
+    assert_covered(&["concurrency", "status"]);
 }
 
 // ── audit ─────────────────────────────────────────────────────────────────────

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -1100,6 +1100,71 @@ pub fn harvest_api_router(api_state: HarvestApiState) -> Router<AppState> {
         .layer(Extension(api_state))
 }
 
+/// Returns the canonical list of all `(METHOD, path-template)` pairs registered
+/// by `harvest_api_router`.  The contract regression test compares this list
+/// against `docs/api-contract.json`; update both together whenever routes change.
+pub fn management_api_routes() -> &'static [(&'static str, &'static str)] {
+    &[
+        // ── workflows ────────────────────────────────────────────────────────
+        ("GET", "/workflows"),
+        ("GET", "/workflows/{id}"),
+        ("GET", "/workflows/{id}/history/export"),
+        ("GET", "/workflows/{id}/children"),
+        ("GET", "/workflows/{id}/stack"),
+        ("POST", "/workflows/{workflow_name}/start"),
+        ("POST", "/workflows/{id}/cancel"),
+        ("POST", "/workflows/{id}/reset"),
+        ("POST", "/workflows/{id}/signal/{signal_name}"),
+        ("GET", "/workflows/{id}/query/{query_name}"),
+        ("POST", "/workflows/{id}/update/{update_name}"),
+        ("GET", "/workflows/{id}/update/{update_id}/result"),
+        // ── DAGs ─────────────────────────────────────────────────────────────
+        ("GET", "/dags"),
+        ("GET", "/dags/{dag_name}/runs"),
+        ("POST", "/dags/{dag_name}/trigger"),
+        ("PATCH", "/dags/{dag_name}"),
+        // ── dead-letter queue ─────────────────────────────────────────────────
+        ("GET", "/dead-letters"),
+        ("POST", "/dead-letters/replay"),
+        ("POST", "/dead-letters/discard"),
+        ("POST", "/dead-letters/{id}/replay"),
+        // ── external activity handoff (issue #92) ────────────────────────────
+        ("POST", "/activities/external/{token}/complete"),
+        ("POST", "/activities/external/{token}/fail"),
+        ("POST", "/activities/external/{token}/heartbeat"),
+        // ── workers (issues #100, #170) ───────────────────────────────────────
+        ("GET", "/workers"),
+        ("GET", "/workers/{worker_id}"),
+        ("GET", "/workers/health"),
+        ("GET", "/workers/drain-preview"),
+        ("POST", "/workers/{worker_id}/drain"),
+        // ── batch operations (issue #102) ─────────────────────────────────────
+        ("GET", "/batch-operations"),
+        ("POST", "/batch-operations"),
+        ("GET", "/batch-operations/{id}"),
+        // ── health & admin ────────────────────────────────────────────────────
+        ("GET", "/health"),
+        ("GET", "/admin/preflight"),
+        ("GET", "/admin/shards/health"),
+        ("GET", "/admin/version-gates/usage"),
+        ("GET", "/admin/version-gates/retirement-check"),
+        ("GET", "/admin/retention"),
+        ("POST", "/admin/retention/run-now"),
+        ("GET", "/admin/concurrency"),
+        ("GET", "/admin/history/exports"),
+        ("GET", "/admin/external-handoffs"),
+        ("GET", "/admin/external-handoffs/{token}"),
+        // ── schedules (issue #91) ─────────────────────────────────────────────
+        ("GET", "/admin/schedules"),
+        ("POST", "/admin/schedules/workflow"),
+        ("POST", "/admin/schedules/{id}/pause"),
+        ("POST", "/admin/schedules/{id}/resume"),
+        ("DELETE", "/admin/schedules/{id}"),
+        // ── audit (issue #158) ────────────────────────────────────────────────
+        ("GET", "/admin/audit"),
+    ]
+}
+
 async fn preflight(
     Extension(api_state): Extension<HarvestApiState>,
     axum::extract::State(autumn_state): axum::extract::State<AppState>,

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -1165,6 +1165,60 @@ pub fn management_api_routes() -> &'static [(&'static str, &'static str)] {
     ]
 }
 
+/// Canonical request-body field registry for every mutating management route.
+///
+/// Each entry is `(method, path_template, fields)` where `fields` is:
+/// - `Some(&[...])` — structured body with these named top-level JSON keys
+/// - `None`         — free-form body (opaque payload, e.g. signal)
+///
+/// This registry is compared against `docs/api-contract.json` by the contract
+/// regression test.  Update this list and the contract together whenever you
+/// add, remove, or rename a request field.
+pub fn management_api_request_fields() -> &'static [(&'static str, &'static str, Option<&'static [&'static str]>)] {
+    &[
+        // ── workflows ────────────────────────────────────────────────────────
+        ("POST", "/workflows/{workflow_name}/start", Some(&[
+            "workflow_id", "input", "queue", "memo", "search_attrs",
+            "execution_timeout_secs", "reuse_policy",
+        ])),
+        ("POST", "/workflows/{id}/cancel", Some(&["reason"])),
+        ("POST", "/workflows/{id}/reset", Some(&[
+            "reset_to_event_id", "reason", "operator_id", "signal_reapply",
+        ])),
+        ("POST", "/workflows/{id}/signal/{signal_name}", None), // free-form
+        ("POST", "/workflows/{id}/update/{update_name}", Some(&["input"])),
+        // ── DAGs ─────────────────────────────────────────────────────────────
+        ("POST", "/dags/{dag_name}/trigger", Some(&["conf"])),
+        ("PATCH", "/dags/{dag_name}", Some(&["paused"])),
+        // ── dead-letter queue ─────────────────────────────────────────────────
+        ("POST", "/dead-letters/replay", Some(&[
+            "activity_name", "workflow_name", "failed_after", "failed_before", "limit", "dry_run",
+        ])),
+        ("POST", "/dead-letters/discard", Some(&[
+            "activity_name", "workflow_name", "failed_after", "failed_before", "limit", "dry_run",
+        ])),
+        ("POST", "/dead-letters/{id}/replay", Some(&[])),
+        // ── external activity handoff ─────────────────────────────────────────
+        ("POST", "/activities/external/{token}/complete", Some(&["output"])),
+        ("POST", "/activities/external/{token}/fail", Some(&["error", "retryable"])),
+        ("POST", "/activities/external/{token}/heartbeat", Some(&["extend_by_secs"])),
+        // ── workers ───────────────────────────────────────────────────────────
+        ("POST", "/workers/{worker_id}/drain", Some(&["deadline_at"])),
+        // ── batch operations ──────────────────────────────────────────────────
+        ("POST", "/batch-operations", Some(&[
+            "action", "filter", "signal_name", "signal_payload",
+        ])),
+        // ── admin ─────────────────────────────────────────────────────────────
+        ("POST", "/admin/retention/run-now", Some(&[])),
+        ("POST", "/admin/schedules/workflow", Some(&[
+            "workflow_name", "schedule_expr", "input", "max_active_runs", "catchup", "paused",
+        ])),
+        ("POST", "/admin/schedules/{id}/pause", Some(&[])),
+        ("POST", "/admin/schedules/{id}/resume", Some(&[])),
+        ("DELETE", "/admin/schedules/{id}", Some(&[])),
+    ]
+}
+
 async fn preflight(
     Extension(api_state): Extension<HarvestApiState>,
     axum::extract::State(autumn_state): axum::extract::State<AppState>,

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -1174,46 +1174,116 @@ pub const fn management_api_routes() -> &'static [(&'static str, &'static str)] 
 /// Compared against `docs/api-contract.json` by the regression test; update
 /// both together when adding, removing, or renaming a request field.
 #[must_use]
-pub const fn management_api_request_fields() -> &'static [(&'static str, &'static str, Option<&'static [&'static str]>)] {
+#[allow(clippy::too_many_lines)]
+pub const fn management_api_request_fields()
+-> &'static [(&'static str, &'static str, Option<&'static [&'static str]>)] {
     &[
         // ── workflows ────────────────────────────────────────────────────────
-        ("POST", "/workflows/{workflow_name}/start", Some(&[
-            "workflow_id", "input", "queue", "memo", "search_attrs",
-            "execution_timeout_secs", "reuse_policy",
-        ])),
+        (
+            "POST",
+            "/workflows/{workflow_name}/start",
+            Some(&[
+                "workflow_id",
+                "input",
+                "queue",
+                "memo",
+                "search_attrs",
+                "execution_timeout_secs",
+                "reuse_policy",
+            ]),
+        ),
         ("POST", "/workflows/{id}/cancel", Some(&["reason"])),
-        ("POST", "/workflows/{id}/reset", Some(&[
-            "reset_to_event_id", "reason", "operator_id", "signal_reapply",
-        ])),
+        (
+            "POST",
+            "/workflows/{id}/reset",
+            Some(&[
+                "reset_to_event_id",
+                "reason",
+                "operator_id",
+                "signal_reapply",
+            ]),
+        ),
         ("POST", "/workflows/{id}/signal/{signal_name}", None), // free-form
-        ("POST", "/workflows/{id}/update/{update_name}", Some(&["input"])),
+        (
+            "POST",
+            "/workflows/{id}/update/{update_name}",
+            Some(&["input"]),
+        ),
         // ── DAGs ─────────────────────────────────────────────────────────────
         ("POST", "/dags/{dag_name}/trigger", Some(&["conf"])),
         ("PATCH", "/dags/{dag_name}", Some(&["paused"])),
         // ── dead-letter queue ─────────────────────────────────────────────────
-        ("POST", "/dead-letters/replay", Some(&[
-            "activity_name", "workflow_name", "failed_after", "failed_before", "limit", "dry_run",
-        ])),
-        ("POST", "/dead-letters/discard", Some(&[
-            "activity_name", "workflow_name", "failed_after", "failed_before", "limit", "dry_run",
-        ])),
+        (
+            "POST",
+            "/dead-letters/replay",
+            Some(&[
+                "activity_name",
+                "workflow_name",
+                "failed_after",
+                "failed_before",
+                "limit",
+                "dry_run",
+            ]),
+        ),
+        (
+            "POST",
+            "/dead-letters/discard",
+            Some(&[
+                "activity_name",
+                "workflow_name",
+                "failed_after",
+                "failed_before",
+                "limit",
+                "dry_run",
+            ]),
+        ),
         ("POST", "/dead-letters/{id}/replay", Some(&[])),
         // ── external activity handoff ─────────────────────────────────────────
-        ("POST", "/activities/external/{token}/complete", Some(&["output"])),
-        ("POST", "/activities/external/{token}/fail", Some(&["error", "retryable"])),
-        ("POST", "/activities/external/{token}/heartbeat", Some(&["extend_by_secs"])),
+        (
+            "POST",
+            "/activities/external/{token}/complete",
+            Some(&["output"]),
+        ),
+        (
+            "POST",
+            "/activities/external/{token}/fail",
+            Some(&["error", "retryable"]),
+        ),
+        (
+            "POST",
+            "/activities/external/{token}/heartbeat",
+            Some(&["extend_by_secs"]),
+        ),
         // ── workers ───────────────────────────────────────────────────────────
         ("POST", "/workers/{worker_id}/drain", Some(&["deadline_at"])),
         // ── batch operations ──────────────────────────────────────────────────
-        ("POST", "/batch-operations", Some(&[
-            "action", "filter", "signal_name", "signal_payload",
-            "idempotency_key", "created_by",
-        ])),
+        (
+            "POST",
+            "/batch-operations",
+            Some(&[
+                "action",
+                "filter",
+                "signal_name",
+                "signal_payload",
+                "idempotency_key",
+                "created_by",
+            ]),
+        ),
         // ── admin ─────────────────────────────────────────────────────────────
         ("POST", "/admin/retention/run-now", Some(&[])),
-        ("POST", "/admin/schedules/workflow", Some(&[
-            "workflow_name", "schedule_expr", "input", "max_active_runs", "catchup", "paused",
-        ])),
+        (
+            "POST",
+            "/admin/schedules/workflow",
+            Some(&[
+                "workflow_name",
+                "schedule_expr",
+                "input",
+                "max_active_runs",
+                "catchup",
+                "paused",
+                "queue_name",
+            ]),
+        ),
         ("POST", "/admin/schedules/{id}/pause", Some(&[])),
         ("POST", "/admin/schedules/{id}/resume", Some(&[])),
         ("DELETE", "/admin/schedules/{id}", Some(&[])),
@@ -1228,74 +1298,243 @@ pub const fn management_api_request_fields() -> &'static [(&'static str, &'stati
 /// `docs/api-contract.json` by the regression test; update both together when
 /// adding, removing, or renaming a top-level response field.
 #[must_use]
-pub const fn management_api_response_fields() -> &'static [(&'static str, &'static str, Option<&'static [&'static str]>)] {
+#[allow(clippy::too_many_lines)]
+pub const fn management_api_response_fields()
+-> &'static [(&'static str, &'static str, Option<&'static [&'static str]>)] {
     &[
         // ── workflows ────────────────────────────────────────────────────────
-        ("GET",  "/workflows",                            None), // Vec<WorkflowExecution>
-        ("GET",  "/workflows/{id}",                       Some(&["parent_id", "execution", "history", "external_handoffs"])),
-        ("GET",  "/workflows/{id}/history/export",        None), // HistoryExportDocument (external)
-        ("GET",  "/workflows/{id}/children",              Some(&["items", "next_cursor"])),
-        ("GET",  "/workflows/{id}/stack",                 Some(&[
-            "exec_id", "workflow_id", "workflow_name", "state", "is_terminal",
-            "pending_activities", "pending_external_handoffs", "pending_local_activities",
-            "pending_timers", "pending_signals", "buffered_signals",
-            "pending_child_workflows", "last_event_id",
-        ])),
-        ("POST", "/workflows/{workflow_name}/start",      Some(&["execution_id", "workflow_name", "workflow_id", "state"])),
-        ("POST", "/workflows/{id}/cancel",                Some(&["ok", "execution_id", "state", "reason", "newly_cancelled", "failed_task_count"])),
-        ("POST", "/workflows/{id}/reset",                 Some(&[
-            "new_exec_id", "reset_from_exec_id", "reset_to_event_id", "events_carried_over",
-            "source_tasks_cancelled", "source_timers_removed",
-            "source_signals_dropped", "source_signals_buffered",
-        ])),
-        ("POST", "/workflows/{id}/signal/{signal_name}",  Some(&["ok"])),
-        ("GET",  "/workflows/{id}/query/{query_name}",    None), // opaque handler return
-        ("POST", "/workflows/{id}/update/{update_name}",  None), // polymorphic admitted/completed/failed
-        ("GET",  "/workflows/{id}/update/{update_id}/result", None), // polymorphic completed/failed
+        ("GET", "/workflows", None), // Vec<WorkflowExecution>
+        (
+            "GET",
+            "/workflows/{id}",
+            Some(&["parent_id", "execution", "history", "external_handoffs"]),
+        ),
+        ("GET", "/workflows/{id}/history/export", None), // HistoryExportDocument (external)
+        (
+            "GET",
+            "/workflows/{id}/children",
+            Some(&["items", "next_cursor"]),
+        ),
+        (
+            "GET",
+            "/workflows/{id}/stack",
+            Some(&[
+                "exec_id",
+                "workflow_id",
+                "workflow_name",
+                "state",
+                "is_terminal",
+                "pending_activities",
+                "pending_external_handoffs",
+                "pending_local_activities",
+                "pending_timers",
+                "pending_signals",
+                "buffered_signals",
+                "pending_child_workflows",
+                "last_event_id",
+            ]),
+        ),
+        (
+            "POST",
+            "/workflows/{workflow_name}/start",
+            Some(&["execution_id", "workflow_name", "workflow_id", "state"]),
+        ),
+        (
+            "POST",
+            "/workflows/{id}/cancel",
+            Some(&[
+                "ok",
+                "execution_id",
+                "state",
+                "reason",
+                "newly_cancelled",
+                "failed_task_count",
+            ]),
+        ),
+        (
+            "POST",
+            "/workflows/{id}/reset",
+            Some(&[
+                "new_exec_id",
+                "reset_from_exec_id",
+                "reset_to_event_id",
+                "events_carried_over",
+                "source_tasks_cancelled",
+                "source_timers_removed",
+                "source_signals_dropped",
+                "source_signals_buffered",
+            ]),
+        ),
+        (
+            "POST",
+            "/workflows/{id}/signal/{signal_name}",
+            Some(&["ok"]),
+        ),
+        ("GET", "/workflows/{id}/query/{query_name}", None), // opaque handler return
+        ("POST", "/workflows/{id}/update/{update_name}", None), // polymorphic admitted/completed/failed
+        ("GET", "/workflows/{id}/update/{update_id}/result", None), // polymorphic completed/failed
         // ── DAGs ─────────────────────────────────────────────────────────────
-        ("GET",  "/dags",                                 None), // Vec<DagSummary>
-        ("GET",  "/dags/{dag_name}/runs",                 None), // Vec<DagRun> (external model)
-        ("POST", "/dags/{dag_name}/trigger",              None), // DagRun (external model)
-        ("PATCH","/dags/{dag_name}",                     None), // HarvestSchedule (external model)
+        ("GET", "/dags", None),                     // Vec<DagSummary>
+        ("GET", "/dags/{dag_name}/runs", None),     // Vec<DagRun> (external model)
+        ("POST", "/dags/{dag_name}/trigger", None), // DagRun (external model)
+        ("PATCH", "/dags/{dag_name}", None),        // HarvestSchedule (external model)
         // ── dead-letter queue ─────────────────────────────────────────────────
-        ("GET",  "/dead-letters",                         None), // Vec<DeadLetter> (external model)
-        ("POST", "/dead-letters/replay",                  Some(&["matched", "acted_on", "skipped", "ids", "dry_run", "failures"])),
-        ("POST", "/dead-letters/discard",                 Some(&["matched", "acted_on", "skipped", "ids", "dry_run", "failures"])),
-        ("POST", "/dead-letters/{id}/replay",             Some(&["ok", "dead_letter_id", "task_id"])),
+        ("GET", "/dead-letters", None), // Vec<DeadLetter> (external model)
+        (
+            "POST",
+            "/dead-letters/replay",
+            Some(&[
+                "matched", "acted_on", "skipped", "ids", "dry_run", "failures",
+            ]),
+        ),
+        (
+            "POST",
+            "/dead-letters/discard",
+            Some(&[
+                "matched", "acted_on", "skipped", "ids", "dry_run", "failures",
+            ]),
+        ),
+        (
+            "POST",
+            "/dead-letters/{id}/replay",
+            Some(&["ok", "dead_letter_id", "task_id"]),
+        ),
         // ── external activity handoff ─────────────────────────────────────────
-        ("POST", "/activities/external/{token}/complete", Some(&["ok", "newly_resolved", "status", "current_state"])),
-        ("POST", "/activities/external/{token}/fail",     Some(&["ok", "newly_resolved", "status", "current_state"])),
-        ("POST", "/activities/external/{token}/heartbeat",Some(&["ok", "newly_resolved", "status", "current_state"])),
+        (
+            "POST",
+            "/activities/external/{token}/complete",
+            Some(&["ok", "newly_resolved", "status", "current_state"]),
+        ),
+        (
+            "POST",
+            "/activities/external/{token}/fail",
+            Some(&["ok", "newly_resolved", "status", "current_state"]),
+        ),
+        (
+            "POST",
+            "/activities/external/{token}/heartbeat",
+            Some(&["ok", "newly_resolved", "status", "current_state"]),
+        ),
         // ── workers ───────────────────────────────────────────────────────────
-        ("GET",  "/workers",                              None), // Vec<WorkerRow> (external model)
-        ("GET",  "/workers/{worker_id}",                  None), // WorkerRow (external model)
-        ("GET",  "/workers/health",                       Some(&["healthy", "stale", "draining", "by_queue", "by_shard"])),
-        ("GET",  "/workers/drain-preview",                None), // Vec<DrainPreviewItem>
-        ("POST", "/workers/{worker_id}/drain",            Some(&["worker_id", "outcome", "in_flight_count", "drain_deadline_at", "shard_ids", "unavailable_shards"])),
+        ("GET", "/workers", None), // Vec<WorkerRow> (external model)
+        ("GET", "/workers/{worker_id}", None), // WorkerRow (external model)
+        (
+            "GET",
+            "/workers/health",
+            Some(&["healthy", "stale", "draining", "by_queue", "by_shard"]),
+        ),
+        ("GET", "/workers/drain-preview", None), // Vec<DrainPreviewItem>
+        (
+            "POST",
+            "/workers/{worker_id}/drain",
+            Some(&[
+                "worker_id",
+                "outcome",
+                "in_flight_count",
+                "drain_deadline_at",
+                "shard_ids",
+                "unavailable_shards",
+            ]),
+        ),
         // ── batch operations ──────────────────────────────────────────────────
-        ("GET",  "/batch-operations",                     None), // Vec<BatchJobView> (external model)
-        ("POST", "/batch-operations",                     Some(&["batch_job_id"])),
-        ("GET",  "/batch-operations/{id}",                None), // BatchJobView (external model)
+        ("GET", "/batch-operations", None), // Vec<BatchJobView> (external model)
+        ("POST", "/batch-operations", Some(&["batch_job_id"])),
+        ("GET", "/batch-operations/{id}", None), // BatchJobView (external model)
         // ── health & admin ────────────────────────────────────────────────────
-        ("GET",  "/health",                               Some(&["runtime_ready", "worker_id", "queues", "dag_count", "scheduler", "shard_readiness_enforced", "shard_readiness"])),
-        ("GET",  "/admin/preflight",                      Some(&["overall_status", "observed_at", "version", "checks"])),
-        ("GET",  "/admin/shards/health",                  Some(&["overall_readiness", "observed_at", "freshness_window_secs", "candidate_shard", "shards"])),
-        ("GET",  "/admin/version-gates/usage",            Some(&["status", "observed_at", "filters", "items", "shards"])),
-        ("GET",  "/admin/version-gates/retirement-check", Some(&["status", "safe_to_retire", "observed_at", "filters", "blockers", "shards"])),
-        ("GET",  "/admin/retention",                      None), // RetentionStatus (external model)
-        ("POST", "/admin/retention/run-now",              Some(&["ok"])),
-        ("GET",  "/admin/concurrency",                    None), // Vec<ConcurrencyKeyStats> (external model)
-        ("GET",  "/admin/history/exports",                Some(&["status", "observed_at", "payload_policy", "filters", "exports", "failures", "shard_coverage"])),
-        ("GET",  "/admin/external-handoffs",              Some(&["status", "items", "shard_coverage"])),
-        ("GET",  "/admin/external-handoffs/{token}",      Some(&["status", "item", "shard_coverage"])),
+        (
+            "GET",
+            "/health",
+            Some(&[
+                "runtime_ready",
+                "worker_id",
+                "queues",
+                "dag_count",
+                "scheduler",
+                "shard_readiness_enforced",
+                "shard_readiness",
+            ]),
+        ),
+        (
+            "GET",
+            "/admin/preflight",
+            Some(&["overall_status", "observed_at", "version", "checks"]),
+        ),
+        (
+            "GET",
+            "/admin/shards/health",
+            Some(&[
+                "overall_readiness",
+                "observed_at",
+                "freshness_window_secs",
+                "candidate_shard",
+                "shards",
+            ]),
+        ),
+        (
+            "GET",
+            "/admin/version-gates/usage",
+            Some(&["status", "observed_at", "filters", "items", "shards"]),
+        ),
+        (
+            "GET",
+            "/admin/version-gates/retirement-check",
+            Some(&[
+                "status",
+                "safe_to_retire",
+                "observed_at",
+                "filters",
+                "blockers",
+                "shards",
+            ]),
+        ),
+        ("GET", "/admin/retention", None), // RetentionStatus (external model)
+        ("POST", "/admin/retention/run-now", Some(&["ok"])),
+        ("GET", "/admin/concurrency", None), // Vec<ConcurrencyKeyStats> (external model)
+        (
+            "GET",
+            "/admin/history/exports",
+            Some(&[
+                "status",
+                "observed_at",
+                "payload_policy",
+                "filters",
+                "exports",
+                "failures",
+                "shard_coverage",
+            ]),
+        ),
+        (
+            "GET",
+            "/admin/external-handoffs",
+            Some(&["status", "items", "shard_coverage"]),
+        ),
+        (
+            "GET",
+            "/admin/external-handoffs/{token}",
+            Some(&["status", "item", "shard_coverage"]),
+        ),
         // ── schedules ─────────────────────────────────────────────────────────
-        ("GET",  "/admin/schedules",                      None), // Vec<ScheduleEntry>
-        ("POST", "/admin/schedules/workflow",             Some(&["id", "kind", "name", "schedule_expr", "is_paused", "next_run_at", "last_run_at", "max_active_runs", "catchup"])),
-        ("POST", "/admin/schedules/{id}/pause",           Some(&["ok"])),
-        ("POST", "/admin/schedules/{id}/resume",          Some(&["ok"])),
-        ("DELETE","/admin/schedules/{id}",                Some(&["ok"])),
+        ("GET", "/admin/schedules", None), // Vec<ScheduleEntry>
+        (
+            "POST",
+            "/admin/schedules/workflow",
+            Some(&[
+                "id",
+                "kind",
+                "name",
+                "schedule_expr",
+                "is_paused",
+                "next_run_at",
+                "last_run_at",
+                "max_active_runs",
+                "catchup",
+            ]),
+        ),
+        ("POST", "/admin/schedules/{id}/pause", Some(&["ok"])),
+        ("POST", "/admin/schedules/{id}/resume", Some(&["ok"])),
+        ("DELETE", "/admin/schedules/{id}", Some(&["ok"])),
         // ── audit ─────────────────────────────────────────────────────────────
-        ("GET",  "/admin/audit",                          None), // Vec<AuditRecord> (external model)
+        ("GET", "/admin/audit", None), // Vec<AuditRecord> (external model)
     ]
 }
 

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -1100,10 +1100,12 @@ pub fn harvest_api_router(api_state: HarvestApiState) -> Router<AppState> {
         .layer(Extension(api_state))
 }
 
-/// Returns the canonical list of all `(METHOD, path-template)` pairs registered
-/// by `harvest_api_router`.  The contract regression test compares this list
-/// against `docs/api-contract.json`; update both together whenever routes change.
-pub fn management_api_routes() -> &'static [(&'static str, &'static str)] {
+/// Canonical `(METHOD, path-template)` list for every route in `harvest_api_router`.
+///
+/// The contract regression test compares this list against `docs/api-contract.json`;
+/// update both together whenever routes change.
+#[must_use]
+pub const fn management_api_routes() -> &'static [(&'static str, &'static str)] {
     &[
         // ── workflows ────────────────────────────────────────────────────────
         ("GET", "/workflows"),
@@ -1167,14 +1169,12 @@ pub fn management_api_routes() -> &'static [(&'static str, &'static str)] {
 
 /// Canonical request-body field registry for every mutating management route.
 ///
-/// Each entry is `(method, path_template, fields)` where `fields` is:
-/// - `Some(&[...])` — structured body with these named top-level JSON keys
-/// - `None`         — free-form body (opaque payload, e.g. signal)
-///
-/// This registry is compared against `docs/api-contract.json` by the contract
-/// regression test.  Update this list and the contract together whenever you
-/// add, remove, or rename a request field.
-pub fn management_api_request_fields() -> &'static [(&'static str, &'static str, Option<&'static [&'static str]>)] {
+/// Each entry is `(method, path_template, fields)` where `fields` is
+/// `Some(&[...])` for a structured body or `None` for a free-form body.
+/// Compared against `docs/api-contract.json` by the regression test; update
+/// both together when adding, removing, or renaming a request field.
+#[must_use]
+pub const fn management_api_request_fields() -> &'static [(&'static str, &'static str, Option<&'static [&'static str]>)] {
     &[
         // ── workflows ────────────────────────────────────────────────────────
         ("POST", "/workflows/{workflow_name}/start", Some(&[
@@ -1222,15 +1222,13 @@ pub fn management_api_request_fields() -> &'static [(&'static str, &'static str,
 
 /// Canonical success-response field registry for every management route.
 ///
-/// Each entry is `(method, path_template, fields)` where `fields` is:
-/// - `Some(&[...])` — structured JSON object with these top-level keys
-/// - `None`         — free-form response (array, external model, or polymorphic)
-///
-/// This registry is compared against `docs/api-contract.json`
-/// (`success_response.fields` / `success_response.free_form`) by the contract
-/// regression test.  Update this list and the contract together whenever you
-/// add, remove, or rename a top-level response field.
-pub fn management_api_response_fields() -> &'static [(&'static str, &'static str, Option<&'static [&'static str]>)] {
+/// Each entry is `(method, path_template, fields)` where `fields` is
+/// `Some(&[...])` for a structured object response or `None` for a free-form
+/// response (array, external model, or polymorphic).  Compared against
+/// `docs/api-contract.json` by the regression test; update both together when
+/// adding, removing, or renaming a top-level response field.
+#[must_use]
+pub const fn management_api_response_fields() -> &'static [(&'static str, &'static str, Option<&'static [&'static str]>)] {
     &[
         // ── workflows ────────────────────────────────────────────────────────
         ("GET",  "/workflows",                            None), // Vec<WorkflowExecution>

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -1207,6 +1207,7 @@ pub fn management_api_request_fields() -> &'static [(&'static str, &'static str,
         // ── batch operations ──────────────────────────────────────────────────
         ("POST", "/batch-operations", Some(&[
             "action", "filter", "signal_name", "signal_payload",
+            "idempotency_key", "created_by",
         ])),
         // ── admin ─────────────────────────────────────────────────────────────
         ("POST", "/admin/retention/run-now", Some(&[])),
@@ -1216,6 +1217,87 @@ pub fn management_api_request_fields() -> &'static [(&'static str, &'static str,
         ("POST", "/admin/schedules/{id}/pause", Some(&[])),
         ("POST", "/admin/schedules/{id}/resume", Some(&[])),
         ("DELETE", "/admin/schedules/{id}", Some(&[])),
+    ]
+}
+
+/// Canonical success-response field registry for every management route.
+///
+/// Each entry is `(method, path_template, fields)` where `fields` is:
+/// - `Some(&[...])` — structured JSON object with these top-level keys
+/// - `None`         — free-form response (array, external model, or polymorphic)
+///
+/// This registry is compared against `docs/api-contract.json`
+/// (`success_response.fields` / `success_response.free_form`) by the contract
+/// regression test.  Update this list and the contract together whenever you
+/// add, remove, or rename a top-level response field.
+pub fn management_api_response_fields() -> &'static [(&'static str, &'static str, Option<&'static [&'static str]>)] {
+    &[
+        // ── workflows ────────────────────────────────────────────────────────
+        ("GET",  "/workflows",                            None), // Vec<WorkflowExecution>
+        ("GET",  "/workflows/{id}",                       Some(&["parent_id", "execution", "history", "external_handoffs"])),
+        ("GET",  "/workflows/{id}/history/export",        None), // HistoryExportDocument (external)
+        ("GET",  "/workflows/{id}/children",              Some(&["items", "next_cursor"])),
+        ("GET",  "/workflows/{id}/stack",                 Some(&[
+            "exec_id", "workflow_id", "workflow_name", "state", "is_terminal",
+            "pending_activities", "pending_external_handoffs", "pending_local_activities",
+            "pending_timers", "pending_signals", "buffered_signals",
+            "pending_child_workflows", "last_event_id",
+        ])),
+        ("POST", "/workflows/{workflow_name}/start",      Some(&["execution_id", "workflow_name", "workflow_id", "state"])),
+        ("POST", "/workflows/{id}/cancel",                Some(&["ok", "execution_id", "state", "reason", "newly_cancelled", "failed_task_count"])),
+        ("POST", "/workflows/{id}/reset",                 Some(&[
+            "new_exec_id", "reset_from_exec_id", "reset_to_event_id", "events_carried_over",
+            "source_tasks_cancelled", "source_timers_removed",
+            "source_signals_dropped", "source_signals_buffered",
+        ])),
+        ("POST", "/workflows/{id}/signal/{signal_name}",  Some(&["ok"])),
+        ("GET",  "/workflows/{id}/query/{query_name}",    None), // opaque handler return
+        ("POST", "/workflows/{id}/update/{update_name}",  None), // polymorphic admitted/completed/failed
+        ("GET",  "/workflows/{id}/update/{update_id}/result", None), // polymorphic completed/failed
+        // ── DAGs ─────────────────────────────────────────────────────────────
+        ("GET",  "/dags",                                 None), // Vec<DagSummary>
+        ("GET",  "/dags/{dag_name}/runs",                 None), // Vec<DagRun> (external model)
+        ("POST", "/dags/{dag_name}/trigger",              None), // DagRun (external model)
+        ("PATCH","/dags/{dag_name}",                     None), // HarvestSchedule (external model)
+        // ── dead-letter queue ─────────────────────────────────────────────────
+        ("GET",  "/dead-letters",                         None), // Vec<DeadLetter> (external model)
+        ("POST", "/dead-letters/replay",                  Some(&["matched", "acted_on", "skipped", "ids", "dry_run", "failures"])),
+        ("POST", "/dead-letters/discard",                 Some(&["matched", "acted_on", "skipped", "ids", "dry_run", "failures"])),
+        ("POST", "/dead-letters/{id}/replay",             Some(&["ok", "dead_letter_id", "task_id"])),
+        // ── external activity handoff ─────────────────────────────────────────
+        ("POST", "/activities/external/{token}/complete", Some(&["ok", "newly_resolved", "status", "current_state"])),
+        ("POST", "/activities/external/{token}/fail",     Some(&["ok", "newly_resolved", "status", "current_state"])),
+        ("POST", "/activities/external/{token}/heartbeat",Some(&["ok", "newly_resolved", "status", "current_state"])),
+        // ── workers ───────────────────────────────────────────────────────────
+        ("GET",  "/workers",                              None), // Vec<WorkerRow> (external model)
+        ("GET",  "/workers/{worker_id}",                  None), // WorkerRow (external model)
+        ("GET",  "/workers/health",                       Some(&["healthy", "stale", "draining", "by_queue", "by_shard"])),
+        ("GET",  "/workers/drain-preview",                None), // Vec<DrainPreviewItem>
+        ("POST", "/workers/{worker_id}/drain",            Some(&["worker_id", "outcome", "in_flight_count", "drain_deadline_at", "shard_ids", "unavailable_shards"])),
+        // ── batch operations ──────────────────────────────────────────────────
+        ("GET",  "/batch-operations",                     None), // Vec<BatchJobView> (external model)
+        ("POST", "/batch-operations",                     Some(&["batch_job_id"])),
+        ("GET",  "/batch-operations/{id}",                None), // BatchJobView (external model)
+        // ── health & admin ────────────────────────────────────────────────────
+        ("GET",  "/health",                               Some(&["runtime_ready", "worker_id", "queues", "dag_count", "scheduler", "shard_readiness_enforced", "shard_readiness"])),
+        ("GET",  "/admin/preflight",                      Some(&["overall_status", "observed_at", "version", "checks"])),
+        ("GET",  "/admin/shards/health",                  Some(&["overall_readiness", "observed_at", "freshness_window_secs", "candidate_shard", "shards"])),
+        ("GET",  "/admin/version-gates/usage",            Some(&["status", "observed_at", "filters", "items", "shards"])),
+        ("GET",  "/admin/version-gates/retirement-check", Some(&["status", "safe_to_retire", "observed_at", "filters", "blockers", "shards"])),
+        ("GET",  "/admin/retention",                      None), // RetentionStatus (external model)
+        ("POST", "/admin/retention/run-now",              Some(&["ok"])),
+        ("GET",  "/admin/concurrency",                    None), // Vec<ConcurrencyKeyStats> (external model)
+        ("GET",  "/admin/history/exports",                Some(&["status", "observed_at", "payload_policy", "filters", "exports", "failures", "shard_coverage"])),
+        ("GET",  "/admin/external-handoffs",              Some(&["status", "items", "shard_coverage"])),
+        ("GET",  "/admin/external-handoffs/{token}",      Some(&["status", "item", "shard_coverage"])),
+        // ── schedules ─────────────────────────────────────────────────────────
+        ("GET",  "/admin/schedules",                      None), // Vec<ScheduleEntry>
+        ("POST", "/admin/schedules/workflow",             Some(&["id", "kind", "name", "schedule_expr", "is_paused", "next_run_at", "last_run_at", "max_active_runs", "catchup"])),
+        ("POST", "/admin/schedules/{id}/pause",           Some(&["ok"])),
+        ("POST", "/admin/schedules/{id}/resume",          Some(&["ok"])),
+        ("DELETE","/admin/schedules/{id}",                Some(&["ok"])),
+        // ── audit ─────────────────────────────────────────────────────────────
+        ("GET",  "/admin/audit",                          None), // Vec<AuditRecord> (external model)
     ]
 }
 

--- a/autumn-harvest-plugin/src/lib.rs
+++ b/autumn-harvest-plugin/src/lib.rs
@@ -15,7 +15,7 @@ pub mod version_usage;
 
 pub use api::{
     HarvestApiRuntime, HarvestApiState, HarvestRetentionRuntime, harvest_api_router,
-    management_api_request_fields, management_api_routes,
+    management_api_request_fields, management_api_response_fields, management_api_routes,
 };
 pub use config::{
     HarvestBatchConfig, HarvestDatabaseConfig, HarvestMode, HarvestOutboxConfig,

--- a/autumn-harvest-plugin/src/lib.rs
+++ b/autumn-harvest-plugin/src/lib.rs
@@ -15,7 +15,7 @@ pub mod version_usage;
 
 pub use api::{
     HarvestApiRuntime, HarvestApiState, HarvestRetentionRuntime, harvest_api_router,
-    management_api_routes,
+    management_api_request_fields, management_api_routes,
 };
 pub use config::{
     HarvestBatchConfig, HarvestDatabaseConfig, HarvestMode, HarvestOutboxConfig,

--- a/autumn-harvest-plugin/src/lib.rs
+++ b/autumn-harvest-plugin/src/lib.rs
@@ -13,7 +13,10 @@ pub mod ui;
 pub mod version_gate_retirement;
 pub mod version_usage;
 
-pub use api::{HarvestApiRuntime, HarvestApiState, HarvestRetentionRuntime, harvest_api_router};
+pub use api::{
+    HarvestApiRuntime, HarvestApiState, HarvestRetentionRuntime, harvest_api_router,
+    management_api_routes,
+};
 pub use config::{
     HarvestBatchConfig, HarvestDatabaseConfig, HarvestMode, HarvestOutboxConfig,
     HarvestReadinessConfig, HarvestRuntimeConfig,

--- a/autumn-harvest-plugin/tests/contract_regression.rs
+++ b/autumn-harvest-plugin/tests/contract_regression.rs
@@ -196,8 +196,7 @@ fn contract_request_fields_match_code_registry() {
             (None, Some(None)) => {} // both free-form ✓
             (Some(cf), Some(Some(contract_f))) => {
                 let mut code_set: Vec<&str> = cf.iter().copied().collect();
-                let mut contract_set: Vec<&str> =
-                    contract_f.iter().map(|s| s.as_str()).collect();
+                let mut contract_set: Vec<&str> = contract_f.iter().map(|s| s.as_str()).collect();
                 code_set.sort_unstable();
                 contract_set.sort_unstable();
                 assert_eq!(
@@ -219,7 +218,6 @@ fn contract_request_fields_match_code_registry() {
         }
     }
 }
-
 
 /// No contract route may be both read_only:true and use a mutating HTTP method.
 #[test]
@@ -283,8 +281,7 @@ fn contract_response_fields_match_code_registry() {
             (None, Some(None)) => {}
             (Some(cf), Some(Some(contract_f))) => {
                 let mut code_set: Vec<&str> = cf.iter().copied().collect();
-                let mut contract_set: Vec<&str> =
-                    contract_f.iter().map(|s| s.as_str()).collect();
+                let mut contract_set: Vec<&str> = contract_f.iter().map(|s| s.as_str()).collect();
                 code_set.sort_unstable();
                 contract_set.sort_unstable();
                 assert_eq!(

--- a/autumn-harvest-plugin/tests/contract_regression.rs
+++ b/autumn-harvest-plugin/tests/contract_regression.rs
@@ -8,7 +8,7 @@
 /// Compatibility rules (stated in the contract):
 ///   - Adding response fields is non-breaking.
 ///   - Removing, renaming, or changing the type of a response field is breaking.
-///   - New mutating routes must be classified (read_only = false) in the contract.
+///   - New mutating routes must be classified (`read_only = false`) in the contract.
 use autumn_harvest_plugin::api::{
     management_api_request_fields, management_api_response_fields, management_api_routes,
 };
@@ -164,7 +164,7 @@ fn contract_mutating_routes_have_structured_request_body() {
 }
 
 /// The request field registry in code must match the structured field list in the contract.
-/// Update management_api_request_fields() AND docs/api-contract.json together.
+/// Update `management_api_request_fields()` AND `docs/api-contract.json` together.
 #[test]
 fn contract_request_fields_match_code_registry() {
     let contract = load_contract();
@@ -183,7 +183,7 @@ fn contract_request_fields_match_code_registry() {
         } else if let Some(arr) = rb["fields"].as_array() {
             let names: Vec<String> = arr
                 .iter()
-                .filter_map(|f| f["name"].as_str().map(|s| s.to_string()))
+                .filter_map(|f| f["name"].as_str().map(ToString::to_string))
                 .collect();
             contract_fields.insert((method, path), Some(names));
         }
@@ -193,17 +193,16 @@ fn contract_request_fields_match_code_registry() {
     for (method, path, code_fields) in management_api_request_fields() {
         let key = (method.to_string(), path.to_string());
         match (code_fields, contract_fields.get(&key)) {
-            (None, Some(None)) => {} // both free-form ✓
             (Some(cf), Some(Some(contract_f))) => {
-                let mut code_set: Vec<&str> = cf.iter().copied().collect();
-                let mut contract_set: Vec<&str> = contract_f.iter().map(|s| s.as_str()).collect();
+                let mut code_set: Vec<&str> = cf.to_vec();
+                let mut contract_set: Vec<&str> = contract_f.iter().map(String::as_str).collect();
                 code_set.sort_unstable();
                 contract_set.sort_unstable();
                 assert_eq!(
                     code_set, contract_set,
                     "Request field mismatch for {method} {path}: \
                      code registry has {code_set:?} but contract has {contract_set:?}. \
-                     Update both management_api_request_fields() and docs/api-contract.json."
+                     Update both `management_api_request_fields()` and docs/api-contract.json."
                 );
             }
             (None, Some(Some(_))) => panic!(
@@ -212,14 +211,13 @@ fn contract_request_fields_match_code_registry() {
             (Some(_), Some(None)) => panic!(
                 "{method} {path}: code registry has structured fields but contract says free-form"
             ),
-            (_, None) => {
-                // Route is read-only or has no body — not in contract_fields map, skip.
-            }
+            // both free-form, or route has no body in contract — skip
+            (None, Some(None)) | (_, None) => {}
         }
     }
 }
 
-/// No contract route may be both read_only:true and use a mutating HTTP method.
+/// No contract route may be both `read_only:true` and use a mutating HTTP method.
 #[test]
 fn contract_read_only_classification_is_consistent() {
     let contract = load_contract();
@@ -239,11 +237,11 @@ fn contract_read_only_classification_is_consistent() {
     }
 }
 
-/// Every contract route that has a structured success_response (i.e. a `fields`
+/// Every contract route that has a structured `success_response` (i.e. a `fields`
 /// array rather than `free_form: true`) must have its top-level response field
 /// names listed in `management_api_response_fields()`, and vice-versa.
 ///
-/// Update management_api_response_fields() AND the `success_response.fields`
+/// Update `management_api_response_fields()` AND the `success_response.fields`
 /// array in docs/api-contract.json together whenever you add, remove, or rename
 /// a top-level response field on any management route.
 #[test]
@@ -267,8 +265,8 @@ fn contract_response_fields_match_code_registry() {
                 .filter_map(|f| {
                     // fields may be plain strings or {name: ...} objects
                     f.as_str()
-                        .map(|s| s.to_string())
-                        .or_else(|| f["name"].as_str().map(|s| s.to_string()))
+                        .map(ToString::to_string)
+                        .or_else(|| f["name"].as_str().map(ToString::to_string))
                 })
                 .collect();
             contract_resp.insert((method, path), Some(names));
@@ -280,8 +278,8 @@ fn contract_response_fields_match_code_registry() {
         match (code_fields, contract_resp.get(&key)) {
             (None, Some(None)) => {}
             (Some(cf), Some(Some(contract_f))) => {
-                let mut code_set: Vec<&str> = cf.iter().copied().collect();
-                let mut contract_set: Vec<&str> = contract_f.iter().map(|s| s.as_str()).collect();
+                let mut code_set: Vec<&str> = cf.to_vec();
+                let mut contract_set: Vec<&str> = contract_f.iter().map(String::as_str).collect();
                 code_set.sort_unstable();
                 contract_set.sort_unstable();
                 assert_eq!(

--- a/autumn-harvest-plugin/tests/contract_regression.rs
+++ b/autumn-harvest-plugin/tests/contract_regression.rs
@@ -1,0 +1,153 @@
+/// Contract regression tests for the Harvest management API.
+///
+/// These tests enforce that `docs/api-contract.json` stays in sync with
+/// the routes registered in `harvest_api_router`.  If you add, remove, rename,
+/// or change the HTTP method of any management route you MUST update
+/// `docs/api-contract.json` AND `CHANGELOG.md` before this test will pass.
+///
+/// Compatibility rules (stated in the contract):
+///   - Adding response fields is non-breaking.
+///   - Removing, renaming, or changing the type of a response field is breaking.
+///   - New mutating routes must be classified (read_only = false) in the contract.
+use autumn_harvest_plugin::api::management_api_routes;
+use std::collections::HashSet;
+
+const CONTRACT_JSON: &str = include_str!("../../docs/api-contract.json");
+
+fn load_contract() -> serde_json::Value {
+    serde_json::from_str(CONTRACT_JSON).expect("docs/api-contract.json must be valid JSON")
+}
+
+fn contract_route_set(contract: &serde_json::Value) -> HashSet<(String, String)> {
+    contract["routes"]
+        .as_array()
+        .expect("contract.routes must be a JSON array")
+        .iter()
+        .map(|r| {
+            let method = r["method"]
+                .as_str()
+                .expect("each route must have a string 'method'")
+                .to_string();
+            let path = r["path"]
+                .as_str()
+                .expect("each route must have a string 'path'")
+                .to_string();
+            (method, path)
+        })
+        .collect()
+}
+
+/// Every route registered in `harvest_api_router` must appear in the contract,
+/// and every route in the contract must exist in `harvest_api_router`.
+/// Drift in either direction causes this test to fail.
+#[test]
+fn management_routes_match_contract() {
+    let contract = load_contract();
+    let contract_routes = contract_route_set(&contract);
+
+    let code_routes: HashSet<(String, String)> = management_api_routes()
+        .iter()
+        .map(|(m, p)| (m.to_string(), p.to_string()))
+        .collect();
+
+    let in_code_not_contract: Vec<_> = code_routes.difference(&contract_routes).collect();
+    let in_contract_not_code: Vec<_> = contract_routes.difference(&code_routes).collect();
+
+    assert!(
+        in_code_not_contract.is_empty(),
+        "Routes in harvest_api_router but missing from docs/api-contract.json \
+         (update the contract and CHANGELOG):\n{in_code_not_contract:#?}"
+    );
+    assert!(
+        in_contract_not_code.is_empty(),
+        "Routes in docs/api-contract.json but not registered in harvest_api_router \
+         (remove stale entries from the contract):\n{in_contract_not_code:#?}"
+    );
+}
+
+/// Every route in the contract must carry all required metadata fields.
+#[test]
+fn contract_routes_have_required_fields() {
+    let contract = load_contract();
+
+    for (i, route) in contract["routes"]
+        .as_array()
+        .expect("contract.routes must be an array")
+        .iter()
+        .enumerate()
+    {
+        let path = route["path"].as_str().unwrap_or("(missing path)");
+        let method = route["method"].as_str().unwrap_or("(missing method)");
+        let loc = format!("route[{i}] {method} {path}");
+
+        assert!(
+            route["method"].is_string(),
+            "{loc}: missing required field 'method'"
+        );
+        assert!(
+            route["path"].is_string(),
+            "{loc}: missing required field 'path'"
+        );
+        assert!(
+            route["description"].is_string(),
+            "{loc}: missing required field 'description'"
+        );
+        assert!(
+            route["read_only"].is_boolean(),
+            "{loc}: missing required boolean field 'read_only'"
+        );
+        assert!(
+            route["category"].is_string(),
+            "{loc}: missing required field 'category'"
+        );
+    }
+}
+
+/// The contract document must carry version and compatibility metadata.
+#[test]
+fn contract_has_version_and_compatibility_rules() {
+    let contract = load_contract();
+
+    assert!(
+        contract["version"].is_string(),
+        "contract must have a 'version' string (matches crate version)"
+    );
+    assert!(
+        contract["contract_version"].is_string(),
+        "contract must have a 'contract_version' string"
+    );
+    assert!(
+        contract["compatibility"].is_object(),
+        "contract must have a 'compatibility' object documenting breaking-change rules"
+    );
+
+    let compat = &contract["compatibility"];
+    assert!(
+        compat["additive_response_fields_allowed"].is_boolean(),
+        "compatibility must declare 'additive_response_fields_allowed'"
+    );
+    assert!(
+        compat["breaking_changes"].is_array(),
+        "compatibility must list 'breaking_changes'"
+    );
+}
+
+/// No contract route may be both read_only:true and use a mutating HTTP method.
+#[test]
+fn contract_read_only_classification_is_consistent() {
+    let contract = load_contract();
+    let mutating_methods = ["POST", "PUT", "PATCH", "DELETE"];
+
+    for route in contract["routes"].as_array().unwrap() {
+        let method = route["method"].as_str().unwrap_or("");
+        let path = route["path"].as_str().unwrap_or("");
+        let read_only = route["read_only"].as_bool().unwrap_or(false);
+
+        if mutating_methods.contains(&method) {
+            assert!(
+                !read_only,
+                "route {method} {path} uses a mutating HTTP method but is marked read_only:true"
+            );
+        }
+    }
+}

--- a/autumn-harvest-plugin/tests/contract_regression.rs
+++ b/autumn-harvest-plugin/tests/contract_regression.rs
@@ -9,8 +9,8 @@
 ///   - Adding response fields is non-breaking.
 ///   - Removing, renaming, or changing the type of a response field is breaking.
 ///   - New mutating routes must be classified (read_only = false) in the contract.
-use autumn_harvest_plugin::api::management_api_routes;
-use std::collections::HashSet;
+use autumn_harvest_plugin::api::{management_api_request_fields, management_api_routes};
+use std::collections::{HashMap, HashSet};
 
 const CONTRACT_JSON: &str = include_str!("../../docs/api-contract.json");
 
@@ -131,6 +131,93 @@ fn contract_has_version_and_compatibility_rules() {
         "compatibility must list 'breaking_changes'"
     );
 }
+
+/// Every mutating route in the contract must have a `request_body.fields` array
+/// so that the body-field coverage tests can validate CLI output against it.
+#[test]
+fn contract_mutating_routes_have_structured_request_body() {
+    let contract = load_contract();
+    let mutating_methods = ["POST", "PUT", "PATCH", "DELETE"];
+
+    for route in contract["routes"].as_array().unwrap() {
+        let method = route["method"].as_str().unwrap_or("");
+        let path = route["path"].as_str().unwrap_or("");
+        if !mutating_methods.contains(&method) {
+            continue;
+        }
+        let rb = &route["request_body"];
+        assert!(
+            rb.is_object(),
+            "{method} {path}: mutating route must have a 'request_body' object"
+        );
+        let free_form = rb["free_form"].as_bool().unwrap_or(false);
+        if !free_form {
+            assert!(
+                rb["fields"].is_array(),
+                "{method} {path}: request_body must have a 'fields' array \
+                 (use free_form:true for routes whose body is an opaque payload)"
+            );
+        }
+    }
+}
+
+/// The request field registry in code must match the structured field list in the contract.
+/// Update management_api_request_fields() AND docs/api-contract.json together.
+#[test]
+fn contract_request_fields_match_code_registry() {
+    let contract = load_contract();
+
+    // Build (method, path) → field names from the contract's structured schemas.
+    let mut contract_fields: HashMap<(String, String), Option<Vec<String>>> = HashMap::new();
+    for route in contract["routes"].as_array().unwrap() {
+        let method = route["method"].as_str().unwrap().to_string();
+        let path = route["path"].as_str().unwrap().to_string();
+        let rb = &route["request_body"];
+        if !rb.is_object() {
+            continue;
+        }
+        if rb["free_form"].as_bool().unwrap_or(false) {
+            contract_fields.insert((method, path), None);
+        } else if let Some(arr) = rb["fields"].as_array() {
+            let names: Vec<String> = arr
+                .iter()
+                .filter_map(|f| f["name"].as_str().map(|s| s.to_string()))
+                .collect();
+            contract_fields.insert((method, path), Some(names));
+        }
+    }
+
+    // Compare against management_api_request_fields().
+    for (method, path, code_fields) in management_api_request_fields() {
+        let key = (method.to_string(), path.to_string());
+        match (code_fields, contract_fields.get(&key)) {
+            (None, Some(None)) => {} // both free-form ✓
+            (Some(cf), Some(Some(contract_f))) => {
+                let mut code_set: Vec<&str> = cf.iter().copied().collect();
+                let mut contract_set: Vec<&str> =
+                    contract_f.iter().map(|s| s.as_str()).collect();
+                code_set.sort_unstable();
+                contract_set.sort_unstable();
+                assert_eq!(
+                    code_set, contract_set,
+                    "Request field mismatch for {method} {path}: \
+                     code registry has {code_set:?} but contract has {contract_set:?}. \
+                     Update both management_api_request_fields() and docs/api-contract.json."
+                );
+            }
+            (None, Some(Some(_))) => panic!(
+                "{method} {path}: code registry says free-form but contract has structured fields"
+            ),
+            (Some(_), Some(None)) => panic!(
+                "{method} {path}: code registry has structured fields but contract says free-form"
+            ),
+            (_, None) => {
+                // Route is read-only or has no body — not in contract_fields map, skip.
+            }
+        }
+    }
+}
+
 
 /// No contract route may be both read_only:true and use a mutating HTTP method.
 #[test]

--- a/autumn-harvest-plugin/tests/contract_regression.rs
+++ b/autumn-harvest-plugin/tests/contract_regression.rs
@@ -9,7 +9,9 @@
 ///   - Adding response fields is non-breaking.
 ///   - Removing, renaming, or changing the type of a response field is breaking.
 ///   - New mutating routes must be classified (read_only = false) in the contract.
-use autumn_harvest_plugin::api::{management_api_request_fields, management_api_routes};
+use autumn_harvest_plugin::api::{
+    management_api_request_fields, management_api_response_fields, management_api_routes,
+};
 use std::collections::{HashMap, HashSet};
 
 const CONTRACT_JSON: &str = include_str!("../../docs/api-contract.json");
@@ -236,5 +238,107 @@ fn contract_read_only_classification_is_consistent() {
                 "route {method} {path} uses a mutating HTTP method but is marked read_only:true"
             );
         }
+    }
+}
+
+/// Every contract route that has a structured success_response (i.e. a `fields`
+/// array rather than `free_form: true`) must have its top-level response field
+/// names listed in `management_api_response_fields()`, and vice-versa.
+///
+/// Update management_api_response_fields() AND the `success_response.fields`
+/// array in docs/api-contract.json together whenever you add, remove, or rename
+/// a top-level response field on any management route.
+#[test]
+fn contract_response_fields_match_code_registry() {
+    let contract = load_contract();
+
+    // Build (method, path) → field names from the contract's success_response.
+    let mut contract_resp: HashMap<(String, String), Option<Vec<String>>> = HashMap::new();
+    for route in contract["routes"].as_array().unwrap() {
+        let method = route["method"].as_str().unwrap().to_string();
+        let path = route["path"].as_str().unwrap().to_string();
+        let sr = &route["success_response"];
+        if !sr.is_object() {
+            continue;
+        }
+        if sr["free_form"].as_bool().unwrap_or(false) {
+            contract_resp.insert((method, path), None);
+        } else if let Some(arr) = sr["fields"].as_array() {
+            let names: Vec<String> = arr
+                .iter()
+                .filter_map(|f| {
+                    // fields may be plain strings or {name: ...} objects
+                    f.as_str()
+                        .map(|s| s.to_string())
+                        .or_else(|| f["name"].as_str().map(|s| s.to_string()))
+                })
+                .collect();
+            contract_resp.insert((method, path), Some(names));
+        }
+    }
+
+    for (method, path, code_fields) in management_api_response_fields() {
+        let key = (method.to_string(), path.to_string());
+        match (code_fields, contract_resp.get(&key)) {
+            (None, Some(None)) => {}
+            (Some(cf), Some(Some(contract_f))) => {
+                let mut code_set: Vec<&str> = cf.iter().copied().collect();
+                let mut contract_set: Vec<&str> =
+                    contract_f.iter().map(|s| s.as_str()).collect();
+                code_set.sort_unstable();
+                contract_set.sort_unstable();
+                assert_eq!(
+                    code_set, contract_set,
+                    "Response field mismatch for {method} {path}: \
+                     code registry has {code_set:?} but contract has {contract_set:?}. \
+                     Update both management_api_response_fields() and docs/api-contract.json."
+                );
+            }
+            (None, Some(Some(_))) => panic!(
+                "{method} {path}: code registry says free-form but contract has structured fields"
+            ),
+            (Some(_), Some(None)) => panic!(
+                "{method} {path}: code registry has structured fields but contract says free-form"
+            ),
+            (_, None) => panic!(
+                "{method} {path}: in code response registry but missing from contract \
+                 success_response (add 'fields' or 'free_form: true' to the route)"
+            ),
+        }
+    }
+}
+
+/// Every contract route must document an `idempotency` field so embedders
+/// know which operations are safe to retry.
+#[test]
+fn contract_mutating_routes_have_idempotency_field() {
+    let contract = load_contract();
+    let mutating_methods = ["POST", "PUT", "PATCH", "DELETE"];
+
+    for route in contract["routes"].as_array().unwrap() {
+        let method = route["method"].as_str().unwrap_or("");
+        let path = route["path"].as_str().unwrap_or("");
+        if !mutating_methods.contains(&method) {
+            continue;
+        }
+        assert!(
+            route["idempotency"].is_string(),
+            "mutating route {method} {path}: missing required 'idempotency' string field \
+             (state whether the operation is idempotent and under what conditions)"
+        );
+    }
+}
+
+/// Every route in the contract must have a `params` array (may be empty).
+#[test]
+fn contract_routes_have_params_array() {
+    let contract = load_contract();
+    for route in contract["routes"].as_array().unwrap() {
+        let method = route["method"].as_str().unwrap_or("?");
+        let path = route["path"].as_str().unwrap_or("?");
+        assert!(
+            route["params"].is_array(),
+            "route {method} {path}: missing 'params' array (use [] when the route has no parameters)"
+        );
     }
 }

--- a/docs/api-contract-guide.md
+++ b/docs/api-contract-guide.md
@@ -1,0 +1,151 @@
+# Harvest Management API Contract — Embedder Guide
+
+This guide is for plugin embedders, CLI authors, and UI developers who consume
+the Harvest management API.  It explains how to inspect the published contract,
+validate your client against it, and understand what counts as a breaking change.
+
+---
+
+## Where to find the contract
+
+`docs/api-contract.json` is the single source of truth.  It is checked into the
+repository, so it is always available without running a server or starting a
+worker process.  The file version matches the `autumn-harvest-plugin` crate
+version (e.g. `"version": "0.2.0"`).
+
+```bash
+# Inspect the full route list
+jq '.routes[] | {method, path, category, read_only}' docs/api-contract.json
+
+# List only mutating routes
+jq '[.routes[] | select(.read_only == false) | {method, path, category}]' \
+   docs/api-contract.json
+
+# List only read-only admin routes
+jq '[.routes[] | select(.read_only == true and .category == "admin") | .path]' \
+   docs/api-contract.json
+```
+
+---
+
+## Contract format
+
+| Top-level key | Meaning |
+|---|---|
+| `version` | Crate version this contract was published with |
+| `contract_version` | Contract schema version (currently `"1"`) |
+| `compatibility` | Breaking vs. non-breaking change rules |
+| `routes` | Array of route entries |
+
+Each route entry:
+
+| Field | Type | Meaning |
+|---|---|---|
+| `method` | string | HTTP method: `GET`, `POST`, `PATCH`, or `DELETE` |
+| `path` | string | Path template using `{param}` placeholders |
+| `category` | string | Route group: `workflow`, `dag`, `dlq`, `external_activity`, `worker`, `batch`, `schedule`, `admin`, `health`, `audit` |
+| `read_only` | bool | `true` for GET endpoints; `false` for mutating operations |
+| `description` | string | Human-readable description |
+| `params` | array | Query and path parameters with name, location, required flag, and description |
+| `request_body` | object | `required` flag and field schema (null when not applicable) |
+| `success_response` | object | HTTP status and response schema description |
+| `error_responses` | array | Documented error status codes and conditions |
+| `idempotency` | string | (Optional) Idempotency semantics for the route |
+
+---
+
+## Compatibility rules
+
+These rules are stated in the `compatibility` section of the contract:
+
+**Non-breaking (safe to ship without a major contract bump):**
+- Adding a new optional response field
+- Adding a new optional query parameter
+- Adding a new read-only route
+- Narrowing an existing error response to be more specific
+
+**Breaking (requires updating the contract, bumping `contract_version`, and a
+CHANGELOG entry before release):**
+- Removing a response field
+- Renaming a response field
+- Changing the type of a response field
+- Removing a route
+- Renaming a route (path or method change)
+- Changing a query parameter from optional to required
+- Adding a new mutating route without classifying it in the contract
+
+---
+
+## Generating or validating a client
+
+Because the contract is plain JSON, any JSON-aware toolchain can consume it.
+A 10-minute workflow to generate a typed Rust client:
+
+```bash
+# 1. Extract routes into a simple TSV for code generation scaffolding
+jq -r '.routes[] | [.method, .path, .category, (.read_only | tostring)] | @tsv' \
+   docs/api-contract.json
+
+# 2. Validate that a hand-written client covers every contract route
+#    (example: check that a list of client methods covers all paths)
+contract_paths=$(jq -r '.routes[].path' docs/api-contract.json | sort)
+# compare against your method list ...
+```
+
+For languages with OpenAPI tooling: the contract is not OpenAPI, but its shape
+is straightforward to translate.  Each route entry maps 1-to-1 to an OpenAPI
+path item; `params` maps to OpenAPI parameters; `request_body.schema` maps to a
+`requestBody`.
+
+---
+
+## Using the contract alongside the CLI
+
+The `harvest` CLI uses `api_request()` to translate every subcommand into an
+`(method, path, body)` triple.  The contract coverage test in
+`autumn-harvest-cli/tests/contract_coverage.rs` asserts that every CLI
+subcommand maps to a documented contract route.
+
+To verify a specific CLI command manually:
+
+```bash
+# See which route a command uses (dry-run print, no network)
+harvest workflow cancel 00000000-0000-0000-0000-000000000001 --dry-run 2>&1 || true
+
+# Cross-reference against the contract
+jq '.routes[] | select(.path == "/workflows/{id}/cancel")' docs/api-contract.json
+```
+
+---
+
+## Integration with auth posture and audit trail
+
+- **Auth posture (issue #174):** The `category` and `read_only` fields in this
+  contract are the input to the auth classification layer.  Read-only routes
+  and admin routes can be assigned different auth requirements.  The contract
+  records the route surface; auth enforcement is owned by issue #174.
+
+- **Audit trail (issue #158):** Every route where `read_only: false` is
+  automatically included in the audit trail when `HarvestPlugin` is active.
+  The `GET /admin/audit` endpoint is the read surface for that log.
+
+---
+
+## Regression test
+
+`autumn-harvest-plugin/tests/contract_regression.rs` uses
+`management_api_routes()` (from `autumn_harvest_plugin::api`) to compare the
+live route set registered in `harvest_api_router` against `docs/api-contract.json`.
+
+**When you add, remove, rename, or change a route:**
+
+1. Update `harvest_api_router` in `autumn-harvest-plugin/src/api.rs`.
+2. Update `management_api_routes()` in the same file (keeps the canonical list
+   in sync with the router).
+3. Update `docs/api-contract.json` to reflect the new route or schema change.
+4. Add a CHANGELOG entry under the current version marking the change as
+   breaking or non-breaking per the compatibility rules above.
+5. Run `cargo test -p autumn-harvest-plugin --test contract_regression` to
+   confirm the regression test passes.
+
+The CI job will catch any drift between these three artefacts.

--- a/docs/api-contract.json
+++ b/docs/api-contract.json
@@ -1,0 +1,866 @@
+{
+  "version": "0.2.0",
+  "contract_version": "1",
+  "description": "Versioned machine-readable contract for the Harvest management API. Update this file and CHANGELOG.md whenever a route is added, removed, renamed, or its request/response shape changes.",
+  "compatibility": {
+    "additive_response_fields_allowed": true,
+    "breaking_changes": [
+      "Removing a response field",
+      "Renaming a response field",
+      "Changing the type of a response field",
+      "Removing a route",
+      "Renaming a route (path or method change)",
+      "Changing a query parameter from optional to required",
+      "Adding a new mutating route without classifying it in this contract"
+    ],
+    "non_breaking_changes": [
+      "Adding a new optional response field",
+      "Adding a new optional query parameter",
+      "Adding a new read-only route",
+      "Narrowing an existing error response to be more specific"
+    ]
+  },
+  "auth_note": "Route authorization posture is classified in issue #174. This contract records the route surface and category; auth enforcement is separate.",
+  "audit_note": "Mutating routes (read_only: false) are covered by the audit trail (issue #158). The audit endpoint itself is read-only.",
+  "routes": [
+    {
+      "method": "GET",
+      "path": "/workflows",
+      "category": "workflow",
+      "read_only": true,
+      "description": "List workflow executions with optional filters.",
+      "params": [
+        { "name": "state", "in": "query", "required": false, "description": "Comma-separated execution states (e.g. RUNNING,FAILED)." },
+        { "name": "workflow_name", "in": "query", "required": false, "description": "Filter by registered workflow name." },
+        { "name": "search_attr", "in": "query", "required": false, "repeated": true, "description": "Search attribute filter in key:value form. May be repeated." },
+        { "name": "limit", "in": "query", "required": false, "description": "Maximum number of results to return." },
+        { "name": "cursor", "in": "query", "required": false, "description": "Opaque pagination cursor from a previous response." }
+      ],
+      "success_response": { "status": 200, "schema": "Array of WorkflowExecution summaries with pagination cursor." },
+      "error_responses": [
+        { "status": 400, "description": "Invalid filter value." },
+        { "status": 500, "description": "Database error." }
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/workflows/{id}",
+      "category": "workflow",
+      "read_only": true,
+      "description": "Get full details and event history for a single workflow execution.",
+      "params": [
+        { "name": "id", "in": "path", "required": true, "description": "Execution UUID." }
+      ],
+      "success_response": { "status": 200, "schema": "WorkflowExecution with full event list." },
+      "error_responses": [
+        { "status": 404, "description": "Execution not found." },
+        { "status": 500, "description": "Database error." }
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/workflows/{id}/history/export",
+      "category": "workflow",
+      "read_only": true,
+      "description": "Export the complete event history for a single execution as a HistoryExportDocument suitable for use as a replay fixture.",
+      "params": [
+        { "name": "id", "in": "path", "required": true, "description": "Execution UUID." },
+        { "name": "payload_policy", "in": "query", "required": false, "description": "Payload inclusion policy: full (default), redacted, or omit." },
+        { "name": "max_bytes", "in": "query", "required": false, "description": "Soft byte cap on total payload size." }
+      ],
+      "success_response": { "status": 200, "schema": "HistoryExportDocument (JSON)." },
+      "error_responses": [
+        { "status": 404, "description": "Execution not found." },
+        { "status": 413, "description": "History exceeds max_bytes cap." },
+        { "status": 500, "description": "Database error." }
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/workflows/{id}/children",
+      "category": "workflow",
+      "read_only": true,
+      "description": "List child workflow executions spawned by a parent execution.",
+      "params": [
+        { "name": "id", "in": "path", "required": true, "description": "Parent execution UUID." },
+        { "name": "status", "in": "query", "required": false, "repeated": true, "description": "Filter by child status (e.g. Running, Failed). May be repeated." },
+        { "name": "workflow_name", "in": "query", "required": false, "description": "Filter by child workflow name." },
+        { "name": "limit", "in": "query", "required": false, "description": "Maximum number of results." },
+        { "name": "cursor", "in": "query", "required": false, "description": "Pagination cursor." },
+        { "name": "depth", "in": "query", "required": false, "description": "Maximum recursion depth for nested children." }
+      ],
+      "success_response": { "status": 200, "schema": "Array of child WorkflowExecution summaries." },
+      "error_responses": [
+        { "status": 404, "description": "Parent execution not found." },
+        { "status": 500, "description": "Database error." }
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/workflows/{id}/stack",
+      "category": "workflow",
+      "read_only": true,
+      "description": "Show the current wait state of a running workflow (what it is blocked on).",
+      "params": [
+        { "name": "id", "in": "path", "required": true, "description": "Execution UUID." }
+      ],
+      "success_response": { "status": 200, "schema": "WorkflowStack describing the current suspension point." },
+      "error_responses": [
+        { "status": 404, "description": "Execution not found." },
+        { "status": 500, "description": "Database error." }
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/workflows/{workflow_name}/start",
+      "category": "workflow",
+      "read_only": false,
+      "description": "Start a new workflow execution. Idempotent when workflow_id is provided: returns the existing execution if one with the same workflow_id is already running.",
+      "idempotency": "Idempotent by workflow_id when id_reuse_policy is reject_duplicate or allow_duplicate_failed_only.",
+      "request_body": {
+        "required": false,
+        "schema": {
+          "workflow_id": "Optional string — stable identifier for idempotent starts.",
+          "input": "Optional JSON — workflow input payload.",
+          "queue": "Optional string — task queue name.",
+          "memo": "Optional JSON object — non-indexed metadata.",
+          "search_attrs": "Optional JSON object — indexed search attributes.",
+          "execution_timeout_secs": "Optional integer — overall execution timeout.",
+          "id_reuse_policy": "Optional string — duplicate-id policy."
+        }
+      },
+      "success_response": { "status": 200, "schema": "Started or existing WorkflowExecution." },
+      "error_responses": [
+        { "status": 400, "description": "Invalid request body or workflow name." },
+        { "status": 409, "description": "Duplicate workflow_id with conflicting reuse policy." },
+        { "status": 500, "description": "Database or scheduling error." }
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/workflows/{id}/cancel",
+      "category": "workflow",
+      "read_only": false,
+      "description": "Cancel a running workflow execution.",
+      "request_body": {
+        "required": false,
+        "schema": {
+          "reason": "Optional string — human-readable cancellation reason recorded in audit log."
+        }
+      },
+      "success_response": { "status": 200, "schema": "Cancellation acknowledgement." },
+      "error_responses": [
+        { "status": 404, "description": "Execution not found." },
+        { "status": 409, "description": "Execution is already in a terminal state." },
+        { "status": 500, "description": "Database error." }
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/workflows/{id}/reset",
+      "category": "workflow",
+      "read_only": false,
+      "description": "Fork a workflow execution at a specific event boundary, replaying from that point with a new execution ID.",
+      "params": [
+        { "name": "dry_run", "in": "query", "required": false, "description": "When true, return the preview without creating a new execution." }
+      ],
+      "request_body": {
+        "required": true,
+        "schema": {
+          "reset_to_event_id": "Integer — event sequence number to reset to.",
+          "reason": "String — reason for the reset, recorded in audit log.",
+          "operator_id": "Optional string — identity of the operator.",
+          "signal_reapply": "Optional string — how to handle buffered signals: drop or buffer."
+        }
+      },
+      "success_response": { "status": 200, "schema": "ResetResult with new execution ID or dry-run preview." },
+      "error_responses": [
+        { "status": 400, "description": "Invalid reset point or request body." },
+        { "status": 404, "description": "Execution not found." },
+        { "status": 500, "description": "Database error." }
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/workflows/{id}/signal/{signal_name}",
+      "category": "workflow",
+      "read_only": false,
+      "description": "Send a named signal to a running workflow execution.",
+      "request_body": {
+        "required": false,
+        "schema": "Optional JSON payload for the signal handler."
+      },
+      "success_response": { "status": 200, "schema": "Signal delivery acknowledgement." },
+      "error_responses": [
+        { "status": 404, "description": "Execution not found." },
+        { "status": 500, "description": "Database error." }
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/workflows/{id}/query/{query_name}",
+      "category": "workflow",
+      "read_only": true,
+      "description": "Query the current state of a running workflow by invoking a registered query handler.",
+      "params": [
+        { "name": "id", "in": "path", "required": true, "description": "Execution UUID." },
+        { "name": "query_name", "in": "path", "required": true, "description": "Registered query handler name." }
+      ],
+      "success_response": { "status": 200, "schema": "JSON result from the query handler." },
+      "error_responses": [
+        { "status": 404, "description": "Execution not found or query handler not registered." },
+        { "status": 500, "description": "Query execution error." }
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/workflows/{id}/update/{update_name}",
+      "category": "workflow",
+      "read_only": false,
+      "description": "Submit a synchronous update request to a running workflow. Blocks until admitted or completed depending on the wait parameter.",
+      "params": [
+        { "name": "wait", "in": "query", "required": false, "description": "admitted — return when the update is validated and accepted; completed — block until the update handler returns (default)." },
+        { "name": "timeout_secs", "in": "query", "required": false, "description": "Maximum seconds to wait for the update to reach the requested state." }
+      ],
+      "request_body": {
+        "required": false,
+        "schema": {
+          "input": "Optional JSON — payload passed to the update handler."
+        }
+      },
+      "success_response": { "status": 200, "schema": "UpdateResult with update_id and outcome." },
+      "error_responses": [
+        { "status": 400, "description": "Update rejected by the validator." },
+        { "status": 404, "description": "Execution not found or update handler not registered." },
+        { "status": 408, "description": "Timed out waiting for completion." },
+        { "status": 500, "description": "Internal error." }
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/workflows/{id}/update/{update_id}/result",
+      "category": "workflow",
+      "read_only": true,
+      "description": "Poll the result of a previously admitted workflow update.",
+      "params": [
+        { "name": "id", "in": "path", "required": true, "description": "Execution UUID." },
+        { "name": "update_id", "in": "path", "required": true, "description": "Update UUID returned by POST …/update/{name}." }
+      ],
+      "success_response": { "status": 200, "schema": "UpdateResult: status (admitted | completed | failed) and output or error." },
+      "error_responses": [
+        { "status": 404, "description": "Update not found." },
+        { "status": 500, "description": "Database error." }
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/dags",
+      "category": "dag",
+      "read_only": true,
+      "description": "List all registered DAGs and their current pause/enabled state.",
+      "params": [],
+      "success_response": { "status": 200, "schema": "Array of RegisteredDag summaries." },
+      "error_responses": [
+        { "status": 500, "description": "Internal error." }
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/dags/{dag_name}/runs",
+      "category": "dag",
+      "read_only": true,
+      "description": "List run history for a specific DAG.",
+      "params": [
+        { "name": "dag_name", "in": "path", "required": true, "description": "Registered DAG name." },
+        { "name": "limit", "in": "query", "required": false, "description": "Maximum number of runs to return." }
+      ],
+      "success_response": { "status": 200, "schema": "Array of DagRun records." },
+      "error_responses": [
+        { "status": 404, "description": "DAG not found." },
+        { "status": 500, "description": "Database error." }
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/dags/{dag_name}/trigger",
+      "category": "dag",
+      "read_only": false,
+      "description": "Manually trigger a DAG run outside its schedule.",
+      "request_body": {
+        "required": false,
+        "schema": {
+          "conf": "Optional JSON object — run configuration passed to the DAG."
+        }
+      },
+      "success_response": { "status": 200, "schema": "DagRun record for the newly triggered run." },
+      "error_responses": [
+        { "status": 404, "description": "DAG not found." },
+        { "status": 409, "description": "DAG is paused or at max_active_runs." },
+        { "status": 500, "description": "Database error." }
+      ]
+    },
+    {
+      "method": "PATCH",
+      "path": "/dags/{dag_name}",
+      "category": "dag",
+      "read_only": false,
+      "description": "Update mutable DAG configuration fields (currently: pause/unpause).",
+      "request_body": {
+        "required": true,
+        "schema": {
+          "paused": "Boolean — true to pause the DAG, false to resume it."
+        }
+      },
+      "success_response": { "status": 200, "schema": "Updated RegisteredDag." },
+      "error_responses": [
+        { "status": 404, "description": "DAG not found." },
+        { "status": 500, "description": "Database error." }
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/dead-letters",
+      "category": "dlq",
+      "read_only": true,
+      "description": "List dead-lettered tasks that have exhausted all retry attempts.",
+      "params": [
+        { "name": "limit", "in": "query", "required": false, "description": "Maximum number of entries to return." },
+        { "name": "cursor", "in": "query", "required": false, "description": "Pagination cursor." }
+      ],
+      "success_response": { "status": 200, "schema": "Array of DeadLetter records with pagination cursor." },
+      "error_responses": [
+        { "status": 500, "description": "Database error." }
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/dead-letters/replay",
+      "category": "dlq",
+      "read_only": false,
+      "description": "Bulk-replay dead-lettered tasks matching the provided filters by re-enqueuing them.",
+      "request_body": {
+        "required": false,
+        "schema": {
+          "activity_name": "Optional string — filter by activity function name.",
+          "workflow_name": "Optional string — filter by workflow name.",
+          "failed_after": "Optional RFC 3339 timestamp — only replay entries failed after this time.",
+          "failed_before": "Optional RFC 3339 timestamp — only replay entries failed before this time.",
+          "limit": "Optional integer — maximum entries to replay.",
+          "dry_run": "Optional boolean — when true, return a preview without re-enqueuing."
+        }
+      },
+      "success_response": { "status": 200, "schema": "BulkReplayResult: replayed count, skipped count, dry_run flag." },
+      "error_responses": [
+        { "status": 400, "description": "Invalid filter values." },
+        { "status": 500, "description": "Database error." }
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/dead-letters/discard",
+      "category": "dlq",
+      "read_only": false,
+      "description": "Bulk-discard dead-lettered tasks matching the provided filters, removing them from the DLQ permanently.",
+      "request_body": {
+        "required": false,
+        "schema": {
+          "activity_name": "Optional string — filter by activity function name.",
+          "workflow_name": "Optional string — filter by workflow name.",
+          "failed_after": "Optional RFC 3339 timestamp — only discard entries failed after this time.",
+          "failed_before": "Optional RFC 3339 timestamp — only discard entries failed before this time.",
+          "limit": "Optional integer — maximum entries to discard.",
+          "dry_run": "Optional boolean — when true, return a preview without deleting."
+        }
+      },
+      "success_response": { "status": 200, "schema": "BulkDiscardResult: discarded count, dry_run flag." },
+      "error_responses": [
+        { "status": 400, "description": "Invalid filter values." },
+        { "status": 500, "description": "Database error." }
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/dead-letters/{id}/replay",
+      "category": "dlq",
+      "read_only": false,
+      "description": "Replay a single dead-lettered task by re-enqueuing it.",
+      "params": [
+        { "name": "id", "in": "path", "required": true, "description": "DeadLetter UUID." }
+      ],
+      "request_body": { "required": false, "schema": null },
+      "success_response": { "status": 200, "schema": "Replay acknowledgement." },
+      "error_responses": [
+        { "status": 404, "description": "Dead letter not found." },
+        { "status": 500, "description": "Database error." }
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/activities/external/{token}/complete",
+      "category": "external_activity",
+      "read_only": false,
+      "description": "Complete an external activity identified by its task token, supplying the success output.",
+      "params": [
+        { "name": "token", "in": "path", "required": true, "description": "Opaque task token issued when the activity was scheduled." }
+      ],
+      "request_body": {
+        "required": false,
+        "schema": {
+          "output": "Optional JSON — result value passed back to the workflow."
+        }
+      },
+      "success_response": { "status": 200, "schema": "Completion acknowledgement." },
+      "error_responses": [
+        { "status": 404, "description": "Token not found or already completed." },
+        { "status": 500, "description": "Database error." }
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/activities/external/{token}/fail",
+      "category": "external_activity",
+      "read_only": false,
+      "description": "Fail an external activity, optionally marking the error as retryable.",
+      "params": [
+        { "name": "token", "in": "path", "required": true, "description": "Opaque task token." }
+      ],
+      "request_body": {
+        "required": true,
+        "schema": {
+          "error": "String — error message.",
+          "retryable": "Optional boolean — true to schedule a retry (default: false)."
+        }
+      },
+      "success_response": { "status": 200, "schema": "Failure acknowledgement." },
+      "error_responses": [
+        { "status": 404, "description": "Token not found." },
+        { "status": 500, "description": "Database error." }
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/activities/external/{token}/heartbeat",
+      "category": "external_activity",
+      "read_only": false,
+      "description": "Send a liveness heartbeat for an in-progress external activity, optionally extending the deadline.",
+      "params": [
+        { "name": "token", "in": "path", "required": true, "description": "Opaque task token." }
+      ],
+      "request_body": {
+        "required": false,
+        "schema": {
+          "extend_by_secs": "Optional integer — seconds to extend the activity deadline."
+        }
+      },
+      "success_response": { "status": 200, "schema": "Heartbeat acknowledgement." },
+      "error_responses": [
+        { "status": 404, "description": "Token not found." },
+        { "status": 500, "description": "Database error." }
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/workers",
+      "category": "worker",
+      "read_only": true,
+      "description": "List registered worker processes and their current lifecycle status.",
+      "params": [
+        { "name": "queue", "in": "query", "required": false, "description": "Filter by task queue name." },
+        { "name": "shard_id", "in": "query", "required": false, "description": "Filter by shard ID." },
+        { "name": "status", "in": "query", "required": false, "description": "Filter by lifecycle status: Active, Draining, or Stopped." },
+        { "name": "health", "in": "query", "required": false, "description": "Filter by health: healthy or stale." },
+        { "name": "limit", "in": "query", "required": false, "description": "Maximum number of workers to return [1–500]." }
+      ],
+      "success_response": { "status": 200, "schema": "Array of WorkerRow records." },
+      "error_responses": [
+        { "status": 500, "description": "Database error." }
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/workers/{worker_id}",
+      "category": "worker",
+      "read_only": true,
+      "description": "Get details for a single worker process.",
+      "params": [
+        { "name": "worker_id", "in": "path", "required": true, "description": "Worker process identifier." }
+      ],
+      "success_response": { "status": 200, "schema": "WorkerRow record." },
+      "error_responses": [
+        { "status": 404, "description": "Worker not found." },
+        { "status": 500, "description": "Database error." }
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/workers/health",
+      "category": "worker",
+      "read_only": true,
+      "description": "Return aggregated fleet health statistics (active, stale, draining, stopped counts per shard).",
+      "params": [],
+      "success_response": { "status": 200, "schema": "FleetHealth summary." },
+      "error_responses": [
+        { "status": 500, "description": "Database error." }
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/workers/drain-preview",
+      "category": "worker",
+      "read_only": true,
+      "description": "Preview which workers would be targeted by a drain request, without modifying anything.",
+      "params": [
+        { "name": "queue", "in": "query", "required": false, "description": "Filter by task queue name." },
+        { "name": "shard_id", "in": "query", "required": false, "description": "Filter by shard ID." },
+        { "name": "status", "in": "query", "required": false, "description": "Filter by lifecycle status." },
+        { "name": "limit", "in": "query", "required": false, "description": "Maximum number of workers to preview." }
+      ],
+      "success_response": { "status": 200, "schema": "Array of DrainPreviewItem records." },
+      "error_responses": [
+        { "status": 500, "description": "Database error." }
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/workers/{worker_id}/drain",
+      "category": "worker",
+      "read_only": false,
+      "description": "Request a graceful drain for a specific worker. Sets its status to Draining so it stops accepting new tasks. The worker transitions to Stopped once all in-flight tasks complete.",
+      "params": [
+        { "name": "worker_id", "in": "path", "required": true, "description": "Worker process identifier." }
+      ],
+      "request_body": {
+        "required": false,
+        "schema": {
+          "deadline_at": "Optional RFC 3339 timestamp — drain-by deadline. When omitted the server uses its configured shutdown timeout."
+        }
+      },
+      "success_response": { "status": 200, "schema": "DrainResponse with updated worker status." },
+      "error_responses": [
+        { "status": 404, "description": "Worker not found." },
+        { "status": 409, "description": "Worker is already Stopped." },
+        { "status": 500, "description": "Database error." }
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/batch-operations",
+      "category": "batch",
+      "read_only": true,
+      "description": "List submitted batch operations and their current progress.",
+      "params": [
+        { "name": "limit", "in": "query", "required": false, "description": "Maximum number of operations to return." }
+      ],
+      "success_response": { "status": 200, "schema": "Array of BatchJobView records." },
+      "error_responses": [
+        { "status": 500, "description": "Database error." }
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/batch-operations",
+      "category": "batch",
+      "read_only": false,
+      "description": "Submit a fleet-wide batch operation (Cancel, Terminate, or Signal) targeting workflows matching a filter.",
+      "request_body": {
+        "required": true,
+        "schema": {
+          "action": "String — batch action: Cancel, Terminate, or Signal.",
+          "filter": "JSON object — workflow filter (states, workflow_name, search attributes).",
+          "signal_name": "Optional string — required when action is Signal.",
+          "signal_payload": "Optional JSON — payload for Signal actions."
+        }
+      },
+      "success_response": { "status": 202, "schema": "BatchSubmissionResult with job_id." },
+      "error_responses": [
+        { "status": 400, "description": "Invalid action or missing required fields." },
+        { "status": 500, "description": "Database error." }
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/batch-operations/{id}",
+      "category": "batch",
+      "read_only": true,
+      "description": "Get the current status and progress of a batch operation.",
+      "params": [
+        { "name": "id", "in": "path", "required": true, "description": "Batch job UUID." }
+      ],
+      "success_response": { "status": 200, "schema": "BatchJobView with status, progress counts, and error summary." },
+      "error_responses": [
+        { "status": 404, "description": "Batch job not found." },
+        { "status": 500, "description": "Database error." }
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/health",
+      "category": "health",
+      "read_only": true,
+      "description": "Liveness health check. Returns 200 when the plugin is reachable. Does not probe the database.",
+      "params": [],
+      "success_response": { "status": 200, "schema": "{ status: string }" },
+      "error_responses": []
+    },
+    {
+      "method": "GET",
+      "path": "/admin/preflight",
+      "category": "admin",
+      "read_only": true,
+      "description": "Run deployment readiness preflight checks: database connectivity, migration status, shard health, and worker coverage.",
+      "params": [],
+      "success_response": { "status": 200, "schema": "PreflightReport with per-check results and overall pass/fail." },
+      "error_responses": [
+        { "status": 500, "description": "Unable to connect to database." }
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/admin/shards/health",
+      "category": "admin",
+      "read_only": true,
+      "description": "Return per-shard readiness: ready, degraded, or unavailable. Optionally probe a candidate shard before adding it to writable_shards.",
+      "params": [
+        { "name": "candidate_shard", "in": "query", "required": false, "description": "Shard ID of a new shard to probe before enabling writes." },
+        { "name": "fail_on_unready", "in": "query", "required": false, "description": "When true, the response uses HTTP 503 if any shard is not ready." }
+      ],
+      "success_response": { "status": 200, "schema": "ShardHealthReport with per-shard readiness." },
+      "error_responses": [
+        { "status": 503, "description": "One or more shards not ready (only when fail_on_unready is true)." }
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/admin/version-gates/usage",
+      "category": "admin",
+      "read_only": true,
+      "description": "Report recorded workflow version-gate usage: how many executions carry each (change_id, version) pair.",
+      "params": [
+        { "name": "workflow_name", "in": "query", "required": false, "description": "Filter by registered workflow name." },
+        { "name": "change_id", "in": "query", "required": false, "description": "Filter by version-gate change ID." },
+        { "name": "recorded_version", "in": "query", "required": false, "description": "Filter by recorded version number." },
+        { "name": "state_group", "in": "query", "required": false, "description": "Execution state group: active or terminal." },
+        { "name": "shard_id", "in": "query", "required": false, "description": "Restrict to a single shard." }
+      ],
+      "success_response": { "status": 200, "schema": "Array of VersionUsageRow records." },
+      "error_responses": [
+        { "status": 500, "description": "Database error." }
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/admin/version-gates/retirement-check",
+      "category": "admin",
+      "read_only": true,
+      "description": "Check whether a version-gate change ID is safe to retire: no non-terminal executions carry a version below the specified threshold.",
+      "params": [
+        { "name": "change_id", "in": "query", "required": true, "description": "Version-gate change ID to inspect." },
+        { "name": "min_safe_version", "in": "query", "required": true, "description": "Versions strictly below this value are considered old branches." },
+        { "name": "workflow_name", "in": "query", "required": false, "description": "Narrow to a specific workflow name." },
+        { "name": "state_group", "in": "query", "required": false, "description": "Execution state group filter." },
+        { "name": "shard_id", "in": "query", "required": false, "description": "Restrict to a single shard." }
+      ],
+      "success_response": { "status": 200, "schema": "RetirementCheckReport: safe (bool), blocking_count, per-shard breakdown." },
+      "error_responses": [
+        { "status": 400, "description": "Missing required parameters." },
+        { "status": 500, "description": "Database error." }
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/admin/retention",
+      "category": "admin",
+      "read_only": true,
+      "description": "Return the current status of the retention janitor: last run time, records deleted, and configured TTL.",
+      "params": [],
+      "success_response": { "status": 200, "schema": "RetentionStatus." },
+      "error_responses": []
+    },
+    {
+      "method": "POST",
+      "path": "/admin/retention/run-now",
+      "category": "admin",
+      "read_only": false,
+      "description": "Trigger the retention janitor to run immediately outside its scheduled interval.",
+      "request_body": { "required": false, "schema": null },
+      "success_response": { "status": 200, "schema": "Trigger acknowledgement." },
+      "error_responses": [
+        { "status": 500, "description": "Internal error." }
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/admin/concurrency",
+      "category": "admin",
+      "read_only": true,
+      "description": "Return per-activity concurrency statistics: configured cap, currently in-flight, and queued counts for each concurrency key.",
+      "params": [],
+      "success_response": { "status": 200, "schema": "Array of ConcurrencyKeyStats records." },
+      "error_responses": [
+        { "status": 500, "description": "Database error." }
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/admin/history/exports",
+      "category": "admin",
+      "read_only": true,
+      "description": "Batch-export event histories for multiple executions matching the provided filters. Useful for replay fixture generation and compliance archiving.",
+      "params": [
+        { "name": "workflow_name", "in": "query", "required": false, "description": "Filter by workflow name." },
+        { "name": "state_group", "in": "query", "required": false, "description": "Execution state group: active or terminal." },
+        { "name": "updated_after", "in": "query", "required": false, "description": "RFC 3339 timestamp — include executions updated after this time." },
+        { "name": "updated_before", "in": "query", "required": false, "description": "RFC 3339 timestamp — include executions updated before this time." },
+        { "name": "shard_id", "in": "query", "required": false, "description": "Restrict to a single shard." },
+        { "name": "limit", "in": "query", "required": false, "description": "Maximum number of histories to export." },
+        { "name": "payload_policy", "in": "query", "required": false, "description": "Payload inclusion: full, redacted, or omit." }
+      ],
+      "success_response": { "status": 200, "schema": "Array of HistoryExportDocument records." },
+      "error_responses": [
+        { "status": 400, "description": "Invalid filter values." },
+        { "status": 500, "description": "Database error." }
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/admin/external-handoffs",
+      "category": "external_activity",
+      "read_only": true,
+      "description": "List pending external activity handoffs with optional filters.",
+      "params": [
+        { "name": "state", "in": "query", "required": false, "description": "Filter by handoff state (e.g. PENDING,FAILED)." },
+        { "name": "workflow_name", "in": "query", "required": false, "description": "Filter by workflow name." },
+        { "name": "execution_id", "in": "query", "required": false, "description": "Filter by execution UUID." },
+        { "name": "activity_name", "in": "query", "required": false, "description": "Filter by activity function name." },
+        { "name": "token", "in": "query", "required": false, "description": "Filter by task token UUID." },
+        { "name": "shard_id", "in": "query", "required": false, "description": "Restrict to a single shard." },
+        { "name": "due_before", "in": "query", "required": false, "description": "RFC 3339 timestamp — only return handoffs due before this time." },
+        { "name": "updated_before", "in": "query", "required": false, "description": "RFC 3339 timestamp — only return handoffs last updated before this time." },
+        { "name": "limit", "in": "query", "required": false, "description": "Maximum number of results." }
+      ],
+      "success_response": { "status": 200, "schema": "Array of ExternalHandoff records." },
+      "error_responses": [
+        { "status": 500, "description": "Database error." }
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/admin/external-handoffs/{token}",
+      "category": "external_activity",
+      "read_only": true,
+      "description": "Get the current state and metadata of a single external activity handoff.",
+      "params": [
+        { "name": "token", "in": "path", "required": true, "description": "Task token UUID." }
+      ],
+      "success_response": { "status": 200, "schema": "ExternalHandoff record." },
+      "error_responses": [
+        { "status": 404, "description": "Token not found." },
+        { "status": 500, "description": "Database error." }
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/admin/schedules",
+      "category": "schedule",
+      "read_only": true,
+      "description": "List all workflow and DAG schedules.",
+      "params": [],
+      "success_response": { "status": 200, "schema": "Array of HarvestSchedule records." },
+      "error_responses": [
+        { "status": 500, "description": "Database error." }
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/admin/schedules/workflow",
+      "category": "schedule",
+      "read_only": false,
+      "description": "Create a new cron or interval schedule for a workflow.",
+      "request_body": {
+        "required": true,
+        "schema": {
+          "workflow_name": "String — registered workflow name.",
+          "schedule_expr": "String — cron expression (e.g. '0 * * * *').",
+          "input": "Optional JSON — workflow input payload.",
+          "max_active_runs": "Optional integer — maximum concurrent scheduled runs.",
+          "catchup": "Optional boolean — whether to backfill missed runs.",
+          "paused": "Optional boolean — create the schedule in paused state."
+        }
+      },
+      "success_response": { "status": 200, "schema": "Created HarvestSchedule record." },
+      "error_responses": [
+        { "status": 400, "description": "Invalid cron expression or missing required fields." },
+        { "status": 500, "description": "Database error." }
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/admin/schedules/{id}/pause",
+      "category": "schedule",
+      "read_only": false,
+      "description": "Pause a schedule, preventing it from triggering new runs.",
+      "params": [
+        { "name": "id", "in": "path", "required": true, "description": "Schedule UUID." }
+      ],
+      "request_body": { "required": false, "schema": null },
+      "success_response": { "status": 200, "schema": "Updated HarvestSchedule." },
+      "error_responses": [
+        { "status": 404, "description": "Schedule not found." },
+        { "status": 500, "description": "Database error." }
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/admin/schedules/{id}/resume",
+      "category": "schedule",
+      "read_only": false,
+      "description": "Resume a paused schedule.",
+      "params": [
+        { "name": "id", "in": "path", "required": true, "description": "Schedule UUID." }
+      ],
+      "request_body": { "required": false, "schema": null },
+      "success_response": { "status": 200, "schema": "Updated HarvestSchedule." },
+      "error_responses": [
+        { "status": 404, "description": "Schedule not found." },
+        { "status": 500, "description": "Database error." }
+      ]
+    },
+    {
+      "method": "DELETE",
+      "path": "/admin/schedules/{id}",
+      "category": "schedule",
+      "read_only": false,
+      "description": "Delete a schedule. In-flight runs started by this schedule continue to completion.",
+      "params": [
+        { "name": "id", "in": "path", "required": true, "description": "Schedule UUID." }
+      ],
+      "request_body": { "required": false, "schema": null },
+      "success_response": { "status": 200, "schema": "Deletion acknowledgement." },
+      "error_responses": [
+        { "status": 404, "description": "Schedule not found." },
+        { "status": 500, "description": "Database error." }
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/admin/audit",
+      "category": "audit",
+      "read_only": true,
+      "description": "Browse the audit trail of management API mutations. Read-only — the audit log itself is never mutated through this surface.",
+      "params": [
+        { "name": "actor", "in": "query", "required": false, "description": "Filter by actor identity." },
+        { "name": "operation", "in": "query", "required": false, "description": "Filter by operation name (e.g. workflow.cancel)." },
+        { "name": "target_type", "in": "query", "required": false, "description": "Filter by target resource type (e.g. workflow, schedule)." },
+        { "name": "target_id", "in": "query", "required": false, "description": "Filter by target resource ID." },
+        { "name": "status", "in": "query", "required": false, "description": "Filter by outcome: succeeded or failed." },
+        { "name": "since", "in": "query", "required": false, "description": "RFC 3339 timestamp — only return records after this time." },
+        { "name": "before", "in": "query", "required": false, "description": "RFC 3339 timestamp — only return records before this time." },
+        { "name": "limit", "in": "query", "required": false, "description": "Maximum number of records to return." }
+      ],
+      "success_response": { "status": 200, "schema": "Array of AuditRecord entries." },
+      "error_responses": [
+        { "status": 500, "description": "Database error." }
+      ]
+    }
+  ]
+}

--- a/docs/api-contract.json
+++ b/docs/api-contract.json
@@ -260,7 +260,7 @@
           { "name": "input", "required": false, "description": "Payload passed to the update handler (any JSON value)." }
         ]
       },
-      "success_response": { "status": 200, "free_form": true },
+      "success_response": { "status": 202, "note": "Returns 202 Accepted when wait=admitted (update durably recorded); returns 200 OK with outcome when wait=completed (default).", "free_form": true },
       "error_responses": [
         { "status": 400, "description": "Update rejected by the validator." },
         { "status": 404, "description": "Execution not found or update handler not registered." },
@@ -699,13 +699,12 @@
       "read_only": true,
       "description": "Return per-shard readiness: ready, degraded, or unavailable.",
       "params": [
-        { "name": "candidate_shard", "in": "query", "required": false, "description": "Shard ID of a new shard to probe before enabling writes." },
-        { "name": "fail_on_unready", "in": "query", "required": false, "description": "When true, the response uses HTTP 503 if any shard is not ready." }
+        { "name": "candidate_shard", "in": "query", "required": false, "description": "Shard ID of a new shard to probe before enabling writes." }
       ],
       "request_body": null,
       "success_response": { "status": 200, "fields": ["overall_readiness", "observed_at", "freshness_window_secs", "candidate_shard", "shards"] },
       "error_responses": [
-        { "status": 503, "description": "One or more shards not ready (only when fail_on_unready is true)." }
+        { "status": 503, "description": "Database or shard connectivity error." }
       ]
     },
     {

--- a/docs/api-contract.json
+++ b/docs/api-contract.json
@@ -40,7 +40,7 @@
         { "name": "cursor", "in": "query", "required": false, "description": "Opaque pagination cursor from a previous response." }
       ],
       "request_body": null,
-      "success_response": { "status": 200, "schema": "Array of WorkflowExecution summaries with pagination cursor." },
+      "success_response": { "status": 200, "free_form": true },
       "error_responses": [
         { "status": 400, "description": "Invalid filter value." },
         { "status": 500, "description": "Database error." }
@@ -56,7 +56,7 @@
         { "name": "id", "in": "path", "required": true, "description": "Execution UUID." }
       ],
       "request_body": null,
-      "success_response": { "status": 200, "schema": "WorkflowExecution with full event list." },
+      "success_response": { "status": 200, "fields": ["parent_id", "execution", "history", "external_handoffs"] },
       "error_responses": [
         { "status": 404, "description": "Execution not found." },
         { "status": 500, "description": "Database error." }
@@ -74,7 +74,7 @@
         { "name": "max_bytes", "in": "query", "required": false, "description": "Soft byte cap on total payload size." }
       ],
       "request_body": null,
-      "success_response": { "status": 200, "schema": "HistoryExportDocument (JSON)." },
+      "success_response": { "status": 200, "free_form": true },
       "error_responses": [
         { "status": 404, "description": "Execution not found." },
         { "status": 413, "description": "History exceeds max_bytes cap." },
@@ -96,7 +96,7 @@
         { "name": "depth", "in": "query", "required": false, "description": "Maximum recursion depth for nested children." }
       ],
       "request_body": null,
-      "success_response": { "status": 200, "schema": "Array of child WorkflowExecution summaries." },
+      "success_response": { "status": 200, "fields": ["items", "next_cursor"] },
       "error_responses": [
         { "status": 404, "description": "Parent execution not found." },
         { "status": 500, "description": "Database error." }
@@ -112,7 +112,7 @@
         { "name": "id", "in": "path", "required": true, "description": "Execution UUID." }
       ],
       "request_body": null,
-      "success_response": { "status": 200, "schema": "WorkflowStack describing the current suspension point." },
+      "success_response": { "status": 200, "fields": ["exec_id", "workflow_id", "workflow_name", "state", "is_terminal", "pending_activities", "pending_external_handoffs", "pending_local_activities", "pending_timers", "pending_signals", "buffered_signals", "pending_child_workflows", "last_event_id"] },
       "error_responses": [
         { "status": 404, "description": "Execution not found." },
         { "status": 500, "description": "Database error." }
@@ -141,7 +141,7 @@
           { "name": "reuse_policy", "required": false, "description": "Duplicate-id policy: allow_duplicate, reject_duplicate, allow_duplicate_failed_only, or terminate_if_running." }
         ]
       },
-      "success_response": { "status": 200, "schema": "Started or existing WorkflowExecution." },
+      "success_response": { "status": 200, "fields": ["execution_id", "workflow_name", "workflow_id", "state"] },
       "error_responses": [
         { "status": 400, "description": "Invalid request body or workflow name." },
         { "status": 409, "description": "Duplicate workflow_id with conflicting reuse policy." },
@@ -154,6 +154,7 @@
       "category": "workflow",
       "read_only": false,
       "description": "Cancel a running workflow execution.",
+      "idempotency": "Idempotent: cancelling an already-cancelled or terminal execution is a no-op.",
       "params": [
         { "name": "id", "in": "path", "required": true, "description": "Execution UUID." }
       ],
@@ -164,7 +165,7 @@
           { "name": "reason", "required": false, "description": "Human-readable cancellation reason recorded in audit log." }
         ]
       },
-      "success_response": { "status": 200, "schema": "Cancellation acknowledgement." },
+      "success_response": { "status": 200, "fields": ["ok", "execution_id", "state", "reason", "newly_cancelled", "failed_task_count"] },
       "error_responses": [
         { "status": 404, "description": "Execution not found." },
         { "status": 409, "description": "Execution is already in a terminal state." },
@@ -177,6 +178,7 @@
       "category": "workflow",
       "read_only": false,
       "description": "Fork a workflow execution at a specific event boundary, replaying from that point with a new execution ID.",
+      "idempotency": "Not idempotent: each call forks the execution and creates a distinct new execution ID.",
       "params": [
         { "name": "id", "in": "path", "required": true, "description": "Execution UUID." },
         { "name": "dry_run", "in": "query", "required": false, "description": "When true, return the preview without creating a new execution." }
@@ -191,7 +193,7 @@
           { "name": "signal_reapply", "required": false, "description": "How to handle buffered signals: drop or buffer." }
         ]
       },
-      "success_response": { "status": 200, "schema": "ResetResult with new execution ID or dry-run preview." },
+      "success_response": { "status": 200, "fields": ["new_exec_id", "reset_from_exec_id", "reset_to_event_id", "events_carried_over", "source_tasks_cancelled", "source_timers_removed", "source_signals_dropped", "source_signals_buffered"] },
       "error_responses": [
         { "status": 400, "description": "Invalid reset point or request body." },
         { "status": 404, "description": "Execution not found." },
@@ -204,6 +206,7 @@
       "category": "workflow",
       "read_only": false,
       "description": "Send a named signal to a running workflow execution. The request body is the signal payload itself (free-form JSON).",
+      "idempotency": "Not idempotent: each call delivers a distinct signal event to the workflow.",
       "params": [
         { "name": "id", "in": "path", "required": true, "description": "Execution UUID." },
         { "name": "signal_name", "in": "path", "required": true, "description": "Registered signal handler name." }
@@ -214,7 +217,7 @@
         "description": "Optional signal payload — the entire body is passed verbatim to the signal handler.",
         "fields": []
       },
-      "success_response": { "status": 200, "schema": "Signal delivery acknowledgement." },
+      "success_response": { "status": 200, "fields": ["ok"] },
       "error_responses": [
         { "status": 404, "description": "Execution not found." },
         { "status": 500, "description": "Database error." }
@@ -231,7 +234,7 @@
         { "name": "query_name", "in": "path", "required": true, "description": "Registered query handler name." }
       ],
       "request_body": null,
-      "success_response": { "status": 200, "schema": "JSON result from the query handler." },
+      "success_response": { "status": 200, "free_form": true },
       "error_responses": [
         { "status": 404, "description": "Execution not found or query handler not registered." },
         { "status": 500, "description": "Query execution error." }
@@ -243,6 +246,7 @@
       "category": "workflow",
       "read_only": false,
       "description": "Submit a synchronous update request to a running workflow. Blocks until admitted or completed depending on the wait parameter.",
+      "idempotency": "Not idempotent: each call appends a distinct UpdateAdmitted event with a new update_id.",
       "params": [
         { "name": "id", "in": "path", "required": true, "description": "Execution UUID." },
         { "name": "update_name", "in": "path", "required": true, "description": "Registered update handler name." },
@@ -256,7 +260,7 @@
           { "name": "input", "required": false, "description": "Payload passed to the update handler (any JSON value)." }
         ]
       },
-      "success_response": { "status": 200, "schema": "UpdateResult with update_id and outcome." },
+      "success_response": { "status": 200, "free_form": true },
       "error_responses": [
         { "status": 400, "description": "Update rejected by the validator." },
         { "status": 404, "description": "Execution not found or update handler not registered." },
@@ -275,7 +279,7 @@
         { "name": "update_id", "in": "path", "required": true, "description": "Update UUID returned by POST …/update/{name}." }
       ],
       "request_body": null,
-      "success_response": { "status": 200, "schema": "UpdateResult: status (admitted | completed | failed) and output or error." },
+      "success_response": { "status": 200, "free_form": true },
       "error_responses": [
         { "status": 404, "description": "Update not found." },
         { "status": 500, "description": "Database error." }
@@ -289,7 +293,7 @@
       "description": "List all registered DAGs and their current pause/enabled state.",
       "params": [],
       "request_body": null,
-      "success_response": { "status": 200, "schema": "Array of RegisteredDag summaries." },
+      "success_response": { "status": 200, "free_form": true },
       "error_responses": [
         { "status": 500, "description": "Internal error." }
       ]
@@ -305,7 +309,7 @@
         { "name": "limit", "in": "query", "required": false, "description": "Maximum number of runs to return." }
       ],
       "request_body": null,
-      "success_response": { "status": 200, "schema": "Array of DagRun records." },
+      "success_response": { "status": 200, "free_form": true },
       "error_responses": [
         { "status": 404, "description": "DAG not found." },
         { "status": 500, "description": "Database error." }
@@ -317,6 +321,7 @@
       "category": "dag",
       "read_only": false,
       "description": "Manually trigger a DAG run outside its schedule.",
+      "idempotency": "Not idempotent: each call starts a new DAG run.",
       "params": [
         { "name": "dag_name", "in": "path", "required": true, "description": "Registered DAG name." }
       ],
@@ -327,7 +332,7 @@
           { "name": "conf", "required": false, "description": "Run configuration passed to the DAG (any JSON value)." }
         ]
       },
-      "success_response": { "status": 200, "schema": "DagRun record for the newly triggered run." },
+      "success_response": { "status": 200, "free_form": true },
       "error_responses": [
         { "status": 404, "description": "DAG not found." },
         { "status": 409, "description": "DAG is paused or at max_active_runs." },
@@ -340,6 +345,7 @@
       "category": "dag",
       "read_only": false,
       "description": "Update mutable DAG configuration fields (currently: pause/unpause).",
+      "idempotency": "Idempotent: applying the same pause state twice is a no-op.",
       "params": [
         { "name": "dag_name", "in": "path", "required": true, "description": "Registered DAG name." }
       ],
@@ -350,7 +356,7 @@
           { "name": "paused", "required": true, "description": "true to pause the DAG, false to resume it." }
         ]
       },
-      "success_response": { "status": 200, "schema": "Updated RegisteredDag." },
+      "success_response": { "status": 200, "free_form": true },
       "error_responses": [
         { "status": 404, "description": "DAG not found." },
         { "status": 500, "description": "Database error." }
@@ -367,7 +373,7 @@
         { "name": "cursor", "in": "query", "required": false, "description": "Pagination cursor." }
       ],
       "request_body": null,
-      "success_response": { "status": 200, "schema": "Array of DeadLetter records with pagination cursor." },
+      "success_response": { "status": 200, "free_form": true },
       "error_responses": [
         { "status": 500, "description": "Database error." }
       ]
@@ -378,6 +384,8 @@
       "category": "dlq",
       "read_only": false,
       "description": "Bulk-replay dead-lettered tasks matching the provided filters by re-enqueuing them.",
+      "idempotency": "Idempotent by filter: already-replayed or already-pending entries are skipped.",
+      "params": [],
       "request_body": {
         "required": false,
         "free_form": false,
@@ -390,7 +398,7 @@
           { "name": "dry_run", "required": false, "description": "When true, return a preview without re-enqueuing." }
         ]
       },
-      "success_response": { "status": 200, "schema": "BulkReplayResult: replayed count, skipped count, dry_run flag." },
+      "success_response": { "status": 200, "fields": ["matched", "acted_on", "skipped", "ids", "dry_run", "failures"] },
       "error_responses": [
         { "status": 400, "description": "Invalid filter values." },
         { "status": 500, "description": "Database error." }
@@ -402,6 +410,8 @@
       "category": "dlq",
       "read_only": false,
       "description": "Bulk-discard dead-lettered tasks matching the provided filters, removing them from the DLQ permanently.",
+      "idempotency": "Idempotent by filter: already-discarded entries are skipped.",
+      "params": [],
       "request_body": {
         "required": false,
         "free_form": false,
@@ -414,7 +424,7 @@
           { "name": "dry_run", "required": false, "description": "When true, return a preview without deleting." }
         ]
       },
-      "success_response": { "status": 200, "schema": "BulkDiscardResult: discarded count, dry_run flag." },
+      "success_response": { "status": 200, "fields": ["matched", "acted_on", "skipped", "ids", "dry_run", "failures"] },
       "error_responses": [
         { "status": 400, "description": "Invalid filter values." },
         { "status": 500, "description": "Database error." }
@@ -426,6 +436,7 @@
       "category": "dlq",
       "read_only": false,
       "description": "Replay a single dead-lettered task by re-enqueuing it.",
+      "idempotency": "Idempotent: replaying an already-replayed entry is a no-op.",
       "params": [
         { "name": "id", "in": "path", "required": true, "description": "DeadLetter UUID." }
       ],
@@ -434,7 +445,7 @@
         "free_form": false,
         "fields": []
       },
-      "success_response": { "status": 200, "schema": "Replay acknowledgement." },
+      "success_response": { "status": 200, "fields": ["ok", "dead_letter_id", "task_id"] },
       "error_responses": [
         { "status": 404, "description": "Dead letter not found." },
         { "status": 500, "description": "Database error." }
@@ -446,6 +457,7 @@
       "category": "external_activity",
       "read_only": false,
       "description": "Complete an external activity identified by its task token, supplying the success output.",
+      "idempotency": "Not idempotent: completing an already-resolved token returns 404.",
       "params": [
         { "name": "token", "in": "path", "required": true, "description": "Opaque task token issued when the activity was scheduled." }
       ],
@@ -456,7 +468,7 @@
           { "name": "output", "required": false, "description": "Result value passed back to the workflow (any JSON value)." }
         ]
       },
-      "success_response": { "status": 200, "schema": "Completion acknowledgement." },
+      "success_response": { "status": 200, "fields": ["ok", "newly_resolved", "status", "current_state"] },
       "error_responses": [
         { "status": 404, "description": "Token not found or already completed." },
         { "status": 500, "description": "Database error." }
@@ -468,6 +480,7 @@
       "category": "external_activity",
       "read_only": false,
       "description": "Fail an external activity, optionally marking the error as retryable.",
+      "idempotency": "Not idempotent: failing an already-resolved token returns 404.",
       "params": [
         { "name": "token", "in": "path", "required": true, "description": "Opaque task token." }
       ],
@@ -479,7 +492,7 @@
           { "name": "retryable", "required": false, "description": "true to schedule a retry (default: false)." }
         ]
       },
-      "success_response": { "status": 200, "schema": "Failure acknowledgement." },
+      "success_response": { "status": 200, "fields": ["ok", "newly_resolved", "status", "current_state"] },
       "error_responses": [
         { "status": 404, "description": "Token not found." },
         { "status": 500, "description": "Database error." }
@@ -491,6 +504,7 @@
       "category": "external_activity",
       "read_only": false,
       "description": "Send a liveness heartbeat for an in-progress external activity, optionally extending the deadline.",
+      "idempotency": "Idempotent: repeated heartbeats extend or maintain the deadline.",
       "params": [
         { "name": "token", "in": "path", "required": true, "description": "Opaque task token." }
       ],
@@ -501,7 +515,7 @@
           { "name": "extend_by_secs", "required": false, "description": "Seconds to extend the activity deadline." }
         ]
       },
-      "success_response": { "status": 200, "schema": "Heartbeat acknowledgement." },
+      "success_response": { "status": 200, "fields": ["ok", "newly_resolved", "status", "current_state"] },
       "error_responses": [
         { "status": 404, "description": "Token not found." },
         { "status": 500, "description": "Database error." }
@@ -521,7 +535,7 @@
         { "name": "limit", "in": "query", "required": false, "description": "Maximum number of workers to return [1–500]." }
       ],
       "request_body": null,
-      "success_response": { "status": 200, "schema": "Array of WorkerRow records." },
+      "success_response": { "status": 200, "free_form": true },
       "error_responses": [
         { "status": 500, "description": "Database error." }
       ]
@@ -536,7 +550,7 @@
         { "name": "worker_id", "in": "path", "required": true, "description": "Worker process identifier." }
       ],
       "request_body": null,
-      "success_response": { "status": 200, "schema": "WorkerRow record." },
+      "success_response": { "status": 200, "free_form": true },
       "error_responses": [
         { "status": 404, "description": "Worker not found." },
         { "status": 500, "description": "Database error." }
@@ -550,7 +564,7 @@
       "description": "Return aggregated fleet health statistics (active, stale, draining, stopped counts per shard).",
       "params": [],
       "request_body": null,
-      "success_response": { "status": 200, "schema": "FleetHealth summary." },
+      "success_response": { "status": 200, "fields": ["healthy", "stale", "draining", "by_queue", "by_shard"] },
       "error_responses": [
         { "status": 500, "description": "Database error." }
       ]
@@ -568,7 +582,7 @@
         { "name": "limit", "in": "query", "required": false, "description": "Maximum number of workers to preview." }
       ],
       "request_body": null,
-      "success_response": { "status": 200, "schema": "Array of DrainPreviewItem records." },
+      "success_response": { "status": 200, "free_form": true },
       "error_responses": [
         { "status": 500, "description": "Database error." }
       ]
@@ -579,6 +593,7 @@
       "category": "worker",
       "read_only": false,
       "description": "Request a graceful drain for a specific worker. Sets its status to Draining so it stops accepting new tasks.",
+      "idempotency": "Idempotent: re-draining an already-draining worker extends the deadline if the new one is later.",
       "params": [
         { "name": "worker_id", "in": "path", "required": true, "description": "Worker process identifier." }
       ],
@@ -589,7 +604,7 @@
           { "name": "deadline_at", "required": false, "description": "RFC 3339 drain-by deadline. Omit to use the server's configured shutdown timeout." }
         ]
       },
-      "success_response": { "status": 200, "schema": "DrainResponse with updated worker status." },
+      "success_response": { "status": 200, "fields": ["worker_id", "outcome", "in_flight_count", "drain_deadline_at", "shard_ids", "unavailable_shards"] },
       "error_responses": [
         { "status": 404, "description": "Worker not found." },
         { "status": 409, "description": "Worker is already Stopped." },
@@ -606,7 +621,7 @@
         { "name": "limit", "in": "query", "required": false, "description": "Maximum number of operations to return." }
       ],
       "request_body": null,
-      "success_response": { "status": 200, "schema": "Array of BatchJobView records." },
+      "success_response": { "status": 200, "free_form": true },
       "error_responses": [
         { "status": 500, "description": "Database error." }
       ]
@@ -617,6 +632,8 @@
       "category": "batch",
       "read_only": false,
       "description": "Submit a fleet-wide batch operation (Cancel, Terminate, or Signal) targeting workflows matching a filter.",
+      "idempotency": "Idempotent by idempotency_key when provided: re-submitting with the same key returns the existing batch_job_id.",
+      "params": [],
       "request_body": {
         "required": true,
         "free_form": false,
@@ -624,10 +641,12 @@
           { "name": "action", "required": true, "description": "Batch action: Cancel, Terminate, or Signal." },
           { "name": "filter", "required": true, "description": "Workflow filter (JSON object with states, workflow_name, search attributes)." },
           { "name": "signal_name", "required": false, "description": "Signal name — required when action is Signal." },
-          { "name": "signal_payload", "required": false, "description": "Signal payload for Signal actions (any JSON value)." }
+          { "name": "signal_payload", "required": false, "description": "Signal payload for Signal actions (any JSON value)." },
+          { "name": "idempotency_key", "required": false, "description": "Operator-supplied idempotency token; re-submitting with the same key returns the existing job." },
+          { "name": "created_by", "required": false, "description": "Optional caller identity for audit." }
         ]
       },
-      "success_response": { "status": 202, "schema": "BatchSubmissionResult with job_id." },
+      "success_response": { "status": 202, "fields": ["batch_job_id"] },
       "error_responses": [
         { "status": 400, "description": "Invalid action or missing required fields." },
         { "status": 500, "description": "Database error." }
@@ -643,7 +662,7 @@
         { "name": "id", "in": "path", "required": true, "description": "Batch job UUID." }
       ],
       "request_body": null,
-      "success_response": { "status": 200, "schema": "BatchJobView with status, progress counts, and error summary." },
+      "success_response": { "status": 200, "free_form": true },
       "error_responses": [
         { "status": 404, "description": "Batch job not found." },
         { "status": 500, "description": "Database error." }
@@ -657,7 +676,7 @@
       "description": "Liveness health check. Returns 200 when the plugin is reachable. Does not probe the database.",
       "params": [],
       "request_body": null,
-      "success_response": { "status": 200, "schema": "{ status: string }" },
+      "success_response": { "status": 200, "fields": ["runtime_ready", "worker_id", "queues", "dag_count", "scheduler", "shard_readiness_enforced", "shard_readiness"] },
       "error_responses": []
     },
     {
@@ -668,7 +687,7 @@
       "description": "Run deployment readiness preflight checks: database connectivity, migration status, shard health, and worker coverage.",
       "params": [],
       "request_body": null,
-      "success_response": { "status": 200, "schema": "PreflightReport with per-check results and overall pass/fail." },
+      "success_response": { "status": 200, "fields": ["overall_status", "observed_at", "version", "checks"] },
       "error_responses": [
         { "status": 500, "description": "Unable to connect to database." }
       ]
@@ -684,7 +703,7 @@
         { "name": "fail_on_unready", "in": "query", "required": false, "description": "When true, the response uses HTTP 503 if any shard is not ready." }
       ],
       "request_body": null,
-      "success_response": { "status": 200, "schema": "ShardHealthReport with per-shard readiness." },
+      "success_response": { "status": 200, "fields": ["overall_readiness", "observed_at", "freshness_window_secs", "candidate_shard", "shards"] },
       "error_responses": [
         { "status": 503, "description": "One or more shards not ready (only when fail_on_unready is true)." }
       ]
@@ -703,7 +722,7 @@
         { "name": "shard_id", "in": "query", "required": false, "description": "Restrict to a single shard." }
       ],
       "request_body": null,
-      "success_response": { "status": 200, "schema": "Array of VersionUsageRow records." },
+      "success_response": { "status": 200, "fields": ["status", "observed_at", "filters", "items", "shards"] },
       "error_responses": [
         { "status": 500, "description": "Database error." }
       ]
@@ -722,7 +741,7 @@
         { "name": "shard_id", "in": "query", "required": false, "description": "Restrict to a single shard." }
       ],
       "request_body": null,
-      "success_response": { "status": 200, "schema": "RetirementCheckReport: safe (bool), blocking_count, per-shard breakdown." },
+      "success_response": { "status": 200, "fields": ["status", "safe_to_retire", "observed_at", "filters", "blockers", "shards"] },
       "error_responses": [
         { "status": 400, "description": "Missing required parameters." },
         { "status": 500, "description": "Database error." }
@@ -736,7 +755,7 @@
       "description": "Return the current status of the retention janitor.",
       "params": [],
       "request_body": null,
-      "success_response": { "status": 200, "schema": "RetentionStatus." },
+      "success_response": { "status": 200, "free_form": true },
       "error_responses": []
     },
     {
@@ -745,12 +764,14 @@
       "category": "admin",
       "read_only": false,
       "description": "Trigger the retention janitor to run immediately outside its scheduled interval.",
+      "idempotency": "Idempotent: triggering an already-running retention janitor is a no-op.",
+      "params": [],
       "request_body": {
         "required": false,
         "free_form": false,
         "fields": []
       },
-      "success_response": { "status": 200, "schema": "Trigger acknowledgement." },
+      "success_response": { "status": 200, "fields": ["ok"] },
       "error_responses": [
         { "status": 500, "description": "Internal error." }
       ]
@@ -763,7 +784,7 @@
       "description": "Return per-activity concurrency statistics: configured cap, currently in-flight, and queued counts for each concurrency key.",
       "params": [],
       "request_body": null,
-      "success_response": { "status": 200, "schema": "Array of ConcurrencyKeyStats records." },
+      "success_response": { "status": 200, "free_form": true },
       "error_responses": [
         { "status": 500, "description": "Database error." }
       ]
@@ -784,7 +805,7 @@
         { "name": "payload_policy", "in": "query", "required": false, "description": "Payload inclusion: full, redacted, or omit." }
       ],
       "request_body": null,
-      "success_response": { "status": 200, "schema": "Array of HistoryExportDocument records." },
+      "success_response": { "status": 200, "fields": ["status", "observed_at", "payload_policy", "filters", "exports", "failures", "shard_coverage"] },
       "error_responses": [
         { "status": 400, "description": "Invalid filter values." },
         { "status": 500, "description": "Database error." }
@@ -808,7 +829,7 @@
         { "name": "limit", "in": "query", "required": false, "description": "Maximum number of results." }
       ],
       "request_body": null,
-      "success_response": { "status": 200, "schema": "Array of ExternalHandoff records." },
+      "success_response": { "status": 200, "fields": ["status", "items", "shard_coverage"] },
       "error_responses": [
         { "status": 500, "description": "Database error." }
       ]
@@ -823,7 +844,7 @@
         { "name": "token", "in": "path", "required": true, "description": "Task token UUID." }
       ],
       "request_body": null,
-      "success_response": { "status": 200, "schema": "ExternalHandoff record." },
+      "success_response": { "status": 200, "fields": ["status", "item", "shard_coverage"] },
       "error_responses": [
         { "status": 404, "description": "Token not found." },
         { "status": 500, "description": "Database error." }
@@ -837,7 +858,7 @@
       "description": "List all workflow and DAG schedules.",
       "params": [],
       "request_body": null,
-      "success_response": { "status": 200, "schema": "Array of HarvestSchedule records." },
+      "success_response": { "status": 200, "free_form": true },
       "error_responses": [
         { "status": 500, "description": "Database error." }
       ]
@@ -848,6 +869,8 @@
       "category": "schedule",
       "read_only": false,
       "description": "Create a new cron or interval schedule for a workflow.",
+      "idempotency": "Not idempotent: each call creates a new schedule row.",
+      "params": [],
       "request_body": {
         "required": true,
         "free_form": false,
@@ -860,7 +883,7 @@
           { "name": "paused", "required": false, "description": "Create the schedule in paused state." }
         ]
       },
-      "success_response": { "status": 200, "schema": "Created HarvestSchedule record." },
+      "success_response": { "status": 200, "fields": ["id", "kind", "name", "schedule_expr", "is_paused", "next_run_at", "last_run_at", "max_active_runs", "catchup"] },
       "error_responses": [
         { "status": 400, "description": "Invalid cron expression or missing required fields." },
         { "status": 500, "description": "Database error." }
@@ -872,6 +895,7 @@
       "category": "schedule",
       "read_only": false,
       "description": "Pause a schedule, preventing it from triggering new runs.",
+      "idempotency": "Idempotent: pausing an already-paused schedule is a no-op.",
       "params": [
         { "name": "id", "in": "path", "required": true, "description": "Schedule UUID." }
       ],
@@ -880,7 +904,7 @@
         "free_form": false,
         "fields": []
       },
-      "success_response": { "status": 200, "schema": "Updated HarvestSchedule." },
+      "success_response": { "status": 200, "fields": ["ok"] },
       "error_responses": [
         { "status": 404, "description": "Schedule not found." },
         { "status": 500, "description": "Database error." }
@@ -892,6 +916,7 @@
       "category": "schedule",
       "read_only": false,
       "description": "Resume a paused schedule.",
+      "idempotency": "Idempotent: resuming an already-active schedule is a no-op.",
       "params": [
         { "name": "id", "in": "path", "required": true, "description": "Schedule UUID." }
       ],
@@ -900,7 +925,7 @@
         "free_form": false,
         "fields": []
       },
-      "success_response": { "status": 200, "schema": "Updated HarvestSchedule." },
+      "success_response": { "status": 200, "fields": ["ok"] },
       "error_responses": [
         { "status": 404, "description": "Schedule not found." },
         { "status": 500, "description": "Database error." }
@@ -912,6 +937,7 @@
       "category": "schedule",
       "read_only": false,
       "description": "Delete a schedule. In-flight runs started by this schedule continue to completion.",
+      "idempotency": "Not idempotent: a second call after successful deletion returns 404.",
       "params": [
         { "name": "id", "in": "path", "required": true, "description": "Schedule UUID." }
       ],
@@ -920,7 +946,7 @@
         "free_form": false,
         "fields": []
       },
-      "success_response": { "status": 200, "schema": "Deletion acknowledgement." },
+      "success_response": { "status": 200, "fields": ["ok"] },
       "error_responses": [
         { "status": 404, "description": "Schedule not found." },
         { "status": 500, "description": "Database error." }
@@ -943,7 +969,7 @@
         { "name": "limit", "in": "query", "required": false, "description": "Maximum number of records to return." }
       ],
       "request_body": null,
-      "success_response": { "status": 200, "schema": "Array of AuditRecord entries." },
+      "success_response": { "status": 200, "free_form": true },
       "error_responses": [
         { "status": 500, "description": "Database error." }
       ]

--- a/docs/api-contract.json
+++ b/docs/api-contract.json
@@ -264,7 +264,7 @@
       "error_responses": [
         { "status": 400, "description": "Update rejected by the validator." },
         { "status": 404, "description": "Execution not found or update handler not registered." },
-        { "status": 408, "description": "Timed out waiting for completion." },
+        { "status": 504, "description": "Timed out waiting for completion (wait=completed exceeded the timeout)." },
         { "status": 500, "description": "Internal error." }
       ]
     },
@@ -280,7 +280,12 @@
       ],
       "request_body": null,
       "success_response": { "status": 200, "free_form": true },
+      "additional_responses": [
+        { "status": 202, "description": "Update admitted but not yet completed (still in-flight)." },
+        { "status": 409, "description": "Update failed or was rejected by the handler." }
+      ],
       "error_responses": [
+        { "status": 400, "description": "Invalid update_id format." },
         { "status": 404, "description": "Update not found." },
         { "status": 500, "description": "Database error." }
       ]
@@ -868,7 +873,7 @@
       "category": "schedule",
       "read_only": false,
       "description": "Create a new cron or interval schedule for a workflow.",
-      "idempotency": "Not idempotent: each call creates a new schedule row.",
+      "idempotency": "Upsert keyed by workflow_name: if a schedule already exists for that name the expression, input, and queue are updated; is_paused is preserved. Safe to retry.",
       "params": [],
       "request_body": {
         "required": true,

--- a/docs/api-contract.json
+++ b/docs/api-contract.json
@@ -11,11 +11,14 @@
       "Removing a route",
       "Renaming a route (path or method change)",
       "Changing a query parameter from optional to required",
+      "Removing a request body field",
+      "Renaming a request body field",
       "Adding a new mutating route without classifying it in this contract"
     ],
     "non_breaking_changes": [
       "Adding a new optional response field",
       "Adding a new optional query parameter",
+      "Adding a new optional request body field",
       "Adding a new read-only route",
       "Narrowing an existing error response to be more specific"
     ]
@@ -36,6 +39,7 @@
         { "name": "limit", "in": "query", "required": false, "description": "Maximum number of results to return." },
         { "name": "cursor", "in": "query", "required": false, "description": "Opaque pagination cursor from a previous response." }
       ],
+      "request_body": null,
       "success_response": { "status": 200, "schema": "Array of WorkflowExecution summaries with pagination cursor." },
       "error_responses": [
         { "status": 400, "description": "Invalid filter value." },
@@ -51,6 +55,7 @@
       "params": [
         { "name": "id", "in": "path", "required": true, "description": "Execution UUID." }
       ],
+      "request_body": null,
       "success_response": { "status": 200, "schema": "WorkflowExecution with full event list." },
       "error_responses": [
         { "status": 404, "description": "Execution not found." },
@@ -68,6 +73,7 @@
         { "name": "payload_policy", "in": "query", "required": false, "description": "Payload inclusion policy: full (default), redacted, or omit." },
         { "name": "max_bytes", "in": "query", "required": false, "description": "Soft byte cap on total payload size." }
       ],
+      "request_body": null,
       "success_response": { "status": 200, "schema": "HistoryExportDocument (JSON)." },
       "error_responses": [
         { "status": 404, "description": "Execution not found." },
@@ -89,6 +95,7 @@
         { "name": "cursor", "in": "query", "required": false, "description": "Pagination cursor." },
         { "name": "depth", "in": "query", "required": false, "description": "Maximum recursion depth for nested children." }
       ],
+      "request_body": null,
       "success_response": { "status": 200, "schema": "Array of child WorkflowExecution summaries." },
       "error_responses": [
         { "status": 404, "description": "Parent execution not found." },
@@ -104,6 +111,7 @@
       "params": [
         { "name": "id", "in": "path", "required": true, "description": "Execution UUID." }
       ],
+      "request_body": null,
       "success_response": { "status": 200, "schema": "WorkflowStack describing the current suspension point." },
       "error_responses": [
         { "status": 404, "description": "Execution not found." },
@@ -116,18 +124,22 @@
       "category": "workflow",
       "read_only": false,
       "description": "Start a new workflow execution. Idempotent when workflow_id is provided: returns the existing execution if one with the same workflow_id is already running.",
-      "idempotency": "Idempotent by workflow_id when id_reuse_policy is reject_duplicate or allow_duplicate_failed_only.",
+      "idempotency": "Idempotent by workflow_id when reuse_policy is reject_duplicate or allow_duplicate_failed_only.",
+      "params": [
+        { "name": "workflow_name", "in": "path", "required": true, "description": "Registered workflow function name." }
+      ],
       "request_body": {
         "required": false,
-        "schema": {
-          "workflow_id": "Optional string — stable identifier for idempotent starts.",
-          "input": "Optional JSON — workflow input payload.",
-          "queue": "Optional string — task queue name.",
-          "memo": "Optional JSON object — non-indexed metadata.",
-          "search_attrs": "Optional JSON object — indexed search attributes.",
-          "execution_timeout_secs": "Optional integer — overall execution timeout.",
-          "id_reuse_policy": "Optional string — duplicate-id policy."
-        }
+        "free_form": false,
+        "fields": [
+          { "name": "workflow_id", "required": false, "description": "Stable identifier for idempotent starts." },
+          { "name": "input", "required": false, "description": "Workflow input payload (any JSON value)." },
+          { "name": "queue", "required": false, "description": "Task queue name." },
+          { "name": "memo", "required": false, "description": "Non-indexed metadata (JSON object)." },
+          { "name": "search_attrs", "required": false, "description": "Indexed search attributes (JSON object)." },
+          { "name": "execution_timeout_secs", "required": false, "description": "Overall execution timeout in seconds." },
+          { "name": "reuse_policy", "required": false, "description": "Duplicate-id policy: allow_duplicate, reject_duplicate, allow_duplicate_failed_only, or terminate_if_running." }
+        ]
       },
       "success_response": { "status": 200, "schema": "Started or existing WorkflowExecution." },
       "error_responses": [
@@ -142,11 +154,15 @@
       "category": "workflow",
       "read_only": false,
       "description": "Cancel a running workflow execution.",
+      "params": [
+        { "name": "id", "in": "path", "required": true, "description": "Execution UUID." }
+      ],
       "request_body": {
         "required": false,
-        "schema": {
-          "reason": "Optional string — human-readable cancellation reason recorded in audit log."
-        }
+        "free_form": false,
+        "fields": [
+          { "name": "reason", "required": false, "description": "Human-readable cancellation reason recorded in audit log." }
+        ]
       },
       "success_response": { "status": 200, "schema": "Cancellation acknowledgement." },
       "error_responses": [
@@ -162,16 +178,18 @@
       "read_only": false,
       "description": "Fork a workflow execution at a specific event boundary, replaying from that point with a new execution ID.",
       "params": [
+        { "name": "id", "in": "path", "required": true, "description": "Execution UUID." },
         { "name": "dry_run", "in": "query", "required": false, "description": "When true, return the preview without creating a new execution." }
       ],
       "request_body": {
         "required": true,
-        "schema": {
-          "reset_to_event_id": "Integer — event sequence number to reset to.",
-          "reason": "String — reason for the reset, recorded in audit log.",
-          "operator_id": "Optional string — identity of the operator.",
-          "signal_reapply": "Optional string — how to handle buffered signals: drop or buffer."
-        }
+        "free_form": false,
+        "fields": [
+          { "name": "reset_to_event_id", "required": true, "description": "Event sequence number to reset to." },
+          { "name": "reason", "required": true, "description": "Reason for the reset, recorded in audit log." },
+          { "name": "operator_id", "required": false, "description": "Identity of the operator." },
+          { "name": "signal_reapply", "required": false, "description": "How to handle buffered signals: drop or buffer." }
+        ]
       },
       "success_response": { "status": 200, "schema": "ResetResult with new execution ID or dry-run preview." },
       "error_responses": [
@@ -185,10 +203,16 @@
       "path": "/workflows/{id}/signal/{signal_name}",
       "category": "workflow",
       "read_only": false,
-      "description": "Send a named signal to a running workflow execution.",
+      "description": "Send a named signal to a running workflow execution. The request body is the signal payload itself (free-form JSON).",
+      "params": [
+        { "name": "id", "in": "path", "required": true, "description": "Execution UUID." },
+        { "name": "signal_name", "in": "path", "required": true, "description": "Registered signal handler name." }
+      ],
       "request_body": {
         "required": false,
-        "schema": "Optional JSON payload for the signal handler."
+        "free_form": true,
+        "description": "Optional signal payload — the entire body is passed verbatim to the signal handler.",
+        "fields": []
       },
       "success_response": { "status": 200, "schema": "Signal delivery acknowledgement." },
       "error_responses": [
@@ -206,6 +230,7 @@
         { "name": "id", "in": "path", "required": true, "description": "Execution UUID." },
         { "name": "query_name", "in": "path", "required": true, "description": "Registered query handler name." }
       ],
+      "request_body": null,
       "success_response": { "status": 200, "schema": "JSON result from the query handler." },
       "error_responses": [
         { "status": 404, "description": "Execution not found or query handler not registered." },
@@ -219,14 +244,17 @@
       "read_only": false,
       "description": "Submit a synchronous update request to a running workflow. Blocks until admitted or completed depending on the wait parameter.",
       "params": [
-        { "name": "wait", "in": "query", "required": false, "description": "admitted — return when the update is validated and accepted; completed — block until the update handler returns (default)." },
-        { "name": "timeout_secs", "in": "query", "required": false, "description": "Maximum seconds to wait for the update to reach the requested state." }
+        { "name": "id", "in": "path", "required": true, "description": "Execution UUID." },
+        { "name": "update_name", "in": "path", "required": true, "description": "Registered update handler name." },
+        { "name": "wait", "in": "query", "required": false, "description": "admitted — return when validated; completed — block until handler returns (default)." },
+        { "name": "timeout_secs", "in": "query", "required": false, "description": "Maximum seconds to wait." }
       ],
       "request_body": {
         "required": false,
-        "schema": {
-          "input": "Optional JSON — payload passed to the update handler."
-        }
+        "free_form": false,
+        "fields": [
+          { "name": "input", "required": false, "description": "Payload passed to the update handler (any JSON value)." }
+        ]
       },
       "success_response": { "status": 200, "schema": "UpdateResult with update_id and outcome." },
       "error_responses": [
@@ -246,6 +274,7 @@
         { "name": "id", "in": "path", "required": true, "description": "Execution UUID." },
         { "name": "update_id", "in": "path", "required": true, "description": "Update UUID returned by POST …/update/{name}." }
       ],
+      "request_body": null,
       "success_response": { "status": 200, "schema": "UpdateResult: status (admitted | completed | failed) and output or error." },
       "error_responses": [
         { "status": 404, "description": "Update not found." },
@@ -259,6 +288,7 @@
       "read_only": true,
       "description": "List all registered DAGs and their current pause/enabled state.",
       "params": [],
+      "request_body": null,
       "success_response": { "status": 200, "schema": "Array of RegisteredDag summaries." },
       "error_responses": [
         { "status": 500, "description": "Internal error." }
@@ -274,6 +304,7 @@
         { "name": "dag_name", "in": "path", "required": true, "description": "Registered DAG name." },
         { "name": "limit", "in": "query", "required": false, "description": "Maximum number of runs to return." }
       ],
+      "request_body": null,
       "success_response": { "status": 200, "schema": "Array of DagRun records." },
       "error_responses": [
         { "status": 404, "description": "DAG not found." },
@@ -286,11 +317,15 @@
       "category": "dag",
       "read_only": false,
       "description": "Manually trigger a DAG run outside its schedule.",
+      "params": [
+        { "name": "dag_name", "in": "path", "required": true, "description": "Registered DAG name." }
+      ],
       "request_body": {
         "required": false,
-        "schema": {
-          "conf": "Optional JSON object — run configuration passed to the DAG."
-        }
+        "free_form": false,
+        "fields": [
+          { "name": "conf", "required": false, "description": "Run configuration passed to the DAG (any JSON value)." }
+        ]
       },
       "success_response": { "status": 200, "schema": "DagRun record for the newly triggered run." },
       "error_responses": [
@@ -305,11 +340,15 @@
       "category": "dag",
       "read_only": false,
       "description": "Update mutable DAG configuration fields (currently: pause/unpause).",
+      "params": [
+        { "name": "dag_name", "in": "path", "required": true, "description": "Registered DAG name." }
+      ],
       "request_body": {
         "required": true,
-        "schema": {
-          "paused": "Boolean — true to pause the DAG, false to resume it."
-        }
+        "free_form": false,
+        "fields": [
+          { "name": "paused", "required": true, "description": "true to pause the DAG, false to resume it." }
+        ]
       },
       "success_response": { "status": 200, "schema": "Updated RegisteredDag." },
       "error_responses": [
@@ -327,6 +366,7 @@
         { "name": "limit", "in": "query", "required": false, "description": "Maximum number of entries to return." },
         { "name": "cursor", "in": "query", "required": false, "description": "Pagination cursor." }
       ],
+      "request_body": null,
       "success_response": { "status": 200, "schema": "Array of DeadLetter records with pagination cursor." },
       "error_responses": [
         { "status": 500, "description": "Database error." }
@@ -340,14 +380,15 @@
       "description": "Bulk-replay dead-lettered tasks matching the provided filters by re-enqueuing them.",
       "request_body": {
         "required": false,
-        "schema": {
-          "activity_name": "Optional string — filter by activity function name.",
-          "workflow_name": "Optional string — filter by workflow name.",
-          "failed_after": "Optional RFC 3339 timestamp — only replay entries failed after this time.",
-          "failed_before": "Optional RFC 3339 timestamp — only replay entries failed before this time.",
-          "limit": "Optional integer — maximum entries to replay.",
-          "dry_run": "Optional boolean — when true, return a preview without re-enqueuing."
-        }
+        "free_form": false,
+        "fields": [
+          { "name": "activity_name", "required": false, "description": "Filter by activity function name." },
+          { "name": "workflow_name", "required": false, "description": "Filter by workflow name." },
+          { "name": "failed_after", "required": false, "description": "RFC 3339 timestamp — only replay entries failed after this time." },
+          { "name": "failed_before", "required": false, "description": "RFC 3339 timestamp — only replay entries failed before this time." },
+          { "name": "limit", "required": false, "description": "Maximum number of entries to replay." },
+          { "name": "dry_run", "required": false, "description": "When true, return a preview without re-enqueuing." }
+        ]
       },
       "success_response": { "status": 200, "schema": "BulkReplayResult: replayed count, skipped count, dry_run flag." },
       "error_responses": [
@@ -363,14 +404,15 @@
       "description": "Bulk-discard dead-lettered tasks matching the provided filters, removing them from the DLQ permanently.",
       "request_body": {
         "required": false,
-        "schema": {
-          "activity_name": "Optional string — filter by activity function name.",
-          "workflow_name": "Optional string — filter by workflow name.",
-          "failed_after": "Optional RFC 3339 timestamp — only discard entries failed after this time.",
-          "failed_before": "Optional RFC 3339 timestamp — only discard entries failed before this time.",
-          "limit": "Optional integer — maximum entries to discard.",
-          "dry_run": "Optional boolean — when true, return a preview without deleting."
-        }
+        "free_form": false,
+        "fields": [
+          { "name": "activity_name", "required": false, "description": "Filter by activity function name." },
+          { "name": "workflow_name", "required": false, "description": "Filter by workflow name." },
+          { "name": "failed_after", "required": false, "description": "RFC 3339 timestamp — only discard entries failed after this time." },
+          { "name": "failed_before", "required": false, "description": "RFC 3339 timestamp — only discard entries failed before this time." },
+          { "name": "limit", "required": false, "description": "Maximum number of entries to discard." },
+          { "name": "dry_run", "required": false, "description": "When true, return a preview without deleting." }
+        ]
       },
       "success_response": { "status": 200, "schema": "BulkDiscardResult: discarded count, dry_run flag." },
       "error_responses": [
@@ -387,7 +429,11 @@
       "params": [
         { "name": "id", "in": "path", "required": true, "description": "DeadLetter UUID." }
       ],
-      "request_body": { "required": false, "schema": null },
+      "request_body": {
+        "required": false,
+        "free_form": false,
+        "fields": []
+      },
       "success_response": { "status": 200, "schema": "Replay acknowledgement." },
       "error_responses": [
         { "status": 404, "description": "Dead letter not found." },
@@ -405,9 +451,10 @@
       ],
       "request_body": {
         "required": false,
-        "schema": {
-          "output": "Optional JSON — result value passed back to the workflow."
-        }
+        "free_form": false,
+        "fields": [
+          { "name": "output", "required": false, "description": "Result value passed back to the workflow (any JSON value)." }
+        ]
       },
       "success_response": { "status": 200, "schema": "Completion acknowledgement." },
       "error_responses": [
@@ -426,10 +473,11 @@
       ],
       "request_body": {
         "required": true,
-        "schema": {
-          "error": "String — error message.",
-          "retryable": "Optional boolean — true to schedule a retry (default: false)."
-        }
+        "free_form": false,
+        "fields": [
+          { "name": "error", "required": true, "description": "Error message string." },
+          { "name": "retryable", "required": false, "description": "true to schedule a retry (default: false)." }
+        ]
       },
       "success_response": { "status": 200, "schema": "Failure acknowledgement." },
       "error_responses": [
@@ -448,9 +496,10 @@
       ],
       "request_body": {
         "required": false,
-        "schema": {
-          "extend_by_secs": "Optional integer — seconds to extend the activity deadline."
-        }
+        "free_form": false,
+        "fields": [
+          { "name": "extend_by_secs", "required": false, "description": "Seconds to extend the activity deadline." }
+        ]
       },
       "success_response": { "status": 200, "schema": "Heartbeat acknowledgement." },
       "error_responses": [
@@ -471,6 +520,7 @@
         { "name": "health", "in": "query", "required": false, "description": "Filter by health: healthy or stale." },
         { "name": "limit", "in": "query", "required": false, "description": "Maximum number of workers to return [1–500]." }
       ],
+      "request_body": null,
       "success_response": { "status": 200, "schema": "Array of WorkerRow records." },
       "error_responses": [
         { "status": 500, "description": "Database error." }
@@ -485,6 +535,7 @@
       "params": [
         { "name": "worker_id", "in": "path", "required": true, "description": "Worker process identifier." }
       ],
+      "request_body": null,
       "success_response": { "status": 200, "schema": "WorkerRow record." },
       "error_responses": [
         { "status": 404, "description": "Worker not found." },
@@ -498,6 +549,7 @@
       "read_only": true,
       "description": "Return aggregated fleet health statistics (active, stale, draining, stopped counts per shard).",
       "params": [],
+      "request_body": null,
       "success_response": { "status": 200, "schema": "FleetHealth summary." },
       "error_responses": [
         { "status": 500, "description": "Database error." }
@@ -515,6 +567,7 @@
         { "name": "status", "in": "query", "required": false, "description": "Filter by lifecycle status." },
         { "name": "limit", "in": "query", "required": false, "description": "Maximum number of workers to preview." }
       ],
+      "request_body": null,
       "success_response": { "status": 200, "schema": "Array of DrainPreviewItem records." },
       "error_responses": [
         { "status": 500, "description": "Database error." }
@@ -525,15 +578,16 @@
       "path": "/workers/{worker_id}/drain",
       "category": "worker",
       "read_only": false,
-      "description": "Request a graceful drain for a specific worker. Sets its status to Draining so it stops accepting new tasks. The worker transitions to Stopped once all in-flight tasks complete.",
+      "description": "Request a graceful drain for a specific worker. Sets its status to Draining so it stops accepting new tasks.",
       "params": [
         { "name": "worker_id", "in": "path", "required": true, "description": "Worker process identifier." }
       ],
       "request_body": {
         "required": false,
-        "schema": {
-          "deadline_at": "Optional RFC 3339 timestamp — drain-by deadline. When omitted the server uses its configured shutdown timeout."
-        }
+        "free_form": false,
+        "fields": [
+          { "name": "deadline_at", "required": false, "description": "RFC 3339 drain-by deadline. Omit to use the server's configured shutdown timeout." }
+        ]
       },
       "success_response": { "status": 200, "schema": "DrainResponse with updated worker status." },
       "error_responses": [
@@ -551,6 +605,7 @@
       "params": [
         { "name": "limit", "in": "query", "required": false, "description": "Maximum number of operations to return." }
       ],
+      "request_body": null,
       "success_response": { "status": 200, "schema": "Array of BatchJobView records." },
       "error_responses": [
         { "status": 500, "description": "Database error." }
@@ -564,12 +619,13 @@
       "description": "Submit a fleet-wide batch operation (Cancel, Terminate, or Signal) targeting workflows matching a filter.",
       "request_body": {
         "required": true,
-        "schema": {
-          "action": "String — batch action: Cancel, Terminate, or Signal.",
-          "filter": "JSON object — workflow filter (states, workflow_name, search attributes).",
-          "signal_name": "Optional string — required when action is Signal.",
-          "signal_payload": "Optional JSON — payload for Signal actions."
-        }
+        "free_form": false,
+        "fields": [
+          { "name": "action", "required": true, "description": "Batch action: Cancel, Terminate, or Signal." },
+          { "name": "filter", "required": true, "description": "Workflow filter (JSON object with states, workflow_name, search attributes)." },
+          { "name": "signal_name", "required": false, "description": "Signal name — required when action is Signal." },
+          { "name": "signal_payload", "required": false, "description": "Signal payload for Signal actions (any JSON value)." }
+        ]
       },
       "success_response": { "status": 202, "schema": "BatchSubmissionResult with job_id." },
       "error_responses": [
@@ -586,6 +642,7 @@
       "params": [
         { "name": "id", "in": "path", "required": true, "description": "Batch job UUID." }
       ],
+      "request_body": null,
       "success_response": { "status": 200, "schema": "BatchJobView with status, progress counts, and error summary." },
       "error_responses": [
         { "status": 404, "description": "Batch job not found." },
@@ -599,6 +656,7 @@
       "read_only": true,
       "description": "Liveness health check. Returns 200 when the plugin is reachable. Does not probe the database.",
       "params": [],
+      "request_body": null,
       "success_response": { "status": 200, "schema": "{ status: string }" },
       "error_responses": []
     },
@@ -609,6 +667,7 @@
       "read_only": true,
       "description": "Run deployment readiness preflight checks: database connectivity, migration status, shard health, and worker coverage.",
       "params": [],
+      "request_body": null,
       "success_response": { "status": 200, "schema": "PreflightReport with per-check results and overall pass/fail." },
       "error_responses": [
         { "status": 500, "description": "Unable to connect to database." }
@@ -619,11 +678,12 @@
       "path": "/admin/shards/health",
       "category": "admin",
       "read_only": true,
-      "description": "Return per-shard readiness: ready, degraded, or unavailable. Optionally probe a candidate shard before adding it to writable_shards.",
+      "description": "Return per-shard readiness: ready, degraded, or unavailable.",
       "params": [
         { "name": "candidate_shard", "in": "query", "required": false, "description": "Shard ID of a new shard to probe before enabling writes." },
         { "name": "fail_on_unready", "in": "query", "required": false, "description": "When true, the response uses HTTP 503 if any shard is not ready." }
       ],
+      "request_body": null,
       "success_response": { "status": 200, "schema": "ShardHealthReport with per-shard readiness." },
       "error_responses": [
         { "status": 503, "description": "One or more shards not ready (only when fail_on_unready is true)." }
@@ -634,7 +694,7 @@
       "path": "/admin/version-gates/usage",
       "category": "admin",
       "read_only": true,
-      "description": "Report recorded workflow version-gate usage: how many executions carry each (change_id, version) pair.",
+      "description": "Report recorded workflow version-gate usage.",
       "params": [
         { "name": "workflow_name", "in": "query", "required": false, "description": "Filter by registered workflow name." },
         { "name": "change_id", "in": "query", "required": false, "description": "Filter by version-gate change ID." },
@@ -642,6 +702,7 @@
         { "name": "state_group", "in": "query", "required": false, "description": "Execution state group: active or terminal." },
         { "name": "shard_id", "in": "query", "required": false, "description": "Restrict to a single shard." }
       ],
+      "request_body": null,
       "success_response": { "status": 200, "schema": "Array of VersionUsageRow records." },
       "error_responses": [
         { "status": 500, "description": "Database error." }
@@ -652,7 +713,7 @@
       "path": "/admin/version-gates/retirement-check",
       "category": "admin",
       "read_only": true,
-      "description": "Check whether a version-gate change ID is safe to retire: no non-terminal executions carry a version below the specified threshold.",
+      "description": "Check whether a version-gate change ID is safe to retire.",
       "params": [
         { "name": "change_id", "in": "query", "required": true, "description": "Version-gate change ID to inspect." },
         { "name": "min_safe_version", "in": "query", "required": true, "description": "Versions strictly below this value are considered old branches." },
@@ -660,6 +721,7 @@
         { "name": "state_group", "in": "query", "required": false, "description": "Execution state group filter." },
         { "name": "shard_id", "in": "query", "required": false, "description": "Restrict to a single shard." }
       ],
+      "request_body": null,
       "success_response": { "status": 200, "schema": "RetirementCheckReport: safe (bool), blocking_count, per-shard breakdown." },
       "error_responses": [
         { "status": 400, "description": "Missing required parameters." },
@@ -671,8 +733,9 @@
       "path": "/admin/retention",
       "category": "admin",
       "read_only": true,
-      "description": "Return the current status of the retention janitor: last run time, records deleted, and configured TTL.",
+      "description": "Return the current status of the retention janitor.",
       "params": [],
+      "request_body": null,
       "success_response": { "status": 200, "schema": "RetentionStatus." },
       "error_responses": []
     },
@@ -682,7 +745,11 @@
       "category": "admin",
       "read_only": false,
       "description": "Trigger the retention janitor to run immediately outside its scheduled interval.",
-      "request_body": { "required": false, "schema": null },
+      "request_body": {
+        "required": false,
+        "free_form": false,
+        "fields": []
+      },
       "success_response": { "status": 200, "schema": "Trigger acknowledgement." },
       "error_responses": [
         { "status": 500, "description": "Internal error." }
@@ -695,6 +762,7 @@
       "read_only": true,
       "description": "Return per-activity concurrency statistics: configured cap, currently in-flight, and queued counts for each concurrency key.",
       "params": [],
+      "request_body": null,
       "success_response": { "status": 200, "schema": "Array of ConcurrencyKeyStats records." },
       "error_responses": [
         { "status": 500, "description": "Database error." }
@@ -705,7 +773,7 @@
       "path": "/admin/history/exports",
       "category": "admin",
       "read_only": true,
-      "description": "Batch-export event histories for multiple executions matching the provided filters. Useful for replay fixture generation and compliance archiving.",
+      "description": "Batch-export event histories for multiple executions matching the provided filters.",
       "params": [
         { "name": "workflow_name", "in": "query", "required": false, "description": "Filter by workflow name." },
         { "name": "state_group", "in": "query", "required": false, "description": "Execution state group: active or terminal." },
@@ -715,6 +783,7 @@
         { "name": "limit", "in": "query", "required": false, "description": "Maximum number of histories to export." },
         { "name": "payload_policy", "in": "query", "required": false, "description": "Payload inclusion: full, redacted, or omit." }
       ],
+      "request_body": null,
       "success_response": { "status": 200, "schema": "Array of HistoryExportDocument records." },
       "error_responses": [
         { "status": 400, "description": "Invalid filter values." },
@@ -738,6 +807,7 @@
         { "name": "updated_before", "in": "query", "required": false, "description": "RFC 3339 timestamp — only return handoffs last updated before this time." },
         { "name": "limit", "in": "query", "required": false, "description": "Maximum number of results." }
       ],
+      "request_body": null,
       "success_response": { "status": 200, "schema": "Array of ExternalHandoff records." },
       "error_responses": [
         { "status": 500, "description": "Database error." }
@@ -752,6 +822,7 @@
       "params": [
         { "name": "token", "in": "path", "required": true, "description": "Task token UUID." }
       ],
+      "request_body": null,
       "success_response": { "status": 200, "schema": "ExternalHandoff record." },
       "error_responses": [
         { "status": 404, "description": "Token not found." },
@@ -765,6 +836,7 @@
       "read_only": true,
       "description": "List all workflow and DAG schedules.",
       "params": [],
+      "request_body": null,
       "success_response": { "status": 200, "schema": "Array of HarvestSchedule records." },
       "error_responses": [
         { "status": 500, "description": "Database error." }
@@ -778,14 +850,15 @@
       "description": "Create a new cron or interval schedule for a workflow.",
       "request_body": {
         "required": true,
-        "schema": {
-          "workflow_name": "String — registered workflow name.",
-          "schedule_expr": "String — cron expression (e.g. '0 * * * *').",
-          "input": "Optional JSON — workflow input payload.",
-          "max_active_runs": "Optional integer — maximum concurrent scheduled runs.",
-          "catchup": "Optional boolean — whether to backfill missed runs.",
-          "paused": "Optional boolean — create the schedule in paused state."
-        }
+        "free_form": false,
+        "fields": [
+          { "name": "workflow_name", "required": true, "description": "Registered workflow name." },
+          { "name": "schedule_expr", "required": true, "description": "Cron expression (e.g. '0 * * * *')." },
+          { "name": "input", "required": false, "description": "Workflow input payload (any JSON value)." },
+          { "name": "max_active_runs", "required": false, "description": "Maximum concurrent scheduled runs." },
+          { "name": "catchup", "required": false, "description": "Whether to backfill missed runs." },
+          { "name": "paused", "required": false, "description": "Create the schedule in paused state." }
+        ]
       },
       "success_response": { "status": 200, "schema": "Created HarvestSchedule record." },
       "error_responses": [
@@ -802,7 +875,11 @@
       "params": [
         { "name": "id", "in": "path", "required": true, "description": "Schedule UUID." }
       ],
-      "request_body": { "required": false, "schema": null },
+      "request_body": {
+        "required": false,
+        "free_form": false,
+        "fields": []
+      },
       "success_response": { "status": 200, "schema": "Updated HarvestSchedule." },
       "error_responses": [
         { "status": 404, "description": "Schedule not found." },
@@ -818,7 +895,11 @@
       "params": [
         { "name": "id", "in": "path", "required": true, "description": "Schedule UUID." }
       ],
-      "request_body": { "required": false, "schema": null },
+      "request_body": {
+        "required": false,
+        "free_form": false,
+        "fields": []
+      },
       "success_response": { "status": 200, "schema": "Updated HarvestSchedule." },
       "error_responses": [
         { "status": 404, "description": "Schedule not found." },
@@ -834,7 +915,11 @@
       "params": [
         { "name": "id", "in": "path", "required": true, "description": "Schedule UUID." }
       ],
-      "request_body": { "required": false, "schema": null },
+      "request_body": {
+        "required": false,
+        "free_form": false,
+        "fields": []
+      },
       "success_response": { "status": 200, "schema": "Deletion acknowledgement." },
       "error_responses": [
         { "status": 404, "description": "Schedule not found." },
@@ -857,6 +942,7 @@
         { "name": "before", "in": "query", "required": false, "description": "RFC 3339 timestamp — only return records before this time." },
         { "name": "limit", "in": "query", "required": false, "description": "Maximum number of records to return." }
       ],
+      "request_body": null,
       "success_response": { "status": 200, "schema": "Array of AuditRecord entries." },
       "error_responses": [
         { "status": 500, "description": "Database error." }

--- a/docs/api-contract.json
+++ b/docs/api-contract.json
@@ -141,7 +141,7 @@
           { "name": "reuse_policy", "required": false, "description": "Duplicate-id policy: allow_duplicate, reject_duplicate, allow_duplicate_failed_only, or terminate_if_running." }
         ]
       },
-      "success_response": { "status": 200, "fields": ["execution_id", "workflow_name", "workflow_id", "state"] },
+      "success_response": { "status": 201, "note": "Returns 200 when an existing execution is returned via reuse_policy instead of creating a new one.", "fields": ["execution_id", "workflow_name", "workflow_id", "state"] },
       "error_responses": [
         { "status": 400, "description": "Invalid request body or workflow name." },
         { "status": 409, "description": "Duplicate workflow_id with conflicting reuse policy." },
@@ -193,7 +193,7 @@
           { "name": "signal_reapply", "required": false, "description": "How to handle buffered signals: drop or buffer." }
         ]
       },
-      "success_response": { "status": 200, "fields": ["new_exec_id", "reset_from_exec_id", "reset_to_event_id", "events_carried_over", "source_tasks_cancelled", "source_timers_removed", "source_signals_dropped", "source_signals_buffered"] },
+      "success_response": { "status": 201, "fields": ["new_exec_id", "reset_from_exec_id", "reset_to_event_id", "events_carried_over", "source_tasks_cancelled", "source_timers_removed", "source_signals_dropped", "source_signals_buffered"] },
       "error_responses": [
         { "status": 400, "description": "Invalid reset point or request body." },
         { "status": 404, "description": "Execution not found." },
@@ -332,7 +332,7 @@
           { "name": "conf", "required": false, "description": "Run configuration passed to the DAG (any JSON value)." }
         ]
       },
-      "success_response": { "status": 200, "free_form": true },
+      "success_response": { "status": 201, "free_form": true },
       "error_responses": [
         { "status": 404, "description": "DAG not found." },
         { "status": 409, "description": "DAG is paused or at max_active_runs." },
@@ -880,10 +880,11 @@
           { "name": "input", "required": false, "description": "Workflow input payload (any JSON value)." },
           { "name": "max_active_runs", "required": false, "description": "Maximum concurrent scheduled runs." },
           { "name": "catchup", "required": false, "description": "Whether to backfill missed runs." },
-          { "name": "paused", "required": false, "description": "Create the schedule in paused state." }
+          { "name": "paused", "required": false, "description": "Create the schedule in paused state." },
+          { "name": "queue_name", "required": false, "description": "Task queue name for scheduled runs (default: 'default')." }
         ]
       },
-      "success_response": { "status": 200, "fields": ["id", "kind", "name", "schedule_expr", "is_paused", "next_run_at", "last_run_at", "max_active_runs", "catchup"] },
+      "success_response": { "status": 201, "fields": ["id", "kind", "name", "schedule_expr", "is_paused", "next_run_at", "last_run_at", "max_active_runs", "catchup"] },
       "error_responses": [
         { "status": 400, "description": "Invalid cron expression or missing required fields." },
         { "status": 500, "description": "Database error." }


### PR DESCRIPTION
## Summary

Introduces a machine-readable API contract (`docs/api-contract.json`) that documents the complete Harvest management API surface, along with comprehensive regression tests to keep the contract in sync with the codebase.

## Key Changes

- **New contract document** (`docs/api-contract.json`):
  - Documents all 60+ management API routes with method, path, category, and `read_only` flag
  - Specifies request-body field schemas for mutating operations
  - Defines success/error response codes and idempotency semantics
  - Includes compatibility rules distinguishing breaking vs. non-breaking changes
  - Versioned to match the `autumn-harvest-plugin` crate version

- **Contract regression tests** (`autumn-harvest-plugin/tests/contract_regression.rs`):
  - Validates that all routes in `harvest_api_router` are documented in the contract
  - Ensures all routes in the contract are actually registered in code
  - Verifies every route has required metadata fields (method, path, description, read_only, category)
  - Confirms mutating routes have structured `request_body.fields` arrays
  - Validates request-field registry matches the contract

- **CLI contract coverage tests** (`autumn-harvest-cli/tests/contract_coverage.rs`):
  - Verifies every CLI subcommand maps to a documented API route
  - Validates that every JSON key sent in request bodies is listed in the contract's field schema
  - Enforces that CLI output conforms to the documented request shape

- **Code registry functions** (`autumn-harvest-plugin/src/api.rs`):
  - `management_api_routes()`: canonical list of all (METHOD, path-template) pairs
  - `management_api_request_fields()`: registry of request-body field schemas for mutating routes
  - `management_api_response_fields()`: registry of documented response fields

- **Embedder guide** (`docs/api-contract-guide.md`):
  - Explains how to inspect and use the contract
  - Documents the contract JSON schema
  - Clarifies breaking vs. non-breaking change rules

- **CHANGELOG entry**: Documents the new contract as a feature

## Implementation Details

- The contract is embedded in test binaries via `include_str!()` to ensure tests always validate against the checked-in version
- Path template matching handles parameterized routes (e.g., `/workflows/{id}/cancel` matches concrete paths like `/workflows/abc-123/cancel`)
- Tests enforce bidirectional consistency: routes in code must be in the contract, and vice versa
- The contract explicitly documents idempotency semantics and audit trail coverage for each route

https://claude.ai/code/session_01Vb1u7P5tpSHD6GisU5qzVo