### PR TITLE
Add schedules management UI page with pause/resume/delete actions

### DIFF
--- a/autumn-harvest-plugin/src/ui.rs
+++ b/autumn-harvest-plugin/src/ui.rs
@@ -12,9 +12,10 @@ use autumn_web::error::AutumnError;
 use autumn_web::extract::{Path, Query};
 use autumn_web::reexports::axum;
 use axum::Extension;
+use axum::Form;
 use axum::Router;
 use axum::middleware;
-use axum::routing::get;
+use axum::routing::{get, post};
 use chrono::{DateTime, Utc};
 use diesel::dsl::sql;
 use diesel::sql_types::{Bool, Text};
@@ -24,9 +25,17 @@ use maud::{Markup, PreEscaped, html};
 use serde::Deserialize;
 use serde_json::Value;
 
+use autumn_harvest::audit::{
+    OP_SCHEDULE_DELETE, OP_SCHEDULE_PAUSE, OP_SCHEDULE_RESUME, SOURCE_API, STATUS_SUCCEEDED,
+    TARGET_SCHEDULE, insert_audit,
+};
 use autumn_harvest::error::{HarvestError, HarvestResult, database_error};
-use autumn_harvest::models::{DeadLetter, HarvestEvent, WorkflowExecution};
-use autumn_harvest::schema::{harvest_dead_letters, harvest_events, harvest_workflow_executions};
+use autumn_harvest::models::{
+    DeadLetter, HarvestEvent, HarvestSchedule, NewAuditRecord, WorkflowExecution,
+};
+use autumn_harvest::schema::{
+    harvest_dead_letters, harvest_events, harvest_schedules, harvest_workflow_executions,
+};
 use autumn_harvest::store;
 use autumn_harvest::types::ShardId;
 use autumn_harvest::workers::{WorkerFilters, WorkerHealth, WorkerRow, list_workers};
@@ -352,6 +361,12 @@ pub fn harvest_ui_router(api_state: HarvestApiState) -> Router<AppState> {
             "/dead-letters",
             get(list_dead_letters_ui).route_layer(require_admin),
         )
+        .route("/schedules", get(list_schedules_ui))
+        .route("/schedules/bulk-pause", post(schedule_bulk_pause_ui))
+        .route("/schedules/bulk-resume", post(schedule_bulk_resume_ui))
+        .route("/schedules/{id}/pause", post(schedule_pause_ui))
+        .route("/schedules/{id}/resume", post(schedule_resume_ui))
+        .route("/schedules/{id}/delete", post(schedule_delete_ui))
         .layer(Extension(api_state))
 }
 
@@ -1307,17 +1322,18 @@ fn layout_dead_letters(title: &str, body: &Markup, refresh: Option<u64>) -> Mark
             body {
                 header {
                     h1 {
-                        a href="workflows" { "ðŸ”­ Vantage" }
+                        a href="workflows" { "🔭 Vantage" }
                         span.subtitle { "Harvest dashboard" }
                     }
                     nav {
                         a href="workflows" { "Workflows" }
                         a href="workers" { "Workers" }
+                        a href="schedules" { "Schedules" }
                         a.active href="dead-letters" { "Dead Letters" }
                     }
                 }
                 main { (body) }
-                footer { "Operational dashboard â€” autumn-harvest" }
+                footer { "Operational dashboard — autumn-harvest" }
             }
         }
     }
@@ -1588,6 +1604,7 @@ fn layout_workers(title: &str, body: &Markup, refresh: Option<u64>) -> Markup {
                     nav {
                         a href="workflows" { "Workflows" }
                         a.active href="workers" { "Workers" }
+                        a href="schedules" { "Schedules" }
                         a href="dead-letters" { "Dead Letters" }
                     }
                 }
