### PR TITLE
🔒 Warden: Prevent integer overflow in event IDs

### DIFF
--- a/autumn-harvest/src/reset.rs
+++ b/autumn-harvest/src/reset.rs
@@ -496,7 +496,11 @@ pub async fn reset_workflow_execution(
             let plan = validate_reset_point(&events, request.reset_to_event_id)?;
 
             let new_exec_id = ExecutionId::new_for_shard(ShardId::new(source.shard_id));
-            let source_next_event_id = rows.last().map_or(0, |row| row.event_id.saturating_add(1));
+            let source_next_event_id = rows.last().map_or(Ok(0), |row| {
+                row.event_id.checked_add(1).ok_or_else(|| {
+                    crate::error::HarvestError::Database("Event ID overflow".to_string())
+                })
+            })?;
 
             terminate_source_execution(conn, exec_id, new_exec_id, &request, source_next_event_id)
                 .await?;

--- a/autumn-harvest/src/store.rs
+++ b/autumn-harvest/src/store.rs
@@ -220,7 +220,10 @@ pub async fn append_single_event(
         .await
         .map_err(crate::error::database_error)?;
 
-    let next_id = max_id.map_or(0, |id| id.saturating_add(1));
+    let next_id = max_id.map_or(Ok(0), |id| {
+        id.checked_add(1)
+            .ok_or_else(|| crate::error::HarvestError::Database("Event ID overflow".to_string()))
+    })?;
     append_events(conn, exec_id, &[event], next_id).await?;
     Ok(())
 }
@@ -284,7 +287,11 @@ pub async fn admit_update_event(
                 .await
                 .map_err(crate::error::database_error)?;
 
-            let next_id = max_id.map_or(0, |id| id.saturating_add(1));
+            let next_id = max_id.map_or(Ok(0), |id| {
+                id.checked_add(1).ok_or_else(|| {
+                    crate::error::HarvestError::Database("Event ID overflow".to_string())
+                })
+            })?;
             let event = WorkflowEvent::UpdateAdmitted {
                 update_id,
                 name,
@@ -337,7 +344,11 @@ pub async fn load_history_with_codecs(
         .await
         .map_err(crate::error::database_error)?;
 
-    let next_event_id = rows.last().map_or(0, |r| r.event_id.saturating_add(1));
+    let next_event_id = rows.last().map_or(Ok(0), |r| {
+        r.event_id
+            .checked_add(1)
+            .ok_or_else(|| crate::error::HarvestError::Database("Event ID overflow".to_string()))
+    })?;
 
     let events = rows
         .into_iter()
@@ -519,6 +530,31 @@ mod tests {
     use crate::event::WorkflowEvent;
     use crate::types::{ActivityExecId, ExecutionId};
     use chrono::Utc;
+
+    #[test]
+    fn event_id_overflow_yields_database_error() {
+        let exec_id = ExecutionId::new();
+        let events = vec![
+            WorkflowEvent::WorkflowStarted {
+                input: serde_json::Value::Null,
+                timestamp: Utc::now(),
+            },
+            WorkflowEvent::ActivityScheduled {
+                activity_id: ActivityExecId::new(),
+                name: "send_email".into(),
+                input: serde_json::Value::Null,
+                queue: "default".into(),
+            },
+        ];
+
+        let err = events_to_insert_rows_from(exec_id, &events, i32::MAX).unwrap_err();
+        match err {
+            crate::error::HarvestError::Database(msg) => {
+                assert!(msg.contains("Event ID overflow"));
+            }
+            _ => panic!("Expected Database error"),
+        }
+    }
 
     #[test]
     fn stored_event_has_sequential_event_id() {


### PR DESCRIPTION
🦠 Threat: Event IDs in `store.rs` and `reset.rs` were advanced using `saturating_add(1)`. If an execution reached `i32::MAX` events, subsequent events would overwrite `i32::MAX`, violating the unique `(workflow_exec_id, event_id)` constraint or silently corrupting event history.
🛡️ Defense: Replaced `saturating_add(1)` with `checked_add(1)`. If `i32::MAX` is reached, it explicitly returns a `HarvestError::Database`, which properly terminates the workflow task execution rather than failing with silent corruption.
💥 Severity: High - Silent data corruption or unexpected worker panics.
🧪 Verification: Added test case simulating event ID overflow when creating insert rows.

---
*PR created automatically by Jules for task [10788669477378177143](https://jules.google.com/task/10788669477378177143) started by @madmax983*