### PR TITLE
⚡ Bolt: Remove intermediate vector allocation in suspended_workflow_error

### DIFF
--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -317,11 +317,18 @@ fn suspended_workflow_error(commands: &[WorkflowCommand]) -> String {
             .to_string();
     }
 
-    let command_names = commands
-        .iter()
-        .map(workflow_command_name)
-        .collect::<Vec<_>>()
-        .join(", ");
+    // ⚡ Bolt: Remove intermediate vector allocation when formatting command names
+    let command_names =
+        commands
+            .iter()
+            .map(workflow_command_name)
+            .fold(String::new(), |mut acc, name| {
+                if !acc.is_empty() {
+                    acc.push_str(", ");
+                }
+                acc.push_str(name);
+                acc
+            });
     format!(
         "workflow task suspended with unsupported commands ({command_names}); this command set is not implemented yet"
     )


### PR DESCRIPTION
💡 What: Replaced `.collect::<Vec<_>>().join(", ")` with a single `.fold` pass when building comma-separated error strings.
🎯 Why: The original code collected an intermediate heap allocation (`Vec<&str>`) before immediately joining it into a `String`. 
📊 Impact: Reduces heap allocations by 1 per suspended workflow error formatting.
🔬 Measurement: Run `cargo test` to verify behavior remains exactly the same.

---
*PR created automatically by Jules for task [14903401655663267333](https://jules.google.com/task/14903401655663267333) started by @madmax983*