### PR TITLE
🔒 Warden: Prevent silent integer overflow on event IDs

### DIFF
--- a/autumn-harvest/src/reset.rs
+++ b/autumn-harvest/src/reset.rs
@@ -496,7 +496,11 @@ pub async fn reset_workflow_execution(
             let plan = validate_reset_point(&events, request.reset_to_event_id)?;
 
             let new_exec_id = ExecutionId::new_for_shard(ShardId::new(source.shard_id));
-            let source_next_event_id = rows.last().map_or(0, |row| row.event_id.saturating_add(1));
+            let source_next_event_id = rows.last().map_or(Ok(0), |row| {
+                row.event_id.checked_add(1).ok_or_else(|| {
+                    crate::error::HarvestError::Database("Event ID overflow".to_string())
+                })
+            })?;
 
             terminate_source_execution(conn, exec_id, new_exec_id, &request, source_next_event_id)
                 .await?;

--- a/autumn-harvest/src/store.rs
+++ b/autumn-harvest/src/store.rs
@@ -220,7 +220,10 @@ pub async fn append_single_event(
         .await
         .map_err(crate::error::database_error)?;
 
-    let next_id = max_id.map_or(0, |id| id.saturating_add(1));
+    let next_id = max_id.map_or(Ok(0), |id| {
+        id.checked_add(1)
+            .ok_or_else(|| crate::error::HarvestError::Database("Event ID overflow".to_string()))
+    })?;
     append_events(conn, exec_id, &[event], next_id).await?;
     Ok(())
 }
@@ -284,7 +287,11 @@ pub async fn admit_update_event(
                 .await
                 .map_err(crate::error::database_error)?;
 
-            let next_id = max_id.map_or(0, |id| id.saturating_add(1));
+            let next_id = max_id.map_or(Ok(0), |id| {
+                id.checked_add(1).ok_or_else(|| {
+                    crate::error::HarvestError::Database("Event ID overflow".to_string())
+                })
+            })?;
             let event = WorkflowEvent::UpdateAdmitted {
                 update_id,
                 name,
@@ -337,7 +344,11 @@ pub async fn load_history_with_codecs(
         .await
         .map_err(crate::error::database_error)?;
 
-    let next_event_id = rows.last().map_or(0, |r| r.event_id.saturating_add(1));
+    let next_event_id = rows.last().map_or(Ok(0), |r| {
+        r.event_id
+            .checked_add(1)
+            .ok_or_else(|| crate::error::HarvestError::Database("Event ID overflow".to_string()))
+    })?;
 
     let events = rows
         .into_iter()

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -712,8 +712,12 @@ async fn run_local_activity_inline(
     }
     if !prefix_events.is_empty() {
         store::append_events(conn, exec_id, &prefix_events, *next_event_id).await?;
-        *next_event_id += i32::try_from(prefix_events.len())
-            .map_err(|_| HarvestError::Config("event count overflow".into()))?;
+        *next_event_id = next_event_id
+            .checked_add(
+                i32::try_from(prefix_events.len())
+                    .map_err(|_| HarvestError::Config("event count overflow".into()))?,
+            )
+            .ok_or_else(|| HarvestError::Database("Event ID overflow".to_string()))?;
     }
 
     let mut all_new_events = prefix_events;
@@ -775,7 +779,9 @@ async fn run_local_activity_inline(
                     *next_event_id,
                 )
                 .await?;
-                *next_event_id += 1;
+                *next_event_id = next_event_id
+                    .checked_add(1)
+                    .ok_or_else(|| HarvestError::Database("Event ID overflow".to_string()))?;
                 all_new_events.push(completed_event);
                 if let Some(event_count) =
                     local_activity_history_cap_reached(*next_event_id, history_event_hard_cap)
@@ -806,7 +812,9 @@ async fn run_local_activity_inline(
                             *next_event_id,
                         )
                         .await?;
-                        *next_event_id += 1;
+                        *next_event_id = next_event_id.checked_add(1).ok_or_else(|| {
+                            HarvestError::Database("Event ID overflow".to_string())
+                        })?;
                         all_new_events.push(failed_event);
                         let event_count = u64::try_from(*next_event_id).unwrap_or(u64::MAX);
                         return Ok(LocalActivityInlineOutcome::HistoryCapReached {
@@ -826,8 +834,12 @@ async fn run_local_activity_inline(
                     };
                     let terminal_pair = [failed_event, exhausted_event];
                     store::append_events(conn, exec_id, &terminal_pair, *next_event_id).await?;
-                    *next_event_id += i32::try_from(terminal_pair.len())
-                        .map_err(|_| HarvestError::Config("event count overflow".into()))?;
+                    *next_event_id = next_event_id
+                        .checked_add(
+                            i32::try_from(terminal_pair.len())
+                                .map_err(|_| HarvestError::Config("event count overflow".into()))?,
+                        )
+                        .ok_or_else(|| HarvestError::Database("Event ID overflow".to_string()))?;
                     all_new_events.extend(terminal_pair);
                     if let Some(event_count) =
                         local_activity_history_cap_reached(*next_event_id, history_event_hard_cap)
@@ -845,7 +857,9 @@ async fn run_local_activity_inline(
                         *next_event_id,
                     )
                     .await?;
-                    *next_event_id += 1;
+                    *next_event_id = next_event_id
+                        .checked_add(1)
+                        .ok_or_else(|| HarvestError::Database("Event ID overflow".to_string()))?;
                     all_new_events.push(failed_event);
                     if let Some(event_count) =
                         local_activity_history_cap_reached(*next_event_id, history_event_hard_cap)

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,7 @@
+1. **Threat**: The `worker.rs` and other files currently use `saturating_add` or standard operators (`+=`) to calculate new event IDs or lengths. For example, `next_event_id += i32::try_from(prefix_events.len())`, or `rows.last().map_or(0, |row| row.event_id.saturating_add(1))`. If there's integer overflow/collison on database IDs or event counters, using `saturating_add` can silently hide the integer overflow, leading to corrupted logic or data collisions when the max integer value is saturated instead of appropriately failing out with a database error.
+2. **Defense**: Replace these calculations with `checked_add` and return an appropriate database error `HarvestError::Database("Event ID overflow".to_string())` when integer overflow occurs. This avoids the silent overflow and enforces data integrity correctly.
+3. **Execution Plan**:
+   - Refactor `autumn-harvest/src/worker.rs` to use `checked_add` instead of `+=`.
+   - Refactor `autumn-harvest/src/store.rs` to use `checked_add` instead of `saturating_add`.
+   - Refactor `autumn-harvest/src/reset.rs` to use `checked_add` instead of `saturating_add`.
+4. **Verification**: Run `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test`, and `cargo fmt --all` to make sure changes build and pass.


### PR DESCRIPTION
* 🦠 Threat: Event IDs and database counters use `saturating_add` and `+=`, which can silently hide integer overflows and cause data corruption or collisions instead of safely failing.
* 🛡️ Defense: Replaced `saturating_add` and `+=` with `checked_add`, returning `HarvestError::Database` upon overflow.
* 💥 Severity: High - Silent data corruption or database collisions on long-running workflows.
* 🧪 Verification: Verified changes with `cargo clippy`, `cargo test`, and `cargo fmt`.

---
*PR created automatically by Jules for task [10212722406320237894](https://jules.google.com/task/10212722406320237894) started by @madmax983*