### PR TITLE
Add schedule backfill API for recovering missed scheduled runs

### DIFF
--- a/autumn-harvest-cli/src/lib.rs
+++ b/autumn-harvest-cli/src/lib.rs
@@ -1422,6 +1422,11 @@ fn format_backfill_table(value: &Value) -> String {
         }
     }
 
+    // Paused schedule warning (DAG backfill with include_paused=true)
+    if let Some(warning) = value.get("paused_schedule_warning").and_then(Value::as_str) {
+        let _ = writeln!(out, "\nWARNING: {warning}");
+    }
+
     out
 }
 

--- a/autumn-harvest-cli/src/lib.rs
+++ b/autumn-harvest-cli/src/lib.rs
@@ -1,6 +1,7 @@
 //! Command-line client for the autumn-harvest management API.
 
 use std::collections::BTreeMap;
+use std::fmt::Write as _;
 use std::fs;
 use std::io::Read;
 use std::path::{Path, PathBuf};
@@ -1341,6 +1342,9 @@ fn render_response(cli: &Cli, value: &Value) -> Result<String, CliError> {
     if retirement_check_wants_table(cli) {
         return Ok(format_retirement_check_table(value));
     }
+    if backfill_wants_table(cli) {
+        return Ok(format_backfill_table(value));
+    }
 
     let output = if workflow_children_wants_raw_json(cli) || handoff_wants_raw_json(cli) {
         OutputFormat::Json
@@ -1348,6 +1352,77 @@ fn render_response(cli: &Cli, value: &Value) -> Result<String, CliError> {
         cli.output
     };
     format_output(value, output)
+}
+
+fn backfill_wants_table(cli: &Cli) -> bool {
+    matches!(
+        &cli.command,
+        Commands::Schedule {
+            command: ScheduleCommand::Backfill { .. }
+        }
+    ) && cli.output == OutputFormat::PrettyJson
+}
+
+fn format_backfill_table(value: &Value) -> String {
+    let status = value.get("status").and_then(Value::as_str).unwrap_or("-");
+    let name = value.get("name").and_then(Value::as_str).unwrap_or("-");
+    let kind = value.get("kind").and_then(Value::as_str).unwrap_or("-");
+    let from = value.get("from").and_then(Value::as_str).unwrap_or("-");
+    let to = value.get("to").and_then(Value::as_str).unwrap_or("-");
+    let total = value.get("total").and_then(Value::as_u64).unwrap_or(0);
+    let dispatched = value.get("dispatched").and_then(Value::as_u64).unwrap_or(0);
+    let skipped = value.get("skipped").and_then(Value::as_u64).unwrap_or(0);
+    let failed = value.get("failed").and_then(Value::as_u64).unwrap_or(0);
+
+    let mut out = String::new();
+    let _ = writeln!(out, "status: {status}  kind: {kind}  name: {name}");
+    let _ = writeln!(out, "window: {from} \u{2192} {to}");
+    let _ = writeln!(
+        out,
+        "total: {total}  dispatched: {dispatched}  skipped: {skipped}  failed: {failed}"
+    );
+
+    // Skipped reasons
+    if let Some(reasons) = value
+        .get("skipped_reasons")
+        .and_then(Value::as_object)
+        .filter(|r| !r.is_empty())
+    {
+        let parts: Vec<String> = reasons
+            .iter()
+            .map(|(k, v)| format!("{k}={}", v.as_u64().unwrap_or(0)))
+            .collect();
+        let _ = writeln!(out, "skipped reasons: {}", parts.join(", "));
+    }
+
+    // Planned timestamps
+    if let Some(timestamps) = value.get("planned_timestamps").and_then(Value::as_array) {
+        if timestamps.is_empty() {
+            out.push_str("\nNo timestamps planned.\n");
+        } else {
+            let _ = writeln!(out, "\nPlanned timestamps ({}):", timestamps.len());
+            for ts in timestamps {
+                let ts_str = ts.as_str().unwrap_or("-");
+                let _ = writeln!(out, "  {ts_str}");
+            }
+        }
+    }
+
+    // Partial shard failures
+    if let Some(failures) = value
+        .get("partial_shard_failures")
+        .and_then(Value::as_array)
+        .filter(|f| !f.is_empty())
+    {
+        out.push_str("\nShard failures:\n");
+        for f in failures {
+            let shard_id = f.get("shard_id").and_then(Value::as_i64).unwrap_or(-1);
+            let reason = f.get("reason").and_then(Value::as_str).unwrap_or("-");
+            let _ = writeln!(out, "  shard {shard_id}: {reason}");
+        }
+    }
+
+    out
 }
 
 fn preflight_wants_table(cli: &Cli) -> bool {

--- a/autumn-harvest-cli/src/lib.rs
+++ b/autumn-harvest-cli/src/lib.rs
@@ -827,6 +827,26 @@ enum ScheduleCommand {
         #[arg(long)]
         paused: bool,
     },
+    /// Backfill missed scheduled runs over an explicit time window.
+    Backfill {
+        /// Schedule row ID (UUID).
+        id: String,
+        /// Start of the backfill window, RFC 3339 (e.g. 2026-04-01T00:00:00Z). Required.
+        #[arg(long, required = true)]
+        from: String,
+        /// End of the backfill window, RFC 3339 (e.g. 2026-04-08T00:00:00Z). Required.
+        #[arg(long, required = true)]
+        to: String,
+        /// Preview planned timestamps without dispatching any runs.
+        #[arg(long)]
+        dry_run: bool,
+        /// Maximum number of timestamps to plan (default: server-side limit of 1000).
+        #[arg(long)]
+        max_count: Option<u64>,
+        /// Backfill even if the schedule is currently paused.
+        #[arg(long)]
+        include_paused: bool,
+    },
     /// Pause a schedule (works for both DAG and workflow schedules).
     Pause {
         /// Schedule row ID (UUID).
@@ -2515,6 +2535,27 @@ fn dag_request(command: &DagCommand) -> Result<ApiRequest, CliError> {
 fn schedule_request(command: &ScheduleCommand) -> Result<ApiRequest, CliError> {
     match command {
         ScheduleCommand::List => Ok(ApiRequest::get("/admin/schedules")),
+        ScheduleCommand::Backfill {
+            id,
+            from,
+            to,
+            dry_run,
+            max_count,
+            include_paused,
+        } => {
+            let mut body = Map::new();
+            body.insert("from".to_string(), Value::String(from.clone()));
+            body.insert("to".to_string(), Value::String(to.clone()));
+            body.insert("dry_run".to_string(), json!(dry_run));
+            body.insert("include_paused".to_string(), json!(include_paused));
+            if let Some(count) = max_count {
+                body.insert("max_count".to_string(), json!(count));
+            }
+            Ok(ApiRequest::post(
+                format!("/admin/schedules/{}/backfill", path_segment(id)),
+                Some(Value::Object(body)),
+            ))
+        }
         ScheduleCommand::CreateWorkflow {
             name,
             cron,

--- a/autumn-harvest-cli/tests/contract_coverage.rs
+++ b/autumn-harvest-cli/tests/contract_coverage.rs
@@ -423,6 +423,19 @@ fn schedule_delete_is_covered() {
     assert_covered(&["schedule", "delete", "00000000-0000-0000-0000-000000000001"]);
 }
 
+#[test]
+fn schedule_backfill_is_covered() {
+    assert_covered(&[
+        "schedule",
+        "backfill",
+        "00000000-0000-0000-0000-000000000001",
+        "--from",
+        "2026-04-01T00:00:00Z",
+        "--to",
+        "2026-04-08T00:00:00Z",
+    ]);
+}
+
 // ── retention ─────────────────────────────────────────────────────────────────
 
 #[test]
@@ -726,5 +739,22 @@ fn schedule_create_workflow_body_fields_are_documented() {
         "3",
         "--catchup",
         "--paused",
+    ]);
+}
+
+#[test]
+fn schedule_backfill_body_fields_are_documented() {
+    assert_body_fields_documented(&[
+        "schedule",
+        "backfill",
+        "00000000-0000-0000-0000-000000000001",
+        "--from",
+        "2026-04-01T00:00:00Z",
+        "--to",
+        "2026-04-08T00:00:00Z",
+        "--dry-run",
+        "--max-count",
+        "50",
+        "--include-paused",
     ]);
 }

--- a/autumn-harvest-cli/tests/request_mapping.rs
+++ b/autumn-harvest-cli/tests/request_mapping.rs
@@ -910,3 +910,135 @@ fn audit_list_partial_filters() {
     assert!(request.path.contains("limit=10"));
     assert!(!request.path.contains("actor="), "actor should be absent");
 }
+
+// ── schedule backfill (issue #177) ──────────────────────────────────────────
+
+#[test]
+fn schedule_backfill_maps_to_post_backfill_route() {
+    let cli = Cli::try_parse_from([
+        "harvest",
+        "schedule",
+        "backfill",
+        "00000000-0000-0000-0000-000000000042",
+        "--from",
+        "2026-04-01T00:00:00Z",
+        "--to",
+        "2026-04-08T00:00:00Z",
+    ])
+    .expect("schedule backfill args should parse");
+
+    let request = cli
+        .api_request()
+        .expect("schedule backfill request should build");
+
+    assert_eq!(request.method, ApiMethod::Post);
+    assert_eq!(
+        request.path,
+        "/admin/schedules/00000000-0000-0000-0000-000000000042/backfill"
+    );
+    let body = request.body.expect("backfill request must have a body");
+    assert_eq!(body["from"], "2026-04-01T00:00:00Z");
+    assert_eq!(body["to"], "2026-04-08T00:00:00Z");
+    assert_eq!(body["dry_run"], false);
+    assert_eq!(body["include_paused"], false);
+}
+
+#[test]
+fn schedule_backfill_dry_run_flag_sets_body_field() {
+    let cli = Cli::try_parse_from([
+        "harvest",
+        "schedule",
+        "backfill",
+        "00000000-0000-0000-0000-000000000099",
+        "--from",
+        "2026-04-01T00:00:00Z",
+        "--to",
+        "2026-04-08T00:00:00Z",
+        "--dry-run",
+    ])
+    .expect("backfill --dry-run args should parse");
+
+    let request = cli
+        .api_request()
+        .expect("backfill dry-run request should build");
+    let body = request.body.expect("dry-run request must have a body");
+
+    assert_eq!(body["dry_run"], true);
+    assert_eq!(body["from"], "2026-04-01T00:00:00Z");
+    assert_eq!(body["to"], "2026-04-08T00:00:00Z");
+}
+
+#[test]
+fn schedule_backfill_max_count_appears_in_body() {
+    let cli = Cli::try_parse_from([
+        "harvest",
+        "schedule",
+        "backfill",
+        "00000000-0000-0000-0000-000000000001",
+        "--from",
+        "2026-04-01T00:00:00Z",
+        "--to",
+        "2026-04-08T00:00:00Z",
+        "--max-count",
+        "50",
+    ])
+    .expect("backfill --max-count args should parse");
+
+    let request = cli.api_request().expect("request should build");
+    let body = request.body.expect("request must have a body");
+
+    assert_eq!(body["max_count"], json!(50u64));
+}
+
+#[test]
+fn schedule_backfill_include_paused_appears_in_body() {
+    let cli = Cli::try_parse_from([
+        "harvest",
+        "schedule",
+        "backfill",
+        "00000000-0000-0000-0000-000000000001",
+        "--from",
+        "2026-04-01T00:00:00Z",
+        "--to",
+        "2026-04-08T00:00:00Z",
+        "--include-paused",
+    ])
+    .expect("backfill --include-paused args should parse");
+
+    let request = cli.api_request().expect("request should build");
+    let body = request.body.expect("request must have a body");
+
+    assert_eq!(body["include_paused"], true);
+}
+
+#[test]
+fn schedule_backfill_missing_from_is_rejected_by_clap() {
+    let result = Cli::try_parse_from([
+        "harvest",
+        "schedule",
+        "backfill",
+        "00000000-0000-0000-0000-000000000001",
+        "--to",
+        "2026-04-08T00:00:00Z",
+    ]);
+    assert!(
+        result.is_err(),
+        "--from is required and its absence should be rejected"
+    );
+}
+
+#[test]
+fn schedule_backfill_missing_to_is_rejected_by_clap() {
+    let result = Cli::try_parse_from([
+        "harvest",
+        "schedule",
+        "backfill",
+        "00000000-0000-0000-0000-000000000001",
+        "--from",
+        "2026-04-01T00:00:00Z",
+    ]);
+    assert!(
+        result.is_err(),
+        "--to is required and its absence should be rejected"
+    );
+}

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -28,10 +28,11 @@ use autumn_harvest::audit::{
     self, AuditFilters, HEADER_ACTOR, HEADER_REQUEST_ID, HEADER_SOURCE, OP_BATCH_SUBMIT,
     OP_DAG_PATCH, OP_DAG_TRIGGER, OP_DLQ_DISCARD_BULK, OP_DLQ_REPLAY, OP_DLQ_REPLAY_BULK,
     OP_EXTERNAL_ACTIVITY_COMPLETE, OP_EXTERNAL_ACTIVITY_FAIL, OP_RETENTION_RUN_NOW,
-    OP_SCHEDULE_CREATE, OP_SCHEDULE_DELETE, OP_SCHEDULE_PAUSE, OP_SCHEDULE_RESUME, OP_WORKER_DRAIN,
-    OP_WORKFLOW_CANCEL, OP_WORKFLOW_RESET, OP_WORKFLOW_SIGNAL, OP_WORKFLOW_START, SOURCE_API,
-    STATUS_FAILED, STATUS_SUCCEEDED, TARGET_BATCH, TARGET_DAG, TARGET_DEAD_LETTER,
-    TARGET_EXTERNAL_ACTIVITY, TARGET_RETENTION, TARGET_SCHEDULE, TARGET_WORKER, TARGET_WORKFLOW,
+    OP_SCHEDULE_BACKFILL, OP_SCHEDULE_CREATE, OP_SCHEDULE_DELETE, OP_SCHEDULE_PAUSE,
+    OP_SCHEDULE_RESUME, OP_WORKER_DRAIN, OP_WORKFLOW_CANCEL, OP_WORKFLOW_RESET, OP_WORKFLOW_SIGNAL,
+    OP_WORKFLOW_START, SOURCE_API, STATUS_FAILED, STATUS_SUCCEEDED, TARGET_BATCH, TARGET_DAG,
+    TARGET_DEAD_LETTER, TARGET_EXTERNAL_ACTIVITY, TARGET_RETENTION, TARGET_SCHEDULE, TARGET_WORKER,
+    TARGET_WORKFLOW,
 };
 use autumn_harvest::batch::{
     self, BatchAction, BatchExecutorConfig, BatchFilter, BatchJobStatus, BatchJobView,
@@ -56,7 +57,8 @@ use autumn_harvest::reset::{
 };
 use autumn_harvest::retention::{RetentionConfig, RetentionMonitor, RetentionStatus};
 use autumn_harvest::scheduler::{
-    DagCatalog, RegisteredDag, SchedulerMonitor, SchedulerSnapshot, trigger_dag,
+    BackfillPlanError, DEFAULT_BACKFILL_MAX_COUNT, DagCatalog, RegisteredDag, SchedulerMonitor,
+    SchedulerSnapshot, plan_backfill_timestamps, trigger_dag,
 };
 use autumn_harvest::schema::{
     harvest_dag_runs, harvest_events, harvest_schedules, harvest_signals, harvest_task_queue,
@@ -1061,10 +1063,12 @@ pub fn harvest_api_router(api_state: HarvestApiState) -> Router<AppState> {
             get(get_external_handoff),
         )
         // Schedule management (issue #91): unified list + workflow-schedule CRUD.
+        // Schedule backfill (issue #177): bounded missed-run recovery.
         .route("/admin/schedules", get(list_schedules))
         .route("/admin/schedules/workflow", post(create_workflow_schedule))
         .route("/admin/schedules/{id}/pause", post(pause_schedule))
         .route("/admin/schedules/{id}/resume", post(resume_schedule))
+        .route("/admin/schedules/{id}/backfill", post(schedule_backfill))
         .route("/admin/schedules/{id}", delete(delete_schedule))
         // External activity completion (issue #92): async task-token API.
         .route(
@@ -1156,11 +1160,12 @@ pub const fn management_api_routes() -> &'static [(&'static str, &'static str)] 
         ("GET", "/admin/history/exports"),
         ("GET", "/admin/external-handoffs"),
         ("GET", "/admin/external-handoffs/{token}"),
-        // ── schedules (issue #91) ─────────────────────────────────────────────
+        // ── schedules (issues #91, #177) ──────────────────────────────────────
         ("GET", "/admin/schedules"),
         ("POST", "/admin/schedules/workflow"),
         ("POST", "/admin/schedules/{id}/pause"),
         ("POST", "/admin/schedules/{id}/resume"),
+        ("POST", "/admin/schedules/{id}/backfill"),
         ("DELETE", "/admin/schedules/{id}"),
         // ── audit (issue #158) ────────────────────────────────────────────────
         ("GET", "/admin/audit"),
@@ -4344,6 +4349,321 @@ async fn delete_schedule(
         return Err(AutumnError::not_found_msg(format!("schedule {id}")));
     }
     Ok(Json(BasicAck { ok: true }))
+}
+
+// ── Schedule backfill (issue #177) ────────────────────────────────────────────
+
+/// Request body for `POST /admin/schedules/{id}/backfill`.
+#[derive(Debug, Deserialize)]
+struct ScheduleBackfillRequest {
+    from: chrono::DateTime<chrono::Utc>,
+    to: chrono::DateTime<chrono::Utc>,
+    #[serde(default)]
+    dry_run: bool,
+    #[serde(default)]
+    include_paused: bool,
+    max_count: Option<usize>,
+}
+
+/// A shard that could not be reached or dispatched during a backfill.
+#[derive(Debug, Serialize)]
+struct BackfillShardFailure {
+    shard_id: i32,
+    reason: String,
+}
+
+/// Response for `POST /admin/schedules/{id}/backfill`.
+#[derive(Debug, Serialize)]
+struct ScheduleBackfillResponse {
+    /// `"dry_run"`, `"complete"`, or `"partial"`.
+    status: String,
+    schedule_id: uuid::Uuid,
+    kind: ScheduleKind,
+    name: String,
+    from: chrono::DateTime<chrono::Utc>,
+    to: chrono::DateTime<chrono::Utc>,
+    planned_timestamps: Vec<chrono::DateTime<chrono::Utc>>,
+    total: usize,
+    dispatched: usize,
+    skipped: usize,
+    failed: usize,
+    partial_shard_failures: Vec<BackfillShardFailure>,
+}
+
+#[allow(clippy::too_many_lines)]
+async fn schedule_backfill(
+    Extension(api_state): Extension<HarvestApiState>,
+    Path(id): Path<String>,
+    headers: axum::http::HeaderMap,
+    Json(request): Json<ScheduleBackfillRequest>,
+) -> Result<Json<ScheduleBackfillResponse>, AutumnError> {
+    use autumn_harvest::execution::StartWorkflowParams;
+    use autumn_harvest::models::NewDagRun;
+    use autumn_harvest::schema::harvest_dag_runs;
+
+    let (actor, source, req_id) = audit_context(&headers, &api_state);
+    let route = "POST /admin/schedules/{id}/backfill";
+
+    let schedule_id = parse_uuid(&id, "schedule id")?;
+    let pool = api_state.storage_pool().map_err(map_error)?;
+
+    if request.to < request.from {
+        return Err(AutumnError::bad_request_msg(
+            "backfill 'to' must be at or after 'from'",
+        ));
+    }
+
+    // Load the schedule row (fan out across shards; schedule rows are not shard-assigned).
+    let schedule = load_schedule_by_id(&api_state, schedule_id).await?;
+
+    // Respect paused state unless the caller explicitly opts in.
+    if schedule.is_paused && !request.include_paused {
+        return Err(AutumnError::bad_request_msg(format!(
+            "schedule {schedule_id} is paused; pass include_paused=true to backfill a paused schedule"
+        )));
+    }
+
+    let parsed_schedule = schedule
+        .schedule_expr
+        .as_deref()
+        .and_then(autumn_harvest::scheduler::parse_schedule_from_expr_pub);
+
+    let max_count = request.max_count.unwrap_or(DEFAULT_BACKFILL_MAX_COUNT);
+
+    let timestamps = plan_backfill_timestamps(
+        parsed_schedule.as_ref(),
+        request.from,
+        request.to,
+        max_count,
+    )
+    .map_err(|e| match e {
+        BackfillPlanError::LimitExceeded { limit } => AutumnError::bad_request_msg(format!(
+            "backfill window contains more than {limit} timestamps; lower the window or pass a higher max_count"
+        )),
+    })?;
+
+    let total = timestamps.len();
+    let (kind, name) = if let Some(ref dag_name) = schedule.dag_name {
+        (ScheduleKind::Dag, dag_name.clone())
+    } else if let Some(ref wf_name) = schedule.workflow_name {
+        (ScheduleKind::Workflow, wf_name.clone())
+    } else {
+        return Err(AutumnError::service_unavailable_msg(
+            "schedule row has neither dag_name nor workflow_name",
+        ));
+    };
+
+    // Dry-run: return plan without dispatching.
+    if request.dry_run {
+        let ar = NewAuditRecord {
+            actor: &actor,
+            operation: OP_SCHEDULE_BACKFILL,
+            target_type: TARGET_SCHEDULE,
+            target_id: Some(id.as_str()),
+            route_or_command: route,
+            request_id: req_id.as_deref(),
+            idempotency_key: None,
+            status: STATUS_SUCCEEDED,
+            error_summary: None,
+            shard_id: None,
+            source: &source,
+        };
+        if let Ok(mut conn) = acquire_conn(pool.default_pool()).await {
+            let _ = audit::insert_audit(&mut conn, &ar).await;
+        }
+        return Ok(Json(ScheduleBackfillResponse {
+            status: "dry_run".to_string(),
+            schedule_id,
+            kind,
+            name,
+            from: request.from,
+            to: request.to,
+            planned_timestamps: timestamps,
+            total,
+            dispatched: 0,
+            skipped: 0,
+            failed: 0,
+            partial_shard_failures: vec![],
+        }));
+    }
+
+    // Non-dry-run: dispatch each timestamp idempotently.
+    let dispatch_queue = schedule.queue_name.as_deref().unwrap_or("default");
+    let mut dispatched = 0usize;
+    let mut skipped = 0usize;
+    let mut failed = 0usize;
+    let mut shard_failures: Vec<BackfillShardFailure> = Vec::new();
+
+    match kind {
+        ScheduleKind::Workflow => {
+            let wf_name = name.clone();
+            for scheduled_for in &timestamps {
+                let workflow_id =
+                    autumn_harvest::scheduler::scheduled_workflow_id_pub(&wf_name, *scheduled_for);
+                let exec_id = autumn_harvest::types::ExecutionId::new();
+                let input = schedule
+                    .workflow_input
+                    .clone()
+                    .unwrap_or(serde_json::Value::Null);
+
+                for (shard_id, shard_pool) in pool.iter_shards() {
+                    let Ok(mut conn) = acquire_conn(shard_pool).await else {
+                        shard_failures.push(BackfillShardFailure {
+                            shard_id: shard_id.as_i32(),
+                            reason: "failed to acquire connection".to_string(),
+                        });
+                        failed += 1;
+                        continue;
+                    };
+                    let result = start_or_load_workflow_execution(
+                        &mut conn,
+                        StartWorkflowParams {
+                            workflow_name: &wf_name,
+                            workflow_id: &workflow_id,
+                            exec_id,
+                            input: input.clone(),
+                            parent_id: None,
+                            queue_name: dispatch_queue,
+                            execution_timeout: None,
+                            memo: None,
+                            search_attrs: None,
+                            reuse_policy:
+                                autumn_harvest::types::WorkflowIdReusePolicy::RejectDuplicate,
+                            trace_context: None,
+                        },
+                    )
+                    .await;
+                    match result {
+                        Ok(started) if started.created => dispatched += 1,
+                        Ok(_) | Err(HarvestError::AlreadyExists { .. }) => skipped += 1,
+                        Err(e) => {
+                            shard_failures.push(BackfillShardFailure {
+                                shard_id: shard_id.as_i32(),
+                                reason: e.to_string(),
+                            });
+                            failed += 1;
+                        }
+                    }
+                    break; // workflow executions go to a single shard
+                }
+            }
+        }
+        ScheduleKind::Dag => {
+            let dag_name = name.clone();
+            for scheduled_for in &timestamps {
+                for (shard_id, shard_pool) in pool.iter_shards() {
+                    let Ok(mut conn) = acquire_conn(shard_pool).await else {
+                        shard_failures.push(BackfillShardFailure {
+                            shard_id: shard_id.as_i32(),
+                            reason: "failed to acquire connection".to_string(),
+                        });
+                        failed += 1;
+                        continue;
+                    };
+                    let row = NewDagRun {
+                        id: uuid::Uuid::new_v4(),
+                        dag_name: &dag_name,
+                        workflow_exec_id: None,
+                        logical_date: *scheduled_for,
+                        data_interval_start: *scheduled_for,
+                        data_interval_end: *scheduled_for,
+                        conf: Some(serde_json::json!({"_harvest_run_source": "backfill"})),
+                    };
+                    let insert_result = diesel::insert_into(harvest_dag_runs::table)
+                        .values(&row)
+                        .on_conflict((harvest_dag_runs::dag_name, harvest_dag_runs::logical_date))
+                        .do_nothing()
+                        .execute(&mut conn)
+                        .await;
+                    match insert_result {
+                        Ok(1) => dispatched += 1,
+                        Ok(_) => skipped += 1, // ON CONFLICT DO NOTHING → already exists
+                        Err(e) => {
+                            shard_failures.push(BackfillShardFailure {
+                                shard_id: shard_id.as_i32(),
+                                reason: e.to_string(),
+                            });
+                            failed += 1;
+                        }
+                    }
+                    break;
+                }
+            }
+        }
+    }
+
+    let status = if shard_failures.is_empty() && failed == 0 {
+        "complete"
+    } else {
+        "partial"
+    };
+    let id_str = schedule_id.to_string();
+    let ar = NewAuditRecord {
+        actor: &actor,
+        operation: OP_SCHEDULE_BACKFILL,
+        target_type: TARGET_SCHEDULE,
+        target_id: Some(id_str.as_str()),
+        route_or_command: route,
+        request_id: req_id.as_deref(),
+        idempotency_key: None,
+        status: if status == "complete" {
+            STATUS_SUCCEEDED
+        } else {
+            STATUS_FAILED
+        },
+        error_summary: if status == "partial" {
+            Some("one or more shard failures")
+        } else {
+            None
+        },
+        shard_id: None,
+        source: &source,
+    };
+    if let Ok(mut conn) = acquire_conn(pool.default_pool()).await {
+        let _ = audit::insert_audit(&mut conn, &ar).await;
+    }
+
+    Ok(Json(ScheduleBackfillResponse {
+        status: status.to_string(),
+        schedule_id,
+        kind,
+        name,
+        from: request.from,
+        to: request.to,
+        planned_timestamps: timestamps,
+        total,
+        dispatched,
+        skipped,
+        failed,
+        partial_shard_failures: shard_failures,
+    }))
+}
+
+/// Load a schedule row by UUID across all shards.
+async fn load_schedule_by_id(
+    api_state: &HarvestApiState,
+    schedule_id: uuid::Uuid,
+) -> Result<HarvestSchedule, AutumnError> {
+    use autumn_harvest::schema::harvest_schedules::dsl;
+
+    let pool = api_state.storage_pool().map_err(map_error)?;
+    for (_shard, shard_pool) in pool.iter_shards() {
+        let mut conn = acquire_conn(shard_pool).await?;
+        let row = dsl::harvest_schedules
+            .find(schedule_id)
+            .select(HarvestSchedule::as_select())
+            .first(&mut conn)
+            .await
+            .optional()
+            .map_err(database_error)
+            .map_err(map_error)?;
+        if let Some(r) = row {
+            return Ok(r);
+        }
+    }
+    Err(AutumnError::not_found_msg(format!(
+        "schedule {schedule_id}"
+    )))
 }
 
 fn parse_schedule_expr(expr: &str) -> Result<autumn_harvest::policy::Schedule, String> {

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -4496,6 +4496,7 @@ async fn schedule_backfill(
 
     let schedule_id = parse_uuid(&id, "schedule id")?;
     let pool = api_state.storage_pool().map_err(map_error)?;
+    let runtime = api_state.runtime().map_err(map_error)?;
 
     if request.to < request.from {
         return Err(AutumnError::bad_request_msg(
@@ -4630,63 +4631,71 @@ async fn schedule_backfill(
                 }
 
                 let workflow_id = scheduled_workflow_id_pub(&wf_name, *scheduled_for);
-                let exec_id = autumn_harvest::types::ExecutionId::new();
+                // Use the same rendezvous-hash routing as normal workflow starts so the
+                // backfill lands on the same shard that owns this (workflow_name, workflow_id).
+                let shard_id = runtime
+                    .router()
+                    .pick_for_new_workflow(&wf_name, &workflow_id);
+                let exec_id = ExecutionId::new_for_shard(shard_id);
                 let input = schedule
                     .workflow_input
                     .clone()
                     .unwrap_or(serde_json::Value::Null);
+                let shard_pool = pool.pool_for(shard_id);
 
-                for (shard_id, shard_pool) in pool.iter_shards() {
-                    let Ok(mut conn) = acquire_conn(shard_pool).await else {
+                let Ok(mut conn) = acquire_conn(shard_pool).await else {
+                    shard_failures.push(BackfillShardFailure {
+                        shard_id: shard_id.as_i32(),
+                        reason: "failed to acquire connection".to_string(),
+                    });
+                    failed += 1;
+                    continue;
+                };
+                let result = start_or_load_workflow_execution(
+                    &mut conn,
+                    StartWorkflowParams {
+                        workflow_name: &wf_name,
+                        workflow_id: &workflow_id,
+                        exec_id,
+                        input: input.clone(),
+                        parent_id: None,
+                        queue_name: dispatch_queue,
+                        execution_timeout: None,
+                        memo: None,
+                        search_attrs: None,
+                        reuse_policy: WorkflowIdReusePolicy::RejectDuplicate,
+                        trace_context: None,
+                    },
+                )
+                .await;
+                match result {
+                    Ok(started) if started.created => {
+                        dispatched += 1;
+                        dispatched_this_call += 1;
+                    }
+                    Ok(_) | Err(HarvestError::AlreadyExists { .. }) => {
+                        skipped += 1;
+                        *skipped_reasons
+                            .entry("already_exists".to_string())
+                            .or_insert(0) += 1;
+                    }
+                    Err(e) => {
                         shard_failures.push(BackfillShardFailure {
                             shard_id: shard_id.as_i32(),
-                            reason: "failed to acquire connection".to_string(),
+                            reason: e.to_string(),
                         });
                         failed += 1;
-                        continue;
-                    };
-                    let result = start_or_load_workflow_execution(
-                        &mut conn,
-                        StartWorkflowParams {
-                            workflow_name: &wf_name,
-                            workflow_id: &workflow_id,
-                            exec_id,
-                            input: input.clone(),
-                            parent_id: None,
-                            queue_name: dispatch_queue,
-                            execution_timeout: None,
-                            memo: None,
-                            search_attrs: None,
-                            reuse_policy: WorkflowIdReusePolicy::RejectDuplicate,
-                            trace_context: None,
-                        },
-                    )
-                    .await;
-                    match result {
-                        Ok(started) if started.created => {
-                            dispatched += 1;
-                            dispatched_this_call += 1;
-                        }
-                        Ok(_) | Err(HarvestError::AlreadyExists { .. }) => {
-                            skipped += 1;
-                            *skipped_reasons
-                                .entry("already_exists".to_string())
-                                .or_insert(0) += 1;
-                        }
-                        Err(e) => {
-                            shard_failures.push(BackfillShardFailure {
-                                shard_id: shard_id.as_i32(),
-                                reason: e.to_string(),
-                            });
-                            failed += 1;
-                        }
                     }
-                    break; // workflow executions go to a single shard
                 }
             }
         }
         ScheduleKind::Dag => {
             let dag_name = name.clone();
+            // DAG runs are pinned to a single shard by dag_name (same rendezvous hash
+            // as the scheduler tick), so ON CONFLICT DO NOTHING is effective across retries.
+            let shard_id = runtime.router().pick_for_dag(&dag_name);
+            let shard_pool = pool.pool_for(shard_id);
+
             for scheduled_for in &timestamps {
                 // Respect max_active_runs for DAGs.
                 if running_at_start + dispatched_this_call >= max_active {
@@ -4697,51 +4706,48 @@ async fn schedule_backfill(
                     continue;
                 }
 
-                for (shard_id, shard_pool) in pool.iter_shards() {
-                    let Ok(mut conn) = acquire_conn(shard_pool).await else {
+                let Ok(mut conn) = acquire_conn(shard_pool).await else {
+                    shard_failures.push(BackfillShardFailure {
+                        shard_id: shard_id.as_i32(),
+                        reason: "failed to acquire connection".to_string(),
+                    });
+                    failed += 1;
+                    continue;
+                };
+                let row = NewDagRun {
+                    id: uuid::Uuid::new_v4(),
+                    dag_name: &dag_name,
+                    workflow_exec_id: None,
+                    logical_date: *scheduled_for,
+                    data_interval_start: *scheduled_for,
+                    data_interval_end: *scheduled_for,
+                    conf: Some(serde_json::json!({"_harvest_run_source": "backfill"})),
+                };
+                let insert_result = diesel::insert_into(harvest_dag_runs::table)
+                    .values(&row)
+                    .on_conflict((harvest_dag_runs::dag_name, harvest_dag_runs::logical_date))
+                    .do_nothing()
+                    .execute(&mut conn)
+                    .await;
+                match insert_result {
+                    Ok(1) => {
+                        dispatched += 1;
+                        dispatched_this_call += 1;
+                    }
+                    Ok(_) => {
+                        // ON CONFLICT DO NOTHING → already exists
+                        skipped += 1;
+                        *skipped_reasons
+                            .entry("already_exists".to_string())
+                            .or_insert(0) += 1;
+                    }
+                    Err(e) => {
                         shard_failures.push(BackfillShardFailure {
                             shard_id: shard_id.as_i32(),
-                            reason: "failed to acquire connection".to_string(),
+                            reason: e.to_string(),
                         });
                         failed += 1;
-                        continue;
-                    };
-                    let row = NewDagRun {
-                        id: uuid::Uuid::new_v4(),
-                        dag_name: &dag_name,
-                        workflow_exec_id: None,
-                        logical_date: *scheduled_for,
-                        data_interval_start: *scheduled_for,
-                        data_interval_end: *scheduled_for,
-                        conf: Some(serde_json::json!({"_harvest_run_source": "backfill"})),
-                    };
-                    let insert_result = diesel::insert_into(harvest_dag_runs::table)
-                        .values(&row)
-                        .on_conflict((harvest_dag_runs::dag_name, harvest_dag_runs::logical_date))
-                        .do_nothing()
-                        .execute(&mut conn)
-                        .await;
-                    match insert_result {
-                        Ok(1) => {
-                            dispatched += 1;
-                            dispatched_this_call += 1;
-                        }
-                        Ok(_) => {
-                            // ON CONFLICT DO NOTHING → already exists
-                            skipped += 1;
-                            *skipped_reasons
-                                .entry("already_exists".to_string())
-                                .or_insert(0) += 1;
-                        }
-                        Err(e) => {
-                            shard_failures.push(BackfillShardFailure {
-                                shard_id: shard_id.as_i32(),
-                                reason: e.to_string(),
-                            });
-                            failed += 1;
-                        }
                     }
-                    break;
                 }
             }
         }
@@ -4810,32 +4816,33 @@ async fn schedule_backfill(
 }
 
 /// Count RUNNING workflow executions or DAG runs for the named entity.
-/// Returns 0 on any DB error (safe: just means we don't artificially cap the backfill).
+/// Returns the total count across all shards. Returns 0 on any DB error (safe: just
+/// means we don't artificially cap the backfill).
 async fn query_running_count(pool: &HarvestDbPool, kind: &ScheduleKind, name: &str) -> i64 {
-    match pool.iter_shards().next() {
-        None => 0,
-        Some((_, shard_pool)) => {
-            let Ok(mut conn) = acquire_conn(shard_pool).await else {
-                return 0;
-            };
-            match kind {
-                ScheduleKind::Workflow => harvest_workflow_executions::table
-                    .filter(harvest_workflow_executions::workflow_name.eq(name))
-                    .filter(harvest_workflow_executions::state.eq("RUNNING"))
-                    .count()
-                    .get_result::<i64>(&mut conn)
-                    .await
-                    .unwrap_or(0),
-                ScheduleKind::Dag => harvest_dag_runs::table
-                    .filter(harvest_dag_runs::dag_name.eq(name))
-                    .filter(harvest_dag_runs::state.eq("RUNNING"))
-                    .count()
-                    .get_result::<i64>(&mut conn)
-                    .await
-                    .unwrap_or(0),
-            }
-        }
+    let mut total = 0i64;
+    for (_, shard_pool) in pool.iter_shards() {
+        let Ok(mut conn) = acquire_conn(shard_pool).await else {
+            continue;
+        };
+        let count = match kind {
+            ScheduleKind::Workflow => harvest_workflow_executions::table
+                .filter(harvest_workflow_executions::workflow_name.eq(name))
+                .filter(harvest_workflow_executions::state.eq("RUNNING"))
+                .count()
+                .get_result::<i64>(&mut conn)
+                .await
+                .unwrap_or(0),
+            ScheduleKind::Dag => harvest_dag_runs::table
+                .filter(harvest_dag_runs::dag_name.eq(name))
+                .filter(harvest_dag_runs::state.eq("RUNNING"))
+                .count()
+                .get_result::<i64>(&mut conn)
+                .await
+                .unwrap_or(0),
+        };
+        total += count;
     }
+    total
 }
 
 /// Write a backfill log row; silently swallows errors (best-effort durability).

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -4651,6 +4651,12 @@ async fn schedule_backfill(
     match kind {
         ScheduleKind::Workflow => {
             let wf_name = name.clone();
+            // Workflow schedules are always dispatched through the scheduler's own
+            // connection, which uses `ExecutionId::new()` (ShardId::UNENCODED → default
+            // shard). The backfill must write to the same shard so that the partial
+            // unique index on (workflow_name, workflow_id) prevents the scheduler from
+            // creating a second run for the same timestamp after the backfill window.
+            let wf_shard_pool = pool.default_pool();
             for scheduled_for in &timestamps {
                 // Respect max_active_runs: skip if we've already saturated the limit.
                 if running_at_start + dispatched_this_call >= max_active {
@@ -4662,21 +4668,17 @@ async fn schedule_backfill(
                 }
 
                 let workflow_id = scheduled_workflow_id_pub(&wf_name, *scheduled_for);
-                // Use the same rendezvous-hash routing as normal workflow starts so the
-                // backfill lands on the same shard that owns this (workflow_name, workflow_id).
-                let shard_id = runtime
-                    .router()
-                    .pick_for_new_workflow(&wf_name, &workflow_id);
-                let exec_id = ExecutionId::new_for_shard(shard_id);
+                // Match the scheduler: ExecutionId::new() encodes ShardId::UNENCODED so
+                // the execution lands on the default shard, same as tick_one_workflow_schedule.
+                let exec_id = ExecutionId::new();
                 let input = schedule
                     .workflow_input
                     .clone()
                     .unwrap_or(serde_json::Value::Null);
-                let shard_pool = pool.pool_for(shard_id);
 
-                let Ok(mut conn) = acquire_conn(shard_pool).await else {
+                let Ok(mut conn) = acquire_conn(wf_shard_pool).await else {
                     shard_failures.push(BackfillShardFailure {
-                        shard_id: shard_id.as_i32(),
+                        shard_id: 0,
                         reason: "failed to acquire connection".to_string(),
                     });
                     failed += 1;
@@ -4733,7 +4735,7 @@ async fn schedule_backfill(
                     }
                     Err(e) => {
                         shard_failures.push(BackfillShardFailure {
-                            shard_id: shard_id.as_i32(),
+                            shard_id: 0,
                             reason: e.to_string(),
                         });
                         failed += 1;

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -47,7 +47,8 @@ use autumn_harvest::history_export::{
     HistoryExportRequest, HistoryPayloadPolicy, export_history,
 };
 use autumn_harvest::models::{
-    AuditRecord, DagRun, DeadLetter, HarvestSchedule, NewAuditRecord, WorkflowExecution,
+    AuditRecord, BackfillLogRow, DagRun, DeadLetter, HarvestSchedule, NewAuditRecord,
+    NewBackfillLogRow, WorkflowExecution,
 };
 use autumn_harvest::policy::WorkflowSchedule;
 use autumn_harvest::queue::{self, ConcurrencyKeyStats};
@@ -58,11 +59,12 @@ use autumn_harvest::reset::{
 use autumn_harvest::retention::{RetentionConfig, RetentionMonitor, RetentionStatus};
 use autumn_harvest::scheduler::{
     BackfillPlanError, DEFAULT_BACKFILL_MAX_COUNT, DagCatalog, RegisteredDag, SchedulerMonitor,
-    SchedulerSnapshot, plan_backfill_timestamps, trigger_dag,
+    SchedulerSnapshot, parse_schedule_from_expr_pub, plan_backfill_timestamps,
+    scheduled_workflow_id_pub, trigger_dag,
 };
 use autumn_harvest::schema::{
-    harvest_dag_runs, harvest_events, harvest_schedules, harvest_signals, harvest_task_queue,
-    harvest_timers, harvest_workflow_executions,
+    harvest_backfill_log, harvest_dag_runs, harvest_events, harvest_schedules, harvest_signals,
+    harvest_task_queue, harvest_timers, harvest_workflow_executions,
 };
 use autumn_harvest::shard::ShardRouter;
 use autumn_harvest::signal;
@@ -783,6 +785,44 @@ enum ScheduleKind {
     Workflow,
 }
 
+/// Summary of the most recent backfill for a schedule (surfaced in `GET /admin/schedules`).
+#[derive(Debug, Serialize)]
+struct BackfillSummary {
+    id: uuid::Uuid,
+    actor: String,
+    from: chrono::DateTime<chrono::Utc>,
+    to: chrono::DateTime<chrono::Utc>,
+    dry_run: bool,
+    total: i32,
+    dispatched: i32,
+    skipped: i32,
+    failed: i32,
+    status: String,
+    error_summary: Option<String>,
+    started_at: chrono::DateTime<chrono::Utc>,
+    completed_at: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+impl From<BackfillLogRow> for BackfillSummary {
+    fn from(r: BackfillLogRow) -> Self {
+        Self {
+            id: r.id,
+            actor: r.actor,
+            from: r.from_ts,
+            to: r.to_ts,
+            dry_run: r.dry_run,
+            total: r.total,
+            dispatched: r.dispatched,
+            skipped: r.skipped,
+            failed: r.failed,
+            status: r.status,
+            error_summary: r.error_summary,
+            started_at: r.started_at,
+            completed_at: r.completed_at,
+        }
+    }
+}
+
 /// A single schedule entry in the `GET /admin/schedules` list.
 #[derive(Debug, Serialize)]
 struct ScheduleEntry {
@@ -795,6 +835,7 @@ struct ScheduleEntry {
     last_run_at: Option<chrono::DateTime<chrono::Utc>>,
     max_active_runs: i32,
     catchup: bool,
+    last_backfill: Option<BackfillSummary>,
 }
 
 /// Request body for `POST /admin/schedules/workflow`.
@@ -3830,6 +3871,11 @@ async fn list_schedules(
     Extension(api_state): Extension<HarvestApiState>,
 ) -> Result<Json<Vec<ScheduleEntry>>, AutumnError> {
     let schedules = load_schedules_from_shards(&api_state).await?;
+    let schedule_ids: Vec<uuid::Uuid> = schedules.iter().map(|s| s.id).collect();
+
+    // Best-effort: load the most recent backfill log row for each schedule.
+    let recent_backfills = load_recent_backfills(&api_state, &schedule_ids).await;
+
     let entries = schedules
         .into_iter()
         .map(|s| {
@@ -3841,6 +3887,10 @@ async fn list_schedules(
                 // Should not occur given the CHECK constraint, but handle gracefully.
                 (ScheduleKind::Dag, String::new())
             };
+            let last_backfill = recent_backfills
+                .get(&s.id)
+                .cloned()
+                .map(BackfillSummary::from);
             ScheduleEntry {
                 id: s.id,
                 kind,
@@ -3851,10 +3901,47 @@ async fn list_schedules(
                 last_run_at: s.last_run_at,
                 max_active_runs: s.max_active_runs,
                 catchup: s.catchup,
+                last_backfill,
             }
         })
         .collect();
     Ok(Json(entries))
+}
+
+/// Load the most recent backfill log row for each of the given schedule IDs.
+/// Returns a map from `schedule_id` to row. Silently returns empty map on any error.
+async fn load_recent_backfills(
+    api_state: &HarvestApiState,
+    schedule_ids: &[uuid::Uuid],
+) -> std::collections::HashMap<uuid::Uuid, BackfillLogRow> {
+    use autumn_harvest::schema::harvest_backfill_log::dsl;
+
+    if schedule_ids.is_empty() {
+        return std::collections::HashMap::new();
+    }
+    let Ok(pool) = api_state.storage_pool() else {
+        return std::collections::HashMap::new();
+    };
+    let Ok(mut conn) = acquire_conn(pool.default_pool()).await else {
+        return std::collections::HashMap::new();
+    };
+
+    // Load all recent backfill rows for these schedules in one query, ordered by
+    // started_at DESC, then de-duplicate keeping only the most recent per schedule.
+    let rows: Vec<BackfillLogRow> = dsl::harvest_backfill_log
+        .filter(dsl::schedule_id.eq_any(schedule_ids))
+        .order((dsl::schedule_id, dsl::started_at.desc()))
+        .select(BackfillLogRow::as_select())
+        .load(&mut conn)
+        .await
+        .unwrap_or_default();
+
+    let mut map: std::collections::HashMap<uuid::Uuid, BackfillLogRow> =
+        std::collections::HashMap::new();
+    for row in rows {
+        map.entry(row.schedule_id).or_insert(row);
+    }
+    map
 }
 
 async fn schedule_create_audit_failed(
@@ -3912,6 +3999,7 @@ async fn upsert_workflow_schedule_and_read_back(
         last_run_at: row.last_run_at,
         max_active_runs: row.max_active_runs,
         catchup: row.catchup,
+        last_backfill: None, // newly created; no backfill history yet
     })
 }
 
@@ -4387,6 +4475,9 @@ struct ScheduleBackfillResponse {
     dispatched: usize,
     skipped: usize,
     failed: usize,
+    /// Machine-readable breakdown of why timestamps were skipped.
+    /// Keys: `"already_exists"`, `"max_active_runs"`.
+    skipped_reasons: std::collections::HashMap<String, usize>,
     partial_shard_failures: Vec<BackfillShardFailure>,
 }
 
@@ -4397,12 +4488,11 @@ async fn schedule_backfill(
     headers: axum::http::HeaderMap,
     Json(request): Json<ScheduleBackfillRequest>,
 ) -> Result<Json<ScheduleBackfillResponse>, AutumnError> {
-    use autumn_harvest::execution::StartWorkflowParams;
     use autumn_harvest::models::NewDagRun;
-    use autumn_harvest::schema::harvest_dag_runs;
 
     let (actor, source, req_id) = audit_context(&headers, &api_state);
     let route = "POST /admin/schedules/{id}/backfill";
+    let started_at = chrono::Utc::now();
 
     let schedule_id = parse_uuid(&id, "schedule id")?;
     let pool = api_state.storage_pool().map_err(map_error)?;
@@ -4426,7 +4516,7 @@ async fn schedule_backfill(
     let parsed_schedule = schedule
         .schedule_expr
         .as_deref()
-        .and_then(autumn_harvest::scheduler::parse_schedule_from_expr_pub);
+        .and_then(parse_schedule_from_expr_pub);
 
     let max_count = request.max_count.unwrap_or(DEFAULT_BACKFILL_MAX_COUNT);
 
@@ -4453,24 +4543,48 @@ async fn schedule_backfill(
         ));
     };
 
-    // Dry-run: return plan without dispatching.
+    let max_active = i64::from(schedule.max_active_runs);
+
+    // Dry-run: query current running count and project what would happen.
     if request.dry_run {
-        let ar = NewAuditRecord {
-            actor: &actor,
-            operation: OP_SCHEDULE_BACKFILL,
-            target_type: TARGET_SCHEDULE,
-            target_id: Some(id.as_str()),
-            route_or_command: route,
-            request_id: req_id.as_deref(),
-            idempotency_key: None,
-            status: STATUS_SUCCEEDED,
-            error_summary: None,
-            shard_id: None,
-            source: &source,
-        };
-        if let Ok(mut conn) = acquire_conn(pool.default_pool()).await {
-            let _ = audit::insert_audit(&mut conn, &ar).await;
+        let running = query_running_count(&pool, &kind, &name).await;
+        let available_slots = usize::try_from((max_active - running).max(0)).unwrap_or(0);
+        let would_dispatch = total.min(available_slots);
+        let would_skip_max = total - would_dispatch;
+
+        let mut skipped_reasons = std::collections::HashMap::new();
+        if would_skip_max > 0 {
+            skipped_reasons.insert("max_active_runs".to_string(), would_skip_max);
         }
+
+        write_backfill_log(
+            &pool,
+            schedule_id,
+            &actor,
+            &source,
+            request.from,
+            request.to,
+            true,
+            total,
+            would_dispatch,
+            would_skip_max,
+            0,
+            "dry_run",
+            None,
+            started_at,
+        )
+        .await;
+        write_audit(
+            &pool,
+            &actor,
+            &source,
+            req_id.as_deref(),
+            route,
+            &id,
+            STATUS_SUCCEEDED,
+            None,
+        )
+        .await;
         return Ok(Json(ScheduleBackfillResponse {
             status: "dry_run".to_string(),
             schedule_id,
@@ -4480,26 +4594,42 @@ async fn schedule_backfill(
             to: request.to,
             planned_timestamps: timestamps,
             total,
-            dispatched: 0,
-            skipped: 0,
+            dispatched: would_dispatch,
+            skipped: would_skip_max,
             failed: 0,
+            skipped_reasons,
             partial_shard_failures: vec![],
         }));
     }
 
-    // Non-dry-run: dispatch each timestamp idempotently.
+    // Non-dry-run: dispatch each timestamp idempotently, respecting max_active_runs.
     let dispatch_queue = schedule.queue_name.as_deref().unwrap_or("default");
     let mut dispatched = 0usize;
     let mut skipped = 0usize;
     let mut failed = 0usize;
     let mut shard_failures: Vec<BackfillShardFailure> = Vec::new();
+    let mut skipped_reasons: std::collections::HashMap<String, usize> =
+        std::collections::HashMap::new();
+
+    // Count running executions once before the loop; track dispatched_this_call separately
+    // so we don't re-query on every timestamp.
+    let running_at_start = query_running_count(&pool, &kind, &name).await;
+    let mut dispatched_this_call: i64 = 0;
 
     match kind {
         ScheduleKind::Workflow => {
             let wf_name = name.clone();
             for scheduled_for in &timestamps {
-                let workflow_id =
-                    autumn_harvest::scheduler::scheduled_workflow_id_pub(&wf_name, *scheduled_for);
+                // Respect max_active_runs: skip if we've already saturated the limit.
+                if running_at_start + dispatched_this_call >= max_active {
+                    skipped += 1;
+                    *skipped_reasons
+                        .entry("max_active_runs".to_string())
+                        .or_insert(0) += 1;
+                    continue;
+                }
+
+                let workflow_id = scheduled_workflow_id_pub(&wf_name, *scheduled_for);
                 let exec_id = autumn_harvest::types::ExecutionId::new();
                 let input = schedule
                     .workflow_input
@@ -4527,15 +4657,22 @@ async fn schedule_backfill(
                             execution_timeout: None,
                             memo: None,
                             search_attrs: None,
-                            reuse_policy:
-                                autumn_harvest::types::WorkflowIdReusePolicy::RejectDuplicate,
+                            reuse_policy: WorkflowIdReusePolicy::RejectDuplicate,
                             trace_context: None,
                         },
                     )
                     .await;
                     match result {
-                        Ok(started) if started.created => dispatched += 1,
-                        Ok(_) | Err(HarvestError::AlreadyExists { .. }) => skipped += 1,
+                        Ok(started) if started.created => {
+                            dispatched += 1;
+                            dispatched_this_call += 1;
+                        }
+                        Ok(_) | Err(HarvestError::AlreadyExists { .. }) => {
+                            skipped += 1;
+                            *skipped_reasons
+                                .entry("already_exists".to_string())
+                                .or_insert(0) += 1;
+                        }
                         Err(e) => {
                             shard_failures.push(BackfillShardFailure {
                                 shard_id: shard_id.as_i32(),
@@ -4551,6 +4688,15 @@ async fn schedule_backfill(
         ScheduleKind::Dag => {
             let dag_name = name.clone();
             for scheduled_for in &timestamps {
+                // Respect max_active_runs for DAGs.
+                if running_at_start + dispatched_this_call >= max_active {
+                    skipped += 1;
+                    *skipped_reasons
+                        .entry("max_active_runs".to_string())
+                        .or_insert(0) += 1;
+                    continue;
+                }
+
                 for (shard_id, shard_pool) in pool.iter_shards() {
                     let Ok(mut conn) = acquire_conn(shard_pool).await else {
                         shard_failures.push(BackfillShardFailure {
@@ -4576,8 +4722,17 @@ async fn schedule_backfill(
                         .execute(&mut conn)
                         .await;
                     match insert_result {
-                        Ok(1) => dispatched += 1,
-                        Ok(_) => skipped += 1, // ON CONFLICT DO NOTHING → already exists
+                        Ok(1) => {
+                            dispatched += 1;
+                            dispatched_this_call += 1;
+                        }
+                        Ok(_) => {
+                            // ON CONFLICT DO NOTHING → already exists
+                            skipped += 1;
+                            *skipped_reasons
+                                .entry("already_exists".to_string())
+                                .or_insert(0) += 1;
+                        }
                         Err(e) => {
                             shard_failures.push(BackfillShardFailure {
                                 shard_id: shard_id.as_i32(),
@@ -4597,31 +4752,45 @@ async fn schedule_backfill(
     } else {
         "partial"
     };
+    let error_summary = if status == "partial" {
+        Some("one or more shard failures")
+    } else {
+        None
+    };
+
+    write_backfill_log(
+        &pool,
+        schedule_id,
+        &actor,
+        &source,
+        request.from,
+        request.to,
+        false,
+        total,
+        dispatched,
+        skipped,
+        failed,
+        status,
+        error_summary,
+        started_at,
+    )
+    .await;
     let id_str = schedule_id.to_string();
-    let ar = NewAuditRecord {
-        actor: &actor,
-        operation: OP_SCHEDULE_BACKFILL,
-        target_type: TARGET_SCHEDULE,
-        target_id: Some(id_str.as_str()),
-        route_or_command: route,
-        request_id: req_id.as_deref(),
-        idempotency_key: None,
-        status: if status == "complete" {
+    write_audit(
+        &pool,
+        &actor,
+        &source,
+        req_id.as_deref(),
+        route,
+        &id_str,
+        if status == "complete" {
             STATUS_SUCCEEDED
         } else {
             STATUS_FAILED
         },
-        error_summary: if status == "partial" {
-            Some("one or more shard failures")
-        } else {
-            None
-        },
-        shard_id: None,
-        source: &source,
-    };
-    if let Ok(mut conn) = acquire_conn(pool.default_pool()).await {
-        let _ = audit::insert_audit(&mut conn, &ar).await;
-    }
+        error_summary,
+    )
+    .await;
 
     Ok(Json(ScheduleBackfillResponse {
         status: status.to_string(),
@@ -4635,8 +4804,113 @@ async fn schedule_backfill(
         dispatched,
         skipped,
         failed,
+        skipped_reasons,
         partial_shard_failures: shard_failures,
     }))
+}
+
+/// Count RUNNING workflow executions or DAG runs for the named entity.
+/// Returns 0 on any DB error (safe: just means we don't artificially cap the backfill).
+async fn query_running_count(pool: &HarvestDbPool, kind: &ScheduleKind, name: &str) -> i64 {
+    match pool.iter_shards().next() {
+        None => 0,
+        Some((_, shard_pool)) => {
+            let Ok(mut conn) = acquire_conn(shard_pool).await else {
+                return 0;
+            };
+            match kind {
+                ScheduleKind::Workflow => harvest_workflow_executions::table
+                    .filter(harvest_workflow_executions::workflow_name.eq(name))
+                    .filter(harvest_workflow_executions::state.eq("RUNNING"))
+                    .count()
+                    .get_result::<i64>(&mut conn)
+                    .await
+                    .unwrap_or(0),
+                ScheduleKind::Dag => harvest_dag_runs::table
+                    .filter(harvest_dag_runs::dag_name.eq(name))
+                    .filter(harvest_dag_runs::state.eq("RUNNING"))
+                    .count()
+                    .get_result::<i64>(&mut conn)
+                    .await
+                    .unwrap_or(0),
+            }
+        }
+    }
+}
+
+/// Write a backfill log row; silently swallows errors (best-effort durability).
+#[allow(clippy::too_many_arguments)]
+async fn write_backfill_log(
+    pool: &HarvestDbPool,
+    schedule_id: uuid::Uuid,
+    actor: &str,
+    source: &str,
+    from: chrono::DateTime<chrono::Utc>,
+    to: chrono::DateTime<chrono::Utc>,
+    dry_run: bool,
+    total: usize,
+    dispatched: usize,
+    skipped: usize,
+    failed: usize,
+    status: &str,
+    error_summary: Option<&str>,
+    started_at: chrono::DateTime<chrono::Utc>,
+) {
+    let Ok(mut conn) = acquire_conn(pool.default_pool()).await else {
+        return;
+    };
+    let row = NewBackfillLogRow {
+        id: uuid::Uuid::new_v4(),
+        schedule_id,
+        actor: actor.to_string(),
+        source: source.to_string(),
+        from_ts: from,
+        to_ts: to,
+        dry_run,
+        total: i32::try_from(total).unwrap_or(i32::MAX),
+        dispatched: i32::try_from(dispatched).unwrap_or(i32::MAX),
+        skipped: i32::try_from(skipped).unwrap_or(i32::MAX),
+        failed: i32::try_from(failed).unwrap_or(i32::MAX),
+        status: status.to_string(),
+        error_summary: error_summary.map(str::to_string),
+        started_at,
+        completed_at: Some(chrono::Utc::now()),
+    };
+    let _ = diesel::insert_into(harvest_backfill_log::table)
+        .values(&row)
+        .execute(&mut conn)
+        .await;
+}
+
+/// Write an audit record; silently swallows errors.
+#[allow(clippy::too_many_arguments)]
+async fn write_audit(
+    pool: &HarvestDbPool,
+    actor: &str,
+    source: &str,
+    request_id: Option<&str>,
+    route: &str,
+    target_id: &str,
+    status: &str,
+    error_summary: Option<&str>,
+) {
+    let Ok(mut conn) = acquire_conn(pool.default_pool()).await else {
+        return;
+    };
+    let ar = NewAuditRecord {
+        actor,
+        operation: OP_SCHEDULE_BACKFILL,
+        target_type: TARGET_SCHEDULE,
+        target_id: Some(target_id),
+        route_or_command: route,
+        request_id,
+        idempotency_key: None,
+        status,
+        error_summary,
+        shard_id: None,
+        source,
+    };
+    let _ = audit::insert_audit(&mut conn, &ar).await;
 }
 
 /// Load a schedule row by UUID across all shards.

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -4651,6 +4651,27 @@ async fn schedule_backfill(
                     failed += 1;
                     continue;
                 };
+
+                // Pre-check across ALL states including CONTINUED_AS_NEW / TERMINATED.
+                // `start_or_load_workflow_execution` uses a partial unique index that
+                // excludes sealed rows, so a sealed prior execution does not conflict
+                // and would allow a duplicate to be created. Backfill must not reuse
+                // sealed workflow IDs because the timestamp was already dispatched.
+                let prior: i64 = harvest_workflow_executions::table
+                    .filter(harvest_workflow_executions::workflow_name.eq(&wf_name))
+                    .filter(harvest_workflow_executions::workflow_id.eq(&workflow_id))
+                    .count()
+                    .get_result::<i64>(&mut conn)
+                    .await
+                    .unwrap_or(0);
+                if prior > 0 {
+                    skipped += 1;
+                    *skipped_reasons
+                        .entry("already_exists".to_string())
+                        .or_insert(0) += 1;
+                    continue;
+                }
+
                 let result = start_or_load_workflow_execution(
                     &mut conn,
                     StartWorkflowParams {

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -778,7 +778,7 @@ struct DagPauseRequest {
 }
 
 /// Kind tag on a schedule entry returned by `GET /admin/schedules`.
-#[derive(Debug, Serialize)]
+#[derive(Debug, Serialize, PartialEq)]
 #[serde(rename_all = "lowercase")]
 enum ScheduleKind {
     Dag,
@@ -4479,6 +4479,11 @@ struct ScheduleBackfillResponse {
     /// Keys: `"already_exists"`, `"max_active_runs"`.
     skipped_reasons: std::collections::HashMap<String, usize>,
     partial_shard_failures: Vec<BackfillShardFailure>,
+    /// Set when a DAG schedule is paused and `include_paused=true`: inserted
+    /// QUEUED runs will not execute until the schedule is resumed because
+    /// `activate_queued_runs` skips paused schedules.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    paused_schedule_warning: Option<String>,
 }
 
 #[allow(clippy::too_many_lines)]
@@ -4549,15 +4554,30 @@ async fn schedule_backfill(
     // Dry-run: query current running count and project what would happen.
     if request.dry_run {
         let running = query_running_count(&pool, &kind, &name).await;
+        let already_exists = count_existing_in_window(&pool, &kind, &name, &timestamps).await;
+        let remaining = total.saturating_sub(already_exists);
         let available_slots = usize::try_from((max_active - running).max(0)).unwrap_or(0);
-        let would_dispatch = total.min(available_slots);
-        let would_skip_max = total - would_dispatch;
+        let would_dispatch = remaining.min(available_slots);
+        let would_skip_max = remaining - would_dispatch;
 
         let mut skipped_reasons = std::collections::HashMap::new();
+        if already_exists > 0 {
+            skipped_reasons.insert("already_exists".to_string(), already_exists);
+        }
         if would_skip_max > 0 {
             skipped_reasons.insert("max_active_runs".to_string(), would_skip_max);
         }
 
+        let paused_schedule_warning = (schedule.is_paused
+            && request.include_paused
+            && kind == ScheduleKind::Dag)
+            .then(|| {
+                "Schedule is paused; backfilled DAG runs are QUEUED but will not \
+                 execute until the schedule is resumed (`harvest schedule resume`)."
+                    .to_string()
+            });
+
+        let would_skip = already_exists + would_skip_max;
         write_backfill_log(
             &pool,
             schedule_id,
@@ -4568,7 +4588,7 @@ async fn schedule_backfill(
             true,
             total,
             would_dispatch,
-            would_skip_max,
+            would_skip,
             0,
             "dry_run",
             None,
@@ -4596,10 +4616,11 @@ async fn schedule_backfill(
             planned_timestamps: timestamps,
             total,
             dispatched: would_dispatch,
-            skipped: would_skip_max,
+            skipped: would_skip,
             failed: 0,
             skipped_reasons,
             partial_shard_failures: vec![],
+            paused_schedule_warning,
         }));
     }
 
@@ -4611,6 +4632,16 @@ async fn schedule_backfill(
     let mut shard_failures: Vec<BackfillShardFailure> = Vec::new();
     let mut skipped_reasons: std::collections::HashMap<String, usize> =
         std::collections::HashMap::new();
+
+    // Warn when the operator uses include_paused=true for a paused DAG schedule.
+    // `activate_queued_runs` skips paused schedules, so the inserted QUEUED runs
+    // will not execute until the schedule is resumed.
+    let paused_schedule_warning =
+        (schedule.is_paused && request.include_paused && kind == ScheduleKind::Dag).then(|| {
+            "Schedule is paused; backfilled DAG runs are QUEUED but will not \
+             execute until the schedule is resumed (`harvest schedule resume`)."
+                .to_string()
+        });
 
     // Count running executions once before the loop; track dispatched_this_call separately
     // so we don't re-query on every timestamp.
@@ -4833,6 +4864,7 @@ async fn schedule_backfill(
         failed,
         skipped_reasons,
         partial_shard_failures: shard_failures,
+        paused_schedule_warning,
     }))
 }
 
@@ -4862,6 +4894,58 @@ async fn query_running_count(pool: &HarvestDbPool, kind: &ScheduleKind, name: &s
                 .unwrap_or(0),
         };
         total += count;
+    }
+    total
+}
+
+/// Count how many of the planned timestamps already have an execution or DAG run.
+/// Used in dry-run mode to improve the accuracy of the would-dispatch estimate.
+/// Returns 0 on any DB error (safe: slightly over-estimates would-dispatch).
+async fn count_existing_in_window(
+    pool: &HarvestDbPool,
+    kind: &ScheduleKind,
+    name: &str,
+    timestamps: &[chrono::DateTime<chrono::Utc>],
+) -> usize {
+    if timestamps.is_empty() {
+        return 0;
+    }
+    let mut total = 0usize;
+    match kind {
+        ScheduleKind::Workflow => {
+            let workflow_ids: Vec<String> = timestamps
+                .iter()
+                .map(|ts| scheduled_workflow_id_pub(name, *ts))
+                .collect();
+            for (_, shard_pool) in pool.iter_shards() {
+                let Ok(mut conn) = acquire_conn(shard_pool).await else {
+                    continue;
+                };
+                let count: i64 = harvest_workflow_executions::table
+                    .filter(harvest_workflow_executions::workflow_name.eq(name))
+                    .filter(harvest_workflow_executions::workflow_id.eq_any(&workflow_ids))
+                    .count()
+                    .get_result(&mut conn)
+                    .await
+                    .unwrap_or(0);
+                total += usize::try_from(count).unwrap_or(0);
+            }
+        }
+        ScheduleKind::Dag => {
+            for (_, shard_pool) in pool.iter_shards() {
+                let Ok(mut conn) = acquire_conn(shard_pool).await else {
+                    continue;
+                };
+                let count: i64 = harvest_dag_runs::table
+                    .filter(harvest_dag_runs::dag_name.eq(name))
+                    .filter(harvest_dag_runs::logical_date.eq_any(timestamps))
+                    .count()
+                    .get_result(&mut conn)
+                    .await
+                    .unwrap_or(0);
+                total += usize::try_from(count).unwrap_or(0);
+            }
+        }
     }
     total
 }

--- a/autumn-harvest/migrations/20260510000000_harvest_backfill_log/down.sql
+++ b/autumn-harvest/migrations/20260510000000_harvest_backfill_log/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS harvest_backfill_log;

--- a/autumn-harvest/migrations/20260510000000_harvest_backfill_log/up.sql
+++ b/autumn-harvest/migrations/20260510000000_harvest_backfill_log/up.sql
@@ -1,0 +1,27 @@
+-- Schedule backfill log (issue #177)
+--
+-- Durable record of each backfill request: requested window, actor, outcome
+-- counts, and timestamps. Queried by GET /admin/schedules to surface recent
+-- backfill activity per schedule without a full audit log scan.
+
+CREATE TABLE IF NOT EXISTS harvest_backfill_log (
+    id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    schedule_id     UUID        NOT NULL,
+    actor           TEXT        NOT NULL DEFAULT 'unknown',
+    source          TEXT        NOT NULL DEFAULT '',
+    from_ts         TIMESTAMPTZ NOT NULL,
+    to_ts           TIMESTAMPTZ NOT NULL,
+    dry_run         BOOLEAN     NOT NULL DEFAULT FALSE,
+    total           INT         NOT NULL DEFAULT 0,
+    dispatched      INT         NOT NULL DEFAULT 0,
+    skipped         INT         NOT NULL DEFAULT 0,
+    failed          INT         NOT NULL DEFAULT 0,
+    status          TEXT        NOT NULL,
+    error_summary   TEXT,
+    started_at      TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    completed_at    TIMESTAMPTZ
+);
+
+-- Index to efficiently fetch the most recent backfill for a given schedule.
+CREATE INDEX IF NOT EXISTS harvest_backfill_log_schedule_id_idx
+    ON harvest_backfill_log (schedule_id, started_at DESC);

--- a/autumn-harvest/src/audit.rs
+++ b/autumn-harvest/src/audit.rs
@@ -42,6 +42,7 @@ pub const OP_SCHEDULE_CREATE: &str = "schedule.create";
 pub const OP_SCHEDULE_PAUSE: &str = "schedule.pause";
 pub const OP_SCHEDULE_RESUME: &str = "schedule.resume";
 pub const OP_SCHEDULE_DELETE: &str = "schedule.delete";
+pub const OP_SCHEDULE_BACKFILL: &str = "schedule.backfill";
 pub const OP_DLQ_REPLAY: &str = "dlq.replay";
 pub const OP_DLQ_REPLAY_BULK: &str = "dlq.replay.bulk";
 pub const OP_DLQ_DISCARD_BULK: &str = "dlq.discard.bulk";
@@ -216,6 +217,7 @@ pub const CLASSIFIED_ROUTES: &[(&str, RouteClass)] = &[
     ("POST /admin/schedules/workflow", RouteClass::Mutating),
     ("POST /admin/schedules/{id}/pause", RouteClass::Mutating),
     ("POST /admin/schedules/{id}/resume", RouteClass::Mutating),
+    ("POST /admin/schedules/{id}/backfill", RouteClass::Mutating),
     ("DELETE /admin/schedules/{id}", RouteClass::Mutating),
     // External activity completion — task-token callbacks from remote workers.
     (
@@ -254,6 +256,7 @@ pub const AUDITED_OPERATIONS: &[&str] = &[
     OP_SCHEDULE_PAUSE,
     OP_SCHEDULE_RESUME,
     OP_SCHEDULE_DELETE,
+    OP_SCHEDULE_BACKFILL,
     OP_DLQ_REPLAY,
     OP_DLQ_REPLAY_BULK,
     OP_DLQ_DISCARD_BULK,
@@ -366,6 +369,10 @@ pub const ALL_MUTATION_ROUTES: &[(&str, Option<&str>)] = &[
         Some(OP_SCHEDULE_RESUME),
     ),
     ("DELETE /admin/schedules/{id}", Some(OP_SCHEDULE_DELETE)),
+    (
+        "POST /admin/schedules/{id}/backfill",
+        Some(OP_SCHEDULE_BACKFILL),
+    ),
     // External activity completion
     (
         "POST /activities/external/{token}/complete",

--- a/autumn-harvest/src/models.rs
+++ b/autumn-harvest/src/models.rs
@@ -10,10 +10,10 @@ use diesel::prelude::*;
 use uuid::Uuid;
 
 use crate::schema::{
-    harvest_audit_log, harvest_batch_jobs, harvest_build_compat, harvest_build_policies,
-    harvest_dag_runs, harvest_dead_letters, harvest_events, harvest_external_tasks,
-    harvest_schedules, harvest_signals, harvest_task_queue, harvest_timers, harvest_workers,
-    harvest_workflow_executions,
+    harvest_audit_log, harvest_backfill_log, harvest_batch_jobs, harvest_build_compat,
+    harvest_build_policies, harvest_dag_runs, harvest_dead_letters, harvest_events,
+    harvest_external_tasks, harvest_schedules, harvest_signals, harvest_task_queue, harvest_timers,
+    harvest_workers, harvest_workflow_executions,
 };
 
 // ── WorkflowExecution ─────────────────────────────────────────────────────────
@@ -556,4 +556,49 @@ pub struct NewHarvestBuildCompat<'a> {
     pub id: Uuid,
     pub build_id: &'a str,
     pub compatible_with: &'a str,
+}
+
+// ── BackfillLog ───────────────────────────────────────────────────────────────
+
+/// One row in `harvest_backfill_log`: durable record of a single backfill request.
+#[derive(Debug, Clone, Queryable, Selectable, serde::Serialize, serde::Deserialize)]
+#[diesel(table_name = harvest_backfill_log)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct BackfillLogRow {
+    pub id: Uuid,
+    pub schedule_id: Uuid,
+    pub actor: String,
+    pub source: String,
+    pub from_ts: DateTime<Utc>,
+    pub to_ts: DateTime<Utc>,
+    pub dry_run: bool,
+    pub total: i32,
+    pub dispatched: i32,
+    pub skipped: i32,
+    pub failed: i32,
+    pub status: String,
+    pub error_summary: Option<String>,
+    pub started_at: DateTime<Utc>,
+    pub completed_at: Option<DateTime<Utc>>,
+}
+
+/// Insert struct for a new backfill log entry.
+#[derive(Debug, Insertable)]
+#[diesel(table_name = harvest_backfill_log)]
+pub struct NewBackfillLogRow {
+    pub id: Uuid,
+    pub schedule_id: Uuid,
+    pub actor: String,
+    pub source: String,
+    pub from_ts: DateTime<Utc>,
+    pub to_ts: DateTime<Utc>,
+    pub dry_run: bool,
+    pub total: i32,
+    pub dispatched: i32,
+    pub skipped: i32,
+    pub failed: i32,
+    pub status: String,
+    pub error_summary: Option<String>,
+    pub started_at: DateTime<Utc>,
+    pub completed_at: Option<DateTime<Utc>>,
 }

--- a/autumn-harvest/src/scheduler.rs
+++ b/autumn-harvest/src/scheduler.rs
@@ -29,6 +29,95 @@ use crate::worker::{DbPool, HandlerRegistry};
 
 const DEFAULT_SCHEDULER_TICK_INTERVAL: Duration = Duration::from_secs(1);
 
+/// Default upper bound on the number of timestamps a single backfill request may plan.
+///
+/// Chosen to cover a 7-day hourly window (168 slots) with comfortable headroom.
+pub const DEFAULT_BACKFILL_MAX_COUNT: usize = 1_000;
+
+/// Errors returned when backfill planning cannot complete.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum BackfillPlanError {
+    /// The window contains more timestamps than the caller-supplied limit.
+    LimitExceeded { limit: usize },
+}
+
+impl std::fmt::Display for BackfillPlanError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::LimitExceeded { limit } => {
+                write!(f, "backfill would exceed the {limit}-timestamp limit")
+            }
+        }
+    }
+}
+
+/// Compute the timestamps a schedule would fire between `from` (inclusive) and `to` (inclusive).
+///
+/// - For `Cron` schedules the first occurrence at or after `from` is included; subsequent
+///   occurrences are stepped through until they exceed `to`.
+/// - For `Interval` schedules `from` is treated as the first backfill timestamp and slots are
+///   spaced by the interval duration.
+/// - `Manual` schedules and `None` return an empty list (no automatic firing times).
+///
+/// # Errors
+///
+/// Returns `Err(BackfillPlanError::LimitExceeded)` if the number of planned timestamps
+/// would exceed `max_count` before the window is fully enumerated.  Callers should pass
+/// [`DEFAULT_BACKFILL_MAX_COUNT`] unless a tighter bound is required.
+pub fn plan_backfill_timestamps(
+    schedule: Option<&Schedule>,
+    from: DateTime<Utc>,
+    to: DateTime<Utc>,
+    max_count: usize,
+) -> Result<Vec<DateTime<Utc>>, BackfillPlanError> {
+    if to < from {
+        return Ok(vec![]);
+    }
+
+    match schedule {
+        None | Some(Schedule::Manual) => Ok(vec![]),
+        Some(Schedule::Cron(_)) => {
+            // Find the first cron occurrence at or after `from` by searching from 1 ms before
+            // it (cron fires on whole-second boundaries; 1 ms is a safe undercut).
+            let reference = from - chrono::Duration::milliseconds(1);
+            let Some(mut cursor) = next_run_after(schedule, reference) else {
+                return Ok(vec![]);
+            };
+            let mut timestamps = Vec::new();
+            loop {
+                if cursor > to {
+                    break;
+                }
+                if timestamps.len() >= max_count {
+                    return Err(BackfillPlanError::LimitExceeded { limit: max_count });
+                }
+                timestamps.push(cursor);
+                let Some(next) = next_run_after(schedule, cursor) else {
+                    break;
+                };
+                cursor = next;
+            }
+            Ok(timestamps)
+        }
+        Some(Schedule::Interval(interval)) => {
+            let dur = chrono::Duration::from_std(*interval).unwrap_or(chrono::Duration::MAX);
+            let mut timestamps = Vec::new();
+            let mut cursor = from;
+            loop {
+                if cursor > to {
+                    break;
+                }
+                if timestamps.len() >= max_count {
+                    return Err(BackfillPlanError::LimitExceeded { limit: max_count });
+                }
+                timestamps.push(cursor);
+                cursor += dur;
+            }
+            Ok(timestamps)
+        }
+    }
+}
+
 /// Represents a fully registered and compiled DAG definition.
 #[derive(Debug, Clone)]
 pub struct RegisteredDag {
@@ -680,6 +769,12 @@ fn scheduled_workflow_id(workflow_name: &str, scheduled_for: DateTime<Utc>) -> S
     format!("sched:{}:{}", workflow_name, scheduled_for.timestamp())
 }
 
+/// Public re-export of `scheduled_workflow_id` for use in the backfill handler.
+#[must_use]
+pub fn scheduled_workflow_id_pub(workflow_name: &str, scheduled_for: DateTime<Utc>) -> String {
+    scheduled_workflow_id(workflow_name, scheduled_for)
+}
+
 const fn scheduled_workflow_reuse_policy() -> WorkflowIdReusePolicy {
     WorkflowIdReusePolicy::RejectDuplicate
 }
@@ -734,9 +829,14 @@ fn scheduled_start_outcome(
 /// Process due workflow-schedule rows and dispatch workflow starts.
 /// Parse a stored `schedule_expr` string back into a [`Schedule`] variant.
 ///
-/// The format written by [`schedule_expr`] is `"cron:<expr>"`, `"interval:<secs>"`,
+/// The format written by `schedule_expr` is `"cron:<expr>"`, `"interval:<secs>"`,
 /// or `"manual"`. Unrecognised strings return `None` and the row is treated as
 /// `Schedule::Manual` (no automatic `next_run_at`).
+#[must_use]
+pub fn parse_schedule_from_expr_pub(expr: &str) -> Option<Schedule> {
+    parse_schedule_from_expr(expr)
+}
+
 fn parse_schedule_from_expr(expr: &str) -> Option<Schedule> {
     expr.strip_prefix("cron:").map_or_else(
         || {
@@ -1309,5 +1409,110 @@ mod tests {
             }
         );
         assert!(!outcome.created());
+    }
+
+    // ── plan_backfill_timestamps ──────────────────────────────────────────────
+
+    #[test]
+    fn plan_backfill_timestamps_hourly_cron_inclusive_bounds() {
+        let schedule = Schedule::Cron("0 * * * *".to_string()); // fires at :00 every hour
+        let from = parse_utc("2026-04-01T10:00:00Z");
+        let to = parse_utc("2026-04-01T13:00:00Z");
+
+        let timestamps = plan_backfill_timestamps(Some(&schedule), from, to, 100)
+            .expect("hourly cron backfill over 3-hour window should succeed");
+
+        assert_eq!(
+            timestamps,
+            vec![
+                parse_utc("2026-04-01T10:00:00Z"),
+                parse_utc("2026-04-01T11:00:00Z"),
+                parse_utc("2026-04-01T12:00:00Z"),
+                parse_utc("2026-04-01T13:00:00Z"),
+            ]
+        );
+    }
+
+    #[test]
+    fn plan_backfill_timestamps_to_before_from_returns_empty() {
+        let schedule = Schedule::Cron("0 * * * *".to_string());
+        let from = parse_utc("2026-04-08T00:00:00Z");
+        let to = parse_utc("2026-04-01T00:00:00Z");
+
+        let timestamps = plan_backfill_timestamps(Some(&schedule), from, to, 100)
+            .expect("inverted window should return empty without error");
+
+        assert!(timestamps.is_empty());
+    }
+
+    #[test]
+    fn plan_backfill_timestamps_manual_schedule_returns_empty() {
+        let from = parse_utc("2026-04-01T00:00:00Z");
+        let to = parse_utc("2026-04-08T00:00:00Z");
+
+        let timestamps = plan_backfill_timestamps(None, from, to, 100)
+            .expect("unset schedule backfill should succeed with empty plan");
+
+        assert!(timestamps.is_empty());
+
+        let timestamps = plan_backfill_timestamps(Some(&Schedule::Manual), from, to, 100)
+            .expect("manual schedule backfill should succeed with empty plan");
+
+        assert!(timestamps.is_empty());
+    }
+
+    #[test]
+    fn plan_backfill_timestamps_enforces_max_count() {
+        // Every-minute interval over a 2-hour window = 120 timestamps > limit of 10
+        let schedule = Schedule::Interval(Duration::from_secs(60));
+        let from = parse_utc("2026-04-01T00:00:00Z");
+        let to = parse_utc("2026-04-01T02:00:00Z");
+
+        let result = plan_backfill_timestamps(Some(&schedule), from, to, 10);
+
+        assert_eq!(result, Err(BackfillPlanError::LimitExceeded { limit: 10 }));
+    }
+
+    #[test]
+    fn plan_backfill_timestamps_interval_from_is_first_slot() {
+        let schedule = Schedule::Interval(Duration::from_secs(3600)); // 1-hour interval
+        let from = parse_utc("2026-04-01T10:00:00Z");
+        let to = parse_utc("2026-04-01T12:00:00Z");
+
+        let timestamps = plan_backfill_timestamps(Some(&schedule), from, to, 100)
+            .expect("interval backfill should succeed");
+
+        assert_eq!(
+            timestamps,
+            vec![
+                parse_utc("2026-04-01T10:00:00Z"),
+                parse_utc("2026-04-01T11:00:00Z"),
+                parse_utc("2026-04-01T12:00:00Z"),
+            ]
+        );
+    }
+
+    #[test]
+    fn plan_backfill_timestamps_equal_from_and_to_returns_single_slot() {
+        let schedule = Schedule::Interval(Duration::from_secs(3600));
+        let ts = parse_utc("2026-04-01T10:00:00Z");
+
+        let timestamps = plan_backfill_timestamps(Some(&schedule), ts, ts, 100)
+            .expect("single-point window should succeed");
+
+        assert_eq!(timestamps, vec![ts]);
+    }
+
+    #[test]
+    fn plan_backfill_timestamps_7_day_hourly_cron_within_default_limit() {
+        let schedule = Schedule::Cron("0 * * * *".to_string());
+        let from = parse_utc("2026-04-01T00:00:00Z");
+        let to = parse_utc("2026-04-08T00:00:00Z");
+
+        let timestamps =
+            plan_backfill_timestamps(Some(&schedule), from, to, DEFAULT_BACKFILL_MAX_COUNT)
+                .expect("168-timestamp 7-day backfill should succeed under default limit");
+
+        assert_eq!(timestamps.len(), 169); // 0h..168h inclusive = 169 slots
     }
 }

--- a/autumn-harvest/src/schema.rs
+++ b/autumn-harvest/src/schema.rs
@@ -273,6 +273,28 @@ diesel::table! {
     }
 }
 
+diesel::table! {
+    use diesel::sql_types::*;
+
+    harvest_backfill_log (id) {
+        id -> Uuid,
+        schedule_id -> Uuid,
+        actor -> Text,
+        source -> Text,
+        from_ts -> Timestamptz,
+        to_ts -> Timestamptz,
+        dry_run -> Bool,
+        total -> Int4,
+        dispatched -> Int4,
+        skipped -> Int4,
+        failed -> Int4,
+        status -> Text,
+        error_summary -> Nullable<Text>,
+        started_at -> Timestamptz,
+        completed_at -> Nullable<Timestamptz>,
+    }
+}
+
 diesel::joinable!(harvest_events -> harvest_workflow_executions (workflow_exec_id));
 diesel::joinable!(harvest_task_queue -> harvest_workflow_executions (workflow_exec_id));
 diesel::joinable!(harvest_dag_runs -> harvest_workflow_executions (workflow_exec_id));
@@ -295,4 +317,5 @@ diesel::allow_tables_to_appear_in_same_query!(
     harvest_audit_log,
     harvest_build_policies,
     harvest_build_compat,
+    harvest_backfill_log,
 );

--- a/docs/api-contract.json
+++ b/docs/api-contract.json
@@ -33,17 +33,52 @@
       "read_only": true,
       "description": "List workflow executions with optional filters.",
       "params": [
-        { "name": "state", "in": "query", "required": false, "description": "Comma-separated execution states (e.g. RUNNING,FAILED)." },
-        { "name": "workflow_name", "in": "query", "required": false, "description": "Filter by registered workflow name." },
-        { "name": "search_attr", "in": "query", "required": false, "repeated": true, "description": "Search attribute filter in key:value form. May be repeated." },
-        { "name": "limit", "in": "query", "required": false, "description": "Maximum number of results to return." },
-        { "name": "cursor", "in": "query", "required": false, "description": "Opaque pagination cursor from a previous response." }
+        {
+          "name": "state",
+          "in": "query",
+          "required": false,
+          "description": "Comma-separated execution states (e.g. RUNNING,FAILED)."
+        },
+        {
+          "name": "workflow_name",
+          "in": "query",
+          "required": false,
+          "description": "Filter by registered workflow name."
+        },
+        {
+          "name": "search_attr",
+          "in": "query",
+          "required": false,
+          "repeated": true,
+          "description": "Search attribute filter in key:value form. May be repeated."
+        },
+        {
+          "name": "limit",
+          "in": "query",
+          "required": false,
+          "description": "Maximum number of results to return."
+        },
+        {
+          "name": "cursor",
+          "in": "query",
+          "required": false,
+          "description": "Opaque pagination cursor from a previous response."
+        }
       ],
       "request_body": null,
-      "success_response": { "status": 200, "free_form": true },
+      "success_response": {
+        "status": 200,
+        "free_form": true
+      },
       "error_responses": [
-        { "status": 400, "description": "Invalid filter value." },
-        { "status": 500, "description": "Database error." }
+        {
+          "status": 400,
+          "description": "Invalid filter value."
+        },
+        {
+          "status": 500,
+          "description": "Database error."
+        }
       ]
     },
     {
@@ -53,13 +88,32 @@
       "read_only": true,
       "description": "Get full details and event history for a single workflow execution.",
       "params": [
-        { "name": "id", "in": "path", "required": true, "description": "Execution UUID." }
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Execution UUID."
+        }
       ],
       "request_body": null,
-      "success_response": { "status": 200, "fields": ["parent_id", "execution", "history", "external_handoffs"] },
+      "success_response": {
+        "status": 200,
+        "fields": [
+          "parent_id",
+          "execution",
+          "history",
+          "external_handoffs"
+        ]
+      },
       "error_responses": [
-        { "status": 404, "description": "Execution not found." },
-        { "status": 500, "description": "Database error." }
+        {
+          "status": 404,
+          "description": "Execution not found."
+        },
+        {
+          "status": 500,
+          "description": "Database error."
+        }
       ]
     },
     {
@@ -69,16 +123,43 @@
       "read_only": true,
       "description": "Export the complete event history for a single execution as a HistoryExportDocument suitable for use as a replay fixture.",
       "params": [
-        { "name": "id", "in": "path", "required": true, "description": "Execution UUID." },
-        { "name": "payload_policy", "in": "query", "required": false, "description": "Payload inclusion policy: full (default), redacted, or omit." },
-        { "name": "max_bytes", "in": "query", "required": false, "description": "Soft byte cap on total payload size." }
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Execution UUID."
+        },
+        {
+          "name": "payload_policy",
+          "in": "query",
+          "required": false,
+          "description": "Payload inclusion policy: full (default), redacted, or omit."
+        },
+        {
+          "name": "max_bytes",
+          "in": "query",
+          "required": false,
+          "description": "Soft byte cap on total payload size."
+        }
       ],
       "request_body": null,
-      "success_response": { "status": 200, "free_form": true },
+      "success_response": {
+        "status": 200,
+        "free_form": true
+      },
       "error_responses": [
-        { "status": 404, "description": "Execution not found." },
-        { "status": 413, "description": "History exceeds max_bytes cap." },
-        { "status": 500, "description": "Database error." }
+        {
+          "status": 404,
+          "description": "Execution not found."
+        },
+        {
+          "status": 413,
+          "description": "History exceeds max_bytes cap."
+        },
+        {
+          "status": 500,
+          "description": "Database error."
+        }
       ]
     },
     {
@@ -88,18 +169,61 @@
       "read_only": true,
       "description": "List child workflow executions spawned by a parent execution.",
       "params": [
-        { "name": "id", "in": "path", "required": true, "description": "Parent execution UUID." },
-        { "name": "status", "in": "query", "required": false, "repeated": true, "description": "Filter by child status (e.g. Running, Failed). May be repeated." },
-        { "name": "workflow_name", "in": "query", "required": false, "description": "Filter by child workflow name." },
-        { "name": "limit", "in": "query", "required": false, "description": "Maximum number of results." },
-        { "name": "cursor", "in": "query", "required": false, "description": "Pagination cursor." },
-        { "name": "depth", "in": "query", "required": false, "description": "Maximum recursion depth for nested children." }
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Parent execution UUID."
+        },
+        {
+          "name": "status",
+          "in": "query",
+          "required": false,
+          "repeated": true,
+          "description": "Filter by child status (e.g. Running, Failed). May be repeated."
+        },
+        {
+          "name": "workflow_name",
+          "in": "query",
+          "required": false,
+          "description": "Filter by child workflow name."
+        },
+        {
+          "name": "limit",
+          "in": "query",
+          "required": false,
+          "description": "Maximum number of results."
+        },
+        {
+          "name": "cursor",
+          "in": "query",
+          "required": false,
+          "description": "Pagination cursor."
+        },
+        {
+          "name": "depth",
+          "in": "query",
+          "required": false,
+          "description": "Maximum recursion depth for nested children."
+        }
       ],
       "request_body": null,
-      "success_response": { "status": 200, "fields": ["items", "next_cursor"] },
+      "success_response": {
+        "status": 200,
+        "fields": [
+          "items",
+          "next_cursor"
+        ]
+      },
       "error_responses": [
-        { "status": 404, "description": "Parent execution not found." },
-        { "status": 500, "description": "Database error." }
+        {
+          "status": 404,
+          "description": "Parent execution not found."
+        },
+        {
+          "status": 500,
+          "description": "Database error."
+        }
       ]
     },
     {
@@ -109,13 +233,41 @@
       "read_only": true,
       "description": "Show the current wait state of a running workflow (what it is blocked on).",
       "params": [
-        { "name": "id", "in": "path", "required": true, "description": "Execution UUID." }
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Execution UUID."
+        }
       ],
       "request_body": null,
-      "success_response": { "status": 200, "fields": ["exec_id", "workflow_id", "workflow_name", "state", "is_terminal", "pending_activities", "pending_external_handoffs", "pending_local_activities", "pending_timers", "pending_signals", "buffered_signals", "pending_child_workflows", "last_event_id"] },
+      "success_response": {
+        "status": 200,
+        "fields": [
+          "exec_id",
+          "workflow_id",
+          "workflow_name",
+          "state",
+          "is_terminal",
+          "pending_activities",
+          "pending_external_handoffs",
+          "pending_local_activities",
+          "pending_timers",
+          "pending_signals",
+          "buffered_signals",
+          "pending_child_workflows",
+          "last_event_id"
+        ]
+      },
       "error_responses": [
-        { "status": 404, "description": "Execution not found." },
-        { "status": 500, "description": "Database error." }
+        {
+          "status": 404,
+          "description": "Execution not found."
+        },
+        {
+          "status": 500,
+          "description": "Database error."
+        }
       ]
     },
     {
@@ -126,26 +278,77 @@
       "description": "Start a new workflow execution. Idempotent when workflow_id is provided: returns the existing execution if one with the same workflow_id is already running.",
       "idempotency": "Idempotent by workflow_id when reuse_policy is reject_duplicate or allow_duplicate_failed_only.",
       "params": [
-        { "name": "workflow_name", "in": "path", "required": true, "description": "Registered workflow function name." }
+        {
+          "name": "workflow_name",
+          "in": "path",
+          "required": true,
+          "description": "Registered workflow function name."
+        }
       ],
       "request_body": {
         "required": false,
         "free_form": false,
         "fields": [
-          { "name": "workflow_id", "required": false, "description": "Stable identifier for idempotent starts." },
-          { "name": "input", "required": false, "description": "Workflow input payload (any JSON value)." },
-          { "name": "queue", "required": false, "description": "Task queue name." },
-          { "name": "memo", "required": false, "description": "Non-indexed metadata (JSON object)." },
-          { "name": "search_attrs", "required": false, "description": "Indexed search attributes (JSON object)." },
-          { "name": "execution_timeout_secs", "required": false, "description": "Overall execution timeout in seconds." },
-          { "name": "reuse_policy", "required": false, "description": "Duplicate-id policy: allow_duplicate, reject_duplicate, allow_duplicate_failed_only, or terminate_if_running." }
+          {
+            "name": "workflow_id",
+            "required": false,
+            "description": "Stable identifier for idempotent starts."
+          },
+          {
+            "name": "input",
+            "required": false,
+            "description": "Workflow input payload (any JSON value)."
+          },
+          {
+            "name": "queue",
+            "required": false,
+            "description": "Task queue name."
+          },
+          {
+            "name": "memo",
+            "required": false,
+            "description": "Non-indexed metadata (JSON object)."
+          },
+          {
+            "name": "search_attrs",
+            "required": false,
+            "description": "Indexed search attributes (JSON object)."
+          },
+          {
+            "name": "execution_timeout_secs",
+            "required": false,
+            "description": "Overall execution timeout in seconds."
+          },
+          {
+            "name": "reuse_policy",
+            "required": false,
+            "description": "Duplicate-id policy: allow_duplicate, reject_duplicate, allow_duplicate_failed_only, or terminate_if_running."
+          }
         ]
       },
-      "success_response": { "status": 201, "note": "Returns 200 when an existing execution is returned via reuse_policy instead of creating a new one.", "fields": ["execution_id", "workflow_name", "workflow_id", "state"] },
+      "success_response": {
+        "status": 201,
+        "note": "Returns 200 when an existing execution is returned via reuse_policy instead of creating a new one.",
+        "fields": [
+          "execution_id",
+          "workflow_name",
+          "workflow_id",
+          "state"
+        ]
+      },
       "error_responses": [
-        { "status": 400, "description": "Invalid request body or workflow name." },
-        { "status": 409, "description": "Duplicate workflow_id with conflicting reuse policy." },
-        { "status": 500, "description": "Database or scheduling error." }
+        {
+          "status": 400,
+          "description": "Invalid request body or workflow name."
+        },
+        {
+          "status": 409,
+          "description": "Duplicate workflow_id with conflicting reuse policy."
+        },
+        {
+          "status": 500,
+          "description": "Database or scheduling error."
+        }
       ]
     },
     {
@@ -156,20 +359,48 @@
       "description": "Cancel a running workflow execution.",
       "idempotency": "Idempotent: cancelling an already-cancelled or terminal execution is a no-op.",
       "params": [
-        { "name": "id", "in": "path", "required": true, "description": "Execution UUID." }
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Execution UUID."
+        }
       ],
       "request_body": {
         "required": false,
         "free_form": false,
         "fields": [
-          { "name": "reason", "required": false, "description": "Human-readable cancellation reason recorded in audit log." }
+          {
+            "name": "reason",
+            "required": false,
+            "description": "Human-readable cancellation reason recorded in audit log."
+          }
         ]
       },
-      "success_response": { "status": 200, "fields": ["ok", "execution_id", "state", "reason", "newly_cancelled", "failed_task_count"] },
+      "success_response": {
+        "status": 200,
+        "fields": [
+          "ok",
+          "execution_id",
+          "state",
+          "reason",
+          "newly_cancelled",
+          "failed_task_count"
+        ]
+      },
       "error_responses": [
-        { "status": 404, "description": "Execution not found." },
-        { "status": 409, "description": "Execution is already in a terminal state." },
-        { "status": 500, "description": "Database error." }
+        {
+          "status": 404,
+          "description": "Execution not found."
+        },
+        {
+          "status": 409,
+          "description": "Execution is already in a terminal state."
+        },
+        {
+          "status": 500,
+          "description": "Database error."
+        }
       ]
     },
     {
@@ -180,24 +411,71 @@
       "description": "Fork a workflow execution at a specific event boundary, replaying from that point with a new execution ID.",
       "idempotency": "Not idempotent: each call forks the execution and creates a distinct new execution ID.",
       "params": [
-        { "name": "id", "in": "path", "required": true, "description": "Execution UUID." },
-        { "name": "dry_run", "in": "query", "required": false, "description": "When true, return the preview without creating a new execution." }
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Execution UUID."
+        },
+        {
+          "name": "dry_run",
+          "in": "query",
+          "required": false,
+          "description": "When true, return the preview without creating a new execution."
+        }
       ],
       "request_body": {
         "required": true,
         "free_form": false,
         "fields": [
-          { "name": "reset_to_event_id", "required": true, "description": "Event sequence number to reset to." },
-          { "name": "reason", "required": true, "description": "Reason for the reset, recorded in audit log." },
-          { "name": "operator_id", "required": false, "description": "Identity of the operator." },
-          { "name": "signal_reapply", "required": false, "description": "How to handle buffered signals: drop or buffer." }
+          {
+            "name": "reset_to_event_id",
+            "required": true,
+            "description": "Event sequence number to reset to."
+          },
+          {
+            "name": "reason",
+            "required": true,
+            "description": "Reason for the reset, recorded in audit log."
+          },
+          {
+            "name": "operator_id",
+            "required": false,
+            "description": "Identity of the operator."
+          },
+          {
+            "name": "signal_reapply",
+            "required": false,
+            "description": "How to handle buffered signals: drop or buffer."
+          }
         ]
       },
-      "success_response": { "status": 201, "fields": ["new_exec_id", "reset_from_exec_id", "reset_to_event_id", "events_carried_over", "source_tasks_cancelled", "source_timers_removed", "source_signals_dropped", "source_signals_buffered"] },
+      "success_response": {
+        "status": 201,
+        "fields": [
+          "new_exec_id",
+          "reset_from_exec_id",
+          "reset_to_event_id",
+          "events_carried_over",
+          "source_tasks_cancelled",
+          "source_timers_removed",
+          "source_signals_dropped",
+          "source_signals_buffered"
+        ]
+      },
       "error_responses": [
-        { "status": 400, "description": "Invalid reset point or request body." },
-        { "status": 404, "description": "Execution not found." },
-        { "status": 500, "description": "Database error." }
+        {
+          "status": 400,
+          "description": "Invalid reset point or request body."
+        },
+        {
+          "status": 404,
+          "description": "Execution not found."
+        },
+        {
+          "status": 500,
+          "description": "Database error."
+        }
       ]
     },
     {
@@ -208,19 +486,40 @@
       "description": "Send a named signal to a running workflow execution. The request body is the signal payload itself (free-form JSON).",
       "idempotency": "Not idempotent: each call delivers a distinct signal event to the workflow.",
       "params": [
-        { "name": "id", "in": "path", "required": true, "description": "Execution UUID." },
-        { "name": "signal_name", "in": "path", "required": true, "description": "Registered signal handler name." }
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Execution UUID."
+        },
+        {
+          "name": "signal_name",
+          "in": "path",
+          "required": true,
+          "description": "Registered signal handler name."
+        }
       ],
       "request_body": {
         "required": false,
         "free_form": true,
-        "description": "Optional signal payload — the entire body is passed verbatim to the signal handler.",
+        "description": "Optional signal payload \u2014 the entire body is passed verbatim to the signal handler.",
         "fields": []
       },
-      "success_response": { "status": 200, "fields": ["ok"] },
+      "success_response": {
+        "status": 200,
+        "fields": [
+          "ok"
+        ]
+      },
       "error_responses": [
-        { "status": 404, "description": "Execution not found." },
-        { "status": 500, "description": "Database error." }
+        {
+          "status": 404,
+          "description": "Execution not found."
+        },
+        {
+          "status": 500,
+          "description": "Database error."
+        }
       ]
     },
     {
@@ -230,14 +529,33 @@
       "read_only": true,
       "description": "Query the current state of a running workflow by invoking a registered query handler.",
       "params": [
-        { "name": "id", "in": "path", "required": true, "description": "Execution UUID." },
-        { "name": "query_name", "in": "path", "required": true, "description": "Registered query handler name." }
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Execution UUID."
+        },
+        {
+          "name": "query_name",
+          "in": "path",
+          "required": true,
+          "description": "Registered query handler name."
+        }
       ],
       "request_body": null,
-      "success_response": { "status": 200, "free_form": true },
+      "success_response": {
+        "status": 200,
+        "free_form": true
+      },
       "error_responses": [
-        { "status": 404, "description": "Execution not found or query handler not registered." },
-        { "status": 500, "description": "Query execution error." }
+        {
+          "status": 404,
+          "description": "Execution not found or query handler not registered."
+        },
+        {
+          "status": 500,
+          "description": "Query execution error."
+        }
       ]
     },
     {
@@ -248,24 +566,64 @@
       "description": "Submit a synchronous update request to a running workflow. Blocks until admitted or completed depending on the wait parameter.",
       "idempotency": "Not idempotent: each call appends a distinct UpdateAdmitted event with a new update_id.",
       "params": [
-        { "name": "id", "in": "path", "required": true, "description": "Execution UUID." },
-        { "name": "update_name", "in": "path", "required": true, "description": "Registered update handler name." },
-        { "name": "wait", "in": "query", "required": false, "description": "admitted — return when validated; completed — block until handler returns (default)." },
-        { "name": "timeout_secs", "in": "query", "required": false, "description": "Maximum seconds to wait." }
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Execution UUID."
+        },
+        {
+          "name": "update_name",
+          "in": "path",
+          "required": true,
+          "description": "Registered update handler name."
+        },
+        {
+          "name": "wait",
+          "in": "query",
+          "required": false,
+          "description": "admitted \u2014 return when validated; completed \u2014 block until handler returns (default)."
+        },
+        {
+          "name": "timeout_secs",
+          "in": "query",
+          "required": false,
+          "description": "Maximum seconds to wait."
+        }
       ],
       "request_body": {
         "required": false,
         "free_form": false,
         "fields": [
-          { "name": "input", "required": false, "description": "Payload passed to the update handler (any JSON value)." }
+          {
+            "name": "input",
+            "required": false,
+            "description": "Payload passed to the update handler (any JSON value)."
+          }
         ]
       },
-      "success_response": { "status": 202, "note": "Returns 202 Accepted when wait=admitted (update durably recorded); returns 200 OK with outcome when wait=completed (default).", "free_form": true },
+      "success_response": {
+        "status": 202,
+        "note": "Returns 202 Accepted when wait=admitted (update durably recorded); returns 200 OK with outcome when wait=completed (default).",
+        "free_form": true
+      },
       "error_responses": [
-        { "status": 400, "description": "Update rejected by the validator." },
-        { "status": 404, "description": "Execution not found or update handler not registered." },
-        { "status": 504, "description": "Timed out waiting for completion (wait=completed exceeded the timeout)." },
-        { "status": 500, "description": "Internal error." }
+        {
+          "status": 400,
+          "description": "Update rejected by the validator."
+        },
+        {
+          "status": 404,
+          "description": "Execution not found or update handler not registered."
+        },
+        {
+          "status": 504,
+          "description": "Timed out waiting for completion (wait=completed exceeded the timeout)."
+        },
+        {
+          "status": 500,
+          "description": "Internal error."
+        }
       ]
     },
     {
@@ -275,19 +633,47 @@
       "read_only": true,
       "description": "Poll the result of a previously admitted workflow update.",
       "params": [
-        { "name": "id", "in": "path", "required": true, "description": "Execution UUID." },
-        { "name": "update_id", "in": "path", "required": true, "description": "Update UUID returned by POST …/update/{name}." }
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Execution UUID."
+        },
+        {
+          "name": "update_id",
+          "in": "path",
+          "required": true,
+          "description": "Update UUID returned by POST \u2026/update/{name}."
+        }
       ],
       "request_body": null,
-      "success_response": { "status": 200, "free_form": true },
+      "success_response": {
+        "status": 200,
+        "free_form": true
+      },
       "additional_responses": [
-        { "status": 202, "description": "Update admitted but not yet completed (still in-flight)." },
-        { "status": 409, "description": "Update failed or was rejected by the handler." }
+        {
+          "status": 202,
+          "description": "Update admitted but not yet completed (still in-flight)."
+        },
+        {
+          "status": 409,
+          "description": "Update failed or was rejected by the handler."
+        }
       ],
       "error_responses": [
-        { "status": 400, "description": "Invalid update_id format." },
-        { "status": 404, "description": "Update not found." },
-        { "status": 500, "description": "Database error." }
+        {
+          "status": 400,
+          "description": "Invalid update_id format."
+        },
+        {
+          "status": 404,
+          "description": "Update not found."
+        },
+        {
+          "status": 500,
+          "description": "Database error."
+        }
       ]
     },
     {
@@ -298,9 +684,15 @@
       "description": "List all registered DAGs and their current pause/enabled state.",
       "params": [],
       "request_body": null,
-      "success_response": { "status": 200, "free_form": true },
+      "success_response": {
+        "status": 200,
+        "free_form": true
+      },
       "error_responses": [
-        { "status": 500, "description": "Internal error." }
+        {
+          "status": 500,
+          "description": "Internal error."
+        }
       ]
     },
     {
@@ -310,14 +702,33 @@
       "read_only": true,
       "description": "List run history for a specific DAG.",
       "params": [
-        { "name": "dag_name", "in": "path", "required": true, "description": "Registered DAG name." },
-        { "name": "limit", "in": "query", "required": false, "description": "Maximum number of runs to return." }
+        {
+          "name": "dag_name",
+          "in": "path",
+          "required": true,
+          "description": "Registered DAG name."
+        },
+        {
+          "name": "limit",
+          "in": "query",
+          "required": false,
+          "description": "Maximum number of runs to return."
+        }
       ],
       "request_body": null,
-      "success_response": { "status": 200, "free_form": true },
+      "success_response": {
+        "status": 200,
+        "free_form": true
+      },
       "error_responses": [
-        { "status": 404, "description": "DAG not found." },
-        { "status": 500, "description": "Database error." }
+        {
+          "status": 404,
+          "description": "DAG not found."
+        },
+        {
+          "status": 500,
+          "description": "Database error."
+        }
       ]
     },
     {
@@ -328,20 +739,41 @@
       "description": "Manually trigger a DAG run outside its schedule.",
       "idempotency": "Not idempotent: each call starts a new DAG run.",
       "params": [
-        { "name": "dag_name", "in": "path", "required": true, "description": "Registered DAG name." }
+        {
+          "name": "dag_name",
+          "in": "path",
+          "required": true,
+          "description": "Registered DAG name."
+        }
       ],
       "request_body": {
         "required": false,
         "free_form": false,
         "fields": [
-          { "name": "conf", "required": false, "description": "Run configuration passed to the DAG (any JSON value)." }
+          {
+            "name": "conf",
+            "required": false,
+            "description": "Run configuration passed to the DAG (any JSON value)."
+          }
         ]
       },
-      "success_response": { "status": 201, "free_form": true },
+      "success_response": {
+        "status": 201,
+        "free_form": true
+      },
       "error_responses": [
-        { "status": 404, "description": "DAG not found." },
-        { "status": 409, "description": "DAG is paused or at max_active_runs." },
-        { "status": 500, "description": "Database error." }
+        {
+          "status": 404,
+          "description": "DAG not found."
+        },
+        {
+          "status": 409,
+          "description": "DAG is paused or at max_active_runs."
+        },
+        {
+          "status": 500,
+          "description": "Database error."
+        }
       ]
     },
     {
@@ -352,19 +784,37 @@
       "description": "Update mutable DAG configuration fields (currently: pause/unpause).",
       "idempotency": "Idempotent: applying the same pause state twice is a no-op.",
       "params": [
-        { "name": "dag_name", "in": "path", "required": true, "description": "Registered DAG name." }
+        {
+          "name": "dag_name",
+          "in": "path",
+          "required": true,
+          "description": "Registered DAG name."
+        }
       ],
       "request_body": {
         "required": true,
         "free_form": false,
         "fields": [
-          { "name": "paused", "required": true, "description": "true to pause the DAG, false to resume it." }
+          {
+            "name": "paused",
+            "required": true,
+            "description": "true to pause the DAG, false to resume it."
+          }
         ]
       },
-      "success_response": { "status": 200, "free_form": true },
+      "success_response": {
+        "status": 200,
+        "free_form": true
+      },
       "error_responses": [
-        { "status": 404, "description": "DAG not found." },
-        { "status": 500, "description": "Database error." }
+        {
+          "status": 404,
+          "description": "DAG not found."
+        },
+        {
+          "status": 500,
+          "description": "Database error."
+        }
       ]
     },
     {
@@ -374,13 +824,29 @@
       "read_only": true,
       "description": "List dead-lettered tasks that have exhausted all retry attempts.",
       "params": [
-        { "name": "limit", "in": "query", "required": false, "description": "Maximum number of entries to return." },
-        { "name": "cursor", "in": "query", "required": false, "description": "Pagination cursor." }
+        {
+          "name": "limit",
+          "in": "query",
+          "required": false,
+          "description": "Maximum number of entries to return."
+        },
+        {
+          "name": "cursor",
+          "in": "query",
+          "required": false,
+          "description": "Pagination cursor."
+        }
       ],
       "request_body": null,
-      "success_response": { "status": 200, "free_form": true },
+      "success_response": {
+        "status": 200,
+        "free_form": true
+      },
       "error_responses": [
-        { "status": 500, "description": "Database error." }
+        {
+          "status": 500,
+          "description": "Database error."
+        }
       ]
     },
     {
@@ -395,18 +861,58 @@
         "required": false,
         "free_form": false,
         "fields": [
-          { "name": "activity_name", "required": false, "description": "Filter by activity function name." },
-          { "name": "workflow_name", "required": false, "description": "Filter by workflow name." },
-          { "name": "failed_after", "required": false, "description": "RFC 3339 timestamp — only replay entries failed after this time." },
-          { "name": "failed_before", "required": false, "description": "RFC 3339 timestamp — only replay entries failed before this time." },
-          { "name": "limit", "required": false, "description": "Maximum number of entries to replay." },
-          { "name": "dry_run", "required": false, "description": "When true, return a preview without re-enqueuing." }
+          {
+            "name": "activity_name",
+            "required": false,
+            "description": "Filter by activity function name."
+          },
+          {
+            "name": "workflow_name",
+            "required": false,
+            "description": "Filter by workflow name."
+          },
+          {
+            "name": "failed_after",
+            "required": false,
+            "description": "RFC 3339 timestamp \u2014 only replay entries failed after this time."
+          },
+          {
+            "name": "failed_before",
+            "required": false,
+            "description": "RFC 3339 timestamp \u2014 only replay entries failed before this time."
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "description": "Maximum number of entries to replay."
+          },
+          {
+            "name": "dry_run",
+            "required": false,
+            "description": "When true, return a preview without re-enqueuing."
+          }
         ]
       },
-      "success_response": { "status": 200, "fields": ["matched", "acted_on", "skipped", "ids", "dry_run", "failures"] },
+      "success_response": {
+        "status": 200,
+        "fields": [
+          "matched",
+          "acted_on",
+          "skipped",
+          "ids",
+          "dry_run",
+          "failures"
+        ]
+      },
       "error_responses": [
-        { "status": 400, "description": "Invalid filter values." },
-        { "status": 500, "description": "Database error." }
+        {
+          "status": 400,
+          "description": "Invalid filter values."
+        },
+        {
+          "status": 500,
+          "description": "Database error."
+        }
       ]
     },
     {
@@ -421,18 +927,58 @@
         "required": false,
         "free_form": false,
         "fields": [
-          { "name": "activity_name", "required": false, "description": "Filter by activity function name." },
-          { "name": "workflow_name", "required": false, "description": "Filter by workflow name." },
-          { "name": "failed_after", "required": false, "description": "RFC 3339 timestamp — only discard entries failed after this time." },
-          { "name": "failed_before", "required": false, "description": "RFC 3339 timestamp — only discard entries failed before this time." },
-          { "name": "limit", "required": false, "description": "Maximum number of entries to discard." },
-          { "name": "dry_run", "required": false, "description": "When true, return a preview without deleting." }
+          {
+            "name": "activity_name",
+            "required": false,
+            "description": "Filter by activity function name."
+          },
+          {
+            "name": "workflow_name",
+            "required": false,
+            "description": "Filter by workflow name."
+          },
+          {
+            "name": "failed_after",
+            "required": false,
+            "description": "RFC 3339 timestamp \u2014 only discard entries failed after this time."
+          },
+          {
+            "name": "failed_before",
+            "required": false,
+            "description": "RFC 3339 timestamp \u2014 only discard entries failed before this time."
+          },
+          {
+            "name": "limit",
+            "required": false,
+            "description": "Maximum number of entries to discard."
+          },
+          {
+            "name": "dry_run",
+            "required": false,
+            "description": "When true, return a preview without deleting."
+          }
         ]
       },
-      "success_response": { "status": 200, "fields": ["matched", "acted_on", "skipped", "ids", "dry_run", "failures"] },
+      "success_response": {
+        "status": 200,
+        "fields": [
+          "matched",
+          "acted_on",
+          "skipped",
+          "ids",
+          "dry_run",
+          "failures"
+        ]
+      },
       "error_responses": [
-        { "status": 400, "description": "Invalid filter values." },
-        { "status": 500, "description": "Database error." }
+        {
+          "status": 400,
+          "description": "Invalid filter values."
+        },
+        {
+          "status": 500,
+          "description": "Database error."
+        }
       ]
     },
     {
@@ -443,17 +989,35 @@
       "description": "Replay a single dead-lettered task by re-enqueuing it.",
       "idempotency": "Idempotent: replaying an already-replayed entry is a no-op.",
       "params": [
-        { "name": "id", "in": "path", "required": true, "description": "DeadLetter UUID." }
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "DeadLetter UUID."
+        }
       ],
       "request_body": {
         "required": false,
         "free_form": false,
         "fields": []
       },
-      "success_response": { "status": 200, "fields": ["ok", "dead_letter_id", "task_id"] },
+      "success_response": {
+        "status": 200,
+        "fields": [
+          "ok",
+          "dead_letter_id",
+          "task_id"
+        ]
+      },
       "error_responses": [
-        { "status": 404, "description": "Dead letter not found." },
-        { "status": 500, "description": "Database error." }
+        {
+          "status": 404,
+          "description": "Dead letter not found."
+        },
+        {
+          "status": 500,
+          "description": "Database error."
+        }
       ]
     },
     {
@@ -464,19 +1028,42 @@
       "description": "Complete an external activity identified by its task token, supplying the success output.",
       "idempotency": "Not idempotent: completing an already-resolved token returns 404.",
       "params": [
-        { "name": "token", "in": "path", "required": true, "description": "Opaque task token issued when the activity was scheduled." }
+        {
+          "name": "token",
+          "in": "path",
+          "required": true,
+          "description": "Opaque task token issued when the activity was scheduled."
+        }
       ],
       "request_body": {
         "required": false,
         "free_form": false,
         "fields": [
-          { "name": "output", "required": false, "description": "Result value passed back to the workflow (any JSON value)." }
+          {
+            "name": "output",
+            "required": false,
+            "description": "Result value passed back to the workflow (any JSON value)."
+          }
         ]
       },
-      "success_response": { "status": 200, "fields": ["ok", "newly_resolved", "status", "current_state"] },
+      "success_response": {
+        "status": 200,
+        "fields": [
+          "ok",
+          "newly_resolved",
+          "status",
+          "current_state"
+        ]
+      },
       "error_responses": [
-        { "status": 404, "description": "Token not found or already completed." },
-        { "status": 500, "description": "Database error." }
+        {
+          "status": 404,
+          "description": "Token not found or already completed."
+        },
+        {
+          "status": 500,
+          "description": "Database error."
+        }
       ]
     },
     {
@@ -487,20 +1074,47 @@
       "description": "Fail an external activity, optionally marking the error as retryable.",
       "idempotency": "Not idempotent: failing an already-resolved token returns 404.",
       "params": [
-        { "name": "token", "in": "path", "required": true, "description": "Opaque task token." }
+        {
+          "name": "token",
+          "in": "path",
+          "required": true,
+          "description": "Opaque task token."
+        }
       ],
       "request_body": {
         "required": true,
         "free_form": false,
         "fields": [
-          { "name": "error", "required": true, "description": "Error message string." },
-          { "name": "retryable", "required": false, "description": "true to schedule a retry (default: false)." }
+          {
+            "name": "error",
+            "required": true,
+            "description": "Error message string."
+          },
+          {
+            "name": "retryable",
+            "required": false,
+            "description": "true to schedule a retry (default: false)."
+          }
         ]
       },
-      "success_response": { "status": 200, "fields": ["ok", "newly_resolved", "status", "current_state"] },
+      "success_response": {
+        "status": 200,
+        "fields": [
+          "ok",
+          "newly_resolved",
+          "status",
+          "current_state"
+        ]
+      },
       "error_responses": [
-        { "status": 404, "description": "Token not found." },
-        { "status": 500, "description": "Database error." }
+        {
+          "status": 404,
+          "description": "Token not found."
+        },
+        {
+          "status": 500,
+          "description": "Database error."
+        }
       ]
     },
     {
@@ -511,19 +1125,42 @@
       "description": "Send a liveness heartbeat for an in-progress external activity, optionally extending the deadline.",
       "idempotency": "Idempotent: repeated heartbeats extend or maintain the deadline.",
       "params": [
-        { "name": "token", "in": "path", "required": true, "description": "Opaque task token." }
+        {
+          "name": "token",
+          "in": "path",
+          "required": true,
+          "description": "Opaque task token."
+        }
       ],
       "request_body": {
         "required": false,
         "free_form": false,
         "fields": [
-          { "name": "extend_by_secs", "required": false, "description": "Seconds to extend the activity deadline." }
+          {
+            "name": "extend_by_secs",
+            "required": false,
+            "description": "Seconds to extend the activity deadline."
+          }
         ]
       },
-      "success_response": { "status": 200, "fields": ["ok", "newly_resolved", "status", "current_state"] },
+      "success_response": {
+        "status": 200,
+        "fields": [
+          "ok",
+          "newly_resolved",
+          "status",
+          "current_state"
+        ]
+      },
       "error_responses": [
-        { "status": 404, "description": "Token not found." },
-        { "status": 500, "description": "Database error." }
+        {
+          "status": 404,
+          "description": "Token not found."
+        },
+        {
+          "status": 500,
+          "description": "Database error."
+        }
       ]
     },
     {
@@ -533,16 +1170,47 @@
       "read_only": true,
       "description": "List registered worker processes and their current lifecycle status.",
       "params": [
-        { "name": "queue", "in": "query", "required": false, "description": "Filter by task queue name." },
-        { "name": "shard_id", "in": "query", "required": false, "description": "Filter by shard ID." },
-        { "name": "status", "in": "query", "required": false, "description": "Filter by lifecycle status: Active, Draining, or Stopped." },
-        { "name": "health", "in": "query", "required": false, "description": "Filter by health: healthy or stale." },
-        { "name": "limit", "in": "query", "required": false, "description": "Maximum number of workers to return [1–500]." }
+        {
+          "name": "queue",
+          "in": "query",
+          "required": false,
+          "description": "Filter by task queue name."
+        },
+        {
+          "name": "shard_id",
+          "in": "query",
+          "required": false,
+          "description": "Filter by shard ID."
+        },
+        {
+          "name": "status",
+          "in": "query",
+          "required": false,
+          "description": "Filter by lifecycle status: Active, Draining, or Stopped."
+        },
+        {
+          "name": "health",
+          "in": "query",
+          "required": false,
+          "description": "Filter by health: healthy or stale."
+        },
+        {
+          "name": "limit",
+          "in": "query",
+          "required": false,
+          "description": "Maximum number of workers to return [1\u2013500]."
+        }
       ],
       "request_body": null,
-      "success_response": { "status": 200, "free_form": true },
+      "success_response": {
+        "status": 200,
+        "free_form": true
+      },
       "error_responses": [
-        { "status": 500, "description": "Database error." }
+        {
+          "status": 500,
+          "description": "Database error."
+        }
       ]
     },
     {
@@ -552,13 +1220,27 @@
       "read_only": true,
       "description": "Get details for a single worker process.",
       "params": [
-        { "name": "worker_id", "in": "path", "required": true, "description": "Worker process identifier." }
+        {
+          "name": "worker_id",
+          "in": "path",
+          "required": true,
+          "description": "Worker process identifier."
+        }
       ],
       "request_body": null,
-      "success_response": { "status": 200, "free_form": true },
+      "success_response": {
+        "status": 200,
+        "free_form": true
+      },
       "error_responses": [
-        { "status": 404, "description": "Worker not found." },
-        { "status": 500, "description": "Database error." }
+        {
+          "status": 404,
+          "description": "Worker not found."
+        },
+        {
+          "status": 500,
+          "description": "Database error."
+        }
       ]
     },
     {
@@ -569,9 +1251,21 @@
       "description": "Return aggregated fleet health statistics (active, stale, draining, stopped counts per shard).",
       "params": [],
       "request_body": null,
-      "success_response": { "status": 200, "fields": ["healthy", "stale", "draining", "by_queue", "by_shard"] },
+      "success_response": {
+        "status": 200,
+        "fields": [
+          "healthy",
+          "stale",
+          "draining",
+          "by_queue",
+          "by_shard"
+        ]
+      },
       "error_responses": [
-        { "status": 500, "description": "Database error." }
+        {
+          "status": 500,
+          "description": "Database error."
+        }
       ]
     },
     {
@@ -581,15 +1275,41 @@
       "read_only": true,
       "description": "Preview which workers would be targeted by a drain request, without modifying anything.",
       "params": [
-        { "name": "queue", "in": "query", "required": false, "description": "Filter by task queue name." },
-        { "name": "shard_id", "in": "query", "required": false, "description": "Filter by shard ID." },
-        { "name": "status", "in": "query", "required": false, "description": "Filter by lifecycle status." },
-        { "name": "limit", "in": "query", "required": false, "description": "Maximum number of workers to preview." }
+        {
+          "name": "queue",
+          "in": "query",
+          "required": false,
+          "description": "Filter by task queue name."
+        },
+        {
+          "name": "shard_id",
+          "in": "query",
+          "required": false,
+          "description": "Filter by shard ID."
+        },
+        {
+          "name": "status",
+          "in": "query",
+          "required": false,
+          "description": "Filter by lifecycle status."
+        },
+        {
+          "name": "limit",
+          "in": "query",
+          "required": false,
+          "description": "Maximum number of workers to preview."
+        }
       ],
       "request_body": null,
-      "success_response": { "status": 200, "free_form": true },
+      "success_response": {
+        "status": 200,
+        "free_form": true
+      },
       "error_responses": [
-        { "status": 500, "description": "Database error." }
+        {
+          "status": 500,
+          "description": "Database error."
+        }
       ]
     },
     {
@@ -600,20 +1320,48 @@
       "description": "Request a graceful drain for a specific worker. Sets its status to Draining so it stops accepting new tasks.",
       "idempotency": "Idempotent: re-draining an already-draining worker extends the deadline if the new one is later.",
       "params": [
-        { "name": "worker_id", "in": "path", "required": true, "description": "Worker process identifier." }
+        {
+          "name": "worker_id",
+          "in": "path",
+          "required": true,
+          "description": "Worker process identifier."
+        }
       ],
       "request_body": {
         "required": false,
         "free_form": false,
         "fields": [
-          { "name": "deadline_at", "required": false, "description": "RFC 3339 drain-by deadline. Omit to use the server's configured shutdown timeout." }
+          {
+            "name": "deadline_at",
+            "required": false,
+            "description": "RFC 3339 drain-by deadline. Omit to use the server's configured shutdown timeout."
+          }
         ]
       },
-      "success_response": { "status": 200, "fields": ["worker_id", "outcome", "in_flight_count", "drain_deadline_at", "shard_ids", "unavailable_shards"] },
+      "success_response": {
+        "status": 200,
+        "fields": [
+          "worker_id",
+          "outcome",
+          "in_flight_count",
+          "drain_deadline_at",
+          "shard_ids",
+          "unavailable_shards"
+        ]
+      },
       "error_responses": [
-        { "status": 404, "description": "Worker not found." },
-        { "status": 409, "description": "Worker is already Stopped." },
-        { "status": 500, "description": "Database error." }
+        {
+          "status": 404,
+          "description": "Worker not found."
+        },
+        {
+          "status": 409,
+          "description": "Worker is already Stopped."
+        },
+        {
+          "status": 500,
+          "description": "Database error."
+        }
       ]
     },
     {
@@ -623,12 +1371,23 @@
       "read_only": true,
       "description": "List submitted batch operations and their current progress.",
       "params": [
-        { "name": "limit", "in": "query", "required": false, "description": "Maximum number of operations to return." }
+        {
+          "name": "limit",
+          "in": "query",
+          "required": false,
+          "description": "Maximum number of operations to return."
+        }
       ],
       "request_body": null,
-      "success_response": { "status": 200, "free_form": true },
+      "success_response": {
+        "status": 200,
+        "free_form": true
+      },
       "error_responses": [
-        { "status": 500, "description": "Database error." }
+        {
+          "status": 500,
+          "description": "Database error."
+        }
       ]
     },
     {
@@ -643,18 +1402,53 @@
         "required": true,
         "free_form": false,
         "fields": [
-          { "name": "action", "required": true, "description": "Batch action: Cancel, Terminate, or Signal." },
-          { "name": "filter", "required": true, "description": "Workflow filter (JSON object with states, workflow_name, search attributes)." },
-          { "name": "signal_name", "required": false, "description": "Signal name — required when action is Signal." },
-          { "name": "signal_payload", "required": false, "description": "Signal payload for Signal actions (any JSON value)." },
-          { "name": "idempotency_key", "required": false, "description": "Operator-supplied idempotency token; re-submitting with the same key returns the existing job." },
-          { "name": "created_by", "required": false, "description": "Optional caller identity for audit." }
+          {
+            "name": "action",
+            "required": true,
+            "description": "Batch action: Cancel, Terminate, or Signal."
+          },
+          {
+            "name": "filter",
+            "required": true,
+            "description": "Workflow filter (JSON object with states, workflow_name, search attributes)."
+          },
+          {
+            "name": "signal_name",
+            "required": false,
+            "description": "Signal name \u2014 required when action is Signal."
+          },
+          {
+            "name": "signal_payload",
+            "required": false,
+            "description": "Signal payload for Signal actions (any JSON value)."
+          },
+          {
+            "name": "idempotency_key",
+            "required": false,
+            "description": "Operator-supplied idempotency token; re-submitting with the same key returns the existing job."
+          },
+          {
+            "name": "created_by",
+            "required": false,
+            "description": "Optional caller identity for audit."
+          }
         ]
       },
-      "success_response": { "status": 202, "fields": ["batch_job_id"] },
+      "success_response": {
+        "status": 202,
+        "fields": [
+          "batch_job_id"
+        ]
+      },
       "error_responses": [
-        { "status": 400, "description": "Invalid action or missing required fields." },
-        { "status": 500, "description": "Database error." }
+        {
+          "status": 400,
+          "description": "Invalid action or missing required fields."
+        },
+        {
+          "status": 500,
+          "description": "Database error."
+        }
       ]
     },
     {
@@ -664,13 +1458,27 @@
       "read_only": true,
       "description": "Get the current status and progress of a batch operation.",
       "params": [
-        { "name": "id", "in": "path", "required": true, "description": "Batch job UUID." }
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Batch job UUID."
+        }
       ],
       "request_body": null,
-      "success_response": { "status": 200, "free_form": true },
+      "success_response": {
+        "status": 200,
+        "free_form": true
+      },
       "error_responses": [
-        { "status": 404, "description": "Batch job not found." },
-        { "status": 500, "description": "Database error." }
+        {
+          "status": 404,
+          "description": "Batch job not found."
+        },
+        {
+          "status": 500,
+          "description": "Database error."
+        }
       ]
     },
     {
@@ -681,7 +1489,18 @@
       "description": "Liveness health check. Returns 200 when the plugin is reachable. Does not probe the database.",
       "params": [],
       "request_body": null,
-      "success_response": { "status": 200, "fields": ["runtime_ready", "worker_id", "queues", "dag_count", "scheduler", "shard_readiness_enforced", "shard_readiness"] },
+      "success_response": {
+        "status": 200,
+        "fields": [
+          "runtime_ready",
+          "worker_id",
+          "queues",
+          "dag_count",
+          "scheduler",
+          "shard_readiness_enforced",
+          "shard_readiness"
+        ]
+      },
       "error_responses": []
     },
     {
@@ -692,9 +1511,20 @@
       "description": "Run deployment readiness preflight checks: database connectivity, migration status, shard health, and worker coverage.",
       "params": [],
       "request_body": null,
-      "success_response": { "status": 200, "fields": ["overall_status", "observed_at", "version", "checks"] },
+      "success_response": {
+        "status": 200,
+        "fields": [
+          "overall_status",
+          "observed_at",
+          "version",
+          "checks"
+        ]
+      },
       "error_responses": [
-        { "status": 500, "description": "Unable to connect to database." }
+        {
+          "status": 500,
+          "description": "Unable to connect to database."
+        }
       ]
     },
     {
@@ -704,12 +1534,29 @@
       "read_only": true,
       "description": "Return per-shard readiness: ready, degraded, or unavailable.",
       "params": [
-        { "name": "candidate_shard", "in": "query", "required": false, "description": "Shard ID of a new shard to probe before enabling writes." }
+        {
+          "name": "candidate_shard",
+          "in": "query",
+          "required": false,
+          "description": "Shard ID of a new shard to probe before enabling writes."
+        }
       ],
       "request_body": null,
-      "success_response": { "status": 200, "fields": ["overall_readiness", "observed_at", "freshness_window_secs", "candidate_shard", "shards"] },
+      "success_response": {
+        "status": 200,
+        "fields": [
+          "overall_readiness",
+          "observed_at",
+          "freshness_window_secs",
+          "candidate_shard",
+          "shards"
+        ]
+      },
       "error_responses": [
-        { "status": 503, "description": "Database or shard connectivity error." }
+        {
+          "status": 503,
+          "description": "Database or shard connectivity error."
+        }
       ]
     },
     {
@@ -719,16 +1566,53 @@
       "read_only": true,
       "description": "Report recorded workflow version-gate usage.",
       "params": [
-        { "name": "workflow_name", "in": "query", "required": false, "description": "Filter by registered workflow name." },
-        { "name": "change_id", "in": "query", "required": false, "description": "Filter by version-gate change ID." },
-        { "name": "recorded_version", "in": "query", "required": false, "description": "Filter by recorded version number." },
-        { "name": "state_group", "in": "query", "required": false, "description": "Execution state group: active or terminal." },
-        { "name": "shard_id", "in": "query", "required": false, "description": "Restrict to a single shard." }
+        {
+          "name": "workflow_name",
+          "in": "query",
+          "required": false,
+          "description": "Filter by registered workflow name."
+        },
+        {
+          "name": "change_id",
+          "in": "query",
+          "required": false,
+          "description": "Filter by version-gate change ID."
+        },
+        {
+          "name": "recorded_version",
+          "in": "query",
+          "required": false,
+          "description": "Filter by recorded version number."
+        },
+        {
+          "name": "state_group",
+          "in": "query",
+          "required": false,
+          "description": "Execution state group: active or terminal."
+        },
+        {
+          "name": "shard_id",
+          "in": "query",
+          "required": false,
+          "description": "Restrict to a single shard."
+        }
       ],
       "request_body": null,
-      "success_response": { "status": 200, "fields": ["status", "observed_at", "filters", "items", "shards"] },
+      "success_response": {
+        "status": 200,
+        "fields": [
+          "status",
+          "observed_at",
+          "filters",
+          "items",
+          "shards"
+        ]
+      },
       "error_responses": [
-        { "status": 500, "description": "Database error." }
+        {
+          "status": 500,
+          "description": "Database error."
+        }
       ]
     },
     {
@@ -738,17 +1622,58 @@
       "read_only": true,
       "description": "Check whether a version-gate change ID is safe to retire.",
       "params": [
-        { "name": "change_id", "in": "query", "required": true, "description": "Version-gate change ID to inspect." },
-        { "name": "min_safe_version", "in": "query", "required": true, "description": "Versions strictly below this value are considered old branches." },
-        { "name": "workflow_name", "in": "query", "required": false, "description": "Narrow to a specific workflow name." },
-        { "name": "state_group", "in": "query", "required": false, "description": "Execution state group filter." },
-        { "name": "shard_id", "in": "query", "required": false, "description": "Restrict to a single shard." }
+        {
+          "name": "change_id",
+          "in": "query",
+          "required": true,
+          "description": "Version-gate change ID to inspect."
+        },
+        {
+          "name": "min_safe_version",
+          "in": "query",
+          "required": true,
+          "description": "Versions strictly below this value are considered old branches."
+        },
+        {
+          "name": "workflow_name",
+          "in": "query",
+          "required": false,
+          "description": "Narrow to a specific workflow name."
+        },
+        {
+          "name": "state_group",
+          "in": "query",
+          "required": false,
+          "description": "Execution state group filter."
+        },
+        {
+          "name": "shard_id",
+          "in": "query",
+          "required": false,
+          "description": "Restrict to a single shard."
+        }
       ],
       "request_body": null,
-      "success_response": { "status": 200, "fields": ["status", "safe_to_retire", "observed_at", "filters", "blockers", "shards"] },
+      "success_response": {
+        "status": 200,
+        "fields": [
+          "status",
+          "safe_to_retire",
+          "observed_at",
+          "filters",
+          "blockers",
+          "shards"
+        ]
+      },
       "error_responses": [
-        { "status": 400, "description": "Missing required parameters." },
-        { "status": 500, "description": "Database error." }
+        {
+          "status": 400,
+          "description": "Missing required parameters."
+        },
+        {
+          "status": 500,
+          "description": "Database error."
+        }
       ]
     },
     {
@@ -759,7 +1684,10 @@
       "description": "Return the current status of the retention janitor.",
       "params": [],
       "request_body": null,
-      "success_response": { "status": 200, "free_form": true },
+      "success_response": {
+        "status": 200,
+        "free_form": true
+      },
       "error_responses": []
     },
     {
@@ -775,9 +1703,17 @@
         "free_form": false,
         "fields": []
       },
-      "success_response": { "status": 200, "fields": ["ok"] },
+      "success_response": {
+        "status": 200,
+        "fields": [
+          "ok"
+        ]
+      },
       "error_responses": [
-        { "status": 500, "description": "Internal error." }
+        {
+          "status": 500,
+          "description": "Internal error."
+        }
       ]
     },
     {
@@ -788,9 +1724,15 @@
       "description": "Return per-activity concurrency statistics: configured cap, currently in-flight, and queued counts for each concurrency key.",
       "params": [],
       "request_body": null,
-      "success_response": { "status": 200, "free_form": true },
+      "success_response": {
+        "status": 200,
+        "free_form": true
+      },
       "error_responses": [
-        { "status": 500, "description": "Database error." }
+        {
+          "status": 500,
+          "description": "Database error."
+        }
       ]
     },
     {
@@ -800,19 +1742,71 @@
       "read_only": true,
       "description": "Batch-export event histories for multiple executions matching the provided filters.",
       "params": [
-        { "name": "workflow_name", "in": "query", "required": false, "description": "Filter by workflow name." },
-        { "name": "state_group", "in": "query", "required": false, "description": "Execution state group: active or terminal." },
-        { "name": "updated_after", "in": "query", "required": false, "description": "RFC 3339 timestamp — include executions updated after this time." },
-        { "name": "updated_before", "in": "query", "required": false, "description": "RFC 3339 timestamp — include executions updated before this time." },
-        { "name": "shard_id", "in": "query", "required": false, "description": "Restrict to a single shard." },
-        { "name": "limit", "in": "query", "required": false, "description": "Maximum number of histories to export." },
-        { "name": "payload_policy", "in": "query", "required": false, "description": "Payload inclusion: full, redacted, or omit." }
+        {
+          "name": "workflow_name",
+          "in": "query",
+          "required": false,
+          "description": "Filter by workflow name."
+        },
+        {
+          "name": "state_group",
+          "in": "query",
+          "required": false,
+          "description": "Execution state group: active or terminal."
+        },
+        {
+          "name": "updated_after",
+          "in": "query",
+          "required": false,
+          "description": "RFC 3339 timestamp \u2014 include executions updated after this time."
+        },
+        {
+          "name": "updated_before",
+          "in": "query",
+          "required": false,
+          "description": "RFC 3339 timestamp \u2014 include executions updated before this time."
+        },
+        {
+          "name": "shard_id",
+          "in": "query",
+          "required": false,
+          "description": "Restrict to a single shard."
+        },
+        {
+          "name": "limit",
+          "in": "query",
+          "required": false,
+          "description": "Maximum number of histories to export."
+        },
+        {
+          "name": "payload_policy",
+          "in": "query",
+          "required": false,
+          "description": "Payload inclusion: full, redacted, or omit."
+        }
       ],
       "request_body": null,
-      "success_response": { "status": 200, "fields": ["status", "observed_at", "payload_policy", "filters", "exports", "failures", "shard_coverage"] },
+      "success_response": {
+        "status": 200,
+        "fields": [
+          "status",
+          "observed_at",
+          "payload_policy",
+          "filters",
+          "exports",
+          "failures",
+          "shard_coverage"
+        ]
+      },
       "error_responses": [
-        { "status": 400, "description": "Invalid filter values." },
-        { "status": 500, "description": "Database error." }
+        {
+          "status": 400,
+          "description": "Invalid filter values."
+        },
+        {
+          "status": 500,
+          "description": "Database error."
+        }
       ]
     },
     {
@@ -822,20 +1816,75 @@
       "read_only": true,
       "description": "List pending external activity handoffs with optional filters.",
       "params": [
-        { "name": "state", "in": "query", "required": false, "description": "Filter by handoff state (e.g. PENDING,FAILED)." },
-        { "name": "workflow_name", "in": "query", "required": false, "description": "Filter by workflow name." },
-        { "name": "execution_id", "in": "query", "required": false, "description": "Filter by execution UUID." },
-        { "name": "activity_name", "in": "query", "required": false, "description": "Filter by activity function name." },
-        { "name": "token", "in": "query", "required": false, "description": "Filter by task token UUID." },
-        { "name": "shard_id", "in": "query", "required": false, "description": "Restrict to a single shard." },
-        { "name": "due_before", "in": "query", "required": false, "description": "RFC 3339 timestamp — only return handoffs due before this time." },
-        { "name": "updated_before", "in": "query", "required": false, "description": "RFC 3339 timestamp — only return handoffs last updated before this time." },
-        { "name": "limit", "in": "query", "required": false, "description": "Maximum number of results." }
+        {
+          "name": "state",
+          "in": "query",
+          "required": false,
+          "description": "Filter by handoff state (e.g. PENDING,FAILED)."
+        },
+        {
+          "name": "workflow_name",
+          "in": "query",
+          "required": false,
+          "description": "Filter by workflow name."
+        },
+        {
+          "name": "execution_id",
+          "in": "query",
+          "required": false,
+          "description": "Filter by execution UUID."
+        },
+        {
+          "name": "activity_name",
+          "in": "query",
+          "required": false,
+          "description": "Filter by activity function name."
+        },
+        {
+          "name": "token",
+          "in": "query",
+          "required": false,
+          "description": "Filter by task token UUID."
+        },
+        {
+          "name": "shard_id",
+          "in": "query",
+          "required": false,
+          "description": "Restrict to a single shard."
+        },
+        {
+          "name": "due_before",
+          "in": "query",
+          "required": false,
+          "description": "RFC 3339 timestamp \u2014 only return handoffs due before this time."
+        },
+        {
+          "name": "updated_before",
+          "in": "query",
+          "required": false,
+          "description": "RFC 3339 timestamp \u2014 only return handoffs last updated before this time."
+        },
+        {
+          "name": "limit",
+          "in": "query",
+          "required": false,
+          "description": "Maximum number of results."
+        }
       ],
       "request_body": null,
-      "success_response": { "status": 200, "fields": ["status", "items", "shard_coverage"] },
+      "success_response": {
+        "status": 200,
+        "fields": [
+          "status",
+          "items",
+          "shard_coverage"
+        ]
+      },
       "error_responses": [
-        { "status": 500, "description": "Database error." }
+        {
+          "status": 500,
+          "description": "Database error."
+        }
       ]
     },
     {
@@ -845,13 +1894,31 @@
       "read_only": true,
       "description": "Get the current state and metadata of a single external activity handoff.",
       "params": [
-        { "name": "token", "in": "path", "required": true, "description": "Task token UUID." }
+        {
+          "name": "token",
+          "in": "path",
+          "required": true,
+          "description": "Task token UUID."
+        }
       ],
       "request_body": null,
-      "success_response": { "status": 200, "fields": ["status", "item", "shard_coverage"] },
+      "success_response": {
+        "status": 200,
+        "fields": [
+          "status",
+          "item",
+          "shard_coverage"
+        ]
+      },
       "error_responses": [
-        { "status": 404, "description": "Token not found." },
-        { "status": 500, "description": "Database error." }
+        {
+          "status": 404,
+          "description": "Token not found."
+        },
+        {
+          "status": 500,
+          "description": "Database error."
+        }
       ]
     },
     {
@@ -862,9 +1929,15 @@
       "description": "List all workflow and DAG schedules.",
       "params": [],
       "request_body": null,
-      "success_response": { "status": 200, "free_form": true },
+      "success_response": {
+        "status": 200,
+        "free_form": true
+      },
       "error_responses": [
-        { "status": 500, "description": "Database error." }
+        {
+          "status": 500,
+          "description": "Database error."
+        }
       ]
     },
     {
@@ -879,19 +1952,66 @@
         "required": true,
         "free_form": false,
         "fields": [
-          { "name": "workflow_name", "required": true, "description": "Registered workflow name." },
-          { "name": "schedule_expr", "required": true, "description": "Cron expression (e.g. '0 * * * *')." },
-          { "name": "input", "required": false, "description": "Workflow input payload (any JSON value)." },
-          { "name": "max_active_runs", "required": false, "description": "Maximum concurrent scheduled runs." },
-          { "name": "catchup", "required": false, "description": "Whether to backfill missed runs." },
-          { "name": "paused", "required": false, "description": "Create the schedule in paused state." },
-          { "name": "queue_name", "required": false, "description": "Task queue name for scheduled runs (default: 'default')." }
+          {
+            "name": "workflow_name",
+            "required": true,
+            "description": "Registered workflow name."
+          },
+          {
+            "name": "schedule_expr",
+            "required": true,
+            "description": "Cron expression (e.g. '0 * * * *')."
+          },
+          {
+            "name": "input",
+            "required": false,
+            "description": "Workflow input payload (any JSON value)."
+          },
+          {
+            "name": "max_active_runs",
+            "required": false,
+            "description": "Maximum concurrent scheduled runs."
+          },
+          {
+            "name": "catchup",
+            "required": false,
+            "description": "Whether to backfill missed runs."
+          },
+          {
+            "name": "paused",
+            "required": false,
+            "description": "Create the schedule in paused state."
+          },
+          {
+            "name": "queue_name",
+            "required": false,
+            "description": "Task queue name for scheduled runs (default: 'default')."
+          }
         ]
       },
-      "success_response": { "status": 201, "fields": ["id", "kind", "name", "schedule_expr", "is_paused", "next_run_at", "last_run_at", "max_active_runs", "catchup"] },
+      "success_response": {
+        "status": 201,
+        "fields": [
+          "id",
+          "kind",
+          "name",
+          "schedule_expr",
+          "is_paused",
+          "next_run_at",
+          "last_run_at",
+          "max_active_runs",
+          "catchup"
+        ]
+      },
       "error_responses": [
-        { "status": 400, "description": "Invalid cron expression or missing required fields." },
-        { "status": 500, "description": "Database error." }
+        {
+          "status": 400,
+          "description": "Invalid cron expression or missing required fields."
+        },
+        {
+          "status": 500,
+          "description": "Database error."
+        }
       ]
     },
     {
@@ -902,17 +2022,33 @@
       "description": "Pause a schedule, preventing it from triggering new runs.",
       "idempotency": "Idempotent: pausing an already-paused schedule is a no-op.",
       "params": [
-        { "name": "id", "in": "path", "required": true, "description": "Schedule UUID." }
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Schedule UUID."
+        }
       ],
       "request_body": {
         "required": false,
         "free_form": false,
         "fields": []
       },
-      "success_response": { "status": 200, "fields": ["ok"] },
+      "success_response": {
+        "status": 200,
+        "fields": [
+          "ok"
+        ]
+      },
       "error_responses": [
-        { "status": 404, "description": "Schedule not found." },
-        { "status": 500, "description": "Database error." }
+        {
+          "status": 404,
+          "description": "Schedule not found."
+        },
+        {
+          "status": 500,
+          "description": "Database error."
+        }
       ]
     },
     {
@@ -923,17 +2059,33 @@
       "description": "Resume a paused schedule.",
       "idempotency": "Idempotent: resuming an already-active schedule is a no-op.",
       "params": [
-        { "name": "id", "in": "path", "required": true, "description": "Schedule UUID." }
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Schedule UUID."
+        }
       ],
       "request_body": {
         "required": false,
         "free_form": false,
         "fields": []
       },
-      "success_response": { "status": 200, "fields": ["ok"] },
+      "success_response": {
+        "status": 200,
+        "fields": [
+          "ok"
+        ]
+      },
       "error_responses": [
-        { "status": 404, "description": "Schedule not found." },
-        { "status": 500, "description": "Database error." }
+        {
+          "status": 404,
+          "description": "Schedule not found."
+        },
+        {
+          "status": 500,
+          "description": "Database error."
+        }
       ]
     },
     {
@@ -944,17 +2096,107 @@
       "description": "Delete a schedule. In-flight runs started by this schedule continue to completion.",
       "idempotency": "Not idempotent: a second call after successful deletion returns 404.",
       "params": [
-        { "name": "id", "in": "path", "required": true, "description": "Schedule UUID." }
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Schedule UUID."
+        }
       ],
       "request_body": {
         "required": false,
         "free_form": false,
         "fields": []
       },
-      "success_response": { "status": 200, "fields": ["ok"] },
+      "success_response": {
+        "status": 200,
+        "fields": [
+          "ok"
+        ]
+      },
       "error_responses": [
-        { "status": 404, "description": "Schedule not found." },
-        { "status": 500, "description": "Database error." }
+        {
+          "status": 404,
+          "description": "Schedule not found."
+        },
+        {
+          "status": 500,
+          "description": "Database error."
+        }
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/admin/schedules/{id}/backfill",
+      "category": "schedule",
+      "read_only": false,
+      "description": "Backfill missed scheduled runs for a workflow or DAG schedule over an explicit time window.",
+      "idempotency": "Idempotent per timestamp: retrying the same backfill window never creates duplicate workflow executions or DAG runs for already-dispatched timestamps.",
+      "params": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Schedule UUID."
+        }
+      ],
+      "request_body": {
+        "required": true,
+        "free_form": false,
+        "fields": [
+          {
+            "name": "from",
+            "type": "string",
+            "required": true,
+            "description": "Start of the backfill window (RFC 3339). Both from and to are required."
+          },
+          {
+            "name": "to",
+            "type": "string",
+            "required": true,
+            "description": "End of the backfill window (RFC 3339). Both from and to are required."
+          },
+          {
+            "name": "dry_run",
+            "type": "boolean",
+            "required": false,
+            "description": "If true, return the planned timestamps without dispatching any runs. Default: false."
+          },
+          {
+            "name": "include_paused",
+            "type": "boolean",
+            "required": false,
+            "description": "If true, backfill even if the schedule is currently paused. Default: false."
+          },
+          {
+            "name": "max_count",
+            "type": "integer",
+            "required": false,
+            "description": "Maximum number of timestamps to plan. Requests that would exceed this limit are rejected before dispatch. Default: server-side limit (1000)."
+          }
+        ]
+      },
+      "success_response": {
+        "status": 200,
+        "free_form": true
+      },
+      "error_responses": [
+        {
+          "status": 400,
+          "description": "Missing or invalid time window, window inverted (to < from), or timestamp count exceeds max_count."
+        },
+        {
+          "status": 400,
+          "description": "Schedule is paused and include_paused was not set."
+        },
+        {
+          "status": 404,
+          "description": "Schedule not found."
+        },
+        {
+          "status": 500,
+          "description": "Database error or partial shard failure."
+        }
       ]
     },
     {
@@ -962,21 +2204,67 @@
       "path": "/admin/audit",
       "category": "audit",
       "read_only": true,
-      "description": "Browse the audit trail of management API mutations. Read-only — the audit log itself is never mutated through this surface.",
+      "description": "Browse the audit trail of management API mutations. Read-only \u2014 the audit log itself is never mutated through this surface.",
       "params": [
-        { "name": "actor", "in": "query", "required": false, "description": "Filter by actor identity." },
-        { "name": "operation", "in": "query", "required": false, "description": "Filter by operation name (e.g. workflow.cancel)." },
-        { "name": "target_type", "in": "query", "required": false, "description": "Filter by target resource type (e.g. workflow, schedule)." },
-        { "name": "target_id", "in": "query", "required": false, "description": "Filter by target resource ID." },
-        { "name": "status", "in": "query", "required": false, "description": "Filter by outcome: succeeded or failed." },
-        { "name": "since", "in": "query", "required": false, "description": "RFC 3339 timestamp — only return records after this time." },
-        { "name": "before", "in": "query", "required": false, "description": "RFC 3339 timestamp — only return records before this time." },
-        { "name": "limit", "in": "query", "required": false, "description": "Maximum number of records to return." }
+        {
+          "name": "actor",
+          "in": "query",
+          "required": false,
+          "description": "Filter by actor identity."
+        },
+        {
+          "name": "operation",
+          "in": "query",
+          "required": false,
+          "description": "Filter by operation name (e.g. workflow.cancel)."
+        },
+        {
+          "name": "target_type",
+          "in": "query",
+          "required": false,
+          "description": "Filter by target resource type (e.g. workflow, schedule)."
+        },
+        {
+          "name": "target_id",
+          "in": "query",
+          "required": false,
+          "description": "Filter by target resource ID."
+        },
+        {
+          "name": "status",
+          "in": "query",
+          "required": false,
+          "description": "Filter by outcome: succeeded or failed."
+        },
+        {
+          "name": "since",
+          "in": "query",
+          "required": false,
+          "description": "RFC 3339 timestamp \u2014 only return records after this time."
+        },
+        {
+          "name": "before",
+          "in": "query",
+          "required": false,
+          "description": "RFC 3339 timestamp \u2014 only return records before this time."
+        },
+        {
+          "name": "limit",
+          "in": "query",
+          "required": false,
+          "description": "Maximum number of records to return."
+        }
       ],
       "request_body": null,
-      "success_response": { "status": 200, "free_form": true },
+      "success_response": {
+        "status": 200,
+        "free_form": true
+      },
       "error_responses": [
-        { "status": 500, "description": "Database error." }
+        {
+          "status": 500,
+          "description": "Database error."
+        }
       ]
     }
   ]

--- a/docs/api-contract.json
+++ b/docs/api-contract.json
@@ -1931,7 +1931,19 @@
       "request_body": null,
       "success_response": {
         "status": 200,
-        "free_form": true
+        "free_form": false,
+        "fields": [
+          { "name": "id", "type": "string", "description": "Schedule UUID." },
+          { "name": "kind", "type": "string", "description": "workflow | dag" },
+          { "name": "name", "type": "string", "description": "Workflow or DAG name." },
+          { "name": "schedule_expr", "type": "string", "description": "Cron or interval expression. Null for manual schedules." },
+          { "name": "is_paused", "type": "boolean", "description": "Whether the schedule is currently paused." },
+          { "name": "next_run_at", "type": "string", "description": "Next scheduled firing time (RFC 3339). Null if paused or unscheduled." },
+          { "name": "last_run_at", "type": "string", "description": "Most recent automatic firing time (RFC 3339). Null if never run." },
+          { "name": "max_active_runs", "type": "integer", "description": "Maximum concurrently running executions for this schedule." },
+          { "name": "catchup", "type": "boolean", "description": "Whether the scheduler catches up missed runs on restart." },
+          { "name": "last_backfill", "type": "object", "description": "Most recent backfill request for this schedule, or null if none. Fields: id, actor, from, to, dry_run, total, dispatched, skipped, failed, status, error_summary, started_at, completed_at." }
+        ]
       },
       "error_responses": [
         {
@@ -2178,7 +2190,22 @@
       },
       "success_response": {
         "status": 200,
-        "free_form": true
+        "free_form": false,
+        "fields": [
+          { "name": "status", "type": "string", "description": "dry_run | complete | partial" },
+          { "name": "schedule_id", "type": "string", "description": "UUID of the schedule." },
+          { "name": "kind", "type": "string", "description": "workflow | dag" },
+          { "name": "name", "type": "string", "description": "Workflow or DAG name." },
+          { "name": "from", "type": "string", "description": "Window start (RFC 3339)." },
+          { "name": "to", "type": "string", "description": "Window end (RFC 3339)." },
+          { "name": "planned_timestamps", "type": "array", "description": "Ordered list of planned firing timestamps." },
+          { "name": "total", "type": "integer", "description": "Total planned timestamps." },
+          { "name": "dispatched", "type": "integer", "description": "Runs created (or estimated for dry_run)." },
+          { "name": "skipped", "type": "integer", "description": "Timestamps skipped (idempotent or max_active_runs). Estimated for dry_run." },
+          { "name": "failed", "type": "integer", "description": "Timestamps that failed to dispatch due to shard errors." },
+          { "name": "skipped_reasons", "type": "object", "description": "Machine-readable breakdown of skip causes. Keys: already_exists, max_active_runs." },
+          { "name": "partial_shard_failures", "type": "array", "description": "Shards that could not be reached. Each item has shard_id and reason." }
+        ]
       },
       "error_responses": [
         {

--- a/docs/runbooks/schedule-backfill.md
+++ b/docs/runbooks/schedule-backfill.md
@@ -1,0 +1,146 @@
+# Schedule Backfill Runbook
+
+Use this runbook to recover missed scheduled runs after downtime, a paused schedule, a bad deploy window, or disabled workers. The backfill API is idempotent: repeating the same request never creates duplicate workflow executions or DAG runs.
+
+## Prerequisites
+
+- Harvest CLI configured with `HARVEST_BASE_URL` pointing to your management API.
+- Operator access to the management API (see `docs/runbooks/audit-trail.md` for auth headers).
+- The schedule ID you want to backfill (`harvest schedule list` shows all IDs).
+
+## Step 1 — Identify the missed window
+
+```bash
+# List all schedules and note the schedule ID and expression.
+harvest schedule list
+```
+
+Calculate `--from` and `--to` as RFC 3339 timestamps. For a 7-day hourly billing schedule that was down from Monday 00:00 UTC to Sunday 23:59 UTC:
+
+```
+--from 2026-04-28T00:00:00Z
+--to   2026-05-04T23:59:59Z
+```
+
+## Step 2 — Dry-run to verify the planned timestamps
+
+Always dry-run first. This is non-destructive: it plans but dispatches nothing.
+
+```bash
+harvest schedule backfill <schedule-id> \
+  --from 2026-04-28T00:00:00Z \
+  --to   2026-05-04T23:59:59Z \
+  --dry-run
+```
+
+**Check the output:**
+
+- `status: dry_run` — no runs were created.
+- `total` — number of timestamps that would fire (e.g. 168 for a 7-day hourly schedule).
+- `dispatched` — estimated count that would be started (respects `max_active_runs`).
+- `skipped` — estimated count that would be skipped (e.g. due to `max_active_runs` saturation).
+- `planned_timestamps` — the full list. Verify the first and last timestamps are correct.
+
+If `total` exceeds the default limit of 1000, reduce the window or pass `--max-count <n>`:
+
+```bash
+harvest schedule backfill <schedule-id> \
+  --from 2026-04-28T00:00:00Z \
+  --to   2026-05-04T23:59:59Z \
+  --dry-run \
+  --max-count 500
+```
+
+## Step 3 — Execute the backfill
+
+Once you are satisfied with the dry-run output:
+
+```bash
+harvest schedule backfill <schedule-id> \
+  --from 2026-04-28T00:00:00Z \
+  --to   2026-05-04T23:59:59Z
+```
+
+**Check the response:**
+
+| Field | Expected | Notes |
+|---|---|---|
+| `status` | `complete` | `partial` means at least one shard failed — see `partial_shard_failures` |
+| `dispatched` | ≥ 1 | New runs created |
+| `skipped` | Any | Already-existing runs for those timestamps (idempotent) |
+| `skipped_reasons` | Object | `already_exists` = duplicate; `max_active_runs` = concurrency cap hit |
+| `failed` | 0 | Non-zero requires investigation |
+
+## Step 4 — Inspect the resulting runs
+
+For **workflow** schedules, query the executions:
+
+```bash
+harvest workflow list --workflow-name billing_workflow
+```
+
+For **DAG** schedules, inspect DAG runs via the management API:
+
+```
+GET /admin/dags/<dag-name>/runs
+```
+
+Backfill-created DAG runs carry `"_harvest_run_source": "backfill"` in their `conf` field, distinguishing them from scheduler-tick runs.
+
+## Step 5 — Retry safely if the client disconnects
+
+The backfill endpoint is idempotent: re-running the exact same request with the same `--from`/`--to` window will skip timestamps that were already dispatched and only create runs for any that were missed due to partial shard failures.
+
+```bash
+# Safe to repeat — duplicates are reported as skipped, not double-started.
+harvest schedule backfill <schedule-id> \
+  --from 2026-04-28T00:00:00Z \
+  --to   2026-05-04T23:59:59Z
+```
+
+After retrying, verify `dispatched` + `skipped` = `total` and `failed` = 0.
+
+## Handling paused schedules
+
+If the schedule is currently paused, the backfill request will be rejected with a 400 error unless you explicitly opt in:
+
+```bash
+harvest schedule backfill <schedule-id> \
+  --from 2026-04-28T00:00:00Z \
+  --to   2026-05-04T23:59:59Z \
+  --include-paused
+```
+
+Resume the schedule afterwards if appropriate:
+
+```bash
+harvest schedule resume <schedule-id>
+```
+
+## Handling max_active_runs saturation
+
+If `skipped_reasons` reports `max_active_runs`, the concurrency cap was reached before all timestamps could be dispatched. Options:
+
+1. **Wait for running executions to finish**, then re-run the backfill — idempotency ensures already-dispatched timestamps are skipped and only the deferred ones are dispatched.
+2. **Increase `max_active_runs`** temporarily via `harvest schedule update` (if implemented), then re-run.
+3. **Batch the window** into smaller sub-ranges and run them sequentially once capacity opens.
+
+## Viewing backfill history
+
+`harvest schedule list` returns a `last_backfill` field for each schedule showing the most recent backfill request: window, actor, counts, status, and timestamps. Use this to confirm an earlier operator ran a backfill and to compare windows if running a follow-up.
+
+## Partial shard failures
+
+If `status` is `partial`, `partial_shard_failures` lists each shard that could not be reached. Investigate DB connectivity for those shards, then re-run the backfill — timestamps that succeeded on reachable shards will be reported as `skipped` (idempotent), and only the failed ones will be retried.
+
+## Audit trail
+
+Every backfill request (including dry-runs) is recorded in the audit log with operation `schedule.backfill`. Query recent backfill audit records:
+
+```bash
+harvest audit list --operation schedule.backfill --target-id <schedule-id>
+```
+
+## Success metric
+
+For a 7-day hourly schedule (168 timestamps): dry-run planning should return in under 1 s. A full backfill dispatch should complete in under 5 s under normal worker availability. After three repeated client retries, `dispatched + skipped = total` with zero duplicates in the workflow execution or DAG run tables.


### PR DESCRIPTION
## Summary

Implements a new schedule backfill API endpoint that allows operators to recover missed scheduled runs after downtime, pauses, or deployment issues. The backfill operation is idempotent and respects existing schedule constraints like `max_active_runs`.

## Key Changes

- **New backfill endpoint** (`POST /admin/schedules/{id}/backfill`): Accepts a time window (`from`/`to`) and plans which timestamps a schedule would have fired, then dispatches workflow executions or DAG runs for those timestamps. Supports dry-run mode for preview-only planning.

- **Backfill planning logic** (`plan_backfill_timestamps`): Computes firing times for Cron and Interval schedules within a window, with configurable limits (default 1000 timestamps) to prevent runaway planning on large windows.

- **Backfill log table** (`harvest_backfill_log`): Durable audit record of each backfill request including actor, window, outcome counts (dispatched/skipped/failed), and status. Surfaced in `GET /admin/schedules` as `last_backfill` summary per schedule.

- **CLI support** (`harvest schedule backfill`): Command-line interface with `--from`, `--to`, `--dry-run`, `--max-count`, and `--include-paused` flags. Includes formatted table output for backfill results.

- **API contract updates**: Reformatted `docs/api-contract.json` for readability (multi-line JSON objects) and added backfill endpoint documentation.

- **Runbook** (`docs/runbooks/schedule-backfill.md`): Operator guide covering dry-run workflow, window calculation, and execution steps.

## Implementation Details

- Backfill respects the schedule's `max_active_runs` constraint by estimating dispatch capacity and skipping runs that would exceed the limit.
- Dry-run mode returns planned timestamps and estimated counts without creating any executions.
- Idempotent by design: repeating the same backfill request never creates duplicate runs (enforced by workflow_id/DAG run deduplication).
- Supports backfilling paused schedules via `--include-paused` flag.
- Backfill log rows are loaded efficiently in `load_recent_backfills` to avoid full audit log scans.

https://claude.ai/code/session_01TsuhmtP6jEeA9Rg19ErkZX