### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/autumn-harvest-cli/src/tui.rs
+++ b/autumn-harvest-cli/src/tui.rs
@@ -1,3 +1,5 @@
+//! Text-based user interface (TUI) built with ratatui for visualizing workflow state.
+
 use std::io;
 use std::time::Duration;
 

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -338,7 +338,7 @@ impl HarvestApiState {
             .expect("harvest api state lock poisoned") = required;
     }
 
-    /// Returns `Some(days)` only when explicitly set via [`set_audit_retention_days`];
+    /// Returns `Some(days)` only when explicitly set via [`HarvestApiState::set_audit_retention_days`];
     /// `None` means "use the builder's retention config unchanged".
     pub(crate) fn audit_retention_days(&self) -> Option<i64> {
         *self

--- a/autumn-harvest-plugin/src/config.rs
+++ b/autumn-harvest-plugin/src/config.rs
@@ -1,3 +1,5 @@
+//! Configuration management for the Harvest plugin (embedded, split, or external modes).
+
 use std::path::{Path, PathBuf};
 
 use autumn_web::config::{ConfigError, DatabaseConfig, Env, OsEnv};

--- a/autumn-harvest-plugin/src/outbox.rs
+++ b/autumn-harvest-plugin/src/outbox.rs
@@ -1,3 +1,5 @@
+//! Transactional outbox implementation for reliable workflow event emission.
+
 use std::time::Duration;
 
 use autumn_web::AppState;

--- a/autumn-harvest-plugin/src/state.rs
+++ b/autumn-harvest-plugin/src/state.rs
@@ -1,3 +1,5 @@
+//! Global shared state and database pools used by the Harvest plugin.
+
 use std::ops::Deref;
 
 use autumn_harvest::shard::ShardedDbPool;

--- a/autumn-harvest-redis/src/redis_queue.rs
+++ b/autumn-harvest-redis/src/redis_queue.rs
@@ -18,7 +18,7 @@
 //!   the stream directly. Instead the stable `task_id` is added to a per-queue
 //!   sorted set (`{prefix}:scheduled:{name}`) with score = unix milliseconds,
 //!   and the envelope payload is stored alongside in a hash
-//!   (`{prefix}:scheduled:{name}:payloads`). A periodic [`promote_due`] call
+//!   (`{prefix}:scheduled:{name}:payloads`). A periodic [`RedisTaskQueue::promote_due`] call
 //!   moves due entries onto the stream atomically via a small Lua script.
 //! - **Visibility timeout**: enforced by [`RedisTaskQueue::recover_pending`],
 //!   which calls XPENDING on each queue and XCLAIMs entries that have been

--- a/autumn-harvest/src/audit.rs
+++ b/autumn-harvest/src/audit.rs
@@ -32,24 +32,43 @@ use crate::schema::harvest_audit_log;
 
 // ── Operation name constants ──────────────────────────────────────────────────
 
+/// Audit operation: Started a new workflow execution.
 pub const OP_WORKFLOW_START: &str = "workflow.start";
+/// Audit operation: Signaled a running workflow execution.
 pub const OP_WORKFLOW_SIGNAL: &str = "workflow.signal";
+/// Audit operation: Cancelled a workflow execution.
 pub const OP_WORKFLOW_CANCEL: &str = "workflow.cancel";
+/// Audit operation: Reset a workflow execution to a previous state.
 pub const OP_WORKFLOW_RESET: &str = "workflow.reset";
+/// Audit operation: Manually triggered a DAG execution.
 pub const OP_DAG_TRIGGER: &str = "dag.trigger";
+/// Audit operation: Applied a hot-patch to an active DAG.
 pub const OP_DAG_PATCH: &str = "dag.patch";
+/// Audit operation: Created a new workflow schedule.
 pub const OP_SCHEDULE_CREATE: &str = "schedule.create";
+/// Audit operation: Paused an active workflow schedule.
 pub const OP_SCHEDULE_PAUSE: &str = "schedule.pause";
+/// Audit operation: Resumed a paused workflow schedule.
 pub const OP_SCHEDULE_RESUME: &str = "schedule.resume";
+/// Audit operation: Deleted a workflow schedule.
 pub const OP_SCHEDULE_DELETE: &str = "schedule.delete";
+/// Audit operation: Triggered a backfill for a workflow schedule.
 pub const OP_SCHEDULE_BACKFILL: &str = "schedule.backfill";
+/// Audit operation: Replayed a dead-letter queue (DLQ) task.
 pub const OP_DLQ_REPLAY: &str = "dlq.replay";
+/// Audit operation: Bulk-replayed dead-letter queue (DLQ) tasks.
 pub const OP_DLQ_REPLAY_BULK: &str = "dlq.replay.bulk";
+/// Audit operation: Bulk-discarded dead-letter queue (DLQ) tasks.
 pub const OP_DLQ_DISCARD_BULK: &str = "dlq.discard.bulk";
+/// Audit operation: Submitted a batch processing job.
 pub const OP_BATCH_SUBMIT: &str = "batch.submit";
+/// Audit operation: Triggered a retention sweep manually.
 pub const OP_RETENTION_RUN_NOW: &str = "retention.run_now";
+/// Audit operation: Completed an external activity.
 pub const OP_EXTERNAL_ACTIVITY_COMPLETE: &str = "external_activity.complete";
+/// Audit operation: Failed an external activity.
 pub const OP_EXTERNAL_ACTIVITY_FAIL: &str = "external_activity.fail";
+/// Audit operation: Initiated draining of a worker fleet.
 pub const OP_WORKER_DRAIN: &str = "worker.drain";
 
 // ── Target type constants ─────────────────────────────────────────────────────

--- a/autumn-harvest/src/build_routing.rs
+++ b/autumn-harvest/src/build_routing.rs
@@ -43,7 +43,7 @@ use crate::error::{HarvestResult, database_error};
 /// Pure in-memory representation of the declared build compatibility graph.
 ///
 /// Built from `harvest_build_compat` rows via [`load_compat_set`]. Workers
-/// call [`is_eligible`] once per task-claim cycle; the struct is cheap to
+/// call [`BuildCompatibilitySet::is_eligible`] once per task-claim cycle; the struct is cheap to
 /// clone and can be refreshed periodically without holding a DB connection.
 ///
 /// ## Eligibility rule

--- a/autumn-harvest/src/diagnostic.rs
+++ b/autumn-harvest/src/diagnostic.rs
@@ -1,3 +1,5 @@
+//! Diagnostic reporting for simulated workflow executions.
+
 use crate::analyzer::{AnalyzerWarning, HistoryAnalyzer};
 use crate::history_export::export_mermaid_sequence;
 use crate::simulator::SimulatorResult;


### PR DESCRIPTION
📖 Chapter: Fixed broken intra-doc links in build routing, redis queue, and plugin API modules. Documented missing modules across the workspace (`diagnostic`, `config`, `outbox`, `state`, `tui`) and audit log constants.
🔦 Insight: Resolved linking errors that prevented cargo doc from building cleanly. Added missing module-level overviews to help developers navigate the codebase without opening every file. Explained the purpose of audit operation constants.
🧪 Example: Verified via `cargo doc --no-deps` that links resolve cleanly.
🖼️ Preview: (None)

---
*PR created automatically by Jules for task [14828633530351915122](https://jules.google.com/task/14828633530351915122) started by @madmax983*