### PR TITLE
feat(harvest): add history guardrails for long-running workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,72 @@ already know an execution ID, use
 compact terminal body with `state`, `output`/`error`, and `completed_at`, or
 `204 No Content` with `Retry-After` while the workflow is still running.
 
+## Long-running workflows
+
+Every workflow replay loads its durable event history. For pollers, monitors,
+and other workflows that may run for weeks, keep that history bounded by
+tail-calling `continue_as_new` once the loaded event count grows past the
+configured soft threshold:
+
+```rust
+use autumn_harvest::prelude::*;
+
+#[workflow]
+async fn polling_loop(ctx: &WorkflowContext, mut state: serde_json::Value)
+    -> HarvestResult<serde_json::Value>
+{
+    loop {
+        let cycle = state["cycle"].as_u64().unwrap_or(0);
+        let result = ctx
+            .execute_activity_raw("poll_remote_system", state.clone(), "pollers")
+            .await?;
+
+        if result["done"].as_bool().unwrap_or(false) {
+            return Ok(result);
+        }
+
+        let next_state = serde_json::json!({
+            "cycle": cycle + 1,
+            "cursor": result.get("next_cursor").cloned(),
+        });
+
+        if ctx.should_continue_as_new() {
+            ctx.continue_as_new(next_state).await?;
+        }
+
+        let timer_id = format!("poll-delay-{cycle}");
+        ctx.timer(&timer_id, 60).await?;
+        state = next_state;
+    }
+}
+```
+
+`ctx.history_event_count()` reports the number of loaded durable history events.
+`ctx.should_continue_as_new()` turns true once that count exceeds the
+`HarvestBuilder::history_continue_as_new_threshold(...)` soft threshold. The
+default threshold is `10_000` events.
+
+```rust
+let harvest = HarvestBuilder::new()
+    .workflows(workflows![polling_loop])
+    .history_continue_as_new_threshold(5_000)
+    .history_event_hard_cap(20_000)
+    .try_build()?;
+```
+
+The optional hard cap is a last-resort guardrail. If an execution reaches
+`history_event_hard_cap` and the workflow does not issue `continue_as_new`, the
+worker fails the execution and moves it to the DLQ with a typed
+`HistoryCapExceeded { count, cap, workflow_type }` reason. No new workflow event
+variant is used for this guardrail.
+
+Harvest emits `harvest.workflow.history_size` for terminal executions and
+`harvest.workflow.continue_as_new` when a workflow rotates. Both metrics use
+only the workflow type label to keep cardinality boring in the useful way.
+
+See [`autumn-harvest/examples/long_running.rs`](autumn-harvest/examples/long_running.rs)
+for a compile-checked polling loop that works with and without the `db` feature.
+
 ## What you get
 
 - **Event-sourced execution.** Workflows are deterministic functions; their

--- a/autumn-harvest/examples/long_running.rs
+++ b/autumn-harvest/examples/long_running.rs
@@ -1,0 +1,84 @@
+//! Example: long-running polling workflow with continue-as-new guardrails.
+//!
+//! This example is intentionally compile-friendly: it demonstrates the workflow
+//! code and registration shape without requiring a database connection in
+//! `main`. Check it with:
+//!
+//! ```bash
+//! cargo check -p autumn-harvest --example long_running --no-default-features
+//! cargo check -p autumn-harvest --example long_running
+//! ```
+
+use autumn_harvest::prelude::*;
+use serde_json::{Value, json};
+
+#[workflow]
+#[allow(clippy::missing_errors_doc)]
+pub async fn poll_customer_exports(
+    ctx: &WorkflowContext,
+    mut state: Value,
+) -> HarvestResult<Value> {
+    loop {
+        let cycle = state.get("cycle").and_then(Value::as_u64).unwrap_or(0);
+        let cursor = state.get("cursor").cloned().unwrap_or(Value::Null);
+
+        let page = ctx
+            .execute_activity_raw(
+                "poll_customer_export_page",
+                json!({
+                    "cycle": cycle,
+                    "cursor": cursor,
+                }),
+                "pollers",
+            )
+            .await?;
+
+        if page.get("ready").and_then(Value::as_bool).unwrap_or(false) {
+            return Ok(json!({
+                "status": "ready",
+                "page": page,
+                "history_events": ctx.history_event_count(),
+            }));
+        }
+
+        let next_state = json!({
+            "cycle": cycle + 1,
+            "cursor": page.get("next_cursor").cloned().unwrap_or(Value::Null),
+        });
+
+        if ctx.should_continue_as_new() {
+            ctx.continue_as_new(next_state).await?;
+            unreachable!("continue_as_new does not resolve while the execution is active");
+        }
+
+        let timer_id = format!("poll-delay-{cycle}");
+        ctx.timer(&timer_id, 60).await?;
+        state = next_state;
+    }
+}
+
+#[activity(start_to_close = "30s", queue = "pollers")]
+#[allow(clippy::missing_errors_doc, clippy::unused_async)]
+pub async fn poll_customer_export_page(
+    _ctx: &ActivityContext,
+    input: Value,
+) -> HarvestResult<Value> {
+    let cycle = input.get("cycle").and_then(Value::as_u64).unwrap_or(0);
+
+    Ok(json!({
+        "ready": cycle >= 5,
+        "next_cursor": format!("page-{cycle}"),
+    }))
+}
+
+fn main() {
+    let _registration = HarvestBuilder::new()
+        .workflows(workflows![poll_customer_exports])
+        .activities(activities![poll_customer_export_page])
+        .history_continue_as_new_threshold(10_000)
+        .history_event_hard_cap(20_000)
+        .try_build()
+        .expect("example registration should be valid");
+
+    println!("long_running example: see module docs for compile checks");
+}

--- a/autumn-harvest/src/builder.rs
+++ b/autumn-harvest/src/builder.rs
@@ -4,7 +4,7 @@ use std::any::{Any, TypeId};
 use std::sync::Arc;
 use std::time::Duration;
 
-use crate::context::SharedStateMap;
+use crate::context::{SharedStateMap, WorkflowHistoryPolicy};
 use crate::info::{ActivityInfo, DagInfo, WorkflowInfo};
 use crate::payload_codec::{PayloadCodec, PayloadCodecs};
 use crate::policy::WorkflowSchedule;
@@ -47,6 +47,7 @@ pub struct HarvestBuilder {
     telemetry: Option<TelemetryConfig>,
     retention: RetentionConfig,
     payload_codecs: PayloadCodecs,
+    history_policy: WorkflowHistoryPolicy,
 }
 
 impl std::fmt::Debug for HarvestBuilder {
@@ -61,6 +62,7 @@ impl std::fmt::Debug for HarvestBuilder {
             .field("telemetry_configured", &self.telemetry.is_some())
             .field("retention", &self.retention)
             .field("payload_codecs", &"configured")
+            .field("history_policy", &self.history_policy)
             .finish()
     }
 }
@@ -76,6 +78,7 @@ pub struct BuiltHarvest {
     telemetry: Arc<TelemetryConfig>,
     retention: RetentionConfig,
     payload_codecs: PayloadCodecs,
+    history_policy: WorkflowHistoryPolicy,
 }
 
 impl std::fmt::Debug for BuiltHarvest {
@@ -90,6 +93,7 @@ impl std::fmt::Debug for BuiltHarvest {
             .field("telemetry", &self.telemetry)
             .field("retention", &self.retention)
             .field("payload_codecs", &"configured")
+            .field("history_policy", &self.history_policy)
             .finish()
     }
 }
@@ -200,6 +204,12 @@ impl BuiltHarvest {
         &self.payload_codecs
     }
 
+    /// History-size guardrails applied to workflow contexts and workers.
+    #[must_use]
+    pub const fn history_policy(&self) -> WorkflowHistoryPolicy {
+        self.history_policy
+    }
+
     /// Number of registered workflows.
     #[must_use]
     pub const fn workflow_count(&self) -> usize {
@@ -285,7 +295,8 @@ impl BuiltHarvest {
                 self.activities,
                 Arc::new(self.state),
                 self.telemetry,
-            ),
+            )
+            .with_history_policy(self.history_policy),
             self.dags,
             self.workflow_schedules,
             self.worker_config,
@@ -312,7 +323,8 @@ impl BuiltHarvest {
                 self.activities,
                 Arc::new(self.state),
                 self.telemetry,
-            ),
+            )
+            .with_history_policy(self.history_policy),
             self.dags,
             self.workflow_schedules,
             self.worker_config,
@@ -431,6 +443,23 @@ impl HarvestBuilder {
         self
     }
 
+    /// Override the soft history-size threshold used by
+    /// [`crate::context::WorkflowContext::should_continue_as_new`].
+    #[must_use]
+    pub const fn history_continue_as_new_threshold(mut self, threshold: u64) -> Self {
+        self.history_policy = self
+            .history_policy
+            .with_continue_as_new_threshold(threshold);
+        self
+    }
+
+    /// Configure an opt-in hard cap for workflow history event counts.
+    #[must_use]
+    pub const fn history_event_hard_cap(mut self, cap: u64) -> Self {
+        self.history_policy = self.history_policy.with_event_hard_cap(cap);
+        self
+    }
+
     /// Number of registered workflows (used in tests and diagnostics).
     #[must_use]
     pub const fn workflow_count(&self) -> usize {
@@ -503,6 +532,7 @@ impl HarvestBuilder {
             telemetry: Arc::new(self.telemetry.unwrap_or_default()),
             retention: self.retention,
             payload_codecs: self.payload_codecs.clone(),
+            history_policy: self.history_policy,
         })
     }
 }
@@ -887,6 +917,41 @@ mod tests {
         let built = HarvestBuilder::new().build();
         // Default is a safe no-op: capturing yields nothing.
         assert!(built.telemetry().capture_trace_context().is_none());
+    }
+
+    #[test]
+    fn harvest_builder_defaults_history_guardrails() {
+        let built = HarvestBuilder::new().build();
+        let policy = built.history_policy();
+
+        assert_eq!(policy.continue_as_new_threshold(), 10_000);
+        assert_eq!(policy.event_hard_cap(), None);
+    }
+
+    #[test]
+    fn harvest_builder_accepts_history_guardrail_overrides() {
+        let built = HarvestBuilder::new()
+            .history_continue_as_new_threshold(128)
+            .history_event_hard_cap(256)
+            .build();
+        let policy = built.history_policy();
+
+        assert_eq!(policy.continue_as_new_threshold(), 128);
+        assert_eq!(policy.event_hard_cap(), Some(256));
+    }
+
+    #[cfg(feature = "db")]
+    #[test]
+    fn harvest_builder_passes_history_policy_to_worker_registry() {
+        let built = HarvestBuilder::new()
+            .history_continue_as_new_threshold(9)
+            .history_event_hard_cap(11)
+            .build();
+
+        let (registry, _dags, _workflow_schedules, _worker_config) = built.into_worker_parts();
+
+        assert_eq!(registry.history_policy().continue_as_new_threshold(), 9);
+        assert_eq!(registry.history_policy().event_hard_cap(), Some(11));
     }
 
     #[test]

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -37,6 +37,53 @@ pub fn empty_shared_state() -> SharedState {
     Arc::new(HashMap::new())
 }
 
+/// Default soft history-size threshold for recommending `continue_as_new`.
+pub const DEFAULT_HISTORY_CONTINUE_AS_NEW_THRESHOLD: u64 = 10_000;
+
+/// Replay-safe history guardrails made available to workflow code.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct WorkflowHistoryPolicy {
+    continue_as_new_threshold: u64,
+    event_hard_cap: Option<u64>,
+}
+
+impl Default for WorkflowHistoryPolicy {
+    fn default() -> Self {
+        Self {
+            continue_as_new_threshold: DEFAULT_HISTORY_CONTINUE_AS_NEW_THRESHOLD,
+            event_hard_cap: None,
+        }
+    }
+}
+
+impl WorkflowHistoryPolicy {
+    /// Soft threshold used by [`WorkflowContext::should_continue_as_new`].
+    #[must_use]
+    pub const fn continue_as_new_threshold(self) -> u64 {
+        self.continue_as_new_threshold
+    }
+
+    /// Optional hard cap that moves an execution to the DLQ when exceeded.
+    #[must_use]
+    pub const fn event_hard_cap(self) -> Option<u64> {
+        self.event_hard_cap
+    }
+
+    /// Override the soft continue-as-new threshold.
+    #[must_use]
+    pub const fn with_continue_as_new_threshold(mut self, threshold: u64) -> Self {
+        self.continue_as_new_threshold = threshold;
+        self
+    }
+
+    /// Override the optional hard cap.
+    #[must_use]
+    pub const fn with_event_hard_cap(mut self, cap: u64) -> Self {
+        self.event_hard_cap = Some(cap);
+        self
+    }
+}
+
 #[cfg(feature = "db")]
 type ActivityCancellationPool =
     diesel_async::pooled_connection::deadpool::Pool<diesel_async::AsyncPgConnection>;
