### PR TITLE
🔒 Warden: [security fix]

### DIFF
--- a/autumn-harvest-cli/src/lib.rs
+++ b/autumn-harvest-cli/src/lib.rs
@@ -2972,7 +2972,7 @@ fn parse_json_source(
 fn read_json_file(path: &Path, label: &'static str) -> Result<String, CliError> {
     if path == Path::new("-") {
         let mut input = String::new();
-        std::io::stdin()
+        std::io::Read::take(std::io::stdin().lock(), 10 * 1024 * 1024)
             .read_to_string(&mut input)
             .map_err(|source| CliError::ReadJson {
                 label,


### PR DESCRIPTION
🦠 Threat: Memory exhaustion (DoS) via unbounded `std::io::stdin().read_to_string`.
🛡️ Defense: Implemented capped reader using `.take(10 * 1024 * 1024)` to restrict maximum read size from stdin to 10MB.
💥 Severity: Medium - malicious or overly large piped data could exhaust memory and crash the CLI tool.
🧪 Verification: Verified by standard test suite and local compilation.

---
*PR created automatically by Jules for task [4929331476682254112](https://jules.google.com/task/4929331476682254112) started by @madmax983*