### PR TITLE
Add WorkflowTestEnv in-process unit-test harness (issue #250)

### DIFF
--- a/autumn-harvest/Cargo.toml
+++ b/autumn-harvest/Cargo.toml
@@ -73,6 +73,10 @@ name = "replayer_tests"
 required-features = ["testing"]
 
 [[test]]
+name = "workflow_test_env_tests"
+required-features = ["testing"]
+
+[[test]]
 name = "dag_unified_tests"
 required-features = ["testing", "unified-dag-execution"]
 

--- a/autumn-harvest/src/lib.rs
+++ b/autumn-harvest/src/lib.rs
@@ -215,6 +215,8 @@ pub use test_generator::TestHarnessGenerator;
 pub use testing::{
     HistorySnapshot, NonDeterminismKind, ReplayReport, ReplayStatus, WorkflowReplayer,
 };
+#[cfg(feature = "testing")]
+pub use testing::{TestRunOutcome, WorkflowTestEnv};
 pub use types::{
     ActivityExecId, BuildId, DeploymentName, ExecutionId, ExternalActivityToken, ShardId, TimerId,
     UpdateId, WorkerId, WorkflowId, WorkflowIdReusePolicy,

--- a/autumn-harvest/src/testing.rs
+++ b/autumn-harvest/src/testing.rs
@@ -1078,12 +1078,22 @@ impl WorkflowTestEnv {
                     };
                 }
                 WorkflowOutcome::Suspended { commands } => {
-                    let made_progress = self.process_suspension(
+                    let made_progress = match self.process_suspension(
                         commands,
                         &mut history,
                         &mut remaining_signals,
                         &mut call_counts,
-                    );
+                    ) {
+                        Ok(p) => p,
+                        Err(e) => {
+                            return TestRunOutcome {
+                                result: Err(e),
+                                events: history,
+                                exec_id,
+                                state: self.state.clone(),
+                            };
+                        }
+                    };
                     if !made_progress {
                         return TestRunOutcome {
                             result: Err("WorkflowTestEnv: workflow suspended with no resolvable \
@@ -1111,14 +1121,17 @@ impl WorkflowTestEnv {
     }
 
     /// Process one suspension batch: resolve commands and append events.
-    /// Returns `true` if at least one command was resolved.
+    ///
+    /// Returns `Ok(true)` if at least one command was resolved, `Ok(false)` if
+    /// no progress was made, or `Err(msg)` if a harness configuration error was
+    /// encountered (e.g. a missing activity mock or child-workflow stub).
     fn process_suspension(
         &self,
         commands: Vec<WorkflowCommand>,
         history: &mut Vec<WorkflowEvent>,
         remaining_signals: &mut Vec<(String, Value)>,
         call_counts: &mut HashMap<String, u32>,
-    ) -> bool {
+    ) -> Result<bool, String> {
         let signal_will_resolve = commands.iter().any(|cmd| {
             if let WorkflowCommand::WaitForSignal { signal_name, .. } = cmd {
                 remaining_signals.iter().any(|(n, _)| n == signal_name)
@@ -1135,13 +1148,16 @@ impl WorkflowTestEnv {
                 history,
                 remaining_signals,
                 call_counts,
-            );
+            )?;
         }
-        made_progress
+        Ok(made_progress)
     }
 
     /// Resolve a single workflow command and append the resulting events.
-    /// Returns `true` if the command produced progress (events appended).
+    ///
+    /// Returns `Ok(true)` when a command produced progress, `Ok(false)` when
+    /// the command was a no-op, or `Err(msg)` when a mock/stub lookup failed
+    /// (harness configuration error — the test must be fixed, not the workflow).
     fn process_command(
         &self,
         cmd: WorkflowCommand,
@@ -1149,7 +1165,7 @@ impl WorkflowTestEnv {
         history: &mut Vec<WorkflowEvent>,
         remaining_signals: &mut Vec<(String, Value)>,
         call_counts: &mut HashMap<String, u32>,
-    ) -> bool {
+    ) -> Result<bool, String> {
         match cmd {
             WorkflowCommand::ScheduleActivity {
                 activity_id,
@@ -1159,7 +1175,7 @@ impl WorkflowTestEnv {
                 ..
             } => {
                 let call_num = Self::next_call_count(call_counts, &name);
-                let result = self.resolve_activity(&name, act_input.clone(), call_num);
+                let result = self.resolve_activity(&name, act_input.clone(), call_num)?;
                 history.push(WorkflowEvent::ActivityScheduled {
                     activity_id,
                     name: name.clone(),
@@ -1167,7 +1183,7 @@ impl WorkflowTestEnv {
                     queue,
                 });
                 Self::push_activity_terminal(history, activity_id, result);
-                true
+                Ok(true)
             }
 
             WorkflowCommand::RunLocalActivity {
@@ -1177,14 +1193,14 @@ impl WorkflowTestEnv {
                 ..
             } => {
                 let call_num = Self::next_call_count(call_counts, &name);
-                let result = self.resolve_activity(&name, act_input.clone(), call_num);
+                let result = self.resolve_activity(&name, act_input.clone(), call_num)?;
                 history.push(WorkflowEvent::LocalActivityScheduled {
                     activity_id,
                     name: name.clone(),
                     input: act_input,
                 });
                 Self::push_local_activity_terminal(history, activity_id, result);
-                true
+                Ok(true)
             }
 
             WorkflowCommand::StartTimer {
@@ -1195,17 +1211,17 @@ impl WorkflowTestEnv {
                 if signal_will_resolve {
                     // Skip firing the timer — a concurrent signal takes priority
                     // so the workflow takes the signal branch in select!.
-                    return false;
+                    return Ok(false);
                 }
                 history.push(WorkflowEvent::TimerStarted {
                     timer_id: timer_id.clone(),
                     duration_secs,
                 });
                 history.push(WorkflowEvent::TimerFired { timer_id });
-                true
+                Ok(true)
             }
 
-            WorkflowCommand::WaitForSignal { signal_name, .. } => remaining_signals
+            WorkflowCommand::WaitForSignal { signal_name, .. } => Ok(remaining_signals
                 .iter()
                 .position(|(n, _)| n == &signal_name)
                 .is_some_and(|pos| {
@@ -1215,7 +1231,7 @@ impl WorkflowTestEnv {
                         payload,
                     });
                     true
-                }),
+                })),
 
             WorkflowCommand::StartChildWorkflow {
                 child_id,
@@ -1223,7 +1239,7 @@ impl WorkflowTestEnv {
                 input: child_input,
                 ..
             } => {
-                let result = self.resolve_child(&workflow_name, child_input.clone());
+                let result = self.resolve_child(&workflow_name, child_input.clone())?;
                 history.push(WorkflowEvent::ChildWorkflowStarted {
                     child_id,
                     workflow_name,
@@ -1237,7 +1253,7 @@ impl WorkflowTestEnv {
                         history.push(WorkflowEvent::ChildWorkflowFailed { child_id, error });
                     }
                 }
-                true
+                Ok(true)
             }
 
             // WaitForActivity: activity was scheduled in a previous iteration;
@@ -1249,7 +1265,7 @@ impl WorkflowTestEnv {
             | WorkflowCommand::ScheduleExternalActivity { .. }
             | WorkflowCommand::Complete { .. }
             | WorkflowCommand::Fail { .. }
-            | WorkflowCommand::ContinueAsNew { .. } => false,
+            | WorkflowCommand::ContinueAsNew { .. } => Ok(false),
         }
     }
 
@@ -1265,12 +1281,22 @@ impl WorkflowTestEnv {
     /// Resolve an activity (regular or local) using registered mocks.
     ///
     /// Per-call-count results take priority over the general fallback mock.
-    fn resolve_activity(&self, name: &str, input: Value, call_num: u32) -> Result<Value, String> {
+    ///
+    /// Returns `Ok(activity_result)` when a mock is found (the inner `Result`
+    /// is the mock's success/failure value), or `Err(harness_error)` when no
+    /// mock is registered — a harness configuration problem that must be fixed
+    /// in the test, not handled as a workflow-level failure.
+    fn resolve_activity(
+        &self,
+        name: &str,
+        input: Value,
+        call_num: u32,
+    ) -> Result<Result<Value, String>, String> {
         if let Some(result) = self.attempt_results.get(&(name.to_string(), call_num)) {
-            return result.clone();
+            return Ok(result.clone());
         }
         if let Some(mock) = self.activity_mocks.get(name) {
-            return mock(input);
+            return Ok(mock(input));
         }
         Err(format!(
             "WorkflowTestEnv: no mock registered for activity '{name}' \
@@ -1280,9 +1306,12 @@ impl WorkflowTestEnv {
     }
 
     /// Resolve a child workflow using registered stubs.
-    fn resolve_child(&self, name: &str, input: Value) -> Result<Value, String> {
+    ///
+    /// Returns `Ok(child_result)` when a stub is found, or `Err(harness_error)`
+    /// when no stub is registered — must be fixed in the test.
+    fn resolve_child(&self, name: &str, input: Value) -> Result<Result<Value, String>, String> {
         if let Some(mock) = self.child_mocks.get(name) {
-            return mock(input);
+            return Ok(mock(input));
         }
         Err(format!(
             "WorkflowTestEnv: no mock registered for child workflow '{name}'. \

--- a/autumn-harvest/src/testing.rs
+++ b/autumn-harvest/src/testing.rs
@@ -42,14 +42,16 @@
 
 use std::any::TypeId;
 use std::collections::HashMap;
+use std::sync::Arc;
 
+use chrono::{DateTime, Utc};
 use serde_json::Value;
 
-use crate::context::{SharedState, empty_shared_state};
+use crate::context::{SharedState, WorkflowCommand, empty_shared_state};
 use crate::event::WorkflowEvent;
-use crate::executor::{WorkflowOutcome, run_workflow_strict};
+use crate::executor::{WorkflowOutcome, run_workflow_strict, run_workflow_with_state};
 use crate::info::{WorkflowHandlerFn, WorkflowInfo};
-use crate::types::ExecutionId;
+use crate::types::{ActivityExecId, ExecutionId};
 
 // ---------------------------------------------------------------------------
 // NonDeterminismKind
@@ -717,6 +719,561 @@ fn find_event_index(events: &[WorkflowEvent], actual: &str) -> usize {
         .iter()
         .position(|e| e.type_name() == target)
         .unwrap_or(0)
+}
+
+// ===========================================================================
+// WorkflowTestEnv  — in-process unit-test harness for workflow functions
+// ===========================================================================
+//
+// Design notes
+// ──────────────
+// `WorkflowTestEnv` drives a workflow function to completion by repeatedly
+// running it through the executor, processing the `WorkflowCommand`s emitted
+// on each suspension, appending mock results to an in-memory event history,
+// and re-running with the updated history.
+//
+// No Postgres, no worker process, no Docker — all side effects are satisfied
+// by closures registered before the run.
+//
+// Execution order
+// ───────────────
+// On each suspension:
+//   1. Regular and local activities are resolved immediately via registered
+//      mocks (either per-call-count or general fallback).
+//   2. Child-workflow spawns are resolved via registered child mocks.
+//   3. Signals are injected from the pre-queued queue when a `WaitForSignal`
+//      command is outstanding.
+//   4. Timers auto-fire *unless* a signal is also being resolved in the same
+//      suspension batch (signal takes priority in concurrent select! branches).
+//
+// The loop terminates when the workflow returns `Completed` or `Failed`, or
+// when no commands can be resolved (workflow stuck) or the iteration cap is
+// reached.
+
+/// Maximum number of executor iterations before declaring an infinite loop.
+const MAX_TEST_ITERATIONS: usize = 1_000;
+
+/// Type alias for the mock closure stored in `WorkflowTestEnv`.
+type MockFn = Arc<dyn Fn(Value) -> Result<Value, String> + Send + Sync>;
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+/// The outcome of a [`WorkflowTestEnv::run`] call.
+///
+/// Contains the workflow's final `result` (success or failure) and the full
+/// ordered event log produced during the run.  Use [`TestRunOutcome::events`]
+/// for event-log assertions and [`TestRunOutcome::replay_check`] to verify
+/// that the produced history is replay-deterministic.
+pub struct TestRunOutcome {
+    /// The workflow's terminal result: `Ok(output)` or `Err(error_string)`.
+    pub result: Result<Value, String>,
+    /// The complete ordered event log built during the test run.
+    events: Vec<WorkflowEvent>,
+    /// Execution ID used for the run (stable for replay checks).
+    exec_id: ExecutionId,
+}
+
+impl TestRunOutcome {
+    /// Returns a reference to the ordered event log.
+    ///
+    /// Use this to assert ordering invariants such as `ActivityCompleted` for
+    /// `charge_card` came after `SignalReceived(approve)`.
+    #[must_use]
+    pub fn events(&self) -> &[WorkflowEvent] {
+        &self.events
+    }
+
+    /// Run the recorded event history through [`WorkflowReplayer`] and return
+    /// the replay report.
+    ///
+    /// If the workflow function is deterministic, this will always return
+    /// [`ReplayStatus::ReplaySucceeded`].  A failure here means the workflow
+    /// code is non-deterministic and would cause problems in production replay.
+    ///
+    /// This check is free — it reuses the event history already produced by
+    /// the test run, so there is no extra DB or network call.
+    pub async fn replay_check(&self, handler: WorkflowHandlerFn) -> ReplayReport {
+        let snapshot = crate::testing::HistorySnapshot {
+            workflow_name: "__test__".to_string(),
+            execution_id: self.exec_id,
+            events: self.events.clone(),
+        };
+        WorkflowReplayer::new()
+            .register_fn("__test__", handler)
+            .replay_from_snapshot(snapshot)
+            .await
+    }
+}
+
+// ---------------------------------------------------------------------------
+// WorkflowTestEnv
+// ---------------------------------------------------------------------------
+
+/// In-process unit-test harness for `#[workflow]` functions.
+///
+/// Run a workflow to completion without Postgres, workers, or Docker.
+/// Activities are satisfied by registered closures; timers auto-fire;
+/// signals are injected from a pre-queued list; child workflows are stubbed.
+///
+/// # Quick start
+///
+/// ```rust,no_run
+/// # use autumn_harvest::testing::WorkflowTestEnv;
+/// # use autumn_harvest::context::WorkflowContext;
+/// # use serde_json::{Value, json};
+/// # use std::pin::Pin;
+/// # fn my_workflow<'a>(ctx: &'a WorkflowContext, _: Value)
+/// #   -> Pin<Box<dyn std::future::Future<Output=Result<Value,String>>+Send+'a>>
+/// # { Box::pin(async move { Ok(json!(null)) }) }
+/// # #[tokio::main] async fn main() {
+/// let outcome = WorkflowTestEnv::new()
+///     .mock_activity("send_email", |_| Ok(json!("delivered")))
+///     .run(my_workflow, json!({"user_id": 1}))
+///     .await;
+///
+/// assert_eq!(outcome.result, Ok(json!("delivered")));
+/// # }
+/// ```
+pub struct WorkflowTestEnv {
+    /// Fallback mocks: activity name → closure(input) → result.
+    activity_mocks: HashMap<String, MockFn>,
+    /// Per-call-count mocks: (name, 1-based call number) → result.
+    ///
+    /// "Call number" is the number of times the workflow has issued a command
+    /// for this activity name (across all iterations).  This corresponds to
+    /// explicit workflow-level retries, not worker-level retry attempts.
+    attempt_results: HashMap<(String, u32), Result<Value, String>>,
+    /// Child-workflow stubs: workflow name → closure(input) → result.
+    child_mocks: HashMap<String, MockFn>,
+    /// Simulated wall-clock time.  Used as the `WorkflowStarted` timestamp so
+    /// `ctx.now()` inside the workflow function is deterministic.
+    simulated_now: DateTime<Utc>,
+    /// Signals pre-queued for delivery when the workflow calls `wait_for_signal`.
+    queued_signals: Vec<(String, Value)>,
+    /// If `Some`, a `WorkflowCancelled` event is prepended to the history so
+    /// `ctx.is_cancelled()` returns `true` from the first execution cycle.
+    cancellation_reason: Option<String>,
+    /// Shared typed state injected into the `WorkflowContext`.
+    state: SharedState,
+}
+
+impl Default for WorkflowTestEnv {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl WorkflowTestEnv {
+    // ── Construction ─────────────────────────────────────────────────────
+
+    /// Create an empty test environment.
+    #[must_use]
+    pub fn new() -> Self {
+        Self {
+            activity_mocks: HashMap::new(),
+            attempt_results: HashMap::new(),
+            child_mocks: HashMap::new(),
+            simulated_now: Utc::now(),
+            queued_signals: Vec::new(),
+            cancellation_reason: None,
+            state: empty_shared_state(),
+        }
+    }
+
+    // ── Fluent builder ───────────────────────────────────────────────────
+
+    /// Register a fallback mock for an activity (or local activity) by name.
+    ///
+    /// The closure receives the deserialized input payload and must return the
+    /// activity result.  This mock is used for every call whose call-number
+    /// does not have a [`mock_activity_attempt`](Self::mock_activity_attempt)
+    /// registered.
+    ///
+    /// The same mock covers both `execute_activity_raw` and
+    /// `execute_local_activity_raw` — the name is the only routing key.
+    #[must_use]
+    pub fn mock_activity<F>(mut self, name: impl Into<String>, mock: F) -> Self
+    where
+        F: Fn(Value) -> Result<Value, String> + Send + Sync + 'static,
+    {
+        self.activity_mocks.insert(name.into(), Arc::new(mock));
+        self
+    }
+
+    /// Register a result for a specific per-call invocation of an activity.
+    ///
+    /// `call_number` is 1-based and counts how many times the workflow code
+    /// has called `execute_activity_raw` / `execute_local_activity_raw` for
+    /// this activity name.  This lets you test explicit workflow-level retry
+    /// logic:
+    ///
+    /// ```rust,no_run
+    /// # use autumn_harvest::testing::WorkflowTestEnv;
+    /// # use serde_json::json;
+    /// let env = WorkflowTestEnv::new()
+    ///     .mock_activity_attempt("charge_card", 1, Err("transient".into()))
+    ///     .mock_activity_attempt("charge_card", 2, Ok(json!({"status": "charged"})));
+    /// ```
+    #[must_use]
+    pub fn mock_activity_attempt(
+        mut self,
+        name: impl Into<String>,
+        call_number: u32,
+        result: Result<Value, String>,
+    ) -> Self {
+        self.attempt_results
+            .insert((name.into(), call_number), result);
+        self
+    }
+
+    /// Stub a child workflow by name.
+    ///
+    /// When the workflow calls `ctx.spawn_child_workflow_raw("name", input)`,
+    /// the closure is invoked instead of actually running the child.
+    #[must_use]
+    pub fn mock_child_workflow<F>(mut self, name: impl Into<String>, mock: F) -> Self
+    where
+        F: Fn(Value) -> Result<Value, String> + Send + Sync + 'static,
+    {
+        self.child_mocks.insert(name.into(), Arc::new(mock));
+        self
+    }
+
+    /// Pre-queue a signal for delivery when the workflow calls
+    /// `ctx.wait_for_signal(name)`.
+    ///
+    /// Signals are delivered in the order they are queued, matched by name.
+    /// Queuing a signal for name "approve" will satisfy the first
+    /// `wait_for_signal("approve")` the workflow issues.
+    #[must_use]
+    pub fn queue_signal(mut self, name: impl Into<String>, payload: Value) -> Self {
+        self.queued_signals.push((name.into(), payload));
+        self
+    }
+
+    /// Inject a `WorkflowCancelled` event so `ctx.is_cancelled()` returns
+    /// `true` and `ctx.check_cancellation()` returns `Err(Cancelled(...))`.
+    ///
+    /// The cancellation is visible from the very first execution cycle.
+    #[must_use]
+    pub fn with_cancellation(mut self, reason: impl Into<String>) -> Self {
+        self.cancellation_reason = Some(reason.into());
+        self
+    }
+
+    /// Inject typed shared state accessible via `ctx.state::<T>()` inside the
+    /// workflow function.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal `Arc` has been cloned — unreachable in normal
+    /// builder usage.
+    #[must_use]
+    pub fn with_state<T: Send + Sync + 'static>(mut self, value: T) -> Self {
+        std::sync::Arc::get_mut(&mut self.state)
+            .expect("state Arc has no other references during WorkflowTestEnv construction")
+            .insert(std::any::TypeId::of::<T>(), Box::new(value));
+        self
+    }
+
+    /// Return the current simulated wall-clock time.
+    ///
+    /// This is the value that `ctx.now()` returns inside the workflow function
+    /// during the run.  The time is fixed at construction and advances by the
+    /// sum of all timers that fire.
+    #[must_use]
+    pub const fn now(&self) -> DateTime<Utc> {
+        self.simulated_now
+    }
+
+    // ── Execution ────────────────────────────────────────────────────────
+
+    /// Run the workflow function to completion and return the outcome.
+    ///
+    /// The workflow is executed in a loop:
+    /// 1. Run the workflow with the current history.
+    /// 2. If suspended: resolve each command (activities, timers, signals,
+    ///    child workflows) and append events to history.
+    /// 3. Repeat until `Completed`, `Failed`, or stuck.
+    ///
+    /// Timers auto-fire unless a signal is being resolved in the same
+    /// suspension batch (signal takes priority in concurrent `tokio::select!`
+    /// branches).
+    pub async fn run(&self, handler: WorkflowHandlerFn, input: Value) -> TestRunOutcome {
+        let exec_id = ExecutionId::new();
+
+        let mut history = vec![WorkflowEvent::WorkflowStarted {
+            input: input.clone(),
+            timestamp: self.simulated_now,
+        }];
+        if let Some(reason) = &self.cancellation_reason {
+            history.push(WorkflowEvent::WorkflowCancelled {
+                reason: reason.clone(),
+            });
+        }
+
+        let mut call_counts: HashMap<String, u32> = HashMap::new();
+        let mut remaining_signals = self.queued_signals.clone();
+
+        for _iter in 0..MAX_TEST_ITERATIONS {
+            let (outcome, _pending_cmds, _span) = run_workflow_with_state(
+                exec_id,
+                history.clone(),
+                handler,
+                input.clone(),
+                self.state.clone(),
+                None,
+            )
+            .await;
+
+            match outcome {
+                WorkflowOutcome::Completed { output } => {
+                    history.push(WorkflowEvent::WorkflowCompleted { output: output.clone() });
+                    return TestRunOutcome { result: Ok(output), events: history, exec_id };
+                }
+                WorkflowOutcome::Failed { error } => {
+                    history.push(WorkflowEvent::WorkflowFailed { error: error.clone() });
+                    return TestRunOutcome { result: Err(error), events: history, exec_id };
+                }
+                WorkflowOutcome::ContinuedAsNew { input: new_input } => {
+                    return TestRunOutcome { result: Ok(new_input), events: history, exec_id };
+                }
+                WorkflowOutcome::Suspended { commands } => {
+                    let made_progress = self.process_suspension(
+                        commands,
+                        &mut history,
+                        &mut remaining_signals,
+                        &mut call_counts,
+                    );
+                    if !made_progress {
+                        return TestRunOutcome {
+                            result: Err(
+                                "WorkflowTestEnv: workflow suspended with no resolvable \
+                                 commands (check that all signals are queued and activities \
+                                 are mocked)"
+                                    .to_string(),
+                            ),
+                            events: history,
+                            exec_id,
+                        };
+                    }
+                }
+            }
+        }
+
+        TestRunOutcome {
+            result: Err(format!(
+                "WorkflowTestEnv: workflow exceeded {MAX_TEST_ITERATIONS} iterations \
+                 (possible infinite loop or unresolvable suspension)"
+            )),
+            events: history,
+            exec_id,
+        }
+    }
+
+    /// Process one suspension batch: resolve commands and append events.
+    /// Returns `true` if at least one command was resolved.
+    fn process_suspension(
+        &self,
+        commands: Vec<WorkflowCommand>,
+        history: &mut Vec<WorkflowEvent>,
+        remaining_signals: &mut Vec<(String, Value)>,
+        call_counts: &mut HashMap<String, u32>,
+    ) -> bool {
+        let signal_will_resolve = commands.iter().any(|cmd| {
+            if let WorkflowCommand::WaitForSignal { signal_name, .. } = cmd {
+                remaining_signals.iter().any(|(n, _)| n == signal_name)
+            } else {
+                false
+            }
+        });
+
+        let mut made_progress = false;
+        for cmd in commands {
+            made_progress |= self.process_command(
+                cmd,
+                signal_will_resolve,
+                history,
+                remaining_signals,
+                call_counts,
+            );
+        }
+        made_progress
+    }
+
+    /// Resolve a single workflow command and append the resulting events.
+    /// Returns `true` if the command produced progress (events appended).
+    fn process_command(
+        &self,
+        cmd: WorkflowCommand,
+        signal_will_resolve: bool,
+        history: &mut Vec<WorkflowEvent>,
+        remaining_signals: &mut Vec<(String, Value)>,
+        call_counts: &mut HashMap<String, u32>,
+    ) -> bool {
+        match cmd {
+            WorkflowCommand::ScheduleActivity { activity_id, name, input: act_input, queue, .. } => {
+                let call_num = Self::next_call_count(call_counts, &name);
+                let result = self.resolve_activity(&name, act_input.clone(), call_num);
+                history.push(WorkflowEvent::ActivityScheduled {
+                    activity_id,
+                    name: name.clone(),
+                    input: act_input,
+                    queue,
+                });
+                Self::push_activity_terminal(history, activity_id, call_num, result);
+                true
+            }
+
+            WorkflowCommand::RunLocalActivity { activity_id, name, input: act_input, .. } => {
+                let call_num = Self::next_call_count(call_counts, &name);
+                let result = self.resolve_activity(&name, act_input.clone(), call_num);
+                history.push(WorkflowEvent::LocalActivityScheduled {
+                    activity_id,
+                    name: name.clone(),
+                    input: act_input,
+                });
+                Self::push_local_activity_terminal(history, activity_id, call_num, result);
+                true
+            }
+
+            WorkflowCommand::StartTimer { timer_id, duration_secs, .. } => {
+                if signal_will_resolve {
+                    // Skip firing the timer — a concurrent signal takes priority
+                    // so the workflow takes the signal branch in select!.
+                    return false;
+                }
+                history.push(WorkflowEvent::TimerStarted {
+                    timer_id: timer_id.clone(),
+                    duration_secs,
+                });
+                history.push(WorkflowEvent::TimerFired { timer_id });
+                true
+            }
+
+            WorkflowCommand::WaitForSignal { signal_name, .. } => {
+                remaining_signals
+                    .iter()
+                    .position(|(n, _)| n == &signal_name)
+                    .is_some_and(|pos| {
+                        let (_, payload) = remaining_signals.remove(pos);
+                        history.push(WorkflowEvent::SignalReceived { signal_name, payload });
+                        true
+                    })
+            }
+
+            WorkflowCommand::StartChildWorkflow { child_id, workflow_name, input: child_input, .. } => {
+                let result = self.resolve_child(&workflow_name, child_input.clone());
+                history.push(WorkflowEvent::ChildWorkflowStarted {
+                    child_id,
+                    workflow_name,
+                    input: child_input,
+                });
+                match result {
+                    Ok(output) => {
+                        history.push(WorkflowEvent::ChildWorkflowCompleted { child_id, output });
+                    }
+                    Err(error) => {
+                        history.push(WorkflowEvent::ChildWorkflowFailed { child_id, error });
+                    }
+                }
+                true
+            }
+
+            // WaitForActivity: activity was scheduled in a previous iteration;
+            // its terminal event is already in history and will be matched on replay.
+            WorkflowCommand::WaitForActivity { .. }
+            | WorkflowCommand::RecordMarker { .. }
+            | WorkflowCommand::RecordUpdateResult { .. }
+            | WorkflowCommand::UpsertSearchAttributes { .. }
+            | WorkflowCommand::ScheduleExternalActivity { .. }
+            | WorkflowCommand::Complete { .. }
+            | WorkflowCommand::Fail { .. }
+            | WorkflowCommand::ContinueAsNew { .. } => false,
+        }
+    }
+
+    // ── Internal helpers ─────────────────────────────────────────────────
+
+    /// Increment and return the per-name call counter (1-based).
+    fn next_call_count(call_counts: &mut HashMap<String, u32>, name: &str) -> u32 {
+        let count = call_counts.entry(name.to_string()).or_insert(0);
+        *count += 1;
+        *count
+    }
+
+    /// Resolve an activity (regular or local) using registered mocks.
+    ///
+    /// Per-call-count results take priority over the general fallback mock.
+    fn resolve_activity(&self, name: &str, input: Value, call_num: u32) -> Result<Value, String> {
+        if let Some(result) = self.attempt_results.get(&(name.to_string(), call_num)) {
+            return result.clone();
+        }
+        if let Some(mock) = self.activity_mocks.get(name) {
+            return mock(input);
+        }
+        Err(format!(
+            "WorkflowTestEnv: no mock registered for activity '{name}' \
+             (call {call_num}). Register one with mock_activity() or \
+             mock_activity_attempt()."
+        ))
+    }
+
+    /// Resolve a child workflow using registered stubs.
+    fn resolve_child(&self, name: &str, input: Value) -> Result<Value, String> {
+        if let Some(mock) = self.child_mocks.get(name) {
+            return mock(input);
+        }
+        Err(format!(
+            "WorkflowTestEnv: no mock registered for child workflow '{name}'. \
+             Register one with mock_child_workflow()."
+        ))
+    }
+
+    /// Append `ActivityCompleted` or `ActivityFailed` to history.
+    fn push_activity_terminal(
+        history: &mut Vec<WorkflowEvent>,
+        activity_id: ActivityExecId,
+        attempt: u32,
+        result: Result<Value, String>,
+    ) {
+        match result {
+            Ok(output) => history.push(WorkflowEvent::ActivityCompleted {
+                activity_id,
+                output,
+            }),
+            Err(error) => history.push(WorkflowEvent::ActivityFailed {
+                activity_id,
+                error,
+                attempt,
+                error_type: "Error".to_string(),
+                non_retryable: false,
+                details: None,
+            }),
+        }
+    }
+
+    /// Append `LocalActivityCompleted` or `LocalActivityExhausted` to history.
+    fn push_local_activity_terminal(
+        history: &mut Vec<WorkflowEvent>,
+        activity_id: ActivityExecId,
+        attempt: u32,
+        result: Result<Value, String>,
+    ) {
+        match result {
+            Ok(output) => history.push(WorkflowEvent::LocalActivityCompleted {
+                activity_id,
+                output,
+            }),
+            Err(error) => history.push(WorkflowEvent::LocalActivityExhausted {
+                activity_id,
+                error,
+                attempt,
+            }),
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/autumn-harvest/src/testing.rs
+++ b/autumn-harvest/src/testing.rs
@@ -1030,15 +1030,31 @@ impl WorkflowTestEnv {
 
             match outcome {
                 WorkflowOutcome::Completed { output } => {
-                    history.push(WorkflowEvent::WorkflowCompleted { output: output.clone() });
-                    return TestRunOutcome { result: Ok(output), events: history, exec_id };
+                    history.push(WorkflowEvent::WorkflowCompleted {
+                        output: output.clone(),
+                    });
+                    return TestRunOutcome {
+                        result: Ok(output),
+                        events: history,
+                        exec_id,
+                    };
                 }
                 WorkflowOutcome::Failed { error } => {
-                    history.push(WorkflowEvent::WorkflowFailed { error: error.clone() });
-                    return TestRunOutcome { result: Err(error), events: history, exec_id };
+                    history.push(WorkflowEvent::WorkflowFailed {
+                        error: error.clone(),
+                    });
+                    return TestRunOutcome {
+                        result: Err(error),
+                        events: history,
+                        exec_id,
+                    };
                 }
                 WorkflowOutcome::ContinuedAsNew { input: new_input } => {
-                    return TestRunOutcome { result: Ok(new_input), events: history, exec_id };
+                    return TestRunOutcome {
+                        result: Ok(new_input),
+                        events: history,
+                        exec_id,
+                    };
                 }
                 WorkflowOutcome::Suspended { commands } => {
                     let made_progress = self.process_suspension(
@@ -1049,12 +1065,10 @@ impl WorkflowTestEnv {
                     );
                     if !made_progress {
                         return TestRunOutcome {
-                            result: Err(
-                                "WorkflowTestEnv: workflow suspended with no resolvable \
+                            result: Err("WorkflowTestEnv: workflow suspended with no resolvable \
                                  commands (check that all signals are queued and activities \
                                  are mocked)"
-                                    .to_string(),
-                            ),
+                                .to_string()),
                             events: history,
                             exec_id,
                         };
@@ -1114,7 +1128,13 @@ impl WorkflowTestEnv {
         call_counts: &mut HashMap<String, u32>,
     ) -> bool {
         match cmd {
-            WorkflowCommand::ScheduleActivity { activity_id, name, input: act_input, queue, .. } => {
+            WorkflowCommand::ScheduleActivity {
+                activity_id,
+                name,
+                input: act_input,
+                queue,
+                ..
+            } => {
                 let call_num = Self::next_call_count(call_counts, &name);
                 let result = self.resolve_activity(&name, act_input.clone(), call_num);
                 history.push(WorkflowEvent::ActivityScheduled {
@@ -1127,7 +1147,12 @@ impl WorkflowTestEnv {
                 true
             }
 
-            WorkflowCommand::RunLocalActivity { activity_id, name, input: act_input, .. } => {
+            WorkflowCommand::RunLocalActivity {
+                activity_id,
+                name,
+                input: act_input,
+                ..
+            } => {
                 let call_num = Self::next_call_count(call_counts, &name);
                 let result = self.resolve_activity(&name, act_input.clone(), call_num);
                 history.push(WorkflowEvent::LocalActivityScheduled {
@@ -1139,7 +1164,11 @@ impl WorkflowTestEnv {
                 true
             }
 
-            WorkflowCommand::StartTimer { timer_id, duration_secs, .. } => {
+            WorkflowCommand::StartTimer {
+                timer_id,
+                duration_secs,
+                ..
+            } => {
                 if signal_will_resolve {
                     // Skip firing the timer — a concurrent signal takes priority
                     // so the workflow takes the signal branch in select!.
@@ -1153,18 +1182,24 @@ impl WorkflowTestEnv {
                 true
             }
 
-            WorkflowCommand::WaitForSignal { signal_name, .. } => {
-                remaining_signals
-                    .iter()
-                    .position(|(n, _)| n == &signal_name)
-                    .is_some_and(|pos| {
-                        let (_, payload) = remaining_signals.remove(pos);
-                        history.push(WorkflowEvent::SignalReceived { signal_name, payload });
-                        true
-                    })
-            }
+            WorkflowCommand::WaitForSignal { signal_name, .. } => remaining_signals
+                .iter()
+                .position(|(n, _)| n == &signal_name)
+                .is_some_and(|pos| {
+                    let (_, payload) = remaining_signals.remove(pos);
+                    history.push(WorkflowEvent::SignalReceived {
+                        signal_name,
+                        payload,
+                    });
+                    true
+                }),
 
-            WorkflowCommand::StartChildWorkflow { child_id, workflow_name, input: child_input, .. } => {
+            WorkflowCommand::StartChildWorkflow {
+                child_id,
+                workflow_name,
+                input: child_input,
+                ..
+            } => {
                 let result = self.resolve_child(&workflow_name, child_input.clone());
                 history.push(WorkflowEvent::ChildWorkflowStarted {
                     child_id,

--- a/autumn-harvest/src/testing.rs
+++ b/autumn-harvest/src/testing.rs
@@ -981,8 +981,7 @@ impl WorkflowTestEnv {
     /// Return the current simulated wall-clock time.
     ///
     /// This is the value that `ctx.now()` returns inside the workflow function
-    /// during the run.  The time is fixed at construction and advances by the
-    /// sum of all timers that fire.
+    /// during the run.  The time is fixed at construction.
     #[must_use]
     pub const fn now(&self) -> DateTime<Utc> {
         self.simulated_now
@@ -1050,6 +1049,10 @@ impl WorkflowTestEnv {
                     };
                 }
                 WorkflowOutcome::ContinuedAsNew { input: new_input } => {
+                    history.push(WorkflowEvent::WorkflowContinuedAsNew {
+                        new_exec_id: ExecutionId::new(),
+                        input: new_input.clone(),
+                    });
                     return TestRunOutcome {
                         result: Ok(new_input),
                         events: history,

--- a/autumn-harvest/src/testing.rs
+++ b/autumn-harvest/src/testing.rs
@@ -296,6 +296,17 @@ impl WorkflowReplayer {
         self
     }
 
+    /// Replace the shared state with a pre-built `SharedState` arc.
+    ///
+    /// Used internally by [`TestRunOutcome::replay_check`] to forward the test
+    /// environment's state to the replayer so the workflow sees the same typed
+    /// state it saw during the original run.
+    #[must_use]
+    fn with_existing_state(mut self, state: SharedState) -> Self {
+        self.state = state;
+        self
+    }
+
     /// Register a batch of workflows from a `workflows![]` macro call.
     ///
     /// ```rust,no_run
@@ -773,6 +784,9 @@ pub struct TestRunOutcome {
     events: Vec<WorkflowEvent>,
     /// Execution ID used for the run (stable for replay checks).
     exec_id: ExecutionId,
+    /// Shared state from the test env — forwarded to `replay_check` so the
+    /// replayer sees the same typed state the workflow saw during the run.
+    state: SharedState,
 }
 
 impl TestRunOutcome {
@@ -801,6 +815,7 @@ impl TestRunOutcome {
             events: self.events.clone(),
         };
         WorkflowReplayer::new()
+            .with_existing_state(self.state.clone())
             .register_fn("__test__", handler)
             .replay_from_snapshot(snapshot)
             .await
@@ -1036,6 +1051,7 @@ impl WorkflowTestEnv {
                         result: Ok(output),
                         events: history,
                         exec_id,
+                        state: self.state.clone(),
                     };
                 }
                 WorkflowOutcome::Failed { error } => {
@@ -1046,6 +1062,7 @@ impl WorkflowTestEnv {
                         result: Err(error),
                         events: history,
                         exec_id,
+                        state: self.state.clone(),
                     };
                 }
                 WorkflowOutcome::ContinuedAsNew { input: new_input } => {
@@ -1057,6 +1074,7 @@ impl WorkflowTestEnv {
                         result: Ok(new_input),
                         events: history,
                         exec_id,
+                        state: self.state.clone(),
                     };
                 }
                 WorkflowOutcome::Suspended { commands } => {
@@ -1074,6 +1092,7 @@ impl WorkflowTestEnv {
                                 .to_string()),
                             events: history,
                             exec_id,
+                            state: self.state.clone(),
                         };
                     }
                 }
@@ -1087,6 +1106,7 @@ impl WorkflowTestEnv {
             )),
             events: history,
             exec_id,
+            state: self.state.clone(),
         }
     }
 
@@ -1146,7 +1166,7 @@ impl WorkflowTestEnv {
                     input: act_input,
                     queue,
                 });
-                Self::push_activity_terminal(history, activity_id, call_num, result);
+                Self::push_activity_terminal(history, activity_id, result);
                 true
             }
 
@@ -1163,7 +1183,7 @@ impl WorkflowTestEnv {
                     name: name.clone(),
                     input: act_input,
                 });
-                Self::push_local_activity_terminal(history, activity_id, call_num, result);
+                Self::push_local_activity_terminal(history, activity_id, result);
                 true
             }
 
@@ -1271,10 +1291,13 @@ impl WorkflowTestEnv {
     }
 
     /// Append `ActivityCompleted` or `ActivityFailed` to history.
+    ///
+    /// `attempt` is always 1 because each explicit call to `execute_activity_raw`
+    /// represents a new scheduling — worker-level retries within one scheduling
+    /// are not modelled by the test harness.
     fn push_activity_terminal(
         history: &mut Vec<WorkflowEvent>,
         activity_id: ActivityExecId,
-        attempt: u32,
         result: Result<Value, String>,
     ) {
         match result {
@@ -1285,7 +1308,7 @@ impl WorkflowTestEnv {
             Err(error) => history.push(WorkflowEvent::ActivityFailed {
                 activity_id,
                 error,
-                attempt,
+                attempt: 1,
                 error_type: "Error".to_string(),
                 non_retryable: false,
                 details: None,
@@ -1293,11 +1316,15 @@ impl WorkflowTestEnv {
         }
     }
 
-    /// Append `LocalActivityCompleted` or `LocalActivityExhausted` to history.
+    /// Append `LocalActivityCompleted`, or `LocalActivityFailed` +
+    /// `LocalActivityExhausted` to history.
+    ///
+    /// Production records one `LocalActivityFailed` per attempt before the
+    /// terminal `LocalActivityExhausted`; the harness models a single attempt
+    /// so it emits exactly one of each on failure.
     fn push_local_activity_terminal(
         history: &mut Vec<WorkflowEvent>,
         activity_id: ActivityExecId,
-        attempt: u32,
         result: Result<Value, String>,
     ) {
         match result {
@@ -1305,11 +1332,18 @@ impl WorkflowTestEnv {
                 activity_id,
                 output,
             }),
-            Err(error) => history.push(WorkflowEvent::LocalActivityExhausted {
-                activity_id,
-                error,
-                attempt,
-            }),
+            Err(error) => {
+                history.push(WorkflowEvent::LocalActivityFailed {
+                    activity_id,
+                    error: error.clone(),
+                    attempt: 1,
+                });
+                history.push(WorkflowEvent::LocalActivityExhausted {
+                    activity_id,
+                    error,
+                    attempt: 1,
+                });
+            }
         }
     }
 }

--- a/autumn-harvest/tests/workflow_test_env_tests.rs
+++ b/autumn-harvest/tests/workflow_test_env_tests.rs
@@ -10,7 +10,7 @@
 //! replay-mode self-check.
 //!
 //! Run with:
-//!   cargo test -p autumn-harvest --test workflow_test_env_tests \
+//!   cargo test -p autumn-harvest --test `workflow_test_env_tests` \
 //!     --features testing --no-default-features
 
 use std::future::Future;
@@ -317,8 +317,7 @@ async fn test_local_activity_mock() {
         .mock_activity("compute_hash", |input| {
             let sum: i64 = input
                 .as_array()
-                .map(Vec::as_slice)
-                .unwrap_or(&[])
+                .map_or(&[][..], Vec::as_slice)
                 .iter()
                 .filter_map(|v: &Value| v.as_i64())
                 .sum();
@@ -437,10 +436,7 @@ fn stateful_workflow<'a>(
     input: Value,
 ) -> Pin<Box<dyn Future<Output = Result<Value, String>> + Send + 'a>> {
     Box::pin(async move {
-        let mult = ctx
-            .state::<CounterConfig>()
-            .map(|c| c.multiplier)
-            .unwrap_or(1);
+        let mult = ctx.state::<CounterConfig>().map_or(1, |c| c.multiplier);
         let v = input.as_i64().unwrap_or(0);
         Ok(json!(v * mult))
     })
@@ -471,7 +467,7 @@ fn max_retries_workflow<'a>(
                 .await
             {
                 Ok(v) => return Ok(v),
-                Err(_) if attempt < MAX => continue,
+                Err(_) if attempt < MAX => {}
                 Err(e) => return Err(e.to_string()),
             }
         }

--- a/autumn-harvest/tests/workflow_test_env_tests.rs
+++ b/autumn-harvest/tests/workflow_test_env_tests.rs
@@ -158,7 +158,9 @@ async fn test_happy_path_one_activity() {
         "expected ActivityScheduled for send_email"
     );
     assert!(
-        events.iter().any(|e| matches!(e, WorkflowEvent::ActivityCompleted { .. })),
+        events
+            .iter()
+            .any(|e| matches!(e, WorkflowEvent::ActivityCompleted { .. })),
         "expected ActivityCompleted"
     );
 }
@@ -178,18 +180,24 @@ async fn test_first_attempt_fails_second_succeeds() {
     let events = outcome.events();
     let scheduled_count = events
         .iter()
-        .filter(|e| matches!(e, WorkflowEvent::ActivityScheduled { name, .. } if name == "charge_card"))
+        .filter(
+            |e| matches!(e, WorkflowEvent::ActivityScheduled { name, .. } if name == "charge_card"),
+        )
         .count();
     assert_eq!(
         scheduled_count, 2,
         "expected two ActivityScheduled events (one failed, one succeeded)"
     );
     assert!(
-        events.iter().any(|e| matches!(e, WorkflowEvent::ActivityFailed { .. })),
+        events
+            .iter()
+            .any(|e| matches!(e, WorkflowEvent::ActivityFailed { .. })),
         "expected an ActivityFailed event for the first attempt"
     );
     assert!(
-        events.iter().any(|e| matches!(e, WorkflowEvent::ActivityCompleted { .. })),
+        events
+            .iter()
+            .any(|e| matches!(e, WorkflowEvent::ActivityCompleted { .. })),
         "expected an ActivityCompleted event for the second attempt"
     );
 }
@@ -204,15 +212,21 @@ async fn test_timer_wins_when_no_signal_queued() {
 
     let events = outcome.events();
     assert!(
-        events.iter().any(|e| matches!(e, WorkflowEvent::TimerStarted { .. })),
+        events
+            .iter()
+            .any(|e| matches!(e, WorkflowEvent::TimerStarted { .. })),
         "expected TimerStarted"
     );
     assert!(
-        events.iter().any(|e| matches!(e, WorkflowEvent::TimerFired { .. })),
+        events
+            .iter()
+            .any(|e| matches!(e, WorkflowEvent::TimerFired { .. })),
         "expected TimerFired"
     );
     assert!(
-        !events.iter().any(|e| matches!(e, WorkflowEvent::SignalReceived { .. })),
+        !events
+            .iter()
+            .any(|e| matches!(e, WorkflowEvent::SignalReceived { .. })),
         "signal must not be in events when timer wins"
     );
 }
@@ -232,7 +246,9 @@ async fn test_signal_wins_when_queued() {
         "expected SignalReceived(approve)"
     );
     assert!(
-        !events.iter().any(|e| matches!(e, WorkflowEvent::TimerFired { .. })),
+        !events
+            .iter()
+            .any(|e| matches!(e, WorkflowEvent::TimerFired { .. })),
         "timer must not fire when signal wins"
     );
 }
@@ -393,7 +409,9 @@ async fn test_cancellation_injection() {
         "expected WorkflowCancelled in the event log"
     );
     assert!(
-        !events.iter().any(|e| matches!(e, WorkflowEvent::ActivityScheduled { .. })),
+        !events
+            .iter()
+            .any(|e| matches!(e, WorkflowEvent::ActivityScheduled { .. })),
         "activity must not be scheduled after cancellation"
     );
 }
@@ -468,7 +486,10 @@ async fn test_all_attempts_fail_returns_error() {
         .run(max_retries_workflow, json!(null))
         .await;
 
-    assert!(outcome.result.is_err(), "exhausted retries should return Err");
+    assert!(
+        outcome.result.is_err(),
+        "exhausted retries should return Err"
+    );
 }
 
 #[tokio::test]
@@ -484,7 +505,9 @@ async fn test_third_attempt_succeeds() {
     let scheduled = outcome
         .events()
         .iter()
-        .filter(|e| matches!(e, WorkflowEvent::ActivityScheduled { name, .. } if name == "flaky_op"))
+        .filter(
+            |e| matches!(e, WorkflowEvent::ActivityScheduled { name, .. } if name == "flaky_op"),
+        )
         .count();
     assert_eq!(scheduled, 3, "expected exactly 3 scheduled events");
 }

--- a/autumn-harvest/tests/workflow_test_env_tests.rs
+++ b/autumn-harvest/tests/workflow_test_env_tests.rs
@@ -1,0 +1,490 @@
+//! Tests for `WorkflowTestEnv` — the in-process workflow unit-test harness (issue #250).
+//!
+//! Three required example tests per AC:
+//! - (a) Happy-path workflow with one activity.
+//! - (b) Workflow whose first attempt fails and retry succeeds.
+//! - (c) Workflow that races a timer against a signal.
+//!
+//! Additional tests cover per-attempt mocks, child-workflow stubbing,
+//! local-activity mocking, event-log inspection, cancellation, and the
+//! replay-mode self-check.
+//!
+//! Run with:
+//!   cargo test -p autumn-harvest --test workflow_test_env_tests \
+//!     --features testing --no-default-features
+
+use std::future::Future;
+use std::pin::Pin;
+
+use autumn_harvest::context::WorkflowContext;
+use autumn_harvest::event::WorkflowEvent;
+use autumn_harvest::testing::{ReplayStatus, WorkflowTestEnv};
+use serde_json::{Value, json};
+
+// ──────────────────────────── workflow helpers ────────────────────────────────
+
+/// (a) One activity, returns its output wrapped.
+fn one_activity_workflow<'a>(
+    ctx: &'a WorkflowContext,
+    _input: Value,
+) -> Pin<Box<dyn Future<Output = Result<Value, String>> + Send + 'a>> {
+    Box::pin(async move {
+        let result = ctx
+            .execute_activity_raw("send_email", json!({"to": "user@example.com"}), "default")
+            .await
+            .map_err(|e| e.to_string())?;
+        Ok(json!({"sent": result}))
+    })
+}
+
+/// (b) Explicitly retries a failing activity by calling it again on error.
+fn retry_workflow<'a>(
+    ctx: &'a WorkflowContext,
+    _input: Value,
+) -> Pin<Box<dyn Future<Output = Result<Value, String>> + Send + 'a>> {
+    Box::pin(async move {
+        let result = match ctx
+            .execute_activity_raw("charge_card", json!({"amount": 100}), "payments")
+            .await
+        {
+            Ok(v) => v,
+            Err(_first_err) => {
+                // Explicit retry: call the activity again after first failure.
+                ctx.execute_activity_raw("charge_card", json!({"amount": 100}), "payments")
+                    .await
+                    .map_err(|e| e.to_string())?
+            }
+        };
+        Ok(result)
+    })
+}
+
+/// (c) Races a timer against a signal; returns which path fired first.
+fn race_workflow<'a>(
+    ctx: &'a WorkflowContext,
+    _input: Value,
+) -> Pin<Box<dyn Future<Output = Result<Value, String>> + Send + 'a>> {
+    Box::pin(async move {
+        tokio::select! {
+            biased;
+            r = ctx.timer("race", 60) => {
+                r.map_err(|e| e.to_string())?;
+                Ok(json!("timer"))
+            }
+            payload = ctx.wait_for_signal("approve") => {
+                Ok(json!({"signal": payload.map_err(|e| e.to_string())?}))
+            }
+        }
+    })
+}
+
+/// Two sequential activities, used for event-log ordering assertions.
+fn two_step_workflow<'a>(
+    ctx: &'a WorkflowContext,
+    _input: Value,
+) -> Pin<Box<dyn Future<Output = Result<Value, String>> + Send + 'a>> {
+    Box::pin(async move {
+        let a = ctx
+            .execute_activity_raw("step_a", Value::Null, "default")
+            .await
+            .map_err(|e| e.to_string())?;
+        let b = ctx
+            .execute_activity_raw("step_b", Value::Null, "default")
+            .await
+            .map_err(|e| e.to_string())?;
+        Ok(json!([a, b]))
+    })
+}
+
+/// Spawns a child workflow and returns its output.
+fn parent_workflow<'a>(
+    ctx: &'a WorkflowContext,
+    _input: Value,
+) -> Pin<Box<dyn Future<Output = Result<Value, String>> + Send + 'a>> {
+    Box::pin(async move {
+        let result = ctx
+            .spawn_child_workflow_raw("child_processing", json!({"id": 42}))
+            .await
+            .map_err(|e| e.to_string())?;
+        Ok(json!({"child": result}))
+    })
+}
+
+/// Uses a local activity.
+fn local_activity_workflow<'a>(
+    ctx: &'a WorkflowContext,
+    _input: Value,
+) -> Pin<Box<dyn Future<Output = Result<Value, String>> + Send + 'a>> {
+    Box::pin(async move {
+        let result = ctx
+            .execute_local_activity_raw("compute_hash", json!([1, 2, 3]), None, None)
+            .await
+            .map_err(|e| e.to_string())?;
+        Ok(json!({"hash": result}))
+    })
+}
+
+/// Checks for cancellation and bails out early.
+fn cancellable_workflow<'a>(
+    ctx: &'a WorkflowContext,
+    _input: Value,
+) -> Pin<Box<dyn Future<Output = Result<Value, String>> + Send + 'a>> {
+    Box::pin(async move {
+        ctx.check_cancellation().map_err(|e| e.to_string())?;
+        let result = ctx
+            .execute_activity_raw("long_op", Value::Null, "default")
+            .await
+            .map_err(|e| e.to_string())?;
+        Ok(result)
+    })
+}
+
+// ─────────────────────── (a) Happy-path test ─────────────────────────────────
+
+#[tokio::test]
+async fn test_happy_path_one_activity() {
+    let outcome = WorkflowTestEnv::new()
+        .mock_activity("send_email", |_| Ok(json!("delivered")))
+        .run(one_activity_workflow, json!(null))
+        .await;
+
+    assert_eq!(outcome.result, Ok(json!({"sent": "delivered"})));
+
+    let events = outcome.events();
+    assert!(
+        events.iter().any(|e| matches!(e,
+            WorkflowEvent::ActivityScheduled { name, .. } if name == "send_email"
+        )),
+        "expected ActivityScheduled for send_email"
+    );
+    assert!(
+        events.iter().any(|e| matches!(e, WorkflowEvent::ActivityCompleted { .. })),
+        "expected ActivityCompleted"
+    );
+}
+
+// ─────────────────────── (b) Retry test ──────────────────────────────────────
+
+#[tokio::test]
+async fn test_first_attempt_fails_second_succeeds() {
+    let outcome = WorkflowTestEnv::new()
+        .mock_activity_attempt("charge_card", 1, Err("transient gateway error".into()))
+        .mock_activity_attempt("charge_card", 2, Ok(json!({"status": "charged"})))
+        .run(retry_workflow, json!(null))
+        .await;
+
+    assert_eq!(outcome.result, Ok(json!({"status": "charged"})));
+
+    let events = outcome.events();
+    let scheduled_count = events
+        .iter()
+        .filter(|e| matches!(e, WorkflowEvent::ActivityScheduled { name, .. } if name == "charge_card"))
+        .count();
+    assert_eq!(
+        scheduled_count, 2,
+        "expected two ActivityScheduled events (one failed, one succeeded)"
+    );
+    assert!(
+        events.iter().any(|e| matches!(e, WorkflowEvent::ActivityFailed { .. })),
+        "expected an ActivityFailed event for the first attempt"
+    );
+    assert!(
+        events.iter().any(|e| matches!(e, WorkflowEvent::ActivityCompleted { .. })),
+        "expected an ActivityCompleted event for the second attempt"
+    );
+}
+
+// ─────────────────────── (c) Timer vs signal race ────────────────────────────
+
+#[tokio::test]
+async fn test_timer_wins_when_no_signal_queued() {
+    let outcome = WorkflowTestEnv::new().run(race_workflow, json!(null)).await;
+
+    assert_eq!(outcome.result, Ok(json!("timer")));
+
+    let events = outcome.events();
+    assert!(
+        events.iter().any(|e| matches!(e, WorkflowEvent::TimerStarted { .. })),
+        "expected TimerStarted"
+    );
+    assert!(
+        events.iter().any(|e| matches!(e, WorkflowEvent::TimerFired { .. })),
+        "expected TimerFired"
+    );
+    assert!(
+        !events.iter().any(|e| matches!(e, WorkflowEvent::SignalReceived { .. })),
+        "signal must not be in events when timer wins"
+    );
+}
+
+#[tokio::test]
+async fn test_signal_wins_when_queued() {
+    let outcome = WorkflowTestEnv::new()
+        .queue_signal("approve", json!("green-light"))
+        .run(race_workflow, json!(null))
+        .await;
+
+    assert_eq!(outcome.result, Ok(json!({"signal": "green-light"})));
+
+    let events = outcome.events();
+    assert!(
+        events.iter().any(|e| matches!(e, WorkflowEvent::SignalReceived { signal_name, .. } if signal_name == "approve")),
+        "expected SignalReceived(approve)"
+    );
+    assert!(
+        !events.iter().any(|e| matches!(e, WorkflowEvent::TimerFired { .. })),
+        "timer must not fire when signal wins"
+    );
+}
+
+// ──────────────────── Child-workflow stubbing ─────────────────────────────────
+
+#[tokio::test]
+async fn test_child_workflow_stub() {
+    let outcome = WorkflowTestEnv::new()
+        .mock_child_workflow("child_processing", |input| {
+            let id = input["id"].as_i64().unwrap_or(0);
+            Ok(json!({"processed": id * 2}))
+        })
+        .run(parent_workflow, json!(null))
+        .await;
+
+    assert_eq!(outcome.result, Ok(json!({"child": {"processed": 84}})));
+
+    let events = outcome.events();
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, WorkflowEvent::ChildWorkflowStarted { .. })),
+        "expected ChildWorkflowStarted"
+    );
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, WorkflowEvent::ChildWorkflowCompleted { .. })),
+        "expected ChildWorkflowCompleted"
+    );
+}
+
+// ──────────────────── Event-log inspection ───────────────────────────────────
+
+#[tokio::test]
+async fn test_event_log_ordering() {
+    let outcome = WorkflowTestEnv::new()
+        .mock_activity("step_a", |_| Ok(json!("a")))
+        .mock_activity("step_b", |_| Ok(json!("b")))
+        .run(two_step_workflow, json!(null))
+        .await;
+
+    assert_eq!(outcome.result, Ok(json!(["a", "b"])));
+
+    let activity_names: Vec<&str> = outcome
+        .events()
+        .iter()
+        .filter_map(|e| match e {
+            WorkflowEvent::ActivityScheduled { name, .. } => Some(name.as_str()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        activity_names,
+        ["step_a", "step_b"],
+        "activities must appear in order"
+    );
+}
+
+// ──────────────────── Local-activity mocking ─────────────────────────────────
+
+#[tokio::test]
+async fn test_local_activity_mock() {
+    let outcome = WorkflowTestEnv::new()
+        .mock_activity("compute_hash", |input| {
+            let sum: i64 = input
+                .as_array()
+                .map(Vec::as_slice)
+                .unwrap_or(&[])
+                .iter()
+                .filter_map(|v: &Value| v.as_i64())
+                .sum();
+            Ok(json!(sum))
+        })
+        .run(local_activity_workflow, json!(null))
+        .await;
+
+    assert_eq!(outcome.result, Ok(json!({"hash": 6})));
+
+    let events = outcome.events();
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, WorkflowEvent::LocalActivityScheduled { .. })),
+        "expected LocalActivityScheduled"
+    );
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, WorkflowEvent::LocalActivityCompleted { .. })),
+        "expected LocalActivityCompleted"
+    );
+}
+
+// ──────────────────── Missing stub → loud failure ────────────────────────────
+
+#[tokio::test]
+async fn test_missing_stub_fails_loudly() {
+    let outcome = WorkflowTestEnv::new()
+        // Intentionally omit the mock for "send_email"
+        .run(one_activity_workflow, json!(null))
+        .await;
+
+    // The workflow should fail because no mock is registered.
+    assert!(
+        outcome.result.is_err(),
+        "missing stub must cause an error result, not a panic"
+    );
+    let err = outcome.result.unwrap_err();
+    assert!(
+        err.contains("send_email"),
+        "error should name the unregistered activity; got: {err}"
+    );
+}
+
+// ──────────────────── Replay self-check ──────────────────────────────────────
+
+#[tokio::test]
+async fn test_replay_self_check_succeeds_for_deterministic_workflow() {
+    let outcome = WorkflowTestEnv::new()
+        .mock_activity("send_email", |_| Ok(json!("delivered")))
+        .run(one_activity_workflow, json!(null))
+        .await;
+
+    // The test env records a real history; replaying through WorkflowReplayer
+    // must succeed, proving the workflow is deterministic.
+    let report = outcome.replay_check(one_activity_workflow).await;
+    assert!(
+        matches!(report.status, ReplayStatus::ReplaySucceeded),
+        "replay self-check failed:\n{report}"
+    );
+}
+
+// ──────────────────── Cancellation injection ─────────────────────────────────
+
+#[tokio::test]
+async fn test_cancellation_injection() {
+    let outcome = WorkflowTestEnv::new()
+        .with_cancellation("operator requested")
+        .run(cancellable_workflow, json!(null))
+        .await;
+
+    // Workflow bails out at check_cancellation() before reaching the activity.
+    assert!(
+        outcome.result.is_err(),
+        "cancelled workflow must return Err"
+    );
+    assert!(
+        outcome.result.as_ref().unwrap_err().contains("cancelled"),
+        "error should indicate cancellation"
+    );
+    let events = outcome.events();
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, WorkflowEvent::WorkflowCancelled { .. })),
+        "expected WorkflowCancelled in the event log"
+    );
+    assert!(
+        !events.iter().any(|e| matches!(e, WorkflowEvent::ActivityScheduled { .. })),
+        "activity must not be scheduled after cancellation"
+    );
+}
+
+// ──────────────────── env.now() ─────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_simulated_time_is_stable() {
+    let env = WorkflowTestEnv::new();
+    let t1 = env.now();
+    let t2 = env.now();
+    assert_eq!(t1, t2, "simulated time must be deterministic");
+}
+
+// ──────────────────── with_state ────────────────────────────────────────────
+
+struct CounterConfig {
+    multiplier: i64,
+}
+
+fn stateful_workflow<'a>(
+    ctx: &'a WorkflowContext,
+    input: Value,
+) -> Pin<Box<dyn Future<Output = Result<Value, String>> + Send + 'a>> {
+    Box::pin(async move {
+        let mult = ctx
+            .state::<CounterConfig>()
+            .map(|c| c.multiplier)
+            .unwrap_or(1);
+        let v = input.as_i64().unwrap_or(0);
+        Ok(json!(v * mult))
+    })
+}
+
+#[tokio::test]
+async fn test_shared_state_injection() {
+    let outcome = WorkflowTestEnv::new()
+        .with_state(CounterConfig { multiplier: 7 })
+        .run(stateful_workflow, json!(3))
+        .await;
+
+    assert_eq!(outcome.result, Ok(json!(21)));
+}
+
+// ──────────────────── Parameterised retry-policy edge cases ─────────────────
+
+/// A workflow that keeps retrying until success or exhaustion.
+fn max_retries_workflow<'a>(
+    ctx: &'a WorkflowContext,
+    _input: Value,
+) -> Pin<Box<dyn Future<Output = Result<Value, String>> + Send + 'a>> {
+    Box::pin(async move {
+        const MAX: usize = 3;
+        for attempt in 1..=MAX {
+            match ctx
+                .execute_activity_raw("flaky_op", json!({"attempt": attempt}), "q")
+                .await
+            {
+                Ok(v) => return Ok(v),
+                Err(_) if attempt < MAX => continue,
+                Err(e) => return Err(e.to_string()),
+            }
+        }
+        unreachable!()
+    })
+}
+
+#[tokio::test]
+async fn test_all_attempts_fail_returns_error() {
+    let outcome = WorkflowTestEnv::new()
+        .mock_activity("flaky_op", |_| Err("always broken".into()))
+        .run(max_retries_workflow, json!(null))
+        .await;
+
+    assert!(outcome.result.is_err(), "exhausted retries should return Err");
+}
+
+#[tokio::test]
+async fn test_third_attempt_succeeds() {
+    let outcome = WorkflowTestEnv::new()
+        .mock_activity_attempt("flaky_op", 1, Err("fail1".into()))
+        .mock_activity_attempt("flaky_op", 2, Err("fail2".into()))
+        .mock_activity_attempt("flaky_op", 3, Ok(json!("finally")))
+        .run(max_retries_workflow, json!(null))
+        .await;
+
+    assert_eq!(outcome.result, Ok(json!("finally")));
+    let scheduled = outcome
+        .events()
+        .iter()
+        .filter(|e| matches!(e, WorkflowEvent::ActivityScheduled { name, .. } if name == "flaky_op"))
+        .count();
+    assert_eq!(scheduled, 3, "expected exactly 3 scheduled events");
+}


### PR DESCRIPTION
Implements WorkflowTestEnv, a no-DB, no-Docker harness that drives
workflow functions to completion by processing commands in a replay
loop.  Covers all AC from issue #250:

- mock_activity / mock_activity_attempt for per-name and per-call mocks
- mock_child_workflow for child-workflow stubbing
- queue_signal for pre-queued signal injection
- with_cancellation for WorkflowCancelled injection
- with_state for typed shared-state injection
- now() for deterministic simulated clock
- TestRunOutcome::events() for full event-log inspection
- TestRunOutcome::replay_check() for replay-determinism self-check

Adds workflow_test_env_tests.rs with 14 tests covering the three
required AC examples (happy path, retry, timer-vs-signal race) plus
child-workflow stubbing, event-log ordering, local-activity mocking,
missing-stub loud failure, replay self-check, cancellation injection,
simulated time stability, shared state injection, and retry-policy
edge cases.

Uses biased tokio::select! with timer polled first in race_workflow
to ensure deterministic poll ordering in replay (prevents match_signal
from encountering TimerStarted and returning Diverged).

Adds [[test]] required-features = ["testing"] entry in Cargo.toml so
cargo test --no-default-features skips the file cleanly.