@@ -421,6 +468,8 @@ pub struct WorkflowContext {
     commands: Mutex<Vec<WorkflowCommand>>,
     /// Deterministic "now" -- the timestamp from the `WorkflowStarted` event.
     start_time: DateTime<Utc>,
+    /// History-size thresholds visible to author code.
+    history_policy: WorkflowHistoryPolicy,
     /// Monotonically increasing counter for generating activity sequence IDs.
     activity_seq: Mutex<u32>,
     /// Shared typed state map (same `AppState` extras as the web server).
@@ -489,6 +538,20 @@ impl WorkflowContext {
         events: Vec<WorkflowEvent>,
         state: SharedState,
     ) -> Self {
+        Self::for_replay_with_state_and_history_policy(
+            exec_id,
+            events,
+            state,
+            WorkflowHistoryPolicy::default(),
+        )
+    }
+
+    pub(crate) fn for_replay_with_state_and_history_policy(
+        exec_id: ExecutionId,
+        events: Vec<WorkflowEvent>,
+        state: SharedState,
+        history_policy: WorkflowHistoryPolicy,
+    ) -> Self {
         // Extract the start_time from WorkflowStarted (first event).
         let start_time = events
             .first()
@@ -515,6 +578,7 @@ impl WorkflowContext {
             matcher: Mutex::new(matcher),
             commands: Mutex::new(Vec::new()),
             start_time,
+            history_policy,
             activity_seq: Mutex::new(0),
             state,
             query_registry: Mutex::new(QueryRegistry::new()),
@@ -577,6 +641,7 @@ impl WorkflowContext {
             matcher: Mutex::new(HistoryMatcher::new(vec![])),
             commands: Mutex::new(Vec::new()),
             start_time,
+            history_policy: WorkflowHistoryPolicy::default(),
             activity_seq: Mutex::new(0),
             state: empty_shared_state(),
             query_registry: Mutex::new(QueryRegistry::new()),
@@ -599,6 +664,23 @@ impl WorkflowContext {
     #[must_use]
     pub const fn execution_id(&self) -> ExecutionId {
         self.exec_id
+    }
+
+    /// Number of events currently loaded in this workflow execution history.
+    ///
+    /// This is replay-safe: it is computed from the in-memory history snapshot
+    /// loaded before the current workflow task, not from a side-effecting
+    /// counter maintained by author code.
+    #[must_use]
+    pub fn history_event_count(&self) -> u64 {
+        self.match_history(|matcher| matcher.event_count())
+    }
+
+    /// Returns `true` once [`Self::history_event_count`] exceeds the configured
+    /// soft continue-as-new threshold.
+    #[must_use]
+    pub fn should_continue_as_new(&self) -> bool {
+        self.history_event_count() > self.history_policy.continue_as_new_threshold()
     }
 
     /// Returns `true` if the context is currently replaying recorded history
@@ -2253,6 +2335,89 @@ mod tests {
     use crate::error::TimeoutType;
     use crate::types::ActivityExecId;
     use chrono::Utc;
+
+    #[test]
+    fn workflow_context_history_event_count_reports_loaded_history() {
+        let activity_id = ActivityExecId::new();
+        let events = vec![
+            WorkflowEvent::WorkflowStarted {
+                input: Value::Null,
+                timestamp: Utc::now(),
+            },
+            WorkflowEvent::ActivityScheduled {
+                activity_id,
+                name: "poll_for_work".into(),
+                input: Value::Null,
+                queue: "default".into(),
+            },
+            WorkflowEvent::ActivityCompleted {
+                activity_id,
+                output: serde_json::json!({"work": false}),
+            },
+        ];
+
+        let ctx = WorkflowContext::for_replay(ExecutionId::new(), events);
+
+        assert_eq!(ctx.history_event_count(), 3);
+        assert!(
+            ctx.is_replaying(),
+            "counting history must not advance replay"
+        );
+    }
+
+    #[test]
+    fn workflow_context_should_continue_as_new_uses_soft_threshold() {
+        let events = vec![
+            WorkflowEvent::WorkflowStarted {
+                input: Value::Null,
+                timestamp: Utc::now(),
+            },
+            WorkflowEvent::MarkerRecorded {
+                name: "poll-cycle".into(),
+                details: serde_json::json!({"n": 1}),
+            },
+            WorkflowEvent::MarkerRecorded {
+                name: "poll-cycle".into(),
+                details: serde_json::json!({"n": 2}),
+            },
+        ];
+        let policy = WorkflowHistoryPolicy::default().with_continue_as_new_threshold(2);
+
+        let ctx = WorkflowContext::for_replay_with_state_and_history_policy(
+            ExecutionId::new(),
+            events,
+            empty_shared_state(),
+            policy,
+        );
+
+        assert_eq!(ctx.history_event_count(), 3);
+        assert!(ctx.should_continue_as_new());
+    }
+
+    #[test]
+    fn workflow_context_should_continue_as_new_is_false_at_threshold_boundary() {
+        let events = vec![
+            WorkflowEvent::WorkflowStarted {
+                input: Value::Null,
+                timestamp: Utc::now(),
+            },
+            WorkflowEvent::MarkerRecorded {
+                name: "poll-cycle".into(),
+                details: serde_json::json!({"n": 1}),
+            },
+        ];
+        let policy = WorkflowHistoryPolicy::default().with_continue_as_new_threshold(2);
+
+        let ctx = WorkflowContext::for_replay_with_state_and_history_policy(
+            ExecutionId::new(),
+            events,
+            empty_shared_state(),
+            policy,
+        );
+
+        assert_eq!(ctx.history_event_count(), 2);
+        assert!(!ctx.should_continue_as_new());
+    }
 
     #[tokio::test]
     async fn workflow_context_continue_as_new_pushes_terminal_command() {

--- a/autumn-harvest/src/dlq.rs
+++ b/autumn-harvest/src/dlq.rs
@@ -94,6 +94,28 @@ pub struct BulkDlqResult {
     pub failures: Vec<BulkDlqFailure>,
 }
 
+/// Typed dead-letter reason for engine-authored DLQ entries.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+#[serde(tag = "type")]
+pub enum DeadLetterReason {
+    /// Workflow history reached the operator-configured hard cap without
+    /// author code explicitly rotating via `continue_as_new`.
+    HistoryCapExceeded {
+        count: u64,
+        cap: u64,
+        workflow_type: String,
+    },
+}
+
+impl std::fmt::Display for DeadLetterReason {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match serde_json::to_string(self) {
+            Ok(json) => f.write_str(&json),
+            Err(_) => f.write_str("DeadLetterReasonSerializationFailed"),
+        }
+    }
+}
+
 fn dead_letter_task_type(dead_letter_id: Uuid, task_type: &str) -> HarvestResult<TaskType> {
     if task_type.eq_ignore_ascii_case("workflow") {
         Ok(TaskType::Workflow)
@@ -553,6 +575,22 @@ mod tests {
         assert!(
             matches!(error, HarvestError::Config(message) if message.contains("invalid task_type"))
         );
+    }
+
+    #[test]
+    fn dead_letter_reason_history_cap_is_typed_json() {
+        let reason = DeadLetterReason::HistoryCapExceeded {
+            count: 12_001,
+            cap: 12_000,
+            workflow_type: "billing_poll".into(),
+        };
+
+        let json = reason.to_string();
+        let back: DeadLetterReason =
+            serde_json::from_str(&json).expect("typed reason should deserialize");
+
+        assert_eq!(back, reason);
+        assert!(json.contains("HistoryCapExceeded"));
     }
 
     #[test]

--- a/autumn-harvest/src/event.rs
+++ b/autumn-harvest/src/event.rs
@@ -369,6 +369,7 @@ impl WorkflowEvent {
             Self::WorkflowCompleted { .. }
                 | Self::WorkflowFailed { .. }
                 | Self::WorkflowCancelled { .. }
+                | Self::WorkflowContinuedAsNew { .. }
                 | Self::WorkflowResetTerminated { .. }
         )
     }

--- a/autumn-harvest/src/executor.rs
+++ b/autumn-harvest/src/executor.rs
@@ -14,7 +14,9 @@ use std::time::Duration;
 use serde_json::Value;
 use tracing::Instrument;
 
-use crate::context::{SharedState, WorkflowCommand, WorkflowContext, empty_shared_state};
+use crate::context::{
+    SharedState, WorkflowCommand, WorkflowContext, WorkflowHistoryPolicy, empty_shared_state,
+};
 use crate::event::WorkflowEvent;
 use crate::info::WorkflowHandlerFn;
 use crate::telemetry::{
@@ -185,7 +187,35 @@ pub async fn run_workflow_with_state(
     state: SharedState,
     span_meta: Option<&WorkflowExecuteSpanMeta>,
 ) -> (WorkflowOutcome, Vec<WorkflowCommand>, tracing::Span) {
-    let ctx = WorkflowContext::for_replay_with_state(exec_id, history, state);
+    run_workflow_with_state_and_history_policy(
+        exec_id,
+        history,
+        handler,
+        input,
+        state,
+        WorkflowHistoryPolicy::default(),
+        span_meta,
+    )
+    .await
+}
+
+/// Like [`run_workflow_with_state`] but installs explicit history guardrails
+/// into the [`WorkflowContext`].
+pub async fn run_workflow_with_state_and_history_policy(
+    exec_id: ExecutionId,
+    history: Vec<WorkflowEvent>,
+    handler: WorkflowHandlerFn,
+    input: Value,
+    state: SharedState,
+    history_policy: WorkflowHistoryPolicy,
+    span_meta: Option<&WorkflowExecuteSpanMeta>,
+) -> (WorkflowOutcome, Vec<WorkflowCommand>, tracing::Span) {
+    let ctx = WorkflowContext::for_replay_with_state_and_history_policy(
+        exec_id,
+        history,
+        state,
+        history_policy,
+    );
 
     // ADR-0001 §2.1: emit harvest.workflow.execute for every executor cycle.
     // harvest.replay defaults to false at span creation so subscribers that only

--- a/autumn-harvest/src/lib.rs
+++ b/autumn-harvest/src/lib.rs
@@ -131,7 +131,10 @@ pub use analyzer::{
 };
 pub use builder::{BuiltHarvest, HarvestBuilder, HarvestBuilderError, WorkerConfig};
 pub use cache::{CachedWorkflowState, WorkflowCache};
-pub use context::{ActivityContext, WorkflowCommand, WorkflowContext};
+pub use context::{
+    ActivityContext, DEFAULT_HISTORY_CONTINUE_AS_NEW_THRESHOLD, WorkflowCommand, WorkflowContext,
+    WorkflowHistoryPolicy,
+};
 pub use critical_path::{CriticalPathAnalyzer, CriticalPathResult};
 pub use dag::{DagBuildError, DagBuilder, DagDefinition, DagTask, DagTaskRef};
 pub use dag_export::{export_dot, export_mermaid};

--- a/autumn-harvest/src/metrics_rs_adapter.rs
+++ b/autumn-harvest/src/metrics_rs_adapter.rs
@@ -47,9 +47,10 @@ use crate::telemetry::{
     ActivityStatus, METRIC_ACTIVITY_DURATION, METRIC_DLQ_ENTRIES, METRIC_LABEL_ACTIVITY,
     METRIC_LABEL_KEY, METRIC_LABEL_KIND, METRIC_LABEL_NAME, METRIC_LABEL_QUEUE,
     METRIC_LABEL_REASON, METRIC_LABEL_SHARD, METRIC_LABEL_STATUS, METRIC_LABEL_WORKFLOW,
-    METRIC_QUEUE_DEPTH, METRIC_RETENTION_DELETED, METRIC_SCHEDULE_RUNS, METRIC_SCHEDULE_SKIPPED,
-    METRIC_TIMER_DURATION, METRIC_TIMER_STARTED, METRIC_WORKFLOW_DURATION, METRIC_WORKFLOW_STARTED,
-    MetricsRecorder, WorkflowStatus,
+    METRIC_LABEL_WORKFLOW_TYPE, METRIC_QUEUE_DEPTH, METRIC_RETENTION_DELETED, METRIC_SCHEDULE_RUNS,
+    METRIC_SCHEDULE_SKIPPED, METRIC_TIMER_DURATION, METRIC_TIMER_STARTED,
+    METRIC_WORKFLOW_CONTINUE_AS_NEW, METRIC_WORKFLOW_DURATION, METRIC_WORKFLOW_HISTORY_SIZE,
+    METRIC_WORKFLOW_STARTED, MetricsRecorder, WorkflowStatus,
 };
 
 /// [`MetricsRecorder`] implementation that forwards every sample to the
@@ -84,6 +85,23 @@ impl MetricsRecorder for MetricsRsRecorder {
             METRIC_LABEL_STATUS => status.as_str(),
         )
         .record(duration_secs);
+    }
+
+    #[allow(clippy::cast_precision_loss)]
+    fn record_workflow_history_size(&self, workflow_name: &str, event_count: u64) {
+        histogram!(
+            METRIC_WORKFLOW_HISTORY_SIZE,
+            METRIC_LABEL_WORKFLOW_TYPE => workflow_name.to_owned(),
+        )
+        .record(event_count as f64);
+    }
+
+    fn record_workflow_continue_as_new(&self, workflow_name: &str) {
+        counter!(
+            METRIC_WORKFLOW_CONTINUE_AS_NEW,
+            METRIC_LABEL_WORKFLOW_TYPE => workflow_name.to_owned(),
+        )
+        .increment(1);
     }
 
     fn record_activity_completed(
@@ -210,6 +228,8 @@ mod tests {
         let rec = MetricsRsRecorder;
         rec.record_workflow_started("wf", "q");
         rec.record_workflow_completed("wf", "q", 1.0, WorkflowStatus::Completed);
+        rec.record_workflow_history_size("wf", 2);
+        rec.record_workflow_continue_as_new("wf");
         rec.record_activity_completed("act", "q", 0.5, ActivityStatus::Completed);
         rec.record_timer_started(30.0);
         rec.record_queue_depth("q", 5);

--- a/autumn-harvest/src/replay.rs
+++ b/autumn-harvest/src/replay.rs
@@ -360,10 +360,16 @@ impl HistoryMatcher {
         cursor < self.events.len()
     }
 
+    /// Number of events loaded into this replay matcher.
+    #[must_use]
+    pub fn event_count(&self) -> u64 {
+        u64::try_from(self.events.len()).unwrap_or(u64::MAX)
+    }
+
     /// Returns `true` if there are unconsumed events that are not terminal
     /// lifecycle events (`WorkflowCompleted`, `WorkflowFailed`,
-    /// `WorkflowCancelled`), or if there are buffered signals that were never
-    /// delivered via `wait_for_signal`.
+    /// `WorkflowCancelled`, `WorkflowContinuedAsNew`), or if there are buffered
+    /// signals that were never delivered via `wait_for_signal`.
     ///
     /// Used by [`crate::context::WorkflowContext::history_has_unconsumed_events`] to avoid
     /// false non-determinism reports when replaying full histories that include

--- a/autumn-harvest/src/telemetry.rs
+++ b/autumn-harvest/src/telemetry.rs
@@ -66,6 +66,12 @@ pub const METRIC_WORKFLOW_STARTED: &str = "harvest.workflow.started";
 /// Histogram: wall-clock seconds a workflow executor cycle took.
 pub const METRIC_WORKFLOW_DURATION: &str = "harvest.workflow.duration";
 
+/// Histogram: number of durable events in a terminal workflow execution history.
+pub const METRIC_WORKFLOW_HISTORY_SIZE: &str = "harvest.workflow.history_size";
+
+/// Counter: incremented once for each continue-as-new rotation.
+pub const METRIC_WORKFLOW_CONTINUE_AS_NEW: &str = "harvest.workflow.continue_as_new";
+
 /// Histogram: wall-clock seconds an activity invocation took (success or failure).
 pub const METRIC_ACTIVITY_DURATION: &str = "harvest.activity.duration";
 
@@ -100,6 +106,8 @@ pub const METRIC_RETENTION_DELETED: &str = "harvest.retention.deleted";
 
 /// Metric label: the workflow name.
 pub const METRIC_LABEL_WORKFLOW: &str = "workflow";
+/// Metric label: the low-cardinality workflow type.
+pub const METRIC_LABEL_WORKFLOW_TYPE: &str = "workflow.type";
 /// Metric label: the activity name.
 pub const METRIC_LABEL_ACTIVITY: &str = "activity";
 /// Metric label: the task queue name.
@@ -358,6 +366,16 @@ pub trait MetricsRecorder: Send + Sync {
         let _ = (workflow_name, queue, duration_secs, status);
     }
 
+    /// A workflow reached a terminal state with this durable history size.
+    fn record_workflow_history_size(&self, workflow_name: &str, event_count: u64) {
+        let _ = (workflow_name, event_count);
+    }
+
+    /// A workflow execution rotated using continue-as-new.
+    fn record_workflow_continue_as_new(&self, workflow_name: &str) {
+        let _ = workflow_name;
+    }
+
     /// An activity invocation finished.
     fn record_activity_completed(
         &self,
@@ -583,6 +601,14 @@ mod tests {
         // OTel semantic naming: instrument.noun (dot-separated).
         assert_eq!(METRIC_WORKFLOW_STARTED, "harvest.workflow.started");
         assert_eq!(METRIC_WORKFLOW_DURATION, "harvest.workflow.duration");
+        assert_eq!(
+            METRIC_WORKFLOW_HISTORY_SIZE,
+            "harvest.workflow.history_size"
+        );
+        assert_eq!(
+            METRIC_WORKFLOW_CONTINUE_AS_NEW,
+            "harvest.workflow.continue_as_new"
+        );
         assert_eq!(METRIC_ACTIVITY_DURATION, "harvest.activity.duration");
         assert_eq!(METRIC_TIMER_STARTED, "harvest.timer.started");
         assert_eq!(METRIC_QUEUE_DEPTH, "harvest.queue.depth");
@@ -590,6 +616,14 @@ mod tests {
         assert_eq!(METRIC_SCHEDULE_RUNS, "harvest.schedule.runs");
         assert_eq!(METRIC_SCHEDULE_SKIPPED, "harvest.schedule.skipped");
         assert_eq!(METRIC_RETENTION_DELETED, "harvest.retention.deleted");
+    }
+
+    #[test]
+    fn metric_label_constants_have_correct_names() {
+        assert_eq!(METRIC_LABEL_WORKFLOW, "workflow");
+        assert_eq!(METRIC_LABEL_WORKFLOW_TYPE, "workflow.type");
+        assert_eq!(METRIC_LABEL_ACTIVITY, "activity");
+        assert_eq!(METRIC_LABEL_QUEUE, "queue");
     }
 
     #[test]
@@ -739,6 +773,8 @@ mod tests {
         // no ExecutionId, no raw UUID params that could smuggle one in.
         rec.record_workflow_started("onboarding", "default");
         rec.record_workflow_completed("onboarding", "default", 1.23, WorkflowStatus::Completed);
+        rec.record_workflow_history_size("onboarding", 42);
+        rec.record_workflow_continue_as_new("onboarding");
         rec.record_activity_completed("send_email", "default", 0.5, ActivityStatus::Completed);
         rec.record_timer_started(60.0);
         rec.record_queue_depth("default", 7);
@@ -774,6 +810,8 @@ mod tests {
             0.01,
             WorkflowStatus::Completed,
         );
+        telemetry.metrics.record_workflow_history_size("demo", 2);
+        telemetry.metrics.record_workflow_continue_as_new("demo");
         telemetry.metrics.record_activity_completed(
             "send_email",
             "default",

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -2617,6 +2617,73 @@ fn terminal_history_event_count(next_event_id: i32, pending_cmds: &[WorkflowComm
         .saturating_add(1)
 }
 
+fn marker_event_count(commands: &[WorkflowCommand]) -> u64 {
+    u64::try_from(
+        commands
+            .iter()
+            .filter(|cmd| matches!(cmd, WorkflowCommand::RecordMarker { .. }))
+            .count(),
+    )
+    .unwrap_or(u64::MAX)
+}
+
+async fn new_child_workflow_event_count(
+    conn: &mut AsyncPgConnection,
+    children: &[StartedChildWorkflowCommand],
+) -> HarvestResult<u64> {
+    let requested_ids: Vec<uuid::Uuid> = children
+        .iter()
+        .map(|child| child.child_id.as_uuid())
+        .collect();
+    if requested_ids.is_empty() {
+        return Ok(0);
+    }
+
+    let existing_ids: HashSet<uuid::Uuid> = harvest_workflow_executions::table
+        .filter(harvest_workflow_executions::id.eq_any(&requested_ids))
+        .select(harvest_workflow_executions::id)
+        .load::<uuid::Uuid>(conn)
+        .await
+        .map_err(crate::error::database_error)?
+        .into_iter()
+        .collect();
+    let requested = u64::try_from(children.len()).unwrap_or(u64::MAX);
+    let existing = u64::try_from(existing_ids.len()).unwrap_or(u64::MAX);
+    Ok(requested.saturating_sub(existing))
+}
+
+async fn suspended_command_event_count(
+    conn: &mut AsyncPgConnection,
+    commands: &[WorkflowCommand],
+) -> HarvestResult<u64> {
+    let update_events = pending_update_result_event_count(commands);
+    let marker_events = marker_event_count(commands);
+    let bookkeeping_events = update_events.saturating_add(marker_events);
+
+    if should_requeue_signal_wait(commands) {
+        return Ok(bookkeeping_events);
+    }
+    if extract_single_schedule_activity(commands).is_some()
+        || extract_single_started_timer(commands).is_some()
+    {
+        return Ok(bookkeeping_events.saturating_add(1));
+    }
+    if let Some(children) = extract_all_started_child_workflows(commands) {
+        return Ok(bookkeeping_events
+            .saturating_add(new_child_workflow_event_count(conn, &children).await?));
+    }
+    if let Some(scheduled) = extract_single_schedule_external_activity(commands) {
+        let awaiting_event = u64::from(
+            external_task::find_by_token(conn, scheduled.token)
+                .await?
+                .is_none(),
+        );
+        return Ok(bookkeeping_events.saturating_add(awaiting_event));
+    }
+
+    Ok(update_events.saturating_add(1))
+}
+
 async fn move_workflow_to_dlq_for_history_cap(
     conn: &mut AsyncPgConnection,
     task: &TaskQueueItem,
@@ -2679,7 +2746,7 @@ async fn fail_workflow_for_history_cap(
     event_count: u64,
     cap: u64,
 ) -> HarvestResult<()> {
-    let terminal_count = event_count.saturating_add(1);
+    let terminal_count = u64::try_from(next_event_id).unwrap_or(0).saturating_add(1);
     telemetry.metrics.record_workflow_completed(
         &execution.workflow_name,
         &task.queue_name,
@@ -2893,9 +2960,21 @@ async fn process_workflow_task(
     };
 
     let (outcome, pending_cmds, execute_span) = loop_result;
+    let pending_durable_event_count = match &outcome {
+        WorkflowOutcome::Suspended { commands } => {
+            match suspended_command_event_count(conn, commands).await {
+                Ok(count) => count,
+                Err(error) => {
+                    return fail_execution_on_error(conn, task, worker_id, Err::<(), _>(error))
+                        .await;
+                }
+            }
+        }
+        _ => pending_update_result_event_count(&pending_cmds),
+    };
     let current_history_event_count = u64::try_from(history_events.len())
         .unwrap_or(u64::MAX)
-        .saturating_add(pending_update_result_event_count(&pending_cmds));
+        .saturating_add(pending_durable_event_count);
 
     if let Some(cap) = registry.history_policy().event_hard_cap()
         && current_history_event_count >= cap

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -22,10 +22,15 @@ use tokio::sync::Semaphore;
 use tokio_util::sync::CancellationToken;
 
 use crate::builder::WorkerConfig;
-use crate::context::{ActivityContext, SharedState, WorkflowCommand, empty_shared_state};
+use crate::context::{
+    ActivityContext, SharedState, WorkflowCommand, WorkflowHistoryPolicy, empty_shared_state,
+};
+use crate::dlq::{self, DeadLetterReason, NewDeadLetterEntry};
 use crate::error::{HarvestError, HarvestResult};
 use crate::event::WorkflowEvent;
-use crate::executor::{WorkflowExecuteSpanMeta, WorkflowOutcome, run_workflow_with_state};
+use crate::executor::{
+    WorkflowExecuteSpanMeta, WorkflowOutcome, run_workflow_with_state_and_history_policy,
+};
 use crate::external_task;
 use crate::info::{ActivityInfo, WorkflowInfo};
 use crate::models::{
@@ -151,6 +156,8 @@ pub struct HandlerRegistry {
     /// Telemetry bundle (trace-context propagator + metrics recorder) applied
     /// around every dispatch.
     telemetry: Arc<crate::telemetry::TelemetryConfig>,
+    /// History-size thresholds visible to workflow contexts.
+    history_policy: WorkflowHistoryPolicy,
 }
 
 impl HandlerRegistry {
@@ -201,7 +208,28 @@ impl HandlerRegistry {
             activities,
             state,
             telemetry,
+            history_policy: WorkflowHistoryPolicy::default(),
         }
+    }
+
+    /// Create a new registry with shared state, telemetry, and history guardrails.
+    #[must_use]
+    pub fn with_state_telemetry_and_history_policy(
+        workflows: Vec<WorkflowInfo>,
+        activities: Vec<ActivityInfo>,
+        state: SharedState,
+        telemetry: Arc<crate::telemetry::TelemetryConfig>,
+        history_policy: WorkflowHistoryPolicy,
+    ) -> Self {
+        Self::with_state_and_telemetry(workflows, activities, state, telemetry)
+            .with_history_policy(history_policy)
+    }
+
+    /// Override the history guardrails carried by this registry.
+    #[must_use]
+    pub const fn with_history_policy(mut self, history_policy: WorkflowHistoryPolicy) -> Self {
+        self.history_policy = history_policy;
+        self
     }
 
     /// Clone the shared state reference for runtime contexts.
@@ -221,6 +249,12 @@ impl HandlerRegistry {
     pub const fn telemetry(&self) -> &Arc<crate::telemetry::TelemetryConfig> {
         &self.telemetry
     }
+
+    /// History-size guardrails applied to workflow contexts run by this registry.
+    #[must_use]
+    pub const fn history_policy(&self) -> WorkflowHistoryPolicy {
+        self.history_policy
+    }
 }
 
 impl std::fmt::Debug for HandlerRegistry {
@@ -230,6 +264,7 @@ impl std::fmt::Debug for HandlerRegistry {
             .field("activities", &self.activities.keys())
             .field("state_count", &self.state.len())
             .field("telemetry", &self.telemetry)
+            .field("history_policy", &self.history_policy)
             .finish()
     }
 }
@@ -2565,6 +2600,67 @@ async fn persist_workflow_outcome(
     }
 }
 
+fn pending_update_result_event_count(commands: &[WorkflowCommand]) -> u64 {
+    u64::try_from(
+        commands
+            .iter()
+            .filter(|cmd| matches!(cmd, WorkflowCommand::RecordUpdateResult { .. }))
+            .count(),
+    )
+    .unwrap_or(u64::MAX)
+}
+
+fn terminal_history_event_count(next_event_id: i32, pending_cmds: &[WorkflowCommand]) -> u64 {
+    u64::try_from(next_event_id)
+        .unwrap_or(0)
+        .saturating_add(pending_update_result_event_count(pending_cmds))
+        .saturating_add(1)
+}
+
+async fn move_workflow_to_dlq_for_history_cap(
+    conn: &mut AsyncPgConnection,
+    task: &TaskQueueItem,
+    exec_id: ExecutionId,
+    next_event_id: i32,
+    worker_id: &str,
+    reason: DeadLetterReason,
+) -> HarvestResult<()> {
+    let reason = reason.to_string();
+
+    conn.transaction::<(), HarvestError, _>(|conn| {
+        let reason = reason.clone();
+        async move {
+            dlq::dead_letter(
+                conn,
+                &NewDeadLetterEntry {
+                    original_task_id: task.id,
+                    queue_name: task.queue_name.clone(),
+                    task_type: task.task_type.clone(),
+                    workflow_exec_id: task.workflow_exec_id,
+                    activity_name: task.activity_name.clone(),
+                    input: task.input.clone(),
+                    error: reason.clone(),
+                    attempts: task.attempt,
+                },
+            )
+            .await?;
+            store::append_events(
+                conn,
+                exec_id,
+                &[WorkflowEvent::WorkflowFailed {
+                    error: reason.clone(),
+                }],
+                next_event_id,
+            )
+            .await?;
+            update_workflow_execution_failed(conn, exec_id, worker_id, &reason).await?;
+            queue::fail_task(conn, task.id, &reason).await
+        }
+        .scope_boxed()
+    })
+    .await
+}
+
 #[allow(clippy::too_many_lines)]
 async fn process_workflow_task(
     conn: &mut AsyncPgConnection,
@@ -2684,12 +2780,13 @@ async fn process_workflow_task(
                 .and_then(|c| c.link_traceparent.clone().or_else(|| c.traceparent.clone())),
         };
 
-        let (run_outcome, pending_cmds, execute_span) = run_workflow_with_state(
+        let (run_outcome, pending_cmds, execute_span) = run_workflow_with_state_and_history_policy(
             prepared.exec_id,
             history_events.clone(),
             workflow.handler,
             task.input.clone(),
             registry.shared_state(),
+            registry.history_policy(),
             Some(&span_meta),
         )
         .await;
@@ -2731,6 +2828,38 @@ async fn process_workflow_task(
     };
 
     let (outcome, pending_cmds, execute_span) = loop_result;
+    let current_history_event_count = u64::try_from(history_events.len()).unwrap_or(u64::MAX);
+
+    if let Some(cap) = registry.history_policy().event_hard_cap()
+        && current_history_event_count >= cap
+        && !matches!(&outcome, WorkflowOutcome::ContinuedAsNew { .. })
+    {
+        let terminal_count = current_history_event_count.saturating_add(1);
+        telemetry.metrics.record_workflow_completed(
+            &prepared.execution.workflow_name,
+            &task.queue_name,
+            started_at.elapsed().as_secs_f64(),
+            WorkflowStatus::Failed,
+        );
+        telemetry
+            .metrics
+            .record_workflow_history_size(&prepared.execution.workflow_name, terminal_count);
+
+        let reason = DeadLetterReason::HistoryCapExceeded {
+            count: current_history_event_count,
+            cap,
+            workflow_type: prepared.execution.workflow_name.clone(),
+        };
+        return move_workflow_to_dlq_for_history_cap(
+            conn,
+            task,
+            prepared.exec_id,
+            next_event_id,
+            worker_id,
+            reason,
+        )
+        .await;
+    }
 
     let status = match &outcome {
         WorkflowOutcome::Completed { .. } => WorkflowStatus::Completed,
@@ -2744,6 +2873,17 @@ async fn process_workflow_task(
         started_at.elapsed().as_secs_f64(),
         status,
     );
+    if !matches!(&outcome, WorkflowOutcome::Suspended { .. }) {
+        telemetry.metrics.record_workflow_history_size(
+            &prepared.execution.workflow_name,
+            terminal_history_event_count(next_event_id, &pending_cmds),
+        );
+    }
+    if matches!(&outcome, WorkflowOutcome::ContinuedAsNew { .. }) {
+        telemetry
+            .metrics
+            .record_workflow_continue_as_new(&prepared.execution.workflow_name);
+    }
 
     // Append UpdateCompleted/UpdateFailed events and apply search-attribute
     // patches for any commands emitted during this live execution cycle before

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -2623,6 +2623,7 @@ async fn move_workflow_to_dlq_for_history_cap(
     exec_id: ExecutionId,
     next_event_id: i32,
     worker_id: &str,
+    parent_exec_id: Option<ExecutionId>,
     reason: DeadLetterReason,
 ) -> HarvestResult<()> {
     let reason = reason.to_string();
@@ -2654,10 +2655,55 @@ async fn move_workflow_to_dlq_for_history_cap(
             )
             .await?;
             update_workflow_execution_failed(conn, exec_id, worker_id, &reason).await?;
-            queue::fail_task(conn, task.id, &reason).await
+            queue::fail_task(conn, task.id, &reason).await?;
+            if let Some(parent_exec_id) = parent_exec_id {
+                wake_parent_for_child_failure(conn, parent_exec_id, exec_id, &reason).await?;
+            }
+            Ok(())
         }
         .scope_boxed()
     })
+    .await
+}
+
+#[allow(clippy::too_many_arguments)]
+async fn fail_workflow_for_history_cap(
+    conn: &mut AsyncPgConnection,
+    telemetry: &crate::telemetry::TelemetryConfig,
+    task: &TaskQueueItem,
+    execution: &WorkflowExecution,
+    exec_id: ExecutionId,
+    next_event_id: i32,
+    worker_id: &str,
+    started_at: std::time::Instant,
+    event_count: u64,
+    cap: u64,
+) -> HarvestResult<()> {
+    let terminal_count = event_count.saturating_add(1);
+    telemetry.metrics.record_workflow_completed(
+        &execution.workflow_name,
+        &task.queue_name,
+        started_at.elapsed().as_secs_f64(),
+        WorkflowStatus::Failed,
+    );
+    telemetry
+        .metrics
+        .record_workflow_history_size(&execution.workflow_name, terminal_count);
+
+    let reason = DeadLetterReason::HistoryCapExceeded {
+        count: event_count,
+        cap,
+        workflow_type: execution.workflow_name.clone(),
+    };
+    move_workflow_to_dlq_for_history_cap(
+        conn,
+        task,
+        exec_id,
+        next_event_id,
+        worker_id,
+        execution.parent_id.map(execution_id_from_uuid),
+        reason,
+    )
     .await
 }
 
@@ -2822,41 +2868,50 @@ async fn process_workflow_task(
                 )
                 .await?;
                 history_events.extend(new_events);
+                let current_history_event_count =
+                    u64::try_from(history_events.len()).unwrap_or(u64::MAX);
+                if let Some(cap) = registry.history_policy().event_hard_cap()
+                    && current_history_event_count >= cap
+                {
+                    return fail_workflow_for_history_cap(
+                        conn,
+                        &telemetry,
+                        task,
+                        &prepared.execution,
+                        prepared.exec_id,
+                        next_event_id,
+                        worker_id,
+                        started_at,
+                        current_history_event_count,
+                        cap,
+                    )
+                    .await;
+                }
             }
             other => break (other, pending_cmds, execute_span),
         }
     };
 
     let (outcome, pending_cmds, execute_span) = loop_result;
-    let current_history_event_count = u64::try_from(history_events.len()).unwrap_or(u64::MAX);
+    let current_history_event_count = u64::try_from(history_events.len())
+        .unwrap_or(u64::MAX)
+        .saturating_add(pending_update_result_event_count(&pending_cmds));
 
     if let Some(cap) = registry.history_policy().event_hard_cap()
         && current_history_event_count >= cap
         && !matches!(&outcome, WorkflowOutcome::ContinuedAsNew { .. })
     {
-        let terminal_count = current_history_event_count.saturating_add(1);
-        telemetry.metrics.record_workflow_completed(
-            &prepared.execution.workflow_name,
-            &task.queue_name,
-            started_at.elapsed().as_secs_f64(),
-            WorkflowStatus::Failed,
-        );
-        telemetry
-            .metrics
-            .record_workflow_history_size(&prepared.execution.workflow_name, terminal_count);
-
-        let reason = DeadLetterReason::HistoryCapExceeded {
-            count: current_history_event_count,
-            cap,
-            workflow_type: prepared.execution.workflow_name.clone(),
-        };
-        return move_workflow_to_dlq_for_history_cap(
+        return fail_workflow_for_history_cap(
             conn,
+            &telemetry,
             task,
+            &prepared.execution,
             prepared.exec_id,
             next_event_id,
             worker_id,
-            reason,
+            started_at,
+            current_history_event_count,
+            cap,
         )
         .await;
     }

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -608,6 +608,20 @@ struct LocalActivityRun {
     last_error: Option<String>,
 }
 
+enum LocalActivityInlineOutcome {
+    Complete(Vec<WorkflowEvent>),
+    HistoryCapReached {
+        events: Vec<WorkflowEvent>,
+        event_count: u64,
+    },
+}
+
+fn local_activity_history_cap_reached(next_event_id: i32, cap: Option<u64>) -> Option<u64> {
+    let cap = cap?;
+    let count = u64::try_from(next_event_id).unwrap_or(u64::MAX);
+    (count >= cap).then_some(count)
+}
+
 /// Extract a `RunLocalActivity` command from an owned command list.
 ///
 /// Marker (`RecordMarker`) events are also extracted and returned so the
@@ -673,10 +687,11 @@ async fn run_local_activity_inline(
     run: LocalActivityRun,
     max_start_to_close: Duration,
     next_event_id: &mut i32,
-) -> HarvestResult<Vec<WorkflowEvent>> {
+) -> HarvestResult<LocalActivityInlineOutcome> {
     let activity = registry.activities.get(&run.name).ok_or_else(|| {
         HarvestError::Config(format!("no activity handler registered for '{}'", run.name))
     })?;
+    let history_event_hard_cap = registry.history_policy().event_hard_cap();
 
     let per_attempt_timeout = run
         .start_to_close_secs
@@ -702,6 +717,15 @@ async fn run_local_activity_inline(
     }
 
     let mut all_new_events = prefix_events;
+    if let Some(event_count) =
+        local_activity_history_cap_reached(*next_event_id, history_event_hard_cap)
+    {
+        return Ok(LocalActivityInlineOutcome::HistoryCapReached {
+            events: all_new_events,
+            event_count,
+        });
+    }
+
     let handler = activity.handler;
     let local_idempotency_key = IdempotencyKey::from_activity_exec_id(run.activity_id);
 
@@ -753,7 +777,15 @@ async fn run_local_activity_inline(
                 .await?;
                 *next_event_id += 1;
                 all_new_events.push(completed_event);
-                return Ok(all_new_events);
+                if let Some(event_count) =
+                    local_activity_history_cap_reached(*next_event_id, history_event_hard_cap)
+                {
+                    return Ok(LocalActivityInlineOutcome::HistoryCapReached {
+                        events: all_new_events,
+                        event_count,
+                    });
+                }
+                return Ok(LocalActivityInlineOutcome::Complete(all_new_events));
             }
             Err(error) => {
                 let failed_event = WorkflowEvent::LocalActivityFailed {
@@ -763,6 +795,26 @@ async fn run_local_activity_inline(
                 };
 
                 if attempt == max_attempts {
+                    let current_count = u64::try_from(*next_event_id).unwrap_or(u64::MAX);
+                    let final_pair_would_exceed_cap = history_event_hard_cap
+                        .is_some_and(|cap| current_count.saturating_add(2) > cap);
+                    if final_pair_would_exceed_cap {
+                        store::append_events(
+                            conn,
+                            exec_id,
+                            std::slice::from_ref(&failed_event),
+                            *next_event_id,
+                        )
+                        .await?;
+                        *next_event_id += 1;
+                        all_new_events.push(failed_event);
+                        let event_count = u64::try_from(*next_event_id).unwrap_or(u64::MAX);
+                        return Ok(LocalActivityInlineOutcome::HistoryCapReached {
+                            events: all_new_events,
+                            event_count,
+                        });
+                    }
+
                     // Final attempt: append LocalActivityFailed and
                     // LocalActivityExhausted atomically so a crash between the
                     // two cannot leave history without the terminal marker,
@@ -777,6 +829,14 @@ async fn run_local_activity_inline(
                     *next_event_id += i32::try_from(terminal_pair.len())
                         .map_err(|_| HarvestError::Config("event count overflow".into()))?;
                     all_new_events.extend(terminal_pair);
+                    if let Some(event_count) =
+                        local_activity_history_cap_reached(*next_event_id, history_event_hard_cap)
+                    {
+                        return Ok(LocalActivityInlineOutcome::HistoryCapReached {
+                            events: all_new_events,
+                            event_count,
+                        });
+                    }
                 } else {
                     store::append_events(
                         conn,
@@ -787,6 +847,14 @@ async fn run_local_activity_inline(
                     .await?;
                     *next_event_id += 1;
                     all_new_events.push(failed_event);
+                    if let Some(event_count) =
+                        local_activity_history_cap_reached(*next_event_id, history_event_hard_cap)
+                    {
+                        return Ok(LocalActivityInlineOutcome::HistoryCapReached {
+                            events: all_new_events,
+                            event_count,
+                        });
+                    }
 
                     if let Some(delay) = run
                         .retry_policy
@@ -800,7 +868,7 @@ async fn run_local_activity_inline(
         }
     }
 
-    Ok(all_new_events)
+    Ok(LocalActivityInlineOutcome::Complete(all_new_events))
 }
 
 fn chrono_duration_from_std(
@@ -2924,7 +2992,7 @@ async fn process_workflow_task(
                 // so the OTel span closes before we start inline execution.
                 drop(execute_span);
                 let (markers, local_run) = extract_run_local_activity(commands);
-                let new_events = run_local_activity_inline(
+                let inline_outcome = run_local_activity_inline(
                     conn,
                     registry,
                     prepared.exec_id,
@@ -2934,6 +3002,31 @@ async fn process_workflow_task(
                     &mut next_event_id,
                 )
                 .await?;
+                let new_events = match inline_outcome {
+                    LocalActivityInlineOutcome::Complete(events) => events,
+                    LocalActivityInlineOutcome::HistoryCapReached {
+                        events,
+                        event_count,
+                    } => {
+                        history_events.extend(events);
+                        return fail_workflow_for_history_cap(
+                            conn,
+                            &telemetry,
+                            task,
+                            &prepared.execution,
+                            prepared.exec_id,
+                            next_event_id,
+                            worker_id,
+                            started_at,
+                            event_count,
+                            registry
+                                .history_policy()
+                                .event_hard_cap()
+                                .expect("HistoryCapReached requires a configured hard cap"),
+                        )
+                        .await;
+                    }
+                };
                 history_events.extend(new_events);
                 let current_history_event_count =
                     u64::try_from(history_events.len()).unwrap_or(u64::MAX);

--- a/autumn-harvest/tests/metrics_coverage.rs
+++ b/autumn-harvest/tests/metrics_coverage.rs
@@ -13,8 +13,8 @@ use std::sync::{Arc, Mutex};
 use autumn_harvest::telemetry::{
     ActivityStatus, METRIC_ACTIVITY_DURATION, METRIC_DLQ_ENTRIES, METRIC_QUEUE_DEPTH,
     METRIC_RETENTION_DELETED, METRIC_SCHEDULE_RUNS, METRIC_SCHEDULE_SKIPPED, METRIC_TIMER_STARTED,
-    METRIC_WORKFLOW_DURATION, METRIC_WORKFLOW_STARTED, MetricsRecorder, NoOpMetrics,
-    WorkflowStatus,
+    METRIC_WORKFLOW_CONTINUE_AS_NEW, METRIC_WORKFLOW_DURATION, METRIC_WORKFLOW_HISTORY_SIZE,
+    METRIC_WORKFLOW_STARTED, MetricsRecorder, NoOpMetrics, WorkflowStatus,
 };
 
 // ---------------------------------------------------------------------------
@@ -69,6 +69,23 @@ impl MetricsRecorder for RecordingMetrics {
                 ("queue", queue.to_owned()),
                 ("status", status.as_str().to_owned()),
             ],
+        });
+    }
+
+    fn record_workflow_history_size(&self, workflow_name: &str, event_count: u64) {
+        self.samples.lock().unwrap().push(MetricSample {
+            name: METRIC_WORKFLOW_HISTORY_SIZE,
+            labels: vec![
+                ("workflow.type", workflow_name.to_owned()),
+                ("count", event_count.to_string()),
+            ],
+        });
+    }
+
+    fn record_workflow_continue_as_new(&self, workflow_name: &str) {
+        self.samples.lock().unwrap().push(MetricSample {
+            name: METRIC_WORKFLOW_CONTINUE_AS_NEW,
+            labels: vec![("workflow.type", workflow_name.to_owned())],
         });
     }
 
@@ -161,6 +178,8 @@ fn all_catalogue_metrics_are_reachable_via_trait() {
 
     rec.record_workflow_started("my_workflow", "default");
     rec.record_workflow_completed("my_workflow", "default", 1.0, WorkflowStatus::Completed);
+    rec.record_workflow_history_size("my_workflow", 42);
+    rec.record_workflow_continue_as_new("my_workflow");
     rec.record_activity_completed("my_activity", "default", 0.5, ActivityStatus::Completed);
     rec.record_timer_started(30.0);
     rec.record_queue_depth("default", 5);
@@ -180,6 +199,28 @@ fn all_catalogue_metrics_are_reachable_via_trait() {
         names.contains(&METRIC_WORKFLOW_DURATION),
         "harvest.workflow.duration not sampled"
     );
+    assert!(
+        names.contains(&METRIC_WORKFLOW_HISTORY_SIZE),
+        "harvest.workflow.history_size not sampled"
+    );
+    assert!(
+        names.contains(&METRIC_WORKFLOW_CONTINUE_AS_NEW),
+        "harvest.workflow.continue_as_new not sampled"
+    );
+    for sample in samples.iter().filter(|sample| {
+        matches!(
+            sample.name,
+            METRIC_WORKFLOW_HISTORY_SIZE | METRIC_WORKFLOW_CONTINUE_AS_NEW
+        )
+    }) {
+        assert!(
+            sample
+                .labels
+                .iter()
+                .any(|(key, value)| *key == "workflow.type" && value == "my_workflow"),
+            "new workflow-history metrics must use workflow.type only; got {sample:?}"
+        );
+    }
     assert!(
         names.contains(&METRIC_ACTIVITY_DURATION),
         "harvest.activity.duration not sampled"
@@ -219,6 +260,8 @@ fn cardinality_no_execution_id_label_on_any_metric() {
 
     rec.record_workflow_started("wf", "default");
     rec.record_workflow_completed("wf", "default", 1.0, WorkflowStatus::Failed);
+    rec.record_workflow_history_size("wf", 12);
+    rec.record_workflow_continue_as_new("wf");
     rec.record_activity_completed("act", "default", 0.5, ActivityStatus::Failed);
     rec.record_timer_started(10.0);
     rec.record_queue_depth("default", 0);
@@ -312,6 +355,8 @@ fn noop_metrics_implements_all_catalogue_methods() {
     let rec: Arc<dyn MetricsRecorder> = Arc::new(NoOpMetrics);
     rec.record_workflow_started("wf", "q");
     rec.record_workflow_completed("wf", "q", 1.0, WorkflowStatus::Completed);
+    rec.record_workflow_history_size("wf", 2);
+    rec.record_workflow_continue_as_new("wf");
     rec.record_activity_completed("act", "q", 0.5, ActivityStatus::Completed);
     rec.record_timer_started(5.0);
     rec.record_queue_depth("q", 0);

--- a/autumn-harvest/tests/metrics_integration.rs
+++ b/autumn-harvest/tests/metrics_integration.rs
@@ -371,13 +371,58 @@ fn history_cap_violator<'a>(
     })
 }
 
-// ---------------------------------------------------------------------------
-// Test 1 — workflow.started / workflow.completed / activity.completed
-// ---------------------------------------------------------------------------
+// History-cap regression workflow handlers.
+fn suspended_command_reaches_history_cap<'a>(
+    ctx: &'a WorkflowContext,
+    input: serde_json::Value,
+) -> Pin<Box<dyn std::future::Future<Output = Result<serde_json::Value, String>> + Send + 'a>> {
+    Box::pin(async move {
+        let _: serde_json::Value = ctx
+            .side_effect("near-cap", || serde_json::json!({"counted": true}))
+            .map_err(|error| error.to_string())?;
 
-/// Runs a real workflow (with one activity) end-to-end through the worker and
-/// verifies that `harvest.workflow.started`, `harvest.workflow.duration`, and
-/// `harvest.activity.duration` metrics are emitted with the correct labels.
+        match input.get("kind").and_then(serde_json::Value::as_str) {
+            Some("timer") => {
+                ctx.timer("history-cap-long-timer", 3_600)
+                    .await
+                    .map_err(|error| error.to_string())?;
+            }
+            Some("activity") => {
+                ctx.execute_activity_raw(
+                    "history_cap_never_polled_activity",
+                    serde_json::json!({"blocked": true}),
+                    "unpolled",
+                )
+                .await
+                .map_err(|error| error.to_string())?;
+            }
+            Some("child") => {
+                ctx.spawn_child_workflow_raw(
+                    "history_cap_never_finishing_child",
+                    serde_json::json!({"blocked": true}),
+                )
+                .await
+                .map_err(|error| error.to_string())?;
+            }
+            other => return Err(format!("unknown suspended-command kind: {other:?}")),
+        }
+
+        Ok(serde_json::json!({"unreachable": true}))
+    })
+}
+
+fn history_cap_never_finishing_child<'a>(
+    ctx: &'a WorkflowContext,
+    _input: serde_json::Value,
+) -> Pin<Box<dyn std::future::Future<Output = Result<serde_json::Value, String>> + Send + 'a>> {
+    Box::pin(async move {
+        ctx.timer("child-history-cap-long-timer", 3_600)
+            .await
+            .map_err(|error| error.to_string())?;
+        Ok(serde_json::json!({"unreachable": true}))
+    })
+}
+
 fn parent_with_history_capped_child<'a>(
     ctx: &'a WorkflowContext,
     input: serde_json::Value,
@@ -424,6 +469,13 @@ fn history_cap_local_step<'a>(
     Box::pin(async move { Ok(input) })
 }
 
+// ---------------------------------------------------------------------------
+// Test 1 — workflow.started / workflow.completed / activity.completed
+// ---------------------------------------------------------------------------
+
+/// Runs a real workflow (with one activity) end-to-end through the worker and
+/// verifies that `harvest.workflow.started`, `harvest.workflow.duration`, and
+/// `harvest.activity.duration` metrics are emitted with the correct labels.
 #[allow(clippy::too_many_lines)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn workflow_and_activity_metrics_are_recorded() {
@@ -820,6 +872,175 @@ async fn workflow_hard_cap_moves_offender_to_dlq() {
 /// Inserts a dead-letter entry, starts the worker (which spawns the DLQ
 /// depth sampler), waits for at least one sampler tick, and asserts that
 /// `harvest.dlq.entries` was recorded with depth >= 1.
+#[allow(clippy::too_many_lines)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn suspended_commands_that_reach_hard_cap_move_to_dlq_immediately() {
+    let (database_url, _container) = setup_test_database_url().await;
+    let mut conn = AsyncPgConnection::establish(&database_url)
+        .await
+        .expect("failed to connect");
+
+    let cases = ["timer", "activity", "child"];
+    let mut exec_ids = Vec::new();
+
+    for kind in cases {
+        let exec_id = ExecutionId::new_for_shard(ShardId::new(0));
+        let workflow_input = serde_json::json!({"kind": kind});
+        let workflow_id = format!("suspended-cap-{kind}-{}", Uuid::new_v4());
+
+        diesel::insert_into(harvest_workflow_executions::table)
+            .values(NewWorkflowExecution {
+                id: exec_id.as_uuid(),
+                workflow_name: "suspended_command_reaches_history_cap",
+                workflow_id: &workflow_id,
+                run_id: Uuid::new_v4(),
+                shard_id: 0,
+                input: workflow_input.clone(),
+                parent_id: None,
+                queue_name: "default",
+                execution_timeout: None,
+                memo: None,
+                search_attrs: None,
+                assigned_build_id: None,
+            })
+            .execute(&mut conn)
+            .await
+            .expect("failed to insert workflow execution row");
+
+        store::append_events(
+            &mut conn,
+            exec_id,
+            &[
+                WorkflowEvent::WorkflowStarted {
+                    input: workflow_input.clone(),
+                    timestamp: Utc::now(),
+                },
+                WorkflowEvent::MarkerRecorded {
+                    name: "side_effect:near-cap".into(),
+                    details: serde_json::json!({"counted": true}),
+                },
+            ],
+            0,
+        )
+        .await
+        .expect("append initial history failed");
+
+        let mut enqueue_params =
+            EnqueueParams::new("default", TaskType::Workflow, workflow_input.clone());
+        enqueue_params.workflow_exec_id = Some(exec_id.as_uuid());
+        enqueue_params.scheduled_at = Utc::now() - chrono::Duration::seconds(1);
+        queue_mod::enqueue(&mut conn, &enqueue_params)
+            .await
+            .expect("enqueue failed");
+
+        exec_ids.push((kind, exec_id));
+    }
+
+    let recording = Arc::new(RecordingMetrics::default());
+    let telemetry = Arc::new(
+        TelemetryConfig::builder()
+            .metrics(Arc::clone(&recording) as Arc<dyn MetricsRecorder>)
+            .build(),
+    );
+    let policy = WorkflowHistoryPolicy::default().with_event_hard_cap(3);
+    let registry = Arc::new(HandlerRegistry::with_state_telemetry_and_history_policy(
+        vec![
+            WorkflowInfo {
+                name: "suspended_command_reaches_history_cap",
+                module: "metrics_integration",
+                handler: suspended_command_reaches_history_cap,
+            },
+            WorkflowInfo {
+                name: "history_cap_never_finishing_child",
+                module: "metrics_integration",
+                handler: history_cap_never_finishing_child,
+            },
+        ],
+        vec![ActivityInfo {
+            name: "history_cap_never_polled_activity",
+            module: "metrics_integration",
+            default_retry_policy: None,
+            default_start_to_close: None,
+            default_heartbeat_timeout: None,
+            default_schedule_to_start: None,
+            default_queue: Some("unpolled"),
+            max_concurrent: None,
+            concurrency_key: None,
+            is_local: false,
+            handler: metrics_activity,
+        }],
+        autumn_harvest::context::empty_shared_state(),
+        telemetry,
+        policy,
+    ));
+
+    let worker = build_worker("metrics-worker-suspended-cap", registry);
+    let pool = build_test_pool(&database_url);
+    let runner = Arc::clone(&worker);
+    let pool_for_run = pool.clone();
+    let handle = tokio::spawn(async move {
+        runner.run(&pool_for_run).await;
+    });
+
+    for (_, exec_id) in &exec_ids {
+        wait_for_state(&database_url, *exec_id, "FAILED").await;
+    }
+
+    worker.shutdown();
+    handle.await.expect("worker task should join cleanly");
+
+    let dead_letters = dlq::list_dead_letters(&mut conn, 10)
+        .await
+        .expect("failed to list DLQ rows");
+
+    for (kind, exec_id) in exec_ids {
+        let execution = load_execution(&database_url, exec_id).await;
+        let error = execution.error.expect("hard cap should fail execution");
+        assert!(
+            error.contains("HistoryCapExceeded"),
+            "{kind} execution error should identify hard cap, got: {error}"
+        );
+
+        let history = load_history(&database_url, exec_id).await;
+        assert!(
+            history
+                .events
+                .iter()
+                .any(|event| matches!(event, WorkflowEvent::WorkflowFailed { .. })),
+            "{kind} execution should record terminal failure; got: {:?}",
+            history.events
+        );
+
+        let appended_suspension_event = history.events.iter().any(|event| match kind {
+            "timer" => matches!(event, WorkflowEvent::TimerStarted { .. }),
+            "activity" => matches!(event, WorkflowEvent::ActivityScheduled { .. }),
+            "child" => matches!(event, WorkflowEvent::ChildWorkflowStarted { .. }),
+            _ => false,
+        });
+        assert!(
+            !appended_suspension_event,
+            "{kind} suspension event should not be persisted after the cap is reached; got: {:?}",
+            history.events
+        );
+
+        assert!(
+            dead_letters.iter().any(|row| {
+                row.workflow_exec_id == Some(exec_id.as_uuid())
+                    && row.error.contains("HistoryCapExceeded")
+            }),
+            "{kind} execution should have a typed DLQ row; got: {dead_letters:?}"
+        );
+
+        if kind == "child" {
+            let children = load_child_executions(&database_url, exec_id).await;
+            assert!(
+                children.is_empty(),
+                "child-start command should not create child executions after cap breach; got: {children:?}"
+            );
+        }
+    }
+}
+
 #[allow(clippy::too_many_lines)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn child_hard_cap_dlq_notifies_parent_and_stops_inline_growth() {

--- a/autumn-harvest/tests/metrics_integration.rs
+++ b/autumn-harvest/tests/metrics_integration.rs
@@ -26,12 +26,12 @@ use autumn_harvest::schema::harvest_workflow_executions;
 use autumn_harvest::store;
 use autumn_harvest::telemetry::{
     ActivityStatus, METRIC_ACTIVITY_DURATION, METRIC_DLQ_ENTRIES, METRIC_QUEUE_DEPTH,
-    METRIC_WORKFLOW_DURATION, METRIC_WORKFLOW_STARTED, MetricsRecorder, TelemetryConfig,
-    WorkflowStatus,
+    METRIC_WORKFLOW_CONTINUE_AS_NEW, METRIC_WORKFLOW_DURATION, METRIC_WORKFLOW_HISTORY_SIZE,
+    METRIC_WORKFLOW_STARTED, MetricsRecorder, TelemetryConfig, WorkflowStatus,
 };
 use autumn_harvest::types::{ExecutionId, ShardId};
 use autumn_harvest::worker::{DbPool, HandlerRegistry, Worker, WorkerRuntimeConfig};
-use autumn_harvest::{ActivityContext, WorkflowContext};
+use autumn_harvest::{ActivityContext, WorkflowContext, WorkflowHistoryPolicy};
 use chrono::Utc;
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
@@ -58,9 +58,13 @@ const INIT_SQL: &str = concat!(
     "\n",
     include_str!("../migrations/20260508000000_harvest_external_task_updated_at/up.sql"),
     "\n",
+    include_str!("../migrations/20260506000000_harvest_audit_log/up.sql"),
+    "\n",
     include_str!("../migrations/20260501000000_harvest_workers/up.sql"),
     "\n",
     include_str!("../migrations/20260508010000_harvest_workers_drain_deadline/up.sql"),
+    "\n",
+    include_str!("../migrations/20260509000000_harvest_build_routing/up.sql"),
 );
 
 // ---------------------------------------------------------------------------
@@ -134,6 +138,23 @@ impl MetricsRecorder for RecordingMetrics {
                 ("status", status.as_str().to_owned()),
                 ("workflow", workflow_name.to_owned()),
             ],
+        );
+    }
+
+    fn record_workflow_history_size(&self, workflow_name: &str, event_count: u64) {
+        self.push(
+            METRIC_WORKFLOW_HISTORY_SIZE,
+            vec![
+                ("count", event_count.to_string()),
+                ("workflow.type", workflow_name.to_owned()),
+            ],
+        );
+    }
+
+    fn record_workflow_continue_as_new(&self, workflow_name: &str) {
+        self.push(
+            METRIC_WORKFLOW_CONTINUE_AS_NEW,
+            vec![("workflow.type", workflow_name.to_owned())],
         );
     }
 
@@ -229,6 +250,24 @@ async fn wait_for_completed(database_url: &str, exec_id: ExecutionId) -> Workflo
     .expect("workflow did not reach COMPLETED within timeout")
 }
 
+async fn wait_for_state(
+    database_url: &str,
+    exec_id: ExecutionId,
+    expected: &str,
+) -> WorkflowExecution {
+    tokio::time::timeout(Duration::from_secs(15), async {
+        loop {
+            let ex = load_execution(database_url, exec_id).await;
+            if ex.state == expected {
+                break ex;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("workflow did not reach {expected} within timeout"))
+}
+
 fn build_worker(worker_id: &str, registry: Arc<HandlerRegistry>) -> Arc<Worker> {
     Arc::new(
         Worker::new(
@@ -274,6 +313,37 @@ fn metrics_activity<'a>(
     input: serde_json::Value,
 ) -> Pin<Box<dyn std::future::Future<Output = Result<serde_json::Value, String>> + Send + 'a>> {
     Box::pin(async move { Ok(input) })
+}
+
+fn continue_metric_workflow<'a>(
+    ctx: &'a WorkflowContext,
+    input: serde_json::Value,
+) -> Pin<Box<dyn std::future::Future<Output = Result<serde_json::Value, String>> + Send + 'a>> {
+    Box::pin(async move {
+        if input
+            .get("rotated")
+            .and_then(serde_json::Value::as_bool)
+            .unwrap_or(false)
+        {
+            return Ok(serde_json::json!({"done": true}));
+        }
+
+        ctx.continue_as_new(serde_json::json!({"rotated": true}))
+            .await
+            .map_err(|error| error.to_string())?;
+        Ok(serde_json::Value::Null)
+    })
+}
+
+fn history_cap_violator<'a>(
+    ctx: &'a WorkflowContext,
+    _input: serde_json::Value,
+) -> Pin<Box<dyn std::future::Future<Output = Result<serde_json::Value, String>> + Send + 'a>> {
+    Box::pin(async move {
+        assert_eq!(ctx.history_event_count(), 2);
+        assert!(!ctx.should_continue_as_new());
+        Ok(serde_json::json!({"ignored": true}))
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -405,6 +475,11 @@ async fn workflow_and_activity_metrics_are_recorded() {
     );
 
     assert!(
+        names.contains(&METRIC_WORKFLOW_HISTORY_SIZE),
+        "harvest.workflow.history_size must be emitted; got: {names:?}"
+    );
+
+    assert!(
         names.contains(&METRIC_ACTIVITY_DURATION),
         "harvest.activity.duration must be emitted; got: {names:?}"
     );
@@ -445,6 +520,225 @@ async fn workflow_and_activity_metrics_are_recorded() {
             .contains("status=completed"),
         "workflow.duration label must have status=completed; got: {}",
         wf_duration_emission.labels_debug
+    );
+
+    let history_size_emission = emissions
+        .iter()
+        .find(|e| e.name == METRIC_WORKFLOW_HISTORY_SIZE)
+        .expect("workflow.history_size emission must exist");
+    assert!(
+        history_size_emission
+            .labels_debug
+            .contains("workflow.type=metrics_test_workflow"),
+        "workflow.history_size label must include workflow.type; got: {}",
+        history_size_emission.labels_debug
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn continue_as_new_records_history_size_and_rotation_metrics() {
+    let (database_url, _container) = setup_test_database_url().await;
+    let mut conn = AsyncPgConnection::establish(&database_url)
+        .await
+        .expect("failed to connect");
+
+    let exec_id = ExecutionId::new_for_shard(ShardId::new(0));
+    let workflow_input = serde_json::json!({"rotated": false});
+    let workflow_id = format!("continue-metrics-{}", Uuid::new_v4());
+
+    diesel::insert_into(harvest_workflow_executions::table)
+        .values(NewWorkflowExecution {
+            id: exec_id.as_uuid(),
+            workflow_name: "continue_metric_workflow",
+            workflow_id: &workflow_id,
+            run_id: Uuid::new_v4(),
+            shard_id: 0,
+            input: workflow_input.clone(),
+            parent_id: None,
+            queue_name: "default",
+            execution_timeout: None,
+            memo: None,
+            search_attrs: None,
+            assigned_build_id: None,
+        })
+        .execute(&mut conn)
+        .await
+        .expect("failed to insert workflow execution row");
+
+    store::append_events(
+        &mut conn,
+        exec_id,
+        &[WorkflowEvent::WorkflowStarted {
+            input: workflow_input.clone(),
+            timestamp: Utc::now(),
+        }],
+        0,
+    )
+    .await
+    .expect("append WorkflowStarted failed");
+
+    let mut enqueue_params =
+        EnqueueParams::new("default", TaskType::Workflow, workflow_input.clone());
+    enqueue_params.workflow_exec_id = Some(exec_id.as_uuid());
+    enqueue_params.scheduled_at = Utc::now() - chrono::Duration::seconds(1);
+    queue_mod::enqueue(&mut conn, &enqueue_params)
+        .await
+        .expect("enqueue failed");
+
+    let recording = Arc::new(RecordingMetrics::default());
+    let telemetry = Arc::new(
+        TelemetryConfig::builder()
+            .metrics(Arc::clone(&recording) as Arc<dyn MetricsRecorder>)
+            .build(),
+    );
+    let registry = Arc::new(HandlerRegistry::with_state_and_telemetry(
+        vec![WorkflowInfo {
+            name: "continue_metric_workflow",
+            module: "metrics_integration",
+            handler: continue_metric_workflow,
+        }],
+        vec![],
+        autumn_harvest::context::empty_shared_state(),
+        telemetry,
+    ));
+
+    let worker = build_worker("metrics-worker-can", registry);
+    let pool = build_test_pool(&database_url);
+    let runner = Arc::clone(&worker);
+    let pool_for_run = pool.clone();
+    let handle = tokio::spawn(async move {
+        runner.run(&pool_for_run).await;
+    });
+
+    wait_for_state(&database_url, exec_id, "CONTINUED_AS_NEW").await;
+
+    worker.shutdown();
+    handle.await.expect("worker task should join cleanly");
+
+    let emissions = recording.drain();
+    assert!(
+        emissions
+            .iter()
+            .any(|e| e.name == METRIC_WORKFLOW_CONTINUE_AS_NEW
+                && e.labels_debug
+                    .contains("workflow.type=continue_metric_workflow")),
+        "continue_as_new metric must be emitted once with workflow.type label; got: {emissions:?}"
+    );
+    assert!(
+        emissions
+            .iter()
+            .any(|e| e.name == METRIC_WORKFLOW_HISTORY_SIZE
+                && e.labels_debug
+                    .contains("workflow.type=continue_metric_workflow")),
+        "history_size metric must be emitted for continued-as-new execution; got: {emissions:?}"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn workflow_hard_cap_moves_offender_to_dlq() {
+    let (database_url, _container) = setup_test_database_url().await;
+    let mut conn = AsyncPgConnection::establish(&database_url)
+        .await
+        .expect("failed to connect");
+
+    let exec_id = ExecutionId::new_for_shard(ShardId::new(0));
+    let workflow_input = serde_json::json!({});
+    let workflow_id = format!("hard-cap-{}", Uuid::new_v4());
+
+    diesel::insert_into(harvest_workflow_executions::table)
+        .values(NewWorkflowExecution {
+            id: exec_id.as_uuid(),
+            workflow_name: "history_cap_violator",
+            workflow_id: &workflow_id,
+            run_id: Uuid::new_v4(),
+            shard_id: 0,
+            input: workflow_input.clone(),
+            parent_id: None,
+            queue_name: "default",
+            execution_timeout: None,
+            memo: None,
+            search_attrs: None,
+            assigned_build_id: None,
+        })
+        .execute(&mut conn)
+        .await
+        .expect("failed to insert workflow execution row");
+
+    store::append_events(
+        &mut conn,
+        exec_id,
+        &[
+            WorkflowEvent::WorkflowStarted {
+                input: workflow_input.clone(),
+                timestamp: Utc::now(),
+            },
+            WorkflowEvent::MarkerRecorded {
+                name: "already-large".into(),
+                details: serde_json::json!({}),
+            },
+        ],
+        0,
+    )
+    .await
+    .expect("append initial history failed");
+
+    let mut enqueue_params =
+        EnqueueParams::new("default", TaskType::Workflow, workflow_input.clone());
+    enqueue_params.workflow_exec_id = Some(exec_id.as_uuid());
+    enqueue_params.scheduled_at = Utc::now() - chrono::Duration::seconds(1);
+    queue_mod::enqueue(&mut conn, &enqueue_params)
+        .await
+        .expect("enqueue failed");
+
+    let recording = Arc::new(RecordingMetrics::default());
+    let telemetry = Arc::new(
+        TelemetryConfig::builder()
+            .metrics(Arc::clone(&recording) as Arc<dyn MetricsRecorder>)
+            .build(),
+    );
+    let policy = WorkflowHistoryPolicy::default().with_event_hard_cap(2);
+    let registry = Arc::new(HandlerRegistry::with_state_telemetry_and_history_policy(
+        vec![WorkflowInfo {
+            name: "history_cap_violator",
+            module: "metrics_integration",
+            handler: history_cap_violator,
+        }],
+        vec![],
+        autumn_harvest::context::empty_shared_state(),
+        telemetry,
+        policy,
+    ));
+
+    let worker = build_worker("metrics-worker-hard-cap", registry);
+    let pool = build_test_pool(&database_url);
+    let runner = Arc::clone(&worker);
+    let pool_for_run = pool.clone();
+    let handle = tokio::spawn(async move {
+        runner.run(&pool_for_run).await;
+    });
+
+    let execution = wait_for_state(&database_url, exec_id, "FAILED").await;
+
+    worker.shutdown();
+    handle.await.expect("worker task should join cleanly");
+
+    let error = execution.error.expect("hard cap should fail execution");
+    assert!(
+        error.contains("HistoryCapExceeded"),
+        "execution error should identify hard cap reason, got: {error}"
+    );
+
+    let dead_letters = dlq::list_dead_letters(&mut conn, 10)
+        .await
+        .expect("failed to list DLQ rows");
+    let dlq_row = dead_letters
+        .iter()
+        .find(|row| row.workflow_exec_id == Some(exec_id.as_uuid()))
+        .expect("hard-cap offender must be moved to DLQ");
+    assert!(
+        dlq_row.error.contains("HistoryCapExceeded"),
+        "DLQ reason should identify hard cap, got: {}",
+        dlq_row.error
     );
 }
 

--- a/autumn-harvest/tests/metrics_integration.rs
+++ b/autumn-harvest/tests/metrics_integration.rs
@@ -236,6 +236,31 @@ async fn load_execution(database_url: &str, exec_id: ExecutionId) -> WorkflowExe
         .expect("failed to load execution")
 }
 
+async fn load_history(database_url: &str, exec_id: ExecutionId) -> store::EventHistory {
+    let mut conn = AsyncPgConnection::establish(database_url)
+        .await
+        .expect("failed to connect for history reload");
+    store::load_history(&mut conn, exec_id)
+        .await
+        .expect("failed to load history")
+}
+
+async fn load_child_executions(
+    database_url: &str,
+    parent_exec_id: ExecutionId,
+) -> Vec<WorkflowExecution> {
+    let mut conn = AsyncPgConnection::establish(database_url)
+        .await
+        .expect("failed to connect for child reload");
+    harvest_workflow_executions::table
+        .filter(harvest_workflow_executions::parent_id.eq(Some(parent_exec_id.as_uuid())))
+        .order(harvest_workflow_executions::started_at.asc())
+        .select(WorkflowExecution::as_select())
+        .load(&mut conn)
+        .await
+        .expect("failed to load child executions")
+}
+
 async fn wait_for_completed(database_url: &str, exec_id: ExecutionId) -> WorkflowExecution {
     tokio::time::timeout(Duration::from_secs(15), async {
         loop {
@@ -353,6 +378,52 @@ fn history_cap_violator<'a>(
 /// Runs a real workflow (with one activity) end-to-end through the worker and
 /// verifies that `harvest.workflow.started`, `harvest.workflow.duration`, and
 /// `harvest.activity.duration` metrics are emitted with the correct labels.
+fn parent_with_history_capped_child<'a>(
+    ctx: &'a WorkflowContext,
+    input: serde_json::Value,
+) -> Pin<Box<dyn std::future::Future<Output = Result<serde_json::Value, String>> + Send + 'a>> {
+    Box::pin(async move {
+        ctx.spawn_child_workflow_raw("child_breaches_history_cap_inline", input)
+            .await
+            .map_err(|error| error.to_string())
+    })
+}
+
+fn child_breaches_history_cap_inline<'a>(
+    ctx: &'a WorkflowContext,
+    _input: serde_json::Value,
+) -> Pin<Box<dyn std::future::Future<Output = Result<serde_json::Value, String>> + Send + 'a>> {
+    Box::pin(async move {
+        let _: serde_json::Value = ctx
+            .side_effect("history-cap-marker", || serde_json::json!({"seen": true}))
+            .map_err(|error| error.to_string())?;
+        ctx.execute_local_activity_raw(
+            "history_cap_local_step",
+            serde_json::json!({"step": 1}),
+            None,
+            Some(5),
+        )
+        .await
+        .map_err(|error| error.to_string())?;
+        ctx.execute_local_activity_raw(
+            "history_cap_local_step",
+            serde_json::json!({"step": 2}),
+            None,
+            Some(5),
+        )
+        .await
+        .map_err(|error| error.to_string())?;
+        Ok(serde_json::json!({"unreachable": true}))
+    })
+}
+
+fn history_cap_local_step<'a>(
+    _ctx: &'a ActivityContext,
+    input: serde_json::Value,
+) -> Pin<Box<dyn std::future::Future<Output = Result<serde_json::Value, String>> + Send + 'a>> {
+    Box::pin(async move { Ok(input) })
+}
+
 #[allow(clippy::too_many_lines)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn workflow_and_activity_metrics_are_recorded() {
@@ -749,6 +820,167 @@ async fn workflow_hard_cap_moves_offender_to_dlq() {
 /// Inserts a dead-letter entry, starts the worker (which spawns the DLQ
 /// depth sampler), waits for at least one sampler tick, and asserts that
 /// `harvest.dlq.entries` was recorded with depth >= 1.
+#[allow(clippy::too_many_lines)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn child_hard_cap_dlq_notifies_parent_and_stops_inline_growth() {
+    let (database_url, _container) = setup_test_database_url().await;
+    let mut conn = AsyncPgConnection::establish(&database_url)
+        .await
+        .expect("failed to connect");
+
+    let parent_exec_id = ExecutionId::new_for_shard(ShardId::new(0));
+    let workflow_input = serde_json::json!({});
+    let workflow_id = format!("parent-hard-cap-{}", Uuid::new_v4());
+
+    diesel::insert_into(harvest_workflow_executions::table)
+        .values(NewWorkflowExecution {
+            id: parent_exec_id.as_uuid(),
+            workflow_name: "parent_with_history_capped_child",
+            workflow_id: &workflow_id,
+            run_id: Uuid::new_v4(),
+            shard_id: 0,
+            input: workflow_input.clone(),
+            parent_id: None,
+            queue_name: "default",
+            execution_timeout: None,
+            memo: None,
+            search_attrs: None,
+            assigned_build_id: None,
+        })
+        .execute(&mut conn)
+        .await
+        .expect("failed to insert parent workflow execution row");
+
+    store::append_events(
+        &mut conn,
+        parent_exec_id,
+        &[WorkflowEvent::WorkflowStarted {
+            input: workflow_input.clone(),
+            timestamp: Utc::now(),
+        }],
+        0,
+    )
+    .await
+    .expect("append parent WorkflowStarted failed");
+
+    let mut enqueue_params =
+        EnqueueParams::new("default", TaskType::Workflow, workflow_input.clone());
+    enqueue_params.workflow_exec_id = Some(parent_exec_id.as_uuid());
+    enqueue_params.scheduled_at = Utc::now() - chrono::Duration::seconds(1);
+    queue_mod::enqueue(&mut conn, &enqueue_params)
+        .await
+        .expect("enqueue parent failed");
+
+    let recording = Arc::new(RecordingMetrics::default());
+    let telemetry = Arc::new(
+        TelemetryConfig::builder()
+            .metrics(Arc::clone(&recording) as Arc<dyn MetricsRecorder>)
+            .build(),
+    );
+    let policy = WorkflowHistoryPolicy::default().with_event_hard_cap(4);
+    let registry = Arc::new(HandlerRegistry::with_state_telemetry_and_history_policy(
+        vec![
+            WorkflowInfo {
+                name: "parent_with_history_capped_child",
+                module: "metrics_integration",
+                handler: parent_with_history_capped_child,
+            },
+            WorkflowInfo {
+                name: "child_breaches_history_cap_inline",
+                module: "metrics_integration",
+                handler: child_breaches_history_cap_inline,
+            },
+        ],
+        vec![ActivityInfo {
+            name: "history_cap_local_step",
+            module: "metrics_integration",
+            default_retry_policy: None,
+            default_start_to_close: Some(Duration::from_secs(5)),
+            default_heartbeat_timeout: None,
+            default_schedule_to_start: None,
+            default_queue: None,
+            max_concurrent: None,
+            concurrency_key: None,
+            is_local: true,
+            handler: history_cap_local_step,
+        }],
+        autumn_harvest::context::empty_shared_state(),
+        telemetry,
+        policy,
+    ));
+
+    let worker = build_worker("metrics-worker-child-hard-cap", registry);
+    let pool = build_test_pool(&database_url);
+    let runner = Arc::clone(&worker);
+    let pool_for_run = pool.clone();
+    let handle = tokio::spawn(async move {
+        runner.run(&pool_for_run).await;
+    });
+
+    let parent_execution = wait_for_state(&database_url, parent_exec_id, "FAILED").await;
+
+    worker.shutdown();
+    handle.await.expect("worker task should join cleanly");
+
+    let parent_error = parent_execution
+        .error
+        .expect("parent should fail with child hard-cap reason");
+    assert!(
+        parent_error.contains("HistoryCapExceeded"),
+        "parent error should include child hard-cap reason, got: {parent_error}"
+    );
+    assert!(
+        parent_error.contains("child_breaches_history_cap_inline"),
+        "parent should fail from the child failure event, not its own hard cap; got: {parent_error}"
+    );
+
+    let parent_history = load_history(&database_url, parent_exec_id).await;
+    assert!(
+        parent_history
+            .events
+            .iter()
+            .any(|event| matches!(event, WorkflowEvent::ChildWorkflowFailed { .. })),
+        "parent history should include ChildWorkflowFailed; got: {:?}",
+        parent_history.events
+    );
+
+    let child_executions = load_child_executions(&database_url, parent_exec_id).await;
+    assert_eq!(child_executions.len(), 1);
+    let child_exec_id = ExecutionId::from_uuid(child_executions[0].id);
+    assert_eq!(child_executions[0].state, "FAILED");
+    assert!(
+        child_executions[0]
+            .error
+            .as_deref()
+            .is_some_and(|error| error.contains("HistoryCapExceeded")),
+        "child error should identify hard-cap reason: {:?}",
+        child_executions[0].error
+    );
+
+    let child_history = load_history(&database_url, child_exec_id).await;
+    let completed_local_activities = child_history
+        .events
+        .iter()
+        .filter(|event| matches!(event, WorkflowEvent::LocalActivityCompleted { .. }))
+        .count();
+    assert_eq!(
+        completed_local_activities, 1,
+        "hard cap should stop inline local-activity growth after the first local activity; got {:?}",
+        child_history.events
+    );
+
+    let dead_letters = dlq::list_dead_letters(&mut conn, 10)
+        .await
+        .expect("failed to list DLQ rows");
+    assert!(
+        dead_letters.iter().any(|row| {
+            row.workflow_exec_id == Some(child_exec_id.as_uuid())
+                && row.error.contains("HistoryCapExceeded")
+        }),
+        "capped child should have a typed DLQ row; got: {dead_letters:?}"
+    );
+}
+
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn dlq_depth_sampler_emits_dlq_entries_metric() {
     let (database_url, _container) = setup_test_database_url().await;

--- a/autumn-harvest/tests/metrics_integration.rs
+++ b/autumn-harvest/tests/metrics_integration.rs
@@ -31,7 +31,7 @@ use autumn_harvest::telemetry::{
 };
 use autumn_harvest::types::{ExecutionId, ShardId};
 use autumn_harvest::worker::{DbPool, HandlerRegistry, Worker, WorkerRuntimeConfig};
-use autumn_harvest::{ActivityContext, WorkflowContext, WorkflowHistoryPolicy};
+use autumn_harvest::{ActivityContext, RetryPolicy, WorkflowContext, WorkflowHistoryPolicy};
 use chrono::Utc;
 use diesel::prelude::*;
 use diesel_async::RunQueryDsl;
@@ -421,6 +421,38 @@ fn history_cap_never_finishing_child<'a>(
             .map_err(|error| error.to_string())?;
         Ok(serde_json::json!({"unreachable": true}))
     })
+}
+
+fn local_activity_retry_reaches_history_cap<'a>(
+    ctx: &'a WorkflowContext,
+    _input: serde_json::Value,
+) -> Pin<Box<dyn std::future::Future<Output = Result<serde_json::Value, String>> + Send + 'a>> {
+    Box::pin(async move {
+        let _: serde_json::Value = ctx
+            .side_effect(
+                "near-cap-local-retry",
+                || serde_json::json!({"counted": true}),
+            )
+            .map_err(|error| error.to_string())?;
+
+        ctx.execute_local_activity_raw(
+            "history_cap_always_failing_local",
+            serde_json::json!({"blocked": true}),
+            Some(RetryPolicy::fixed(5, Duration::ZERO)),
+            Some(5),
+        )
+        .await
+        .map_err(|error| error.to_string())?;
+
+        Ok(serde_json::json!({"unreachable": true}))
+    })
+}
+
+fn history_cap_always_failing_local<'a>(
+    _ctx: &'a ActivityContext,
+    _input: serde_json::Value,
+) -> Pin<Box<dyn std::future::Future<Output = Result<serde_json::Value, String>> + Send + 'a>> {
+    Box::pin(async move { Err("intentional local failure".into()) })
 }
 
 fn parent_with_history_capped_child<'a>(
@@ -1039,6 +1071,145 @@ async fn suspended_commands_that_reach_hard_cap_move_to_dlq_immediately() {
             );
         }
     }
+}
+
+#[allow(clippy::too_many_lines)]
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn local_activity_retries_stop_when_hard_cap_is_reached() {
+    let (database_url, _container) = setup_test_database_url().await;
+    let mut conn = AsyncPgConnection::establish(&database_url)
+        .await
+        .expect("failed to connect");
+
+    let exec_id = ExecutionId::new_for_shard(ShardId::new(0));
+    let workflow_input = serde_json::json!({});
+    let workflow_id = format!("local-retry-cap-{}", Uuid::new_v4());
+
+    diesel::insert_into(harvest_workflow_executions::table)
+        .values(NewWorkflowExecution {
+            id: exec_id.as_uuid(),
+            workflow_name: "local_activity_retry_reaches_history_cap",
+            workflow_id: &workflow_id,
+            run_id: Uuid::new_v4(),
+            shard_id: 0,
+            input: workflow_input.clone(),
+            parent_id: None,
+            queue_name: "default",
+            execution_timeout: None,
+            memo: None,
+            search_attrs: None,
+            assigned_build_id: None,
+        })
+        .execute(&mut conn)
+        .await
+        .expect("failed to insert workflow execution row");
+
+    store::append_events(
+        &mut conn,
+        exec_id,
+        &[
+            WorkflowEvent::WorkflowStarted {
+                input: workflow_input.clone(),
+                timestamp: Utc::now(),
+            },
+            WorkflowEvent::MarkerRecorded {
+                name: "side_effect:near-cap-local-retry".into(),
+                details: serde_json::json!({"counted": true}),
+            },
+        ],
+        0,
+    )
+    .await
+    .expect("append initial history failed");
+
+    let mut enqueue_params =
+        EnqueueParams::new("default", TaskType::Workflow, workflow_input.clone());
+    enqueue_params.workflow_exec_id = Some(exec_id.as_uuid());
+    enqueue_params.scheduled_at = Utc::now() - chrono::Duration::seconds(1);
+    queue_mod::enqueue(&mut conn, &enqueue_params)
+        .await
+        .expect("enqueue failed");
+
+    let recording = Arc::new(RecordingMetrics::default());
+    let telemetry = Arc::new(
+        TelemetryConfig::builder()
+            .metrics(Arc::clone(&recording) as Arc<dyn MetricsRecorder>)
+            .build(),
+    );
+    let policy = WorkflowHistoryPolicy::default().with_event_hard_cap(4);
+    let registry = Arc::new(HandlerRegistry::with_state_telemetry_and_history_policy(
+        vec![WorkflowInfo {
+            name: "local_activity_retry_reaches_history_cap",
+            module: "metrics_integration",
+            handler: local_activity_retry_reaches_history_cap,
+        }],
+        vec![ActivityInfo {
+            name: "history_cap_always_failing_local",
+            module: "metrics_integration",
+            default_retry_policy: None,
+            default_start_to_close: Some(Duration::from_secs(5)),
+            default_heartbeat_timeout: None,
+            default_schedule_to_start: None,
+            default_queue: None,
+            max_concurrent: None,
+            concurrency_key: None,
+            is_local: true,
+            handler: history_cap_always_failing_local,
+        }],
+        autumn_harvest::context::empty_shared_state(),
+        telemetry,
+        policy,
+    ));
+
+    let worker = build_worker("metrics-worker-local-retry-cap", registry);
+    let pool = build_test_pool(&database_url);
+    let runner = Arc::clone(&worker);
+    let pool_for_run = pool.clone();
+    let handle = tokio::spawn(async move {
+        runner.run(&pool_for_run).await;
+    });
+
+    let execution = wait_for_state(&database_url, exec_id, "FAILED").await;
+
+    worker.shutdown();
+    handle.await.expect("worker task should join cleanly");
+
+    let error = execution.error.expect("hard cap should fail execution");
+    assert!(
+        error.contains("HistoryCapExceeded"),
+        "execution error should identify hard cap reason, got: {error}"
+    );
+
+    let history = load_history(&database_url, exec_id).await;
+    let failed_local_attempts = history
+        .events
+        .iter()
+        .filter(|event| matches!(event, WorkflowEvent::LocalActivityFailed { .. }))
+        .count();
+    assert_eq!(
+        failed_local_attempts, 1,
+        "hard cap should stop before running local activity retry attempts; got {:?}",
+        history.events
+    );
+    assert!(
+        !history
+            .events
+            .iter()
+            .any(|event| matches!(event, WorkflowEvent::LocalActivityExhausted { .. })),
+        "hard cap should preempt local activity retry exhaustion; got {:?}",
+        history.events
+    );
+
+    let dead_letters = dlq::list_dead_letters(&mut conn, 10)
+        .await
+        .expect("failed to list DLQ rows");
+    assert!(
+        dead_letters.iter().any(|row| {
+            row.workflow_exec_id == Some(exec_id.as_uuid())
+                && row.error.contains("HistoryCapExceeded")
+        }),
+        "workflow should have a typed DLQ row; got: {dead_letters:?}"
+    );
 }
 
 #[allow(clippy::too_many_lines)]


### PR DESCRIPTION
  - add replay-safe history_event_count and should_continue_as_new helpers
  - wire soft threshold and opt-in hard cap through HarvestBuilder
  - emit history_size and continue_as_new metrics with workflow.type labels
  - move hard-cap offenders to DLQ with HistoryCapExceeded reason
  - document long-running workflow pattern and add compile-checked example

  Refs #22