@@ -1932,11 +1949,966 @@ fn layout(title: &str, body: &Markup, base_href: &str) -> Markup {
                     nav {
                         a.active href={ (base_href) "workflows" } { "Workflows" }
                         a href={ (base_href) "workers" } { "Workers" }
+                        a href={ (base_href) "schedules" } { "Schedules" }
                         a href={ (base_href) "dead-letters" } { "Dead Letters" }
                     }
                 }
                 main { (body) }
                 footer { "Read-only dashboard — autumn-harvest" }
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Schedules UI page
+// ---------------------------------------------------------------------------
+
+const DEFAULT_SCHEDULE_PAGE_SIZE: i64 = 50;
+
+type ShardScheduleResult = (ShardId, Result<Vec<HarvestSchedule>, String>);
+
+#[derive(Debug, Deserialize)]
+pub(crate) struct ScheduleListParams {
+    #[serde(default)]
+    page: Option<i64>,
+    #[serde(default)]
+    limit: Option<i64>,
+    #[serde(default)]
+    target: Option<String>,
+    /// "Workflow", "Dag", or empty/absent for All.
+    #[serde(default)]
+    kind: Option<String>,
+    /// "Paused", "Active", or empty/absent for All.
+    #[serde(default)]
+    paused: Option<String>,
+    #[serde(default)]
+    shard_id: Option<i32>,
+    #[serde(default)]
+    refresh: Option<u64>,
+    #[serde(default)]
+    flash: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Default)]
+struct ScheduleBulkParams {
+    #[serde(default)]
+    target: Option<String>,
+    #[serde(default)]
+    kind: Option<String>,
+    #[serde(default)]
+    paused: Option<String>,
+    #[serde(default)]
+    shard_id: Option<i32>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+enum ScheduleKindFilter {
+    #[default]
+    All,
+    Workflow,
+    Dag,
+}
+
+impl ScheduleKindFilter {
+    fn parse(raw: &str) -> Result<Self, AutumnError> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "" => Ok(Self::All),
+            "workflow" => Ok(Self::Workflow),
+            "dag" => Ok(Self::Dag),
+            other => Err(AutumnError::bad_request_msg(format!(
+                "unknown kind '{other}'; expected Workflow, Dag, or empty"
+            ))),
+        }
+    }
+
+    const fn as_label(self) -> &'static str {
+        match self {
+            Self::All => "",
+            Self::Workflow => "Workflow",
+            Self::Dag => "Dag",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+enum SchedulePausedFilter {
+    #[default]
+    All,
+    Paused,
+    Active,
+}
+
+impl SchedulePausedFilter {
+    fn parse(raw: &str) -> Result<Self, AutumnError> {
+        match raw.trim().to_ascii_lowercase().as_str() {
+            "" => Ok(Self::All),
+            "paused" => Ok(Self::Paused),
+            "active" => Ok(Self::Active),
+            other => Err(AutumnError::bad_request_msg(format!(
+                "unknown paused value '{other}'; expected Paused, Active, or empty"
+            ))),
+        }
+    }
+
+    const fn as_label(self) -> &'static str {
+        match self {
+            Self::All => "",
+            Self::Paused => "Paused",
+            Self::Active => "Active",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Default)]
+struct ScheduleUiFilters {
+    target: Option<String>,
+    kind: ScheduleKindFilter,
+    paused: SchedulePausedFilter,
+    shard_id: Option<i32>,
+}
+
+impl ScheduleUiFilters {
+    fn matches(&self, shard_id: ShardId, row: &HarvestSchedule) -> bool {
+        let name = row
+            .workflow_name
+            .as_deref()
+            .or(row.dag_name.as_deref())
+            .unwrap_or("");
+
+        if self.target.as_deref().is_some_and(|t| !name.contains(t)) {
+            return false;
+        }
+        match self.kind {
+            ScheduleKindFilter::Workflow if row.workflow_name.is_none() => return false,
+            ScheduleKindFilter::Dag if row.dag_name.is_none() => return false,
+            _ => {}
+        }
+        match self.paused {
+            SchedulePausedFilter::Paused if !row.is_paused => return false,
+            SchedulePausedFilter::Active if row.is_paused => return false,
+            _ => {}
+        }
+        if self.shard_id.is_some_and(|sid| shard_id.as_i32() != sid) {
+            return false;
+        }
+        true
+    }
+
+    const fn is_empty(&self) -> bool {
+        self.target.is_none()
+            && matches!(self.kind, ScheduleKindFilter::All)
+            && matches!(self.paused, SchedulePausedFilter::All)
+            && self.shard_id.is_none()
+    }
+}
+
+async fn load_schedules_from_shards_ui(api_state: &HarvestApiState) -> Vec<ShardScheduleResult> {
+    let pool = match api_state.storage_pool() {
+        Ok(p) => p,
+        Err(e) => {
+            return vec![(ShardId::UNENCODED, Err(e.to_string()))];
+        }
+    };
+
+    let futs: Vec<_> = pool
+        .iter_shards()
+        .map(|(shard_id, shard_pool)| async move {
+            let result = async {
+                let mut conn = acquire_conn(shard_pool).await.map_err(|e| e.to_string())?;
+                harvest_schedules::table
+                    .order(harvest_schedules::next_run_at.asc())
+                    .select(HarvestSchedule::as_select())
+                    .load(&mut conn)
+                    .await
+                    .map_err(|e| e.to_string())
+            }
+            .await;
+            (shard_id, result)
+        })
+        .collect();
+
+    futures::future::join_all(futs).await
+}
+
+async fn list_schedules_ui(
+    Extension(api_state): Extension<HarvestApiState>,
+    Query(params): Query<ScheduleListParams>,
+) -> Result<Markup, AutumnError> {
+    let limit = params
+        .limit
+        .unwrap_or(DEFAULT_SCHEDULE_PAGE_SIZE)
+        .clamp(1, MAX_PAGE_SIZE);
+    let page = params.page.unwrap_or(0).max(0);
+    let offset = page.saturating_mul(limit);
+
+    let kind = params
+        .kind
+        .as_deref()
+        .map(ScheduleKindFilter::parse)
+        .transpose()?
+        .unwrap_or(ScheduleKindFilter::All);
+    let paused_filter = params
+        .paused
+        .as_deref()
+        .map(SchedulePausedFilter::parse)
+        .transpose()?
+        .unwrap_or(SchedulePausedFilter::All);
+    let target = params
+        .target
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+
+    let filters = ScheduleUiFilters {
+        target,
+        kind,
+        paused: paused_filter,
+        shard_id: params.shard_id,
+    };
+
+    let shard_results = load_schedules_from_shards_ui(&api_state).await;
+    let is_multi_shard = shard_results.len() > 1;
+
+    let shard_errors: Vec<(ShardId, String)> = shard_results
+        .iter()
+        .filter_map(|(sid, r)| r.as_ref().err().map(|e| (*sid, e.clone())))
+        .collect();
+
+    // Flatten + filter across all shards.
+    let mut all_rows: Vec<(ShardId, HarvestSchedule)> = shard_results
+        .into_iter()
+        .flat_map(|(shard_id, result)| {
+            result
+                .into_iter()
+                .flat_map(move |rows| rows.into_iter().map(move |r| (shard_id, r)))
+        })
+        .filter(|(sid, row)| filters.matches(*sid, row))
+        .collect();
+
+    // Secondary sort: by name for stability when next_run_at is NULL.
+    all_rows.sort_by(|(_, a), (_, b)| {
+        let a_next = a.next_run_at;
+        let b_next = b.next_run_at;
+        match (a_next, b_next) {
+            (Some(a_ts), Some(b_ts)) => a_ts.cmp(&b_ts),
+            (Some(_), None) => std::cmp::Ordering::Less,
+            (None, Some(_)) => std::cmp::Ordering::Greater,
+            (None, None) => {
+                let a_name = a
+                    .workflow_name
+                    .as_deref()
+                    .or(a.dag_name.as_deref())
+                    .unwrap_or("");
+                let b_name = b
+                    .workflow_name
+                    .as_deref()
+                    .or(b.dag_name.as_deref())
+                    .unwrap_or("");
+                a_name.cmp(b_name)
+            }
+        }
+        .then_with(|| a.id.cmp(&b.id))
+    });
+
+    let total_filtered = all_rows.len();
+    let offset_usize = usize::try_from(offset).unwrap_or(usize::MAX);
+    let limit_usize = usize::try_from(limit).unwrap_or(usize::MAX);
+    let has_next = total_filtered > offset_usize.saturating_add(limit_usize);
+    let page_rows: Vec<(ShardId, HarvestSchedule)> = all_rows
+        .into_iter()
+        .skip(offset_usize)
+        .take(limit_usize)
+        .collect();
+
+    Ok(render_schedules_page(
+        &page_rows,
+        &shard_errors,
+        is_multi_shard,
+        &filters,
+        page,
+        limit,
+        has_next,
+        total_filtered,
+        params.refresh,
+        params.flash.as_deref(),
+    ))
+}
+
+/// Parse a `ScheduleUiFilters` from optional string fields.
+fn parse_schedule_bulk_filters(params: &ScheduleBulkParams) -> ScheduleUiFilters {
+    let kind = params
+        .kind
+        .as_deref()
+        .and_then(|s| ScheduleKindFilter::parse(s).ok())
+        .unwrap_or(ScheduleKindFilter::All);
+    let paused = params
+        .paused
+        .as_deref()
+        .and_then(|s| SchedulePausedFilter::parse(s).ok())
+        .unwrap_or(SchedulePausedFilter::All);
+    let target = params
+        .target
+        .as_deref()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string);
+    ScheduleUiFilters {
+        target,
+        kind,
+        paused,
+        shard_id: params.shard_id,
+    }
+}
+
+/// Find a schedule by id across all shards. Returns the row and a conn on success.
+async fn find_schedule_row(
+    api_state: &HarvestApiState,
+    id_str: &str,
+) -> Result<Option<(HarvestSchedule, crate::api::PoolConn)>, axum::response::Response> {
+    use autumn_harvest::schema::harvest_schedules::dsl;
+    use axum::response::IntoResponse as _;
+
+    let Ok(id) = id_str.parse::<uuid::Uuid>() else {
+        return Err(
+            AutumnError::bad_request_msg(format!("invalid schedule id '{id_str}'")).into_response(),
+        );
+    };
+    let pool = api_state
+        .storage_pool()
+        .map_err(|e| map_error(e).into_response())?;
+
+    for (_shard, shard_pool) in pool.iter_shards() {
+        let mut conn = match acquire_conn(shard_pool).await {
+            Ok(c) => c,
+            Err(e) => return Err(e.into_response()),
+        };
+        let row: Option<HarvestSchedule> = dsl::harvest_schedules
+            .find(id)
+            .select(HarvestSchedule::as_select())
+            .first(&mut conn)
+            .await
+            .optional()
+            .map_err(database_error)
+            .map_err(|e| map_error(e).into_response())?;
+        if let Some(row) = row {
+            return Ok(Some((row, conn)));
+        }
+    }
+    Ok(None)
+}
+
+fn schedule_name(row: &HarvestSchedule) -> String {
+    row.workflow_name
+        .as_deref()
+        .or(row.dag_name.as_deref())
+        .unwrap_or("")
+        .to_string()
+}
+
+async fn schedule_pause_ui(
+    Extension(api_state): Extension<HarvestApiState>,
+    Path(id_str): Path<String>,
+) -> axum::response::Response {
+    use autumn_harvest::schema::harvest_schedules::dsl;
+
+    let found = match find_schedule_row(&api_state, &id_str).await {
+        Ok(f) => f,
+        Err(response) => return response,
+    };
+
+    let flash = if let Some((row, mut conn)) = found {
+        let name = schedule_name(&row);
+        let now = Utc::now();
+        let _ = diesel::update(
+            dsl::harvest_schedules
+                .find(row.id)
+                .filter(dsl::is_paused.ne(true)),
+        )
+        .set((
+            dsl::is_paused.eq(true),
+            dsl::paused_at.eq(Some(now)),
+            dsl::paused_by.eq(Some("ui")),
+            dsl::updated_at.eq(now),
+        ))
+        .execute(&mut conn)
+        .await;
+        let ar = NewAuditRecord {
+            actor: "ui",
+            operation: OP_SCHEDULE_PAUSE,
+            target_type: TARGET_SCHEDULE,
+            target_id: Some(id_str.as_str()),
+            route_or_command: "POST /ui/schedules/pause",
+            request_id: None,
+            idempotency_key: None,
+            status: STATUS_SUCCEEDED,
+            error_summary: None,
+            shard_id: None,
+            source: SOURCE_API,
+        };
+        let _ = insert_audit(&mut conn, &ar).await;
+        format!("Paused {name}")
+    } else {
+        format!("Paused schedule {}", &id_str[..8.min(id_str.len())])
+    };
+    schedule_redirect(&flash)
+}
+
+async fn schedule_resume_ui(
+    Extension(api_state): Extension<HarvestApiState>,
+    Path(id_str): Path<String>,
+) -> axum::response::Response {
+    use autumn_harvest::schema::harvest_schedules::dsl;
+
+    let found = match find_schedule_row(&api_state, &id_str).await {
+        Ok(f) => f,
+        Err(response) => return response,
+    };
+
+    let flash = if let Some((row, mut conn)) = found {
+        let name = schedule_name(&row);
+        let now = Utc::now();
+        let _ = diesel::update(
+            dsl::harvest_schedules
+                .find(row.id)
+                .filter(dsl::is_paused.ne(false)),
+        )
+        .set((
+            dsl::is_paused.eq(false),
+            dsl::paused_at.eq(None::<chrono::DateTime<Utc>>),
+            dsl::paused_by.eq(None::<&str>),
+            dsl::pause_reason.eq(None::<&str>),
+            dsl::updated_at.eq(now),
+        ))
+        .execute(&mut conn)
+        .await;
+        let ar = NewAuditRecord {
+            actor: "ui",
+            operation: OP_SCHEDULE_RESUME,
+            target_type: TARGET_SCHEDULE,
+            target_id: Some(id_str.as_str()),
+            route_or_command: "POST /ui/schedules/resume",
+            request_id: None,
+            idempotency_key: None,
+            status: STATUS_SUCCEEDED,
+            error_summary: None,
+            shard_id: None,
+            source: SOURCE_API,
+        };
+        let _ = insert_audit(&mut conn, &ar).await;
+        format!("Resumed {name}")
+    } else {
+        format!("Resumed schedule {}", &id_str[..8.min(id_str.len())])
+    };
+    schedule_redirect(&flash)
+}
+
+async fn schedule_delete_ui(
+    Extension(api_state): Extension<HarvestApiState>,
+    Path(id_str): Path<String>,
+) -> axum::response::Response {
+    use autumn_harvest::schema::harvest_schedules::dsl;
+
+    let found = match find_schedule_row(&api_state, &id_str).await {
+        Ok(f) => f,
+        Err(response) => return response,
+    };
+
+    let flash = if let Some((row, mut conn)) = found {
+        let name = schedule_name(&row);
+        let n = diesel::delete(dsl::harvest_schedules.find(row.id))
+            .execute(&mut conn)
+            .await
+            .unwrap_or(0);
+        if n > 0 {
+            let ar = NewAuditRecord {
+                actor: "ui",
+                operation: OP_SCHEDULE_DELETE,
+                target_type: TARGET_SCHEDULE,
+                target_id: Some(id_str.as_str()),
+                route_or_command: "POST /ui/schedules/delete",
+                request_id: None,
+                idempotency_key: None,
+                status: STATUS_SUCCEEDED,
+                error_summary: None,
+                shard_id: None,
+                source: SOURCE_API,
+            };
+            let _ = insert_audit(&mut conn, &ar).await;
+            format!("Deleted {name}")
+        } else {
+            format!(
+                "Schedule {} was already deleted",
+                &id_str[..8.min(id_str.len())]
+            )
+        }
+    } else {
+        format!("Schedule {} not found", &id_str[..8.min(id_str.len())])
+    };
+    schedule_redirect(&flash)
+}
+
+async fn schedule_bulk_pause_ui(
+    Extension(api_state): Extension<HarvestApiState>,
+    Form(params): Form<ScheduleBulkParams>,
+) -> axum::response::Response {
+    use autumn_harvest::schema::harvest_schedules::dsl;
+    use axum::response::IntoResponse as _;
+
+    let filters = parse_schedule_bulk_filters(&params);
+
+    let pool = match api_state.storage_pool() {
+        Ok(p) => p,
+        Err(e) => return map_error(e).into_response(),
+    };
+
+    let now = Utc::now();
+    let mut acted_on = 0usize;
+
+    for (shard_id, shard_pool) in pool.iter_shards() {
+        let Ok(mut conn) = acquire_conn(shard_pool).await else {
+            continue;
+        };
+        let rows: Vec<HarvestSchedule> = harvest_schedules::table
+            .select(HarvestSchedule::as_select())
+            .load(&mut conn)
+            .await
+            .unwrap_or_default();
+        for row in rows {
+            if !filters.matches(shard_id, &row) {
+                continue;
+            }
+            let id_str = row.id.to_string();
+            let n = diesel::update(
+                dsl::harvest_schedules
+                    .find(row.id)
+                    .filter(dsl::is_paused.ne(true)),
+            )
+            .set((
+                dsl::is_paused.eq(true),
+                dsl::paused_at.eq(Some(now)),
+                dsl::paused_by.eq(Some("ui-bulk")),
+                dsl::updated_at.eq(now),
+            ))
+            .execute(&mut conn)
+            .await
+            .unwrap_or(0);
+            if n > 0 {
+                acted_on += 1;
+                let ar = NewAuditRecord {
+                    actor: "ui",
+                    operation: OP_SCHEDULE_PAUSE,
+                    target_type: TARGET_SCHEDULE,
+                    target_id: Some(id_str.as_str()),
+                    route_or_command: "POST /ui/schedules/bulk-pause",
+                    request_id: None,
+                    idempotency_key: None,
+                    status: STATUS_SUCCEEDED,
+                    error_summary: None,
+                    shard_id: None,
+                    source: SOURCE_API,
+                };
+                let _ = insert_audit(&mut conn, &ar).await;
+            }
+        }
+    }
+
+    schedule_redirect(&format!("Paused {acted_on} schedule(s)"))
+}
+
+async fn schedule_bulk_resume_ui(
+    Extension(api_state): Extension<HarvestApiState>,
+    Form(params): Form<ScheduleBulkParams>,
+) -> axum::response::Response {
+    use autumn_harvest::schema::harvest_schedules::dsl;
+    use axum::response::IntoResponse as _;
+
+    let filters = parse_schedule_bulk_filters(&params);
+
+    let pool = match api_state.storage_pool() {
+        Ok(p) => p,
+        Err(e) => return map_error(e).into_response(),
+    };
+
+    let now = Utc::now();
+    let mut acted_on = 0usize;
+
+    for (shard_id, shard_pool) in pool.iter_shards() {
+        let Ok(mut conn) = acquire_conn(shard_pool).await else {
+            continue;
+        };
+        let rows: Vec<HarvestSchedule> = harvest_schedules::table
+            .select(HarvestSchedule::as_select())
+            .load(&mut conn)
+            .await
+            .unwrap_or_default();
+        for row in rows {
+            if !filters.matches(shard_id, &row) {
+                continue;
+            }
+            let id_str = row.id.to_string();
+            let n = diesel::update(
+                dsl::harvest_schedules
+                    .find(row.id)
+                    .filter(dsl::is_paused.ne(false)),
+            )
+            .set((
+                dsl::is_paused.eq(false),
+                dsl::paused_at.eq(None::<chrono::DateTime<Utc>>),
+                dsl::paused_by.eq(None::<&str>),
+                dsl::pause_reason.eq(None::<&str>),
+                dsl::updated_at.eq(now),
+            ))
+            .execute(&mut conn)
+            .await
+            .unwrap_or(0);
+            if n > 0 {
+                acted_on += 1;
+                let ar = NewAuditRecord {
+                    actor: "ui",
+                    operation: OP_SCHEDULE_RESUME,
+                    target_type: TARGET_SCHEDULE,
+                    target_id: Some(id_str.as_str()),
+                    route_or_command: "POST /ui/schedules/bulk-resume",
+                    request_id: None,
+                    idempotency_key: None,
+                    status: STATUS_SUCCEEDED,
+                    error_summary: None,
+                    shard_id: None,
+                    source: SOURCE_API,
+                };
+                let _ = insert_audit(&mut conn, &ar).await;
+            }
+        }
+    }
+
+    schedule_redirect(&format!("Resumed {acted_on} schedule(s)"))
+}
+
+fn schedule_redirect(flash: &str) -> axum::response::Response {
+    use axum::response::IntoResponse as _;
+    let location = format!("schedules?flash={}", url_encode(flash));
+    axum::response::Redirect::to(&location).into_response()
+}
+
+// ---------------------------------------------------------------------------
+// Schedule rendering helpers
+// ---------------------------------------------------------------------------
+
+#[allow(clippy::too_many_arguments)]
+fn render_schedules_page(
+    rows: &[(ShardId, HarvestSchedule)],
+    shard_errors: &[(ShardId, String)],
+    is_multi_shard: bool,
+    filters: &ScheduleUiFilters,
+    page: i64,
+    limit: i64,
+    has_next: bool,
+    total_filtered: usize,
+    refresh: Option<u64>,
+    flash: Option<&str>,
+) -> Markup {
+    let body = html! {
+        h2 { "Schedules" }
+
+        @if let Some(message) = flash {
+            div.flash { (message) }
+        }
+
+        (render_schedule_filters(filters, limit, refresh))
+        (render_schedule_bulk_actions(filters, limit, refresh, total_filtered))
+
+        @if rows.is_empty() && shard_errors.is_empty() {
+            div.card.empty {
+                @if filters.is_empty() {
+                    "No schedules registered."
+                } @else {
+                    "No schedules match this filter."
+                }
+            }
+        } @else {
+            @for (shard_id, error) in shard_errors {
+                div.shard-error {
+                    @if is_multi_shard {
+                        strong { "Shard " (shard_id.as_i32()) " unavailable: " }
+                    } @else {
+                        strong { "Shard unavailable: " }
+                    }
+                    (error)
+                }
+            }
+            (render_schedule_table(rows, is_multi_shard))
+        }
+
+        (render_schedule_pagination(page, limit, has_next, filters, refresh))
+    };
+
+    layout_schedules("Schedules · Vantage", &body, refresh)
+}
+
+fn render_schedule_filters(
+    filters: &ScheduleUiFilters,
+    limit: i64,
+    refresh: Option<u64>,
+) -> Markup {
+    let target_val = filters.target.as_deref().unwrap_or("");
+    let kind_val = filters.kind.as_label();
+    let paused_val = filters.paused.as_label();
+    let shard_val = filters.shard_id.map(|s| s.to_string()).unwrap_or_default();
+    let refresh_value = refresh.map(|s| s.to_string()).unwrap_or_default();
+
+    html! {
+        form.filters method="get" action="schedules" {
+            label {
+                "Target"
+                input type="text" name="target" value=(target_val) placeholder="e.g. payment_workflow";
+            }
+            label {
+                "Kind"
+                select name="kind" {
+                    option value="" selected[kind_val.is_empty()] { "All" }
+                    option value="Workflow" selected[kind_val == "Workflow"] { "Workflow" }
+                    option value="Dag" selected[kind_val == "Dag"] { "Dag" }
+                }
+            }
+            label {
+                "Paused"
+                select name="paused" {
+                    option value="" selected[paused_val.is_empty()] { "All" }
+                    option value="Paused" selected[paused_val == "Paused"] { "Paused" }
+                    option value="Active" selected[paused_val == "Active"] { "Active" }
+                }
+            }
+            label {
+                "Shard"
+                input type="number" name="shard_id" value=(shard_val) placeholder="e.g. 0";
+            }
+            label {
+                "Per page"
+                input type="number" name="limit" min="1" max=(MAX_PAGE_SIZE) value=(limit);
+            }
+            label {
+                "Refresh"
+                select name="refresh" {
+                    option value="" selected[refresh.is_none()] { "Off" }
+                    option value="30" selected[refresh == Some(30)] { "30s" }
+                    option value="60" selected[refresh == Some(60)] { "60s" }
+                    @if refresh.is_some_and(|secs| secs != 30 && secs != 60) {
+                        option value=(refresh_value) selected { (refresh_value) "s" }
+                    }
+                }
+            }
+            button type="submit" { "Apply" }
+            a.reset href="schedules" { "Reset" }
+        }
+    }
+}
+
+fn render_schedule_bulk_actions(
+    filters: &ScheduleUiFilters,
+    limit: i64,
+    refresh: Option<u64>,
+    total_matching: usize,
+) -> Markup {
+    let return_qs = build_schedule_query_string(limit, filters, refresh);
+    html! {
+        div."bulk-actions" {
+            form method="post" action="schedules/bulk-pause"
+                onsubmit={ "return confirm('Pause " (total_matching) " matching schedule(s)?')" } {
+                (render_schedule_hidden_filters(filters))
+                button type="submit" disabled[total_matching == 0] {
+                    "Pause all matching (" (total_matching) ")"
+                }
+            }
+            form method="post" action="schedules/bulk-resume"
+                onsubmit={ "return confirm('Resume " (total_matching) " matching schedule(s)?')" } {
+                (render_schedule_hidden_filters(filters))
+                button type="submit" disabled[total_matching == 0] {
+                    "Resume all matching (" (total_matching) ")"
+                }
+            }
+            @if !return_qs.is_empty() {
+                span { "Filters active" }
+            }
+        }
+    }
+}
+
+fn render_schedule_hidden_filters(filters: &ScheduleUiFilters) -> Markup {
+    html! {
+        @if let Some(ref target) = filters.target {
+            input type="hidden" name="target" value=(target);
+        }
+        @if !matches!(filters.kind, ScheduleKindFilter::All) {
+            input type="hidden" name="kind" value=(filters.kind.as_label());
+        }
+        @if !matches!(filters.paused, SchedulePausedFilter::All) {
+            input type="hidden" name="paused" value=(filters.paused.as_label());
+        }
+        @if let Some(shard_id) = filters.shard_id {
+            input type="hidden" name="shard_id" value=(shard_id);
+        }
+    }
+}
+
+fn render_schedule_table(rows: &[(ShardId, HarvestSchedule)], is_multi_shard: bool) -> Markup {
+    html! {
+        table {
+            thead {
+                tr {
+                    th { "Schedule ID" }
+                    th { "Kind" }
+                    th { "Target" }
+                    th { "Expression" }
+                    th { "Next Run" }
+                    th { "Last Run" }
+                    th { "State" }
+                    th { "Created" }
+                    @if is_multi_shard { th { "Shard" } }
+                    th { "Actions" }
+                }
+            }
+            tbody {
+                @for (shard_id, row) in rows {
+                    @let id_str = row.id.to_string();
+                    @let kind_label = if row.dag_name.is_some() { "Dag" } else { "Workflow" };
+                    @let target_name = row.workflow_name.as_deref()
+                        .or(row.dag_name.as_deref())
+                        .unwrap_or("—");
+                    @let expr = row.schedule_expr.as_deref().unwrap_or("—");
+                    tr {
+                        td { code { (short_id(&id_str)) } }
+                        td { (kind_label) }
+                        td { code { (target_name) } }
+                        td { code { (expr) } }
+                        td { (format_timestamp(row.next_run_at)) }
+                        td { (format_timestamp(row.last_run_at)) }
+                        td { (schedule_state_badge(row.is_paused)) }
+                        td { (format_timestamp(Some(row.created_at))) }
+                        @if is_multi_shard { td { (shard_id.as_i32()) } }
+                        td {
+                            div.actions {
+                                @if !row.is_paused {
+                                    form method="post"
+                                        action={ "schedules/" (id_str) "/pause" }
+                                        onsubmit="return confirm('Pause this schedule?')" {
+                                        button type="submit" { "Pause" }
+                                    }
+                                }
+                                @if row.is_paused {
+                                    form method="post"
+                                        action={ "schedules/" (id_str) "/resume" }
+                                        onsubmit="return confirm('Resume this schedule?')" {
+                                        button type="submit" { "Resume" }
+                                    }
+                                }
+                                form method="post"
+                                    action={ "schedules/" (id_str) "/delete" }
+                                    onsubmit={ "return confirm('Delete schedule " (id_str) "? This cannot be undone.')" } {
+                                    button.danger type="submit" { "Delete" }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn schedule_state_badge(is_paused: bool) -> Markup {
+    if is_paused {
+        html! { span.badge.CANCELLED { "Paused" } }
+    } else {
+        html! { span.badge.Active { "Active" } }
+    }
+}
+
+fn render_schedule_pagination(
+    page: i64,
+    limit: i64,
+    has_next: bool,
+    filters: &ScheduleUiFilters,
+    refresh: Option<u64>,
+) -> Markup {
+    let base = build_schedule_query_string(limit, filters, refresh);
+    html! {
+        div.pagination {
+            @if page > 0 {
+                a href={ "schedules?page=" (page - 1) (PreEscaped(&base)) } {
+                    (PreEscaped("&larr;")) " Previous"
+                }
+            } @else {
+                span.disabled { (PreEscaped("&larr;")) " Previous" }
+            }
+            span { "Page " (page + 1) }
+            @if has_next {
+                a href={ "schedules?page=" (page + 1) (PreEscaped(&base)) } {
+                    "Next " (PreEscaped("&rarr;"))
+                }
+            } @else {
+                span.disabled { "Next " (PreEscaped("&rarr;")) }
+            }
+        }
+    }
+}
+
+fn build_schedule_query_string(
+    limit: i64,
+    filters: &ScheduleUiFilters,
+    refresh: Option<u64>,
+) -> String {
+    let mut out = String::new();
+    if limit != DEFAULT_SCHEDULE_PAGE_SIZE {
+        let _ = write!(out, "&limit={limit}");
+    }
+    if let Some(ref target) = filters.target {
+        let _ = write!(out, "&target={}", url_encode(target));
+    }
+    if !matches!(filters.kind, ScheduleKindFilter::All) {
+        let _ = write!(out, "&kind={}", filters.kind.as_label());
+    }
+    if !matches!(filters.paused, SchedulePausedFilter::All) {
+        let _ = write!(out, "&paused={}", filters.paused.as_label());
+    }
+    if let Some(shard_id) = filters.shard_id {
+        let _ = write!(out, "&shard_id={shard_id}");
+    }
+    if let Some(secs) = refresh {
+        let _ = write!(out, "&refresh={secs}");
+    }
+    out
+}
+
+fn layout_schedules(title: &str, body: &Markup, refresh: Option<u64>) -> Markup {
+    html! {
+        (PreEscaped("<!DOCTYPE html>"))
+        html lang="en" {
+            head {
+                meta charset="utf-8";
+                meta name="viewport" content="width=device-width,initial-scale=1";
+                @if let Some(secs) = refresh {
+                    meta http-equiv="refresh" content=(secs);
+                }
+                title { (title) }
+                style { (PreEscaped(STYLE)) }
+            }
+            body {
+                header {
+                    h1 {
+                        a href="workflows" { "🔭 Vantage" }
+                        span.subtitle { "Harvest dashboard" }
+                    }
+                    nav {
+                        a href="workflows" { "Workflows" }
+                        a href="workers" { "Workers" }
+                        a.active href="schedules" { "Schedules" }
+                        a href="dead-letters" { "Dead Letters" }
+                    }
+                }
+                main { (body) }
+                footer { "Operational dashboard — autumn-harvest" }
             }
         }
     }
@@ -2169,5 +3141,223 @@ mod tests {
         let html = worker_status_badge("Active", false).into_string();
         assert!(html.contains("Active"));
         assert!(!html.contains("stale"));
+    }
+
+    // -- Schedule page pure-logic unit tests --
+
+    fn make_schedule(
+        workflow_name: Option<&str>,
+        dag_name: Option<&str>,
+        is_paused: bool,
+    ) -> HarvestSchedule {
+        HarvestSchedule {
+            id: uuid::Uuid::new_v4(),
+            dag_name: dag_name.map(str::to_string),
+            schedule_expr: Some("0 * * * *".to_string()),
+            timezone: "UTC".to_string(),
+            catchup: false,
+            max_active_runs: 1,
+            is_paused,
+            last_run_at: None,
+            next_run_at: None,
+            created_at: chrono::Utc::now(),
+            updated_at: chrono::Utc::now(),
+            workflow_name: workflow_name.map(str::to_string),
+            workflow_input: None,
+            queue_name: None,
+            paused_at: None,
+            paused_by: None,
+            pause_reason: None,
+        }
+    }
+
+    #[test]
+    fn schedule_filter_matches_all_when_empty() {
+        let filters = ScheduleUiFilters::default();
+        let wf = make_schedule(Some("my_workflow"), None, false);
+        let dag = make_schedule(None, Some("my_dag"), true);
+        assert!(filters.matches(ShardId::new(0), &wf));
+        assert!(filters.matches(ShardId::new(0), &dag));
+    }
+
+    #[test]
+    fn schedule_filter_kind_workflow_excludes_dags() {
+        let filters = ScheduleUiFilters {
+            kind: ScheduleKindFilter::Workflow,
+            ..Default::default()
+        };
+        let wf = make_schedule(Some("wf"), None, false);
+        let dag = make_schedule(None, Some("dag"), false);
+        assert!(filters.matches(ShardId::new(0), &wf));
+        assert!(!filters.matches(ShardId::new(0), &dag));
+    }
+
+    #[test]
+    fn schedule_filter_kind_dag_excludes_workflows() {
+        let filters = ScheduleUiFilters {
+            kind: ScheduleKindFilter::Dag,
+            ..Default::default()
+        };
+        let wf = make_schedule(Some("wf"), None, false);
+        let dag = make_schedule(None, Some("dag"), false);
+        assert!(!filters.matches(ShardId::new(0), &wf));
+        assert!(filters.matches(ShardId::new(0), &dag));
+    }
+
+    #[test]
+    fn schedule_filter_paused_excludes_active() {
+        let filters = ScheduleUiFilters {
+            paused: SchedulePausedFilter::Paused,
+            ..Default::default()
+        };
+        let active = make_schedule(Some("wf"), None, false);
+        let paused = make_schedule(Some("wf2"), None, true);
+        assert!(!filters.matches(ShardId::new(0), &active));
+        assert!(filters.matches(ShardId::new(0), &paused));
+    }
+
+    #[test]
+    fn schedule_filter_active_excludes_paused() {
+        let filters = ScheduleUiFilters {
+            paused: SchedulePausedFilter::Active,
+            ..Default::default()
+        };
+        let active = make_schedule(Some("wf"), None, false);
+        let paused = make_schedule(Some("wf2"), None, true);
+        assert!(filters.matches(ShardId::new(0), &active));
+        assert!(!filters.matches(ShardId::new(0), &paused));
+    }
+
+    #[test]
+    fn schedule_filter_target_substring_match() {
+        let filters = ScheduleUiFilters {
+            target: Some("payment".to_string()),
+            ..Default::default()
+        };
+        let matching = make_schedule(Some("payment_workflow"), None, false);
+        let other = make_schedule(Some("invoice_workflow"), None, false);
+        assert!(filters.matches(ShardId::new(0), &matching));
+        assert!(!filters.matches(ShardId::new(0), &other));
+    }
+
+    #[test]
+    fn schedule_filter_shard_id_match() {
+        let filters = ScheduleUiFilters {
+            shard_id: Some(1),
+            ..Default::default()
+        };
+        let row = make_schedule(Some("wf"), None, false);
+        assert!(filters.matches(ShardId::new(1), &row));
+        assert!(!filters.matches(ShardId::new(0), &row));
+    }
+
+    #[test]
+    fn schedule_state_badge_paused() {
+        let html = schedule_state_badge(true).into_string();
+        assert!(html.contains("Paused"));
+    }
+
+    #[test]
+    fn schedule_state_badge_active() {
+        let html = schedule_state_badge(false).into_string();
+        assert!(html.contains("Active"));
+    }
+
+    #[test]
+    fn build_schedule_query_string_omits_defaults() {
+        let filters = ScheduleUiFilters::default();
+        assert_eq!(
+            build_schedule_query_string(DEFAULT_SCHEDULE_PAGE_SIZE, &filters, None),
+            ""
+        );
+    }
+
+    #[test]
+    fn build_schedule_query_string_includes_all_params() {
+        let filters = ScheduleUiFilters {
+            target: Some("payment".to_string()),
+            kind: ScheduleKindFilter::Workflow,
+            paused: SchedulePausedFilter::Paused,
+            shard_id: Some(2),
+        };
+        let q = build_schedule_query_string(10, &filters, Some(30));
+        assert!(q.contains("limit=10"), "missing limit: {q}");
+        assert!(q.contains("target=payment"), "missing target: {q}");
+        assert!(q.contains("kind=Workflow"), "missing kind: {q}");
+        assert!(q.contains("paused=Paused"), "missing paused: {q}");
+        assert!(q.contains("shard_id=2"), "missing shard_id: {q}");
+        assert!(q.contains("refresh=30"), "missing refresh: {q}");
+    }
+
+    #[test]
+    fn layout_schedules_has_nav_link() {
+        let body = html! { p { "test" } };
+        let html = layout_schedules("Test", &body, None).into_string();
+        assert!(
+            html.contains("schedules"),
+            "layout_schedules must include schedules link"
+        );
+        assert!(
+            html.contains("Workflows"),
+            "layout_schedules must include workflows link"
+        );
+        assert!(
+            html.contains("Workers"),
+            "layout_schedules must include workers link"
+        );
+    }
+
+    #[test]
+    fn layout_schedules_auto_refresh_tag() {
+        let body = html! { p { "test" } };
+        let html_with = layout_schedules("T", &body, Some(30)).into_string();
+        assert!(html_with.contains("http-equiv=\"refresh\""));
+        assert!(html_with.contains("content=\"30\""));
+        let html_without = layout_schedules("T", &body, None).into_string();
+        assert!(!html_without.contains("http-equiv=\"refresh\""));
+    }
+
+    #[test]
+    fn layout_includes_schedules_nav_link() {
+        let body = html! { p { "test" } };
+        let html = layout("Test", &body, "").into_string();
+        assert!(
+            html.contains("schedules"),
+            "layout must include schedules nav link"
+        );
+    }
+
+    #[test]
+    fn schedule_kind_filter_parse_roundtrips() {
+        assert!(matches!(
+            ScheduleKindFilter::parse("").unwrap(),
+            ScheduleKindFilter::All
+        ));
+        assert!(matches!(
+            ScheduleKindFilter::parse("Workflow").unwrap(),
+            ScheduleKindFilter::Workflow
+        ));
+        assert!(matches!(
+            ScheduleKindFilter::parse("Dag").unwrap(),
+            ScheduleKindFilter::Dag
+        ));
+        assert!(ScheduleKindFilter::parse("bogus").is_err());
+    }
+
+    #[test]
+    fn schedule_paused_filter_parse_roundtrips() {
+        assert!(matches!(
+            SchedulePausedFilter::parse("").unwrap(),
+            SchedulePausedFilter::All
+        ));
+        assert!(matches!(
+            SchedulePausedFilter::parse("Paused").unwrap(),
+            SchedulePausedFilter::Paused
+        ));
+        assert!(matches!(
+            SchedulePausedFilter::parse("Active").unwrap(),
+            SchedulePausedFilter::Active
+        ));
+        assert!(SchedulePausedFilter::parse("maybe").is_err());
     }
 }

--- a/autumn-harvest-plugin/src/ui.rs
+++ b/autumn-harvest-plugin/src/ui.rs
@@ -2076,7 +2076,11 @@ impl ScheduleUiFilters {
             .or(row.dag_name.as_deref())
             .unwrap_or("");
 
-        if self.target.as_deref().is_some_and(|t| !name.contains(t)) {
+        if !self
+            .target
+            .as_deref()
+            .is_none_or(|t| name.to_lowercase().contains(&t.to_lowercase()))
+        {
             return false;
         }
         match self.kind {
@@ -2282,9 +2286,8 @@ async fn find_schedule_row(
         .map_err(|e| map_error(e).into_response())?;
 
     for (_shard, shard_pool) in pool.iter_shards() {
-        let mut conn = match acquire_conn(shard_pool).await {
-            Ok(c) => c,
-            Err(e) => return Err(e.into_response()),
+        let Ok(mut conn) = acquire_conn(shard_pool).await else {
+            continue;
         };
         let row: Option<HarvestSchedule> = dsl::harvest_schedules
             .find(id)
@@ -2292,8 +2295,7 @@ async fn find_schedule_row(
             .first(&mut conn)
             .await
             .optional()
-            .map_err(database_error)
-            .map_err(|e| map_error(e).into_response())?;
+            .unwrap_or(None);
         if let Some(row) = row {
             return Ok(Some((row, conn)));
         }
@@ -2469,50 +2471,70 @@ async fn schedule_bulk_pause_ui(
     let mut acted_on = 0usize;
 
     for (shard_id, shard_pool) in pool.iter_shards() {
+        if filters.shard_id.is_some_and(|sid| shard_id.as_i32() != sid) {
+            continue;
+        }
         let Ok(mut conn) = acquire_conn(shard_pool).await else {
             continue;
         };
-        let rows: Vec<HarvestSchedule> = harvest_schedules::table
-            .select(HarvestSchedule::as_select())
+        // Load just id + name fields to apply kind/target filters without N+1 updates.
+        let candidates: Vec<(uuid::Uuid, Option<String>, Option<String>)> = dsl::harvest_schedules
+            .filter(dsl::is_paused.ne(true))
+            .select((dsl::id, dsl::workflow_name, dsl::dag_name))
             .load(&mut conn)
             .await
             .unwrap_or_default();
-        for row in rows {
-            if !filters.matches(shard_id, &row) {
-                continue;
-            }
-            let id_str = row.id.to_string();
-            let n = diesel::update(
-                dsl::harvest_schedules
-                    .find(row.id)
-                    .filter(dsl::is_paused.ne(true)),
-            )
-            .set((
-                dsl::is_paused.eq(true),
-                dsl::paused_at.eq(Some(now)),
-                dsl::paused_by.eq(Some("ui-bulk")),
-                dsl::updated_at.eq(now),
-            ))
-            .execute(&mut conn)
-            .await
-            .unwrap_or(0);
-            if n > 0 {
-                acted_on += 1;
-                let ar = NewAuditRecord {
-                    actor: "ui",
-                    operation: OP_SCHEDULE_PAUSE,
-                    target_type: TARGET_SCHEDULE,
-                    target_id: Some(id_str.as_str()),
-                    route_or_command: "POST /ui/schedules/bulk-pause",
-                    request_id: None,
-                    idempotency_key: None,
-                    status: STATUS_SUCCEEDED,
-                    error_summary: None,
-                    shard_id: None,
-                    source: SOURCE_API,
-                };
-                let _ = insert_audit(&mut conn, &ar).await;
-            }
+        let matching_ids: Vec<uuid::Uuid> = candidates
+            .into_iter()
+            .filter(|(_, wf, dag)| {
+                let name = wf.as_deref().or(dag.as_deref()).unwrap_or("");
+                match filters.kind {
+                    ScheduleKindFilter::Workflow if wf.is_none() => return false,
+                    ScheduleKindFilter::Dag if dag.is_none() => return false,
+                    _ => {}
+                }
+                filters
+                    .target
+                    .as_deref()
+                    .is_none_or(|t| name.to_lowercase().contains(&t.to_lowercase()))
+            })
+            .map(|(id, _, _)| id)
+            .collect();
+        if matching_ids.is_empty() {
+            continue;
+        }
+        let updated_ids: Vec<uuid::Uuid> = diesel::update(
+            dsl::harvest_schedules
+                .filter(dsl::id.eq_any(&matching_ids))
+                .filter(dsl::is_paused.ne(true)),
+        )
+        .set((
+            dsl::is_paused.eq(true),
+            dsl::paused_at.eq(Some(now)),
+            dsl::paused_by.eq(Some("ui-bulk")),
+            dsl::updated_at.eq(now),
+        ))
+        .returning(dsl::id)
+        .get_results(&mut conn)
+        .await
+        .unwrap_or_default();
+        acted_on += updated_ids.len();
+        for id in &updated_ids {
+            let id_str = id.to_string();
+            let ar = NewAuditRecord {
+                actor: "ui",
+                operation: OP_SCHEDULE_PAUSE,
+                target_type: TARGET_SCHEDULE,
+                target_id: Some(id_str.as_str()),
+                route_or_command: "POST /ui/schedules/bulk-pause",
+                request_id: None,
+                idempotency_key: None,
+                status: STATUS_SUCCEEDED,
+                error_summary: None,
+                shard_id: Some(shard_id.as_i32()),
+                source: SOURCE_API,
+            };
+            let _ = insert_audit(&mut conn, &ar).await;
         }
     }
 
@@ -2537,51 +2559,70 @@ async fn schedule_bulk_resume_ui(
     let mut acted_on = 0usize;
 
     for (shard_id, shard_pool) in pool.iter_shards() {
+        if filters.shard_id.is_some_and(|sid| shard_id.as_i32() != sid) {
+            continue;
+        }
         let Ok(mut conn) = acquire_conn(shard_pool).await else {
             continue;
         };
-        let rows: Vec<HarvestSchedule> = harvest_schedules::table
-            .select(HarvestSchedule::as_select())
+        let candidates: Vec<(uuid::Uuid, Option<String>, Option<String>)> = dsl::harvest_schedules
+            .filter(dsl::is_paused.eq(true))
+            .select((dsl::id, dsl::workflow_name, dsl::dag_name))
             .load(&mut conn)
             .await
             .unwrap_or_default();
-        for row in rows {
-            if !filters.matches(shard_id, &row) {
-                continue;
-            }
-            let id_str = row.id.to_string();
-            let n = diesel::update(
-                dsl::harvest_schedules
-                    .find(row.id)
-                    .filter(dsl::is_paused.ne(false)),
-            )
-            .set((
-                dsl::is_paused.eq(false),
-                dsl::paused_at.eq(None::<chrono::DateTime<Utc>>),
-                dsl::paused_by.eq(None::<&str>),
-                dsl::pause_reason.eq(None::<&str>),
-                dsl::updated_at.eq(now),
-            ))
-            .execute(&mut conn)
-            .await
-            .unwrap_or(0);
-            if n > 0 {
-                acted_on += 1;
-                let ar = NewAuditRecord {
-                    actor: "ui",
-                    operation: OP_SCHEDULE_RESUME,
-                    target_type: TARGET_SCHEDULE,
-                    target_id: Some(id_str.as_str()),
-                    route_or_command: "POST /ui/schedules/bulk-resume",
-                    request_id: None,
-                    idempotency_key: None,
-                    status: STATUS_SUCCEEDED,
-                    error_summary: None,
-                    shard_id: None,
-                    source: SOURCE_API,
-                };
-                let _ = insert_audit(&mut conn, &ar).await;
-            }
+        let matching_ids: Vec<uuid::Uuid> = candidates
+            .into_iter()
+            .filter(|(_, wf, dag)| {
+                let name = wf.as_deref().or(dag.as_deref()).unwrap_or("");
+                match filters.kind {
+                    ScheduleKindFilter::Workflow if wf.is_none() => return false,
+                    ScheduleKindFilter::Dag if dag.is_none() => return false,
+                    _ => {}
+                }
+                filters
+                    .target
+                    .as_deref()
+                    .is_none_or(|t| name.to_lowercase().contains(&t.to_lowercase()))
+            })
+            .map(|(id, _, _)| id)
+            .collect();
+        if matching_ids.is_empty() {
+            continue;
+        }
+        let updated_ids: Vec<uuid::Uuid> = diesel::update(
+            dsl::harvest_schedules
+                .filter(dsl::id.eq_any(&matching_ids))
+                .filter(dsl::is_paused.eq(true)),
+        )
+        .set((
+            dsl::is_paused.eq(false),
+            dsl::paused_at.eq(None::<chrono::DateTime<Utc>>),
+            dsl::paused_by.eq(None::<&str>),
+            dsl::pause_reason.eq(None::<&str>),
+            dsl::updated_at.eq(now),
+        ))
+        .returning(dsl::id)
+        .get_results(&mut conn)
+        .await
+        .unwrap_or_default();
+        acted_on += updated_ids.len();
+        for id in &updated_ids {
+            let id_str = id.to_string();
+            let ar = NewAuditRecord {
+                actor: "ui",
+                operation: OP_SCHEDULE_RESUME,
+                target_type: TARGET_SCHEDULE,
+                target_id: Some(id_str.as_str()),
+                route_or_command: "POST /ui/schedules/bulk-resume",
+                request_id: None,
+                idempotency_key: None,
+                status: STATUS_SUCCEEDED,
+                error_summary: None,
+                shard_id: Some(shard_id.as_i32()),
+                source: SOURCE_API,
+            };
+            let _ = insert_audit(&mut conn, &ar).await;
         }
     }
 
@@ -3266,6 +3307,16 @@ mod tests {
         let other = make_schedule(Some("invoice_workflow"), None, false);
         assert!(filters.matches(ShardId::new(0), &matching));
         assert!(!filters.matches(ShardId::new(0), &other));
+    }
+
+    #[test]
+    fn schedule_filter_target_case_insensitive() {
+        let filters = ScheduleUiFilters {
+            target: Some("PAYMENT".to_string()),
+            ..Default::default()
+        };
+        let matching = make_schedule(Some("payment_workflow"), None, false);
+        assert!(filters.matches(ShardId::new(0), &matching));
     }
 
     #[test]

--- a/autumn-harvest-plugin/src/ui.rs
+++ b/autumn-harvest-plugin/src/ui.rs
@@ -2213,6 +2213,7 @@ async fn list_schedules_ui(
     });
 
     let total_filtered = all_rows.len();
+    let distribution = schedule_kind_distribution(&all_rows);
     let offset_usize = usize::try_from(offset).unwrap_or(usize::MAX);
     let limit_usize = usize::try_from(limit).unwrap_or(usize::MAX);
     let has_next = total_filtered > offset_usize.saturating_add(limit_usize);
@@ -2231,6 +2232,7 @@ async fn list_schedules_ui(
         limit,
         has_next,
         total_filtered,
+        &distribution,
         params.refresh,
         params.flash.as_deref(),
     ))
@@ -2596,6 +2598,25 @@ fn schedule_redirect(flash: &str) -> axum::response::Response {
 // Schedule rendering helpers
 // ---------------------------------------------------------------------------
 
+/// Returns a short distribution string like "3 Workflow, 2 Dag" for all matching rows.
+fn schedule_kind_distribution(rows: &[(ShardId, HarvestSchedule)]) -> String {
+    let mut wf = 0usize;
+    let mut dag = 0usize;
+    for (_, row) in rows {
+        if row.workflow_name.is_some() {
+            wf += 1;
+        } else {
+            dag += 1;
+        }
+    }
+    match (wf, dag) {
+        (0, 0) => String::new(),
+        (w, 0) => format!("{w} Workflow"),
+        (0, d) => format!("{d} Dag"),
+        (w, d) => format!("{w} Workflow, {d} Dag"),
+    }
+}
+
 #[allow(clippy::too_many_arguments)]
 fn render_schedules_page(
     rows: &[(ShardId, HarvestSchedule)],
@@ -2606,6 +2627,7 @@ fn render_schedules_page(
     limit: i64,
     has_next: bool,
     total_filtered: usize,
+    distribution: &str,
     refresh: Option<u64>,
     flash: Option<&str>,
 ) -> Markup {
@@ -2617,7 +2639,7 @@ fn render_schedules_page(
         }
 
         (render_schedule_filters(filters, limit, refresh))
-        (render_schedule_bulk_actions(filters, limit, refresh, total_filtered))
+        (render_schedule_bulk_actions(filters, limit, refresh, total_filtered, distribution))
 
         @if rows.is_empty() && shard_errors.is_empty() {
             div.card.empty {
@@ -2710,19 +2732,25 @@ fn render_schedule_bulk_actions(
     limit: i64,
     refresh: Option<u64>,
     total_matching: usize,
+    distribution: &str,
 ) -> Markup {
     let return_qs = build_schedule_query_string(limit, filters, refresh);
+    let dist_suffix = if distribution.is_empty() {
+        String::new()
+    } else {
+        format!(" ({distribution})")
+    };
     html! {
         div."bulk-actions" {
             form method="post" action="schedules/bulk-pause"
-                onsubmit={ "return confirm('Pause " (total_matching) " matching schedule(s)?')" } {
+                onsubmit={ "return confirm('Pause " (total_matching) " matching schedule(s)" (&dist_suffix) "?')" } {
                 (render_schedule_hidden_filters(filters))
                 button type="submit" disabled[total_matching == 0] {
                     "Pause all matching (" (total_matching) ")"
                 }
             }
             form method="post" action="schedules/bulk-resume"
-                onsubmit={ "return confirm('Resume " (total_matching) " matching schedule(s)?')" } {
+                onsubmit={ "return confirm('Resume " (total_matching) " matching schedule(s)" (&dist_suffix) "?')" } {
                 (render_schedule_hidden_filters(filters))
                 button type="submit" disabled[total_matching == 0] {
                     "Resume all matching (" (total_matching) ")"
@@ -3261,6 +3289,42 @@ mod tests {
     fn schedule_state_badge_active() {
         let html = schedule_state_badge(false).into_string();
         assert!(html.contains("Active"));
+    }
+
+    #[test]
+    fn schedule_kind_distribution_empty() {
+        assert_eq!(schedule_kind_distribution(&[]), "");
+    }
+
+    #[test]
+    fn schedule_kind_distribution_workflow_only() {
+        let row = make_schedule(Some("wf"), None, false);
+        assert_eq!(
+            schedule_kind_distribution(&[(ShardId::UNENCODED, row)]),
+            "1 Workflow"
+        );
+    }
+
+    #[test]
+    fn schedule_kind_distribution_dag_only() {
+        let row = make_schedule(None, Some("my_dag"), false);
+        assert_eq!(
+            schedule_kind_distribution(&[(ShardId::UNENCODED, row)]),
+            "1 Dag"
+        );
+    }
+
+    #[test]
+    fn schedule_kind_distribution_mixed() {
+        let wf = make_schedule(Some("wf"), None, false);
+        let dag1 = make_schedule(None, Some("dag_a"), false);
+        let dag2 = make_schedule(None, Some("dag_b"), false);
+        let rows = vec![
+            (ShardId::UNENCODED, wf),
+            (ShardId::UNENCODED, dag1),
+            (ShardId::UNENCODED, dag2),
+        ];
+        assert_eq!(schedule_kind_distribution(&rows), "1 Workflow, 2 Dag");
     }
 
     #[test]

--- a/autumn-harvest-plugin/tests/ui_integration.rs
+++ b/autumn-harvest-plugin/tests/ui_integration.rs
@@ -1246,3 +1246,572 @@ async fn ui_workers_perf_1k_workers_4_shards_under_500ms() {
         elapsed.as_millis()
     );
 }
+
+// ---------------------------------------------------------------------------
+// Schedules page tests
+// ---------------------------------------------------------------------------
+
+/// Insert a test row into `harvest_schedules`.
+/// `kind` is "Workflow" or "Dag"; `name` is the workflow_name / dag_name.
+async fn insert_test_schedule(
+    database_url: &str,
+    kind: &str,
+    name: &str,
+    is_paused: bool,
+) -> uuid::Uuid {
+    let id = uuid::Uuid::new_v4();
+    let mut conn = AsyncPgConnection::establish(database_url)
+        .await
+        .expect("failed to connect for schedule insert");
+    let (dag_col, wf_col) = if kind == "Dag" {
+        (format!("'{name}'"), "NULL".to_string())
+    } else {
+        ("NULL".to_string(), format!("'{name}'"))
+    };
+    let paused_at_col = if is_paused { "NOW()" } else { "NULL" };
+    let sql = format!(
+        "INSERT INTO harvest_schedules \
+            (id, dag_name, workflow_name, schedule_expr, timezone, catchup, \
+             max_active_runs, is_paused, paused_at, created_at, updated_at) \
+         VALUES \
+            ('{id}', {dag_col}, {wf_col}, '0 * * * *', 'UTC', false, 1, \
+             {is_paused}, {paused_at_col}, NOW(), NOW())"
+    );
+    conn.batch_execute(&sql)
+        .await
+        .expect("insert_test_schedule failed");
+    id
+}
+
+/// Empty schedules table → page renders "No schedules registered."
+#[tokio::test]
+async fn ui_schedules_empty_state() {
+    let (database_url, _container) = setup_test_database_url().await;
+    let app = build_single_shard_ui_app(&database_url);
+
+    let (status, html) = fetch_html(&app, "/schedules").await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "schedules page must return 200: {html}"
+    );
+    assert!(html.contains("Schedules"), "page heading missing: {html}");
+    assert!(
+        html.contains("No schedules registered."),
+        "empty state message missing: {html}"
+    );
+    assert!(html.contains("🔭 Vantage"), "layout header missing: {html}");
+    assert!(!html.contains("<script"), "no script tags allowed: {html}");
+    assert!(!html.contains("http://"), "no external http URLs: {html}");
+    assert!(!html.contains("https://"), "no external https URLs: {html}");
+}
+
+/// Six schedules (3 Workflow + 3 Dag, mix of paused/active) all render.
+#[tokio::test]
+async fn ui_schedules_lists_all_rows() {
+    let (database_url, _container) = setup_test_database_url().await;
+    let id_wf1 = insert_test_schedule(&database_url, "Workflow", "payment_workflow", false).await;
+    let id_wf2 = insert_test_schedule(&database_url, "Workflow", "invoice_workflow", true).await;
+    let id_wf3 = insert_test_schedule(&database_url, "Workflow", "report_workflow", false).await;
+    let id_dag1 = insert_test_schedule(&database_url, "Dag", "nightly_etl", true).await;
+    let id_dag2 = insert_test_schedule(&database_url, "Dag", "hourly_sync", false).await;
+    let id_dag3 = insert_test_schedule(&database_url, "Dag", "weekly_report", true).await;
+
+    let app = build_single_shard_ui_app(&database_url);
+    let (status, html) = fetch_html(&app, "/schedules").await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "schedules page must return 200: {html}"
+    );
+
+    for id in [id_wf1, id_wf2, id_wf3, id_dag1, id_dag2, id_dag3] {
+        assert!(
+            html.contains(&id.to_string()),
+            "schedule id {id} missing from page: {html}"
+        );
+    }
+    assert!(
+        html.contains("payment_workflow"),
+        "payment_workflow missing: {html}"
+    );
+    assert!(
+        html.contains("invoice_workflow"),
+        "invoice_workflow missing: {html}"
+    );
+    assert!(html.contains("nightly_etl"), "nightly_etl missing: {html}");
+    assert!(html.contains("Workflow"), "Workflow kind missing: {html}");
+    assert!(html.contains("Dag"), "Dag kind missing: {html}");
+    assert!(html.contains("Paused"), "paused badge missing: {html}");
+    assert!(html.contains("Active"), "active badge missing: {html}");
+    // Nav must link to Schedules
+    assert!(
+        html.contains("schedules"),
+        "nav must include schedules link: {html}"
+    );
+}
+
+/// Filter `kind=Workflow` shows only Workflow rows and hides Dag rows.
+#[tokio::test]
+async fn ui_schedules_filter_by_kind_workflow() {
+    let (database_url, _container) = setup_test_database_url().await;
+    insert_test_schedule(&database_url, "Workflow", "target_wf", false).await;
+    insert_test_schedule(&database_url, "Dag", "target_dag", false).await;
+
+    let app = build_single_shard_ui_app(&database_url);
+    let (status, html) = fetch_html(&app, "/schedules?kind=Workflow").await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(
+        html.contains("target_wf"),
+        "workflow row missing after kind=Workflow: {html}"
+    );
+    assert!(
+        !html.contains("target_dag"),
+        "dag row should not appear after kind=Workflow: {html}"
+    );
+}
+
+/// Filter `kind=Dag` shows only Dag rows.
+#[tokio::test]
+async fn ui_schedules_filter_by_kind_dag() {
+    let (database_url, _container) = setup_test_database_url().await;
+    insert_test_schedule(&database_url, "Workflow", "wf_hidden", false).await;
+    insert_test_schedule(&database_url, "Dag", "dag_visible", false).await;
+
+    let app = build_single_shard_ui_app(&database_url);
+    let (status, html) = fetch_html(&app, "/schedules?kind=Dag").await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(
+        html.contains("dag_visible"),
+        "dag row missing after kind=Dag: {html}"
+    );
+    assert!(
+        !html.contains("wf_hidden"),
+        "workflow row should not appear after kind=Dag: {html}"
+    );
+}
+
+/// Filter `paused=Paused` shows only paused rows.
+#[tokio::test]
+async fn ui_schedules_filter_by_paused() {
+    let (database_url, _container) = setup_test_database_url().await;
+    insert_test_schedule(&database_url, "Workflow", "active_wf", false).await;
+    insert_test_schedule(&database_url, "Workflow", "paused_wf", true).await;
+
+    let app = build_single_shard_ui_app(&database_url);
+    let (status, html) = fetch_html(&app, "/schedules?paused=Paused").await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(
+        html.contains("paused_wf"),
+        "paused row missing after paused=Paused: {html}"
+    );
+    assert!(
+        !html.contains("active_wf"),
+        "active row should not appear after paused=Paused: {html}"
+    );
+}
+
+/// Filter `paused=Active` shows only active rows.
+#[tokio::test]
+async fn ui_schedules_filter_by_active() {
+    let (database_url, _container) = setup_test_database_url().await;
+    insert_test_schedule(&database_url, "Workflow", "active_visible", false).await;
+    insert_test_schedule(&database_url, "Workflow", "paused_hidden", true).await;
+
+    let app = build_single_shard_ui_app(&database_url);
+    let (status, html) = fetch_html(&app, "/schedules?paused=Active").await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(
+        html.contains("active_visible"),
+        "active row missing after paused=Active: {html}"
+    );
+    assert!(
+        !html.contains("paused_hidden"),
+        "paused row should not appear after paused=Active: {html}"
+    );
+}
+
+/// Filter `target=my_wf` narrows by name substring.
+#[tokio::test]
+async fn ui_schedules_filter_by_target() {
+    let (database_url, _container) = setup_test_database_url().await;
+    insert_test_schedule(&database_url, "Workflow", "my_special_wf", false).await;
+    insert_test_schedule(&database_url, "Workflow", "other_wf", false).await;
+
+    let app = build_single_shard_ui_app(&database_url);
+    let (status, html) = fetch_html(&app, "/schedules?target=my_special").await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(
+        html.contains("my_special_wf"),
+        "target row missing after target filter: {html}"
+    );
+    assert!(
+        !html.contains("other_wf"),
+        "other row should not appear after target filter: {html}"
+    );
+}
+
+/// Filter returns empty-set message when nothing matches.
+#[tokio::test]
+async fn ui_schedules_filter_no_match() {
+    let (database_url, _container) = setup_test_database_url().await;
+    insert_test_schedule(&database_url, "Workflow", "some_workflow", false).await;
+
+    let app = build_single_shard_ui_app(&database_url);
+    let (status, html) = fetch_html(&app, "/schedules?target=nonexistent").await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(
+        html.contains("No schedules match this filter"),
+        "empty filter message missing: {html}"
+    );
+}
+
+/// Pause action: POST to /schedules/{id}/pause → 303 redirect with flash.
+#[tokio::test]
+async fn ui_schedules_pause_action_redirects() {
+    let (database_url, _container) = setup_test_database_url().await;
+    let id = insert_test_schedule(&database_url, "Workflow", "pause_target", false).await;
+
+    let app = build_single_shard_ui_app(&database_url);
+    let (status, headers, _body) =
+        post_form(&app, &format!("/schedules/{id}/pause"), String::new()).await;
+    assert!(
+        status == StatusCode::SEE_OTHER || status == StatusCode::FOUND,
+        "pause action must redirect (got {status})"
+    );
+    let location = headers
+        .get("location")
+        .expect("redirect must have Location header")
+        .to_str()
+        .unwrap();
+    assert!(
+        location.contains("schedules"),
+        "redirect must go back to the schedules page: {location}"
+    );
+    assert!(
+        location.contains("flash"),
+        "redirect must carry a flash message: {location}"
+    );
+
+    // Verify the DB row is now paused.
+    let mut conn = AsyncPgConnection::establish(&database_url).await.unwrap();
+    let is_paused: bool = autumn_harvest::schema::harvest_schedules::table
+        .filter(autumn_harvest::schema::harvest_schedules::id.eq(id))
+        .select(autumn_harvest::schema::harvest_schedules::is_paused)
+        .first(&mut conn)
+        .await
+        .expect("schedule should exist");
+    assert!(is_paused, "schedule should be paused after pause action");
+}
+
+/// Resume action: POST to /schedules/{id}/resume → 303 redirect with flash.
+#[tokio::test]
+async fn ui_schedules_resume_action_redirects() {
+    let (database_url, _container) = setup_test_database_url().await;
+    let id = insert_test_schedule(&database_url, "Workflow", "resume_target", true).await;
+
+    let app = build_single_shard_ui_app(&database_url);
+    let (status, headers, _body) =
+        post_form(&app, &format!("/schedules/{id}/resume"), String::new()).await;
+    assert!(
+        status == StatusCode::SEE_OTHER || status == StatusCode::FOUND,
+        "resume action must redirect (got {status})"
+    );
+    let location = headers
+        .get("location")
+        .expect("redirect must have Location header")
+        .to_str()
+        .unwrap();
+    assert!(
+        location.contains("schedules"),
+        "redirect must go back to the schedules page: {location}"
+    );
+    assert!(
+        location.contains("flash"),
+        "redirect must carry a flash message: {location}"
+    );
+
+    // Verify the DB row is now active.
+    let mut conn = AsyncPgConnection::establish(&database_url).await.unwrap();
+    let is_paused: bool = autumn_harvest::schema::harvest_schedules::table
+        .filter(autumn_harvest::schema::harvest_schedules::id.eq(id))
+        .select(autumn_harvest::schema::harvest_schedules::is_paused)
+        .first(&mut conn)
+        .await
+        .expect("schedule should exist");
+    assert!(!is_paused, "schedule should be active after resume action");
+}
+
+/// Delete action: POST to /schedules/{id}/delete → 303 redirect with flash.
+#[tokio::test]
+async fn ui_schedules_delete_action_redirects() {
+    let (database_url, _container) = setup_test_database_url().await;
+    let id = insert_test_schedule(&database_url, "Workflow", "delete_target", false).await;
+
+    let app = build_single_shard_ui_app(&database_url);
+    let (status, headers, _body) =
+        post_form(&app, &format!("/schedules/{id}/delete"), String::new()).await;
+    assert!(
+        status == StatusCode::SEE_OTHER || status == StatusCode::FOUND,
+        "delete action must redirect (got {status})"
+    );
+    let location = headers
+        .get("location")
+        .expect("redirect must have Location header")
+        .to_str()
+        .unwrap();
+    assert!(
+        location.contains("schedules"),
+        "redirect must go back to the schedules page: {location}"
+    );
+    assert!(
+        location.contains("flash"),
+        "redirect must carry a flash message: {location}"
+    );
+
+    // Verify the row is gone.
+    let mut conn = AsyncPgConnection::establish(&database_url).await.unwrap();
+    let count: i64 = autumn_harvest::schema::harvest_schedules::table
+        .filter(autumn_harvest::schema::harvest_schedules::id.eq(id))
+        .count()
+        .get_result(&mut conn)
+        .await
+        .expect("count query");
+    assert_eq!(count, 0, "schedule should be deleted");
+}
+
+/// Auto-refresh: `?refresh=30` emits a meta http-equiv refresh tag.
+#[tokio::test]
+async fn ui_schedules_auto_refresh_meta_tag() {
+    let (database_url, _container) = setup_test_database_url().await;
+    let app = build_single_shard_ui_app(&database_url);
+
+    let (status, html) = fetch_html(&app, "/schedules?refresh=30").await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(
+        html.contains("content=\"30\"") && html.contains("http-equiv=\"refresh\""),
+        "auto-refresh meta tag with content=30 missing: {html}"
+    );
+
+    let (_, html_no_refresh) = fetch_html(&app, "/schedules").await;
+    assert!(
+        !html_no_refresh.contains("http-equiv=\"refresh\""),
+        "refresh tag must not appear when refresh not requested: {html_no_refresh}"
+    );
+}
+
+/// Bulk pause/resume forms are present in the HTML.
+#[tokio::test]
+async fn ui_schedules_bulk_actions_present() {
+    let (database_url, _container) = setup_test_database_url().await;
+    insert_test_schedule(&database_url, "Workflow", "bulk_wf", false).await;
+
+    let app = build_single_shard_ui_app(&database_url);
+    let (status, html) = fetch_html(&app, "/schedules").await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(
+        html.contains("bulk-pause") || html.contains("Pause all"),
+        "bulk pause action missing: {html}"
+    );
+    assert!(
+        html.contains("bulk-resume") || html.contains("Resume all"),
+        "bulk resume action missing: {html}"
+    );
+}
+
+/// Bulk pause: POST to /schedules/bulk-pause with filter → redirects and pauses matching rows.
+#[tokio::test]
+async fn ui_schedules_bulk_pause_pauses_matching_rows() {
+    let (database_url, _container) = setup_test_database_url().await;
+    let id1 = insert_test_schedule(&database_url, "Workflow", "bulk_target_a", false).await;
+    let id2 = insert_test_schedule(&database_url, "Workflow", "bulk_target_b", false).await;
+    let id_other = insert_test_schedule(&database_url, "Dag", "other_dag", false).await;
+
+    let app = build_single_shard_ui_app(&database_url);
+    let (status, headers, _body) =
+        post_form(&app, "/schedules/bulk-pause", "kind=Workflow&paused=Active").await;
+    assert!(
+        status == StatusCode::SEE_OTHER || status == StatusCode::FOUND,
+        "bulk-pause must redirect (got {status})"
+    );
+    let location = headers
+        .get("location")
+        .expect("redirect must have Location header")
+        .to_str()
+        .unwrap();
+    assert!(
+        location.contains("schedules"),
+        "redirect must go to schedules: {location}"
+    );
+
+    // Verify workflow schedules are paused, dag is not.
+    let mut conn = AsyncPgConnection::establish(&database_url).await.unwrap();
+    let paused1: bool = autumn_harvest::schema::harvest_schedules::table
+        .filter(autumn_harvest::schema::harvest_schedules::id.eq(id1))
+        .select(autumn_harvest::schema::harvest_schedules::is_paused)
+        .first(&mut conn)
+        .await
+        .unwrap();
+    let paused2: bool = autumn_harvest::schema::harvest_schedules::table
+        .filter(autumn_harvest::schema::harvest_schedules::id.eq(id2))
+        .select(autumn_harvest::schema::harvest_schedules::is_paused)
+        .first(&mut conn)
+        .await
+        .unwrap();
+    let paused_other: bool = autumn_harvest::schema::harvest_schedules::table
+        .filter(autumn_harvest::schema::harvest_schedules::id.eq(id_other))
+        .select(autumn_harvest::schema::harvest_schedules::is_paused)
+        .first(&mut conn)
+        .await
+        .unwrap();
+    assert!(paused1, "bulk_target_a should be paused");
+    assert!(paused2, "bulk_target_b should be paused");
+    assert!(
+        !paused_other,
+        "other_dag should NOT be paused (different kind)"
+    );
+}
+
+/// Pagination: `?limit=1` caps the list to 1 row and shows Next link.
+#[tokio::test]
+async fn ui_schedules_pagination() {
+    let (database_url, _container) = setup_test_database_url().await;
+    insert_test_schedule(&database_url, "Workflow", "pag_wf_1", false).await;
+    insert_test_schedule(&database_url, "Workflow", "pag_wf_2", false).await;
+    insert_test_schedule(&database_url, "Workflow", "pag_wf_3", false).await;
+
+    let app = build_single_shard_ui_app(&database_url);
+    let (status, html) = fetch_html(&app, "/schedules?limit=1").await;
+    assert_eq!(status, StatusCode::OK);
+    let row_count = html.matches("pag_wf_").count();
+    assert_eq!(row_count, 1, "limit=1 should render exactly 1 row: {html}");
+    assert!(
+        html.contains("Next"),
+        "Next pagination link missing when there are more rows: {html}"
+    );
+}
+
+/// Multi-shard: schedules from two shards both appear.
+#[tokio::test]
+async fn ui_schedules_multi_shard() {
+    let ((shard0_url, shard1_url), _container) = setup_sharded_test_database_urls().await;
+    insert_test_schedule(&shard0_url, "Workflow", "shard0_schedule", false).await;
+    insert_test_schedule(&shard1_url, "Dag", "shard1_dag_schedule", false).await;
+
+    let api_state = HarvestApiState::new();
+    api_state.install_storage_pool(build_two_shard_pool(&shard0_url, &shard1_url));
+    api_state.install(HarvestApiRuntime::new(
+        echo_registry(),
+        Arc::new(HashMap::new()),
+        Arc::new(Vec::new()),
+        None,
+        vec!["default".to_string()],
+        SchedulerMonitor::offline(),
+        HarvestRetentionRuntime::disabled(autumn_harvest::RetentionConfig::default()),
+        ShardRouter::new(
+            vec![ShardId::new(0), ShardId::new(1)],
+            vec![ShardId::new(0), ShardId::new(1)],
+            ShardId::new(0),
+        ),
+    ));
+    let app = harvest_ui_router(api_state).with_state(test_app_state_without_database());
+
+    let (status, html) = fetch_html(&app, "/schedules").await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "multi-shard schedules page must return 200: {html}"
+    );
+    assert!(
+        html.contains("shard0_schedule"),
+        "shard 0 schedule missing: {html}"
+    );
+    assert!(
+        html.contains("shard1_dag_schedule"),
+        "shard 1 schedule missing: {html}"
+    );
+}
+
+/// Partial shard failure: renders 200 with shard-error banner, does not 5xx.
+#[tokio::test]
+async fn ui_schedules_partial_shard_failure() {
+    let (good_url, _container) = setup_test_database_url().await;
+    insert_test_schedule(&good_url, "Workflow", "good_shard_schedule", false).await;
+
+    let bad_pool = build_test_pool("postgres://invalid:5432/nonexistent");
+    let good_pool = build_test_pool(&good_url);
+    let mut pools = BTreeMap::new();
+    pools.insert(ShardId::new(0), good_pool);
+    pools.insert(ShardId::new(1), bad_pool);
+    let harvest_pool = HarvestDbPool::sharded(ShardedDbPool::from_map(pools, ShardId::new(0)));
+
+    let api_state = HarvestApiState::new();
+    api_state.install_storage_pool(harvest_pool);
+    api_state.install(HarvestApiRuntime::new(
+        echo_registry(),
+        Arc::new(HashMap::new()),
+        Arc::new(Vec::new()),
+        None,
+        vec!["default".to_string()],
+        SchedulerMonitor::offline(),
+        HarvestRetentionRuntime::disabled(autumn_harvest::RetentionConfig::default()),
+        ShardRouter::new(
+            vec![ShardId::new(0), ShardId::new(1)],
+            vec![ShardId::new(0), ShardId::new(1)],
+            ShardId::new(0),
+        ),
+    ));
+    let app = harvest_ui_router(api_state).with_state(test_app_state_without_database());
+
+    let (status, html) = fetch_html(&app, "/schedules").await;
+    assert_ne!(
+        status,
+        StatusCode::INTERNAL_SERVER_ERROR,
+        "partial shard failure must not 5xx: {html}"
+    );
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "partial shard failure should return 200: {html}"
+    );
+    assert!(
+        html.contains("unavailable") || html.contains("Shard"),
+        "partial shard failure should show shard-error banner: {html}"
+    );
+    assert!(
+        html.contains("good_shard_schedule"),
+        "good shard row should still appear: {html}"
+    );
+}
+
+/// Flash message from a redirect renders in the schedules list page.
+#[tokio::test]
+async fn ui_schedules_flash_message_renders() {
+    let (database_url, _container) = setup_test_database_url().await;
+    let app = build_single_shard_ui_app(&database_url);
+
+    let (status, html) = fetch_html(&app, "/schedules?flash=Paused+my_workflow").await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(
+        html.contains("Paused my_workflow") || html.contains("Paused+my_workflow"),
+        "flash message should appear on the page: {html}"
+    );
+}
+
+/// Existing nav layouts include a Schedules link so operators can navigate.
+#[tokio::test]
+async fn ui_all_pages_have_schedules_nav_link() {
+    let (database_url, _container) = setup_test_database_url().await;
+    let app = build_single_shard_ui_app(&database_url);
+
+    for path in ["/workflows", "/workers", "/schedules"] {
+        let (status, html) = fetch_html(&app, path).await;
+        assert_eq!(status, StatusCode::OK, "page {path} must render: {html}");
+        assert!(
+            html.contains("href=\"schedules\"")
+                || html.contains("href=\"/schedules\"")
+                || html.contains(">Schedules<"),
+            "page {path} must include a Schedules nav link: {html}"
+        );
+    }
+}

--- a/autumn-harvest-plugin/tests/ui_integration.rs
+++ b/autumn-harvest-plugin/tests/ui_integration.rs
@@ -1252,7 +1252,7 @@ async fn ui_workers_perf_1k_workers_4_shards_under_500ms() {
 // ---------------------------------------------------------------------------
 
 /// Insert a test row into `harvest_schedules`.
-/// `kind` is "Workflow" or "Dag"; `name` is the workflow_name / dag_name.
+/// `kind` is `"Workflow"` or `"Dag"`; `name` is the `workflow_name` / `dag_name`.
 async fn insert_test_schedule(
     database_url: &str,
     kind: &str,


### PR DESCRIPTION
## Summary

Adds a new "Schedules" page to the Vantage UI dashboard, enabling operators to view, filter, and manage workflow and DAG schedules. The page supports individual and bulk pause/resume/delete operations with audit logging.

## Key Changes

- **New schedules UI page** (`/schedules`): Lists all `HarvestSchedule` rows across shards with filtering by target name, kind (Workflow/Dag), paused status, and shard ID
- **Filter and search**: Query parameters for `target`, `kind`, `paused`, `shard_id`, `limit`, `page`, and `refresh` with form-based UI
- **Individual actions**: POST endpoints for pause, resume, and delete on single schedules (`/schedules/{id}/pause`, `/schedules/{id}/resume`, `/schedules/{id}/delete`)
- **Bulk actions**: POST endpoints for bulk pause and resume (`/schedules/bulk-pause`, `/schedules/bulk-resume`) that apply filters across all matching schedules
- **Audit logging**: All schedule mutations (pause, resume, delete) are recorded via `insert_audit()` with operation types `OP_SCHEDULE_PAUSE`, `OP_SCHEDULE_RESUME`, `OP_SCHEDULE_DELETE`
- **Navigation**: Added "Schedules" link to the main navigation menu in all layout templates
- **Pagination and distribution**: Page supports configurable per-page limits, pagination controls, and displays a summary of kind distribution (e.g., "3 Workflow, 2 Dag")
- **Error handling**: Graceful handling of shard unavailability with per-shard error display
- **Flash messages**: Redirect-based feedback for user actions (e.g., "Paused payment_workflow")
- **Comprehensive tests**: 13 new integration tests covering empty state, filtering by kind/paused/target, pagination, and action redirects with DB verification

## Implementation Details

- Schedules are loaded from all shards in parallel via `load_schedules_from_shards_ui()` and filtered client-side using `ScheduleUiFilters::matches()`
- Filter enums (`ScheduleKindFilter`, `SchedulePausedFilter`) provide type-safe parsing and validation
- Bulk operations iterate across shards and apply filters to each row, recording individual audit entries
- Redirect-based POST handlers use URL-encoded flash messages to provide feedback without page state
- Layout templates updated to include "Schedules" in navigation alongside Workflows, Workers, and Dead Letters
- Fixed Unicode rendering issues in layout footers (em-dash and telescope emoji)

https://claude.ai/code/session_018HVgXgz3VFQsUJCSDVXUHL