### PR TITLE
🌟 Nova: Chrome Trace Exporter for DAG Profiles

### DIFF
--- a/autumn-harvest/src/lib.rs
+++ b/autumn-harvest/src/lib.rs
@@ -71,7 +71,7 @@ pub mod dag;
 /// Export format types for Directed Acyclic Graphs (DAGs) representing workflows.
 pub mod dag_export;
 pub mod dag_linter;
-#[cfg(feature = "testing")]
+#[cfg(any(test, feature = "testing"))]
 pub mod dag_profiler;
 #[cfg(any(test, feature = "testing"))]
 pub mod dag_simulator;
@@ -147,6 +147,8 @@ pub mod test_generator;
 pub mod testing;
 /// Workflow-start throttle — pace admissions, defer the excess (issue #607).
 pub mod throttle;
+#[cfg(any(test, feature = "testing"))]
+pub mod trace_export;
 pub mod types;
 pub mod update;
 /// Read-only per-tenant/per-workflow usage aggregation (issue #596).
@@ -243,7 +245,7 @@ pub use dag_linter::{
     DagLinter, DagRule, DagWarning, ExcessiveParallelismRule, MissingRetryPolicyRule,
     MissingTimeoutRule,
 };
-#[cfg(feature = "testing")]
+#[cfg(any(test, feature = "testing"))]
 pub use dag_profiler::{DagProfile, DagProfiler, ProfilerEvent, ProfilerEventKind};
 #[cfg(any(test, feature = "testing"))]
 pub use dag_simulator::{DagSimulator, DagSimulatorResult};
@@ -355,6 +357,8 @@ pub use testing::{
 pub use testing::{
     HistorySnapshot, NonDeterminismKind, ReplayReport, ReplayStatus, WorkflowReplayer,
 };
+#[cfg(any(test, feature = "testing"))]
+pub use trace_export::export_chrome_trace;
 pub use types::{
     ActivityExecId, BuildId, DeploymentName, ExecutionId, ExternalActivityToken, ExternalCancelId,
     ExternalSignalId, ParentClosePolicy, Priority, SessionId, ShardId, TimerId, UpdateId, WorkerId,

--- a/autumn-harvest/src/trace_export.rs
+++ b/autumn-harvest/src/trace_export.rs
@@ -1,0 +1,84 @@
+//! Chrome Trace Event Format exporter for DAG profiles.
+//!
+//! Converts a `DagProfile` into a JSON structure compatible with trace viewers
+//! like `chrome://tracing` or `ui.perfetto.dev`.
+
+use crate::dag_profiler::{DagProfile, ProfilerEventKind};
+use serde_json::{Value, json};
+use std::collections::HashMap;
+
+/// Exports a `DagProfile` to Chrome Trace Event Format.
+///
+/// Converts the simulated DAG timeline into a series of "Complete" (`"ph": "X"`)
+/// trace events. Each task is represented as a span with a start time (`ts`)
+/// and duration (`dur`) in microseconds.
+///
+/// # Returns
+/// A JSON `Value` representing the trace events array.
+#[must_use]
+pub fn export_chrome_trace(profile: &DagProfile) -> Value {
+    let mut events = Vec::new();
+    let mut start_times = HashMap::new();
+
+    for event in &profile.timeline {
+        match &event.kind {
+            ProfilerEventKind::TaskStarted(idx, _) => {
+                start_times.insert(*idx, event.time);
+            }
+            ProfilerEventKind::TaskCompleted(idx, name) => {
+                if let Some(start_time) = start_times.remove(idx) {
+                    let dur = event.time.saturating_sub(start_time);
+                    events.push(json!({
+                        "name": name,
+                        "cat": "dag_task",
+                        "ph": "X",
+                        "ts": u64::try_from(start_time.as_micros()).unwrap_or(u64::MAX),
+                        "dur": u64::try_from(dur.as_micros()).unwrap_or(u64::MAX),
+                        "pid": 1,
+                        "tid": 1,
+                        "args": {
+                            "task_index": idx
+                        }
+                    }));
+                }
+            }
+        }
+    }
+
+    json!(events)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::dag_profiler::{ProfilerEvent, ProfilerEventKind};
+    use std::time::Duration;
+
+    #[test]
+    fn test_export_chrome_trace() {
+        let profile = DagProfile {
+            total_duration: Duration::from_secs(5),
+            peak_concurrency: 1,
+            timeline: vec![
+                ProfilerEvent {
+                    time: Duration::from_secs(1),
+                    kind: ProfilerEventKind::TaskStarted(0, "activity_a".to_string()),
+                },
+                ProfilerEvent {
+                    time: Duration::from_secs(3),
+                    kind: ProfilerEventKind::TaskCompleted(0, "activity_a".to_string()),
+                },
+            ],
+        };
+
+        let trace = export_chrome_trace(&profile);
+        let arr = trace.as_array().expect("Expected JSON array");
+        assert_eq!(arr.len(), 1);
+
+        let event = &arr[0];
+        assert_eq!(event["name"], "activity_a");
+        assert_eq!(event["ph"], "X");
+        assert_eq!(event["ts"], 1_000_000);
+        assert_eq!(event["dur"], 2_000_000);
+    }
+}


### PR DESCRIPTION
💡 **The Spark:** We have an awesome `DagProfiler` that computes timelines and peak concurrency, but we don't have a way to visually inspect the exact overlapping timelines of those tasks in a standard tool.
🚀 **The Feature:** Implemented `export_chrome_trace` in `trace_export.rs` which converts a `DagProfile` timeline into the Chrome Trace Event Format.
🔮 **The Potential:** By exporting the JSON, users can drop the file into `ui.perfetto.dev` or `chrome://tracing` and instantly see a beautiful Gantt chart of their simulated workflow execution. It's an incredible debugging power-up.
⚠️ **Risk:** Low. Additive only, self-contained, and guarded behind testing feature flags.

---
*PR created automatically by Jules for task [16679336001140528047](https://jules.google.com/task/16679336001140528047) started by @madmax983*