### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/autumn-harvest/src/reset.rs
+++ b/autumn-harvest/src/reset.rs
@@ -105,14 +105,23 @@ pub struct ResetUnresolvedSideEffect {
 /// Valid reset-boundary plan, also used as dry-run output after DB counts are attached.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ResetPlan {
+    /// The event ID representing the new start of the workflow execution fork.
     pub reset_to_event_id: i64,
+    /// Number of events that will be copied over to the new execution history.
     pub events_carried_over: usize,
+    /// List of side effects that were pending resolution at the reset boundary.
     pub unresolved_side_effects: Vec<ResetUnresolvedSideEffect>,
+    /// The closest earlier event ID that is a valid reset boundary.
     pub nearest_valid_before: Option<i64>,
+    /// The closest later event ID that is a valid reset boundary.
     pub nearest_valid_after: Option<i64>,
+    /// Number of scheduled tasks on the original execution that will be cancelled.
     pub source_tasks_to_cancel: usize,
+    /// Number of timers on the original execution that will be removed.
     pub source_timers_to_remove: usize,
+    /// Number of undelivered signals on the original execution that will be dropped.
     pub source_signals_to_drop: usize,
+    /// Number of undelivered signals on the original execution that will be re-buffered.
     pub source_signals_to_buffer: usize,
 }
 
@@ -135,11 +144,17 @@ impl ResetPlan {
 /// Invalid reset-boundary details surfaced by the management API as `400`.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ResetInvalidPoint {
+    /// Description of why the reset point is invalid.
     pub message: String,
+    /// The event ID requested as the reset boundary.
     pub reset_to_event_id: i64,
+    /// The highest event ID present in the workflow execution history.
     pub last_event_id: i64,
+    /// List of side effects still unresolved at the requested boundary.
     pub unresolved_side_effects: Vec<ResetUnresolvedSideEffect>,
+    /// The closest earlier event ID that is a valid reset boundary.
     pub nearest_valid_before: Option<i64>,
+    /// The closest later event ID that is a valid reset boundary.
     pub nearest_valid_after: Option<i64>,
 }
 
@@ -154,28 +169,47 @@ impl std::error::Error for ResetInvalidPoint {}
 /// Result of a committed workflow reset.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ResetResult {
+    /// The ID of the newly created workflow execution fork.
     pub new_exec_id: ExecutionId,
+    /// The ID of the original workflow execution that was reset.
     pub reset_from_exec_id: ExecutionId,
+    /// The event ID acting as the reset boundary.
     pub reset_to_event_id: i64,
+    /// Number of events copied over from the original execution.
     pub events_carried_over: usize,
+    /// Number of pending tasks on the original execution that were cancelled.
     pub source_tasks_cancelled: usize,
+    /// Number of pending timers on the original execution that were removed.
     pub source_timers_removed: usize,
+    /// Number of undelivered signals on the original execution that were dropped.
     pub source_signals_dropped: usize,
