### PR TITLE
🛡️ Sentry: Add FromStr tests for BatchJobStatus and HistoryPayloadPolicy

### DIFF
--- a/autumn-harvest/src/batch.rs
+++ b/autumn-harvest/src/batch.rs
@@ -826,6 +826,26 @@ mod tests {
     }
 
     #[test]
+    fn batch_job_status_round_trips_through_string() {
+        for status in [
+            BatchJobStatus::Pending,
+            BatchJobStatus::Running,
+            BatchJobStatus::Completed,
+            BatchJobStatus::Failed,
+        ] {
+            let s = status.as_str();
+            let parsed: BatchJobStatus = s.parse().expect("known status must parse");
+            assert_eq!(parsed, status);
+        }
+    }
+
+    #[test]
+    fn batch_job_status_rejects_unknown_string() {
+        let err = BatchJobStatus::from_str("Unknown").expect_err("unknown status must fail");
+        assert!(err.contains("unknown batch job status"));
+    }
+
+    #[test]
     fn batch_job_status_terminal_predicate() {
         assert!(!BatchJobStatus::Pending.is_terminal());
         assert!(!BatchJobStatus::Running.is_terminal());

--- a/autumn-harvest/src/history_export.rs
+++ b/autumn-harvest/src/history_export.rs
@@ -705,6 +705,24 @@ mod tests {
     use chrono::Utc;
 
     #[test]
+    fn history_payload_policy_round_trips_through_string() {
+        let full = HistoryPayloadPolicy::from_str("full").expect("full should parse");
+        assert_eq!(full, HistoryPayloadPolicy::Full);
+
+        for s in ["redacted", "summary", "summarized"] {
+            let redacted =
+                HistoryPayloadPolicy::from_str(s).expect("redacted aliases should parse");
+            assert_eq!(redacted, HistoryPayloadPolicy::Redacted);
+        }
+    }
+
+    #[test]
+    fn history_payload_policy_rejects_unknown_string() {
+        let err = HistoryPayloadPolicy::from_str("invalid").expect_err("unknown policy must fail");
+        assert!(err.contains("unknown payload_policy"));
+    }
+
+    #[test]
     fn test_export_mermaid_sequence_empty() {
         let events = vec![];
         let diagram = export_mermaid_sequence(&events).expect("export should succeed");


### PR DESCRIPTION
🎯 Target: autumn-harvest/src/batch.rs and autumn-harvest/src/history_export.rs
💣 Risk: Missing test coverage for string conversions of configuration enumerations can mask regressions if variants are renamed or string mappings change.
🧪 Strategy: Implemented table-driven tests checking `FromStr` trait bounds and `as_str` methods along with invalid string rejection.
🔬 Verification: `cargo test -p autumn-harvest`

---
*PR created automatically by Jules for task [12395483148926180790](https://jules.google.com/task/12395483148926180790) started by @madmax983*