### PR TITLE
fix(security): prevent scheduler workflow-id collision hijacking

### DIFF
--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -769,6 +769,12 @@ async fn start_workflow(
     let workflow_id = request
         .workflow_id
         .unwrap_or_else(|| uuid::Uuid::new_v4().to_string());
+    if is_reserved_scheduler_workflow_id(&workflow_id) {
+        return AutumnError::bad_request_msg(
+            "workflow_id values starting with 'sched:' are reserved for scheduler-managed runs",
+        )
+        .into_response();
+    }
     let queue_name = request
         .queue
         .or_else(|| runtime.queues.as_slice().first().cloned())
@@ -1742,6 +1748,10 @@ fn parse_reuse_policy(raw: Option<&str>) -> Result<WorkflowIdReusePolicy, Autumn
     }
 }
 
+fn is_reserved_scheduler_workflow_id(workflow_id: &str) -> bool {
+    workflow_id.starts_with("sched:")
+}
+
 pub(crate) fn parse_execution_id(raw: &str) -> Result<ExecutionId, AutumnError> {
     raw.parse::<ExecutionId>()
         .map_err(|_| AutumnError::bad_request_msg(format!("invalid execution id '{raw}'")))
@@ -2435,6 +2445,14 @@ mod tests {
             parse_reuse_policy(Some("allow_DUPLICATE")).is_err(),
             "wrong case must not silently fall back"
         );
+    }
+
+    #[test]
+    fn reserved_scheduler_workflow_id_prefix_is_detected() {
+        assert!(is_reserved_scheduler_workflow_id("sched:daily:1777550400"));
+        assert!(!is_reserved_scheduler_workflow_id(
+            "manual:daily:1777550400"
+        ));
     }
 
     // -- Worker filter parsing via API wrapper --

--- a/autumn-harvest/src/scheduler.rs
+++ b/autumn-harvest/src/scheduler.rs
@@ -844,6 +844,18 @@ async fn tick_one_workflow_schedule(
         .await
         {
             Ok(started) => {
+                if !started.created {
+                    tracing::warn!(
+                        workflow_name = %wf_name,
+                        workflow_id = %workflow_id,
+                        execution_id = %started.exec_id,
+                        "harvest: scheduled workflow id collision detected; refusing to advance cursor"
+                    );
+                    return Err(HarvestError::Config(format!(
+                        "scheduled workflow id collision for workflow '{wf_name}' at {scheduled_for}; \
+                         refusing to treat an existing execution as a scheduled dispatch"
+                    )));
+                }
                 dispatched += 1;
                 last_dispatched_at = Some(*scheduled_for);
                 metrics.record_schedule_run("workflow", wf_name);


### PR DESCRIPTION
### Motivation
- Scheduled workflow IDs are deterministic (`sched:{workflow_name}:{timestamp}`) and visible via the management API, making them guessable. 
- The scheduler started scheduled runs using the normal workflow-id namespace with `WorkflowIdReusePolicy::AllowDuplicate`, and treated any `Ok` result as a successful dispatch even when `created == false`, allowing an attacker to pre-create a colliding execution and cause legitimate scheduled runs to be skipped or substituted. 
- Provide a minimal, conservative remediation that prevents namespace abuse and avoids silently advancing schedule cursors while preserving existing non-reserved behavior. 

### Description
- Hardened the scheduler dispatch path so that when `start_or_load_workflow_execution` returns `Ok(started)` with `started.created == false` the scheduler logs a warning and returns an error instead of advancing the schedule cursor, preventing silent substitution of scheduled runs. 
- Reserved the scheduler-owned workflow-id namespace by rejecting public `start_workflow` requests whose `workflow_id` begins with the `sched:` prefix via a new `is_reserved_scheduler_workflow_id` helper. 
- Added a small unit test to assert detection of the reserved `sched:` prefix and kept the change minimal and focused on security fixes without altering scheduling semantics otherwise. 

### Testing
- Ran `cargo fmt` and formatting succeeded. 
- Ran `cargo test -p autumn-harvest-plugin reserved_scheduler_workflow_id_prefix_is_detected` and the added unit test passed. 
- Existing behavior for non-reserved workflow IDs is preserved and no other tests were modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f6ce138264832a862c84dde575fd35)