+    /// Number of undelivered signals on the original execution that were re-buffered on the new fork.
     pub source_signals_buffered: usize,
 }
 
 /// Errors specific to the reset workflow.
 #[derive(Debug, thiserror::Error)]
 pub enum WorkflowResetError {
+    /// The requested reset point is invalid.
     #[error(transparent)]
     InvalidPoint(#[from] ResetInvalidPoint),
+    /// The execution being reset is already in a terminal state.
     #[error("workflow execution {exec_id} is terminal ({state})")]
-    TerminalSource { exec_id: ExecutionId, state: String },
+    TerminalSource {
+        /// The ID of the terminal workflow execution.
+        exec_id: ExecutionId,
+        /// The stringified terminal state of the execution.
+        state: String,
+    },
+    /// Resetting child workflows is currently not supported.
     #[error("workflow execution {exec_id} is a child workflow; reset the root parent in v1")]
     ChildWorkflow {
+        /// The ID of the child workflow execution.
         exec_id: ExecutionId,
+        /// The execution ID of the parent workflow.
         parent_id: Uuid,
     },
+    /// The history contains a `ContinueAsNew` event, which cannot be reset across.
     #[error("continue-as-new histories cannot be reset in v1")]
     ContinueAsNew,
     /// An underlying storage or database error occurred during the reset operation.

--- a/autumn-harvest/src/scheduler.rs
+++ b/autumn-harvest/src/scheduler.rs
@@ -40,7 +40,10 @@ pub const DEFAULT_BACKFILL_MAX_COUNT: usize = 1_000;
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum BackfillPlanError {
     /// The window contains more timestamps than the caller-supplied limit.
-    LimitExceeded { limit: usize },
+    LimitExceeded {
+        /// The maximum number of timestamps that were permitted.
+        limit: usize,
+    },
 }
 
 impl std::fmt::Display for BackfillPlanError {

--- a/autumn-harvest/src/version_gate_retirement.rs
+++ b/autumn-harvest/src/version_gate_retirement.rs
@@ -52,15 +52,23 @@ pub struct RetirementCheckFilters {
 /// before retiring the old branch."
 #[derive(Debug, Clone, Eq, PartialEq, Serialize)]
 pub struct RetirementCheckShardRow {
+    /// The name of the workflow this check corresponds to.
     pub workflow_name: String,
+    /// The identifier for the version gate change.
     pub change_id: String,
+    /// The highest version observed for executions passing this gate.
     pub recorded_version: u32,
+    /// Number of non-terminal executions referencing this version.
     pub active_executions: i64,
+    /// Number of terminal executions referencing this version.
     pub terminal_executions: i64,
+    /// Earliest start time of an execution acting as a blocker for retirement.
     pub oldest_blocker_started_at: DateTime<Utc>,
+    /// Most recent start time of an execution acting as a blocker for retirement.
     pub newest_blocker_started_at: DateTime<Utc>,
     /// Up to 10 active (non-terminal) execution IDs for manual investigation.
     pub sample_active_execution_ids: Vec<Uuid>,
+    /// The database shard ID containing these executions.
     pub shard_id: i32,
 }
 

--- a/autumn-harvest/src/version_usage.rs
+++ b/autumn-harvest/src/version_usage.rs
@@ -22,6 +22,7 @@ pub enum VersionExecutionStateGroup {
 }
 
 impl VersionExecutionStateGroup {
+    /// Returns the string representation of the state group.
     #[must_use]
     pub const fn as_str(self) -> &'static str {
         match self {
@@ -50,23 +51,36 @@ impl std::str::FromStr for VersionExecutionStateGroup {
 /// Filters applied when reading version-gate marker usage from one shard.
 #[derive(Debug, Clone, Default, Eq, PartialEq)]
 pub struct VersionUsageFilters {
+    /// Only include usage for this specific workflow name.
     pub workflow_name: Option<String>,
+    /// Only include usage for this specific change identifier.
     pub change_id: Option<String>,
+    /// Only include usage matching this recorded version.
     pub recorded_version: Option<u32>,
+    /// Limit the usage metrics to specific execution states (active/terminal/all).
     pub state_group: VersionExecutionStateGroup,
+    /// Only query the specified database shard.
     pub shard_id: Option<i32>,
 }
 
 /// One grouped version-gate usage row read from a single database shard.
 #[derive(Debug, Clone, Eq, PartialEq, Serialize)]
 pub struct VersionUsageShardRow {
+    /// The name of the workflow this usage corresponds to.
     pub workflow_name: String,
+    /// The identifier for the version gate change.
     pub change_id: String,
+    /// The recorded version value for the executions in this row.
     pub recorded_version: u32,
+    /// Number of non-terminal executions referencing this version.
     pub active_executions: i64,
+    /// Number of terminal executions referencing this version.
     pub terminal_executions: i64,
+    /// Earliest start time of an execution that matched the filters.
     pub oldest_matching_started_at: DateTime<Utc>,
+    /// Most recent start time of an execution that matched the filters.
     pub newest_matching_started_at: DateTime<Utc>,
+    /// The database shard ID containing these executions.
     pub shard_id: i32,
 }
 


### PR DESCRIPTION
📖 Chapter: Documented missing public fields in `ResetPlan`, `ResetInvalidPoint`, `ResetResult`, `WorkflowResetError`, `RetirementCheckShardRow`, `VersionUsageFilters`, `VersionUsageShardRow`, and `BackfillPlanError`.
🔦 Insight: Provided clear context on what each field represents within the workflow reset and version gate queries.
🧪 Example: Resolved over 40 clippy `missing_docs` warnings.
🖼️ Preview: All undocumented fields on public structures are now correctly described.

---
*PR created automatically by Jules for task [15295286058442979444](https://jules.google.com/task/15295286058442979444) started by @madmax983*