### PR TITLE
Add timezone-aware cron schedules (Schedule::CronInTimezone)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to autumn-harvest will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Timezone-aware cron schedules** (`Schedule::CronInTimezone`, issue #245).
+  A new `Schedule` variant lets schedule authors anchor a cron expression to an
+  IANA timezone so that jobs like `"0 9 * * 1-5"` fire at 9 AM local time
+  year-round, regardless of DST transitions:
+
+  ```rust
+  Schedule::CronInTimezone {
+      expr: "0 9 * * 1-5".into(),
+      tz: "America/Los_Angeles".into(),
+  }
+  ```
+
+  DST disambiguation rules: spring-forward gaps do not produce spurious firings
+  (the skipped local time is not back-fired); fall-back repetitions fire exactly
+  once on the first occurrence of the repeated hour.
+
+  Unknown IANA timezone names are rejected at builder/registration time with
+  `HarvestBuilderError::UnknownTimezone { name }`, not at first scheduler tick.
+
+  The `harvest_schedules.timezone` column is now written with the schedule's
+  declared timezone (was always hard-coded `"UTC"`). The management API
+  `GET /admin/schedules` and `POST /admin/schedules/workflow` accept and emit a
+  `"timezone"` field; schedules created without the field default to `"UTC"`.
+
+  **Backward compatibility:** `Schedule::Cron(expr)` schedules retain UTC
+  semantics on upgrade. The new variant is strictly opt-in. No migration is
+  required — the `timezone` column already exists.
+
 ## [0.3.0] - 2026-05-13
 
 ### Documentation

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,6 +174,7 @@ dependencies = [
  "autumn-harvest-macros",
  "base64 0.22.1",
  "chrono",
+ "chrono-tz",
  "criterion",
  "croner 2.2.0",
  "deadpool",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ toml = "1.1"
 thiserror = "2"
 uuid = { version = "1", features = ["v4", "v5", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
+chrono-tz = "0.10"
 tracing = "0.1"
 futures = "0.3"
 

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -6731,7 +6731,10 @@ fn parse_schedule_expr_with_tz(
         if timezone == "UTC" {
             Schedule::Cron(cron_expr)
         } else {
-            Schedule::CronInTimezone { expr: cron_expr, tz: timezone.to_string() }
+            Schedule::CronInTimezone {
+                expr: cron_expr,
+                tz: timezone.to_string(),
+            }
         }
     } else if let Some(secs_str) = trimmed.strip_prefix("interval:") {
         let secs: u64 = secs_str
@@ -6749,7 +6752,10 @@ fn parse_schedule_expr_with_tz(
         if timezone == "UTC" {
             Schedule::Cron(trimmed.to_string())
         } else {
-            Schedule::CronInTimezone { expr: trimmed.to_string(), tz: timezone.to_string() }
+            Schedule::CronInTimezone {
+                expr: trimmed.to_string(),
+                tz: timezone.to_string(),
+            }
         }
     };
     // Validate cron expressions eagerly (including timezone names) so callers
@@ -10015,8 +10021,8 @@ mod tests {
     #[test]
     fn parse_schedule_expr_with_tz_utc_produces_cron_variant() {
         use autumn_harvest::policy::Schedule;
-        let result = parse_schedule_expr_with_tz("0 9 * * 1-5", "UTC")
-            .expect("valid cron+UTC should parse");
+        let result =
+            parse_schedule_expr_with_tz("0 9 * * 1-5", "UTC").expect("valid cron+UTC should parse");
         assert!(
             matches!(result, Schedule::Cron(_)),
             "UTC timezone must produce Schedule::Cron, not CronInTimezone: {result:?}"

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -6726,7 +6726,17 @@ fn parse_schedule_expr_with_tz(
     use autumn_harvest::policy::Schedule;
 
     let trimmed = expr.trim();
-    let schedule = if let Some(cron) = trimmed.strip_prefix("cron:") {
+    let schedule = if let Some(rest) = trimmed.strip_prefix("cron_tz:") {
+        // Canonical round-trip format emitted by GET /admin/schedules.
+        // The embedded timezone takes precedence over the separate `timezone` field.
+        let (tz, cron_expr) = rest.split_once(':').ok_or_else(|| {
+            format!("malformed cron_tz expression '{expr}'; expected 'cron_tz:<tz>:<expr>'")
+        })?;
+        Schedule::CronInTimezone {
+            expr: cron_expr.to_string(),
+            tz: tz.to_string(),
+        }
+    } else if let Some(cron) = trimmed.strip_prefix("cron:") {
         let cron_expr = cron.trim().to_string();
         if timezone == "UTC" {
             Schedule::Cron(cron_expr)
@@ -10051,6 +10061,29 @@ mod tests {
         assert!(
             err.contains("Not/ATimezone"),
             "error should name the bad timezone: {err}"
+        );
+    }
+
+    #[test]
+    fn parse_schedule_expr_with_tz_cron_tz_prefix_round_trips() {
+        use autumn_harvest::policy::Schedule;
+        // Simulate GET returning the canonical cron_tz: form, then POST-ing it back.
+        let canonical = "cron_tz:America/Los_Angeles:0 9 * * 1-5";
+        let result = parse_schedule_expr_with_tz(canonical, "UTC")
+            .expect("cron_tz: prefixed expr must parse regardless of timezone param");
+        assert!(
+            matches!(&result, Schedule::CronInTimezone { tz, expr }
+                if tz == "America/Los_Angeles" && expr == "0 9 * * 1-5"),
+            "embedded timezone must be preserved: {result:?}"
+        );
+    }
+
+    #[test]
+    fn parse_schedule_expr_with_tz_cron_tz_prefix_malformed_is_rejected() {
+        let result = parse_schedule_expr_with_tz("cron_tz:MissingColonExpr", "UTC");
+        assert!(
+            result.is_err(),
+            "malformed cron_tz: must be rejected: {result:?}"
         );
     }
 

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -1085,6 +1085,9 @@ struct ScheduleEntry {
     kind: ScheduleKind,
     name: String,
     schedule_expr: Option<String>,
+    /// IANA timezone the cron expression is evaluated in.
+    /// Always `"UTC"` for `Schedule::Cron` and non-cron schedules.
+    timezone: String,
     is_paused: bool,
     paused_at: Option<chrono::DateTime<chrono::Utc>>,
     paused_by: Option<String>,
@@ -1119,6 +1122,13 @@ struct PauseResumeRequest {
 struct CreateWorkflowScheduleRequest {
     workflow_name: String,
     schedule_expr: String,
+    /// IANA timezone the cron expression is evaluated in (e.g.
+    /// `"America/Los_Angeles"`, `"Europe/London"`, `"UTC"`).
+    ///
+    /// Defaults to `"UTC"`, preserving the pre-existing behavior.
+    /// Ignored for `interval:*` and `manual` expressions.
+    #[serde(default = "default_timezone")]
+    timezone: String,
     #[serde(default)]
     input: serde_json::Value,
     #[serde(default)]
@@ -1143,6 +1153,10 @@ struct CreateWorkflowScheduleRequest {
 
 fn default_queue_name() -> String {
     "default".to_string()
+}
+
+fn default_timezone() -> String {
+    "UTC".to_string()
 }
 
 const fn default_max_active_runs() -> u32 {
@@ -4819,6 +4833,7 @@ async fn list_workflow_type_handlers(
 fn schedule_expr_for_summary(schedule: &Schedule) -> String {
     match schedule {
         Schedule::Cron(expr) => format!("cron:{expr}"),
+        Schedule::CronInTimezone { expr, tz } => format!("cron_tz:{tz}:{expr}"),
         Schedule::Interval(interval) => format!("interval:{}", interval.as_secs()),
         Schedule::Manual => "manual".to_string(),
     }
@@ -5130,6 +5145,7 @@ async fn list_schedules(
                 kind,
                 name,
                 schedule_expr: s.schedule_expr,
+                timezone: s.timezone,
                 is_paused: s.is_paused,
                 paused_at: s.paused_at,
                 paused_by: s.paused_by,
@@ -5199,6 +5215,7 @@ async fn get_schedule(
         kind,
         name,
         schedule_expr: s.schedule_expr,
+        timezone: s.timezone,
         is_paused: s.is_paused,
         paused_at: s.paused_at,
         paused_by: s.paused_by,
@@ -5362,6 +5379,7 @@ async fn upsert_workflow_schedule_and_read_back(
         kind: ScheduleKind::Workflow,
         name: ws.workflow_name.clone(),
         schedule_expr: row.schedule_expr,
+        timezone: row.timezone,
         is_paused: row.is_paused,
         paused_at: row.paused_at,
         paused_by: row.paused_by,
@@ -5407,7 +5425,7 @@ async fn create_workflow_schedule(
     )
     .await?;
 
-    let schedule = match parse_schedule_expr(&request.schedule_expr) {
+    let schedule = match parse_schedule_expr_with_tz(&request.schedule_expr, &request.timezone) {
         Ok(s) => s,
         Err(e) => {
             let err_summary = format!("invalid schedule_expr: {e}");
@@ -6701,12 +6719,20 @@ async fn load_schedule_by_id(
     )))
 }
 
-fn parse_schedule_expr(expr: &str) -> Result<autumn_harvest::policy::Schedule, String> {
+fn parse_schedule_expr_with_tz(
+    expr: &str,
+    timezone: &str,
+) -> Result<autumn_harvest::policy::Schedule, String> {
     use autumn_harvest::policy::Schedule;
 
     let trimmed = expr.trim();
     let schedule = if let Some(cron) = trimmed.strip_prefix("cron:") {
-        Schedule::Cron(cron.trim().to_string())
+        let cron_expr = cron.trim().to_string();
+        if timezone == "UTC" {
+            Schedule::Cron(cron_expr)
+        } else {
+            Schedule::CronInTimezone { expr: cron_expr, tz: timezone.to_string() }
+        }
     } else if let Some(secs_str) = trimmed.strip_prefix("interval:") {
         let secs: u64 = secs_str
             .trim()
@@ -6720,10 +6746,15 @@ fn parse_schedule_expr(expr: &str) -> Result<autumn_harvest::policy::Schedule, S
         Schedule::Manual
     } else {
         // Treat a bare expression as a cron string for convenience.
-        Schedule::Cron(trimmed.to_string())
+        if timezone == "UTC" {
+            Schedule::Cron(trimmed.to_string())
+        } else {
+            Schedule::CronInTimezone { expr: trimmed.to_string(), tz: timezone.to_string() }
+        }
     };
-    // Validate cron expressions eagerly so callers receive a 400 rather than
-    // silently persisting an expression that will never fire.
+    // Validate cron expressions eagerly (including timezone names) so callers
+    // receive a 400 rather than silently persisting an expression that will
+    // never fire or an unknown timezone that would misfire.
     autumn_harvest::validate_schedule(&schedule)?;
     Ok(schedule)
 }
@@ -9976,6 +10007,91 @@ mod tests {
         assert!(
             !sql.contains("COALESCE(completed_at, started_at, created_at) >="),
             "updated windows must not be based only on workflow row timestamps"
+        );
+    }
+
+    // ── Timezone-aware schedule API ───────────────────────────────────────────
+
+    #[test]
+    fn parse_schedule_expr_with_tz_utc_produces_cron_variant() {
+        use autumn_harvest::policy::Schedule;
+        let result = parse_schedule_expr_with_tz("0 9 * * 1-5", "UTC")
+            .expect("valid cron+UTC should parse");
+        assert!(
+            matches!(result, Schedule::Cron(_)),
+            "UTC timezone must produce Schedule::Cron, not CronInTimezone: {result:?}"
+        );
+    }
+
+    #[test]
+    fn parse_schedule_expr_with_tz_non_utc_produces_cron_in_timezone_variant() {
+        use autumn_harvest::policy::Schedule;
+        let result = parse_schedule_expr_with_tz("0 9 * * 1-5", "America/Los_Angeles")
+            .expect("valid cron+timezone should parse");
+        assert!(
+            matches!(&result, Schedule::CronInTimezone { tz, .. } if tz == "America/Los_Angeles"),
+            "non-UTC timezone must produce Schedule::CronInTimezone: {result:?}"
+        );
+    }
+
+    #[test]
+    fn parse_schedule_expr_with_tz_unknown_timezone_is_rejected() {
+        let result = parse_schedule_expr_with_tz("0 9 * * *", "Not/ATimezone");
+        assert!(
+            result.is_err(),
+            "unknown timezone must be rejected with an error, got: {result:?}"
+        );
+        let err = result.unwrap_err();
+        assert!(
+            err.contains("Not/ATimezone"),
+            "error should name the bad timezone: {err}"
+        );
+    }
+
+    #[test]
+    fn create_workflow_schedule_request_timezone_defaults_to_utc() {
+        let json = r#"{"workflow_name":"my_wf","schedule_expr":"0 9 * * *"}"#;
+        let req: CreateWorkflowScheduleRequest =
+            serde_json::from_str(json).expect("should deserialize");
+        assert_eq!(req.timezone, "UTC", "missing timezone must default to UTC");
+    }
+
+    #[test]
+    fn create_workflow_schedule_request_timezone_round_trips() {
+        let json =
+            r#"{"workflow_name":"my_wf","schedule_expr":"0 9 * * *","timezone":"Europe/London"}"#;
+        let req: CreateWorkflowScheduleRequest =
+            serde_json::from_str(json).expect("should deserialize");
+        assert_eq!(req.timezone, "Europe/London");
+    }
+
+    #[test]
+    fn schedule_entry_timezone_field_is_serialized() {
+        let entry = ScheduleEntry {
+            id: uuid::Uuid::nil(),
+            kind: ScheduleKind::Workflow,
+            name: "test".to_string(),
+            schedule_expr: Some("cron:0 9 * * *".to_string()),
+            timezone: "Asia/Tokyo".to_string(),
+            is_paused: false,
+            paused_at: None,
+            paused_by: None,
+            pause_reason: None,
+            next_run_at: None,
+            last_run_at: None,
+            max_active_runs: 1,
+            catchup: false,
+            last_backfill: None,
+            jitter_secs: 0,
+            effective_fire_time: None,
+            overlap_policy: "skip".to_string(),
+            buffered_count: 0,
+            buffer_all_max: 100,
+        };
+        let json = serde_json::to_string(&entry).expect("serialize");
+        assert!(
+            json.contains("\"timezone\":\"Asia/Tokyo\""),
+            "timezone field must be present in JSON: {json}"
         );
     }
 }

--- a/autumn-harvest/Cargo.toml
+++ b/autumn-harvest/Cargo.toml
@@ -35,6 +35,7 @@ base64 = "0.22"
 thiserror = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
+chrono-tz = { workspace = true }
 tracing = { workspace = true }
 futures = { workspace = true }
 lru = "0.16"
@@ -99,6 +100,9 @@ required-features = ["db"]
 [[example]]
 name = "signal_with_start_webhook"
 required-features = ["db"]
+
+[[example]]
+name = "timezone_cron_schedule"
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }

--- a/autumn-harvest/examples/timezone_cron_schedule.rs
+++ b/autumn-harvest/examples/timezone_cron_schedule.rs
@@ -1,0 +1,94 @@
+//! Timezone-aware cron schedule example (issue #245).
+//!
+//! Demonstrates registering a `Schedule::CronInTimezone` so that a "9am Pacific
+//! weekdays" job fires at the correct local time year-round without any manual
+//! DST adjustments.
+//!
+//! ## DST guarantee
+//!
+//! When America/Los_Angeles transitions between PST (UTC-8) and PDT (UTC-7),
+//! the scheduler automatically evaluates the cron expression in the declared
+//! timezone:
+//! - Spring-forward: the non-existent 02:00-03:00 window is skipped; the next
+//!   firing is on the following day.
+//! - Fall-back: the repeated 01:00-02:00 window fires exactly once (on the
+//!   first occurrence, PDT); the second occurrence of that hour is not fired.
+//!
+//! ## Usage
+//!
+//! ```rust
+//! use std::time::Duration;
+//! use autumn_harvest::policy::{Schedule, WorkflowSchedule};
+//!
+//! // Fire every weekday at 9:00 AM Pacific time.
+//! // The tz field accepts any IANA timezone name.
+//! let schedule = Schedule::CronInTimezone {
+//!     expr: "0 9 * * 1-5".into(),
+//!     tz: "America/Los_Angeles".into(),
+//! };
+//!
+//! let workflow_schedule = WorkflowSchedule::new("daily_finance_report", schedule);
+//! ```
+//!
+//! Compare to the UTC-only variant, which drifts by 1 hour twice a year:
+//!
+//! ```rust
+//! use autumn_harvest::policy::Schedule;
+//!
+//! // Fires at 09:00 UTC year-round — that's 01:00 or 02:00 Pacific depending on DST.
+//! let drifting = Schedule::Cron("0 9 * * 1-5".into());
+//!
+//! // Fires at 09:00 Pacific year-round — correct regardless of DST.
+//! let stable = Schedule::CronInTimezone {
+//!     expr: "0 9 * * 1-5".into(),
+//!     tz: "America/Los_Angeles".into(),
+//! };
+//! ```
+//!
+//! ## Validation
+//!
+//! Unknown timezone names are rejected at builder time, not at first tick:
+//!
+//! ```rust
+//! use autumn_harvest::{
+//!     builder::{HarvestBuilder, HarvestBuilderError},
+//!     policy::{Schedule, WorkflowSchedule},
+//! };
+//!
+//! // This workflow info would normally come from `#[workflow]` + `workflows![]`.
+//! // Abbreviated here for illustration.
+//! //
+//! // let result = HarvestBuilder::new()
+//! //     .workflows(workflows![my_workflow])
+//! //     .workflow_schedule(WorkflowSchedule::new(
+//! //         "my_workflow",
+//! //         Schedule::CronInTimezone {
+//! //             expr: "0 9 * * *".into(),
+//! //             tz: "Not/ATimezone".into(),   // ← rejected here
+//! //         },
+//! //     ))
+//! //     .try_build();
+//! //
+//! // assert!(matches!(
+//! //     result.unwrap_err(),
+//! //     HarvestBuilderError::UnknownTimezone { ref name } if name == "Not/ATimezone"
+//! // ));
+//! ```
+
+fn main() {
+    use autumn_harvest::policy::{Schedule, WorkflowSchedule};
+
+    let schedule = Schedule::CronInTimezone {
+        expr: "0 9 * * 1-5".into(),
+        tz: "America/Los_Angeles".into(),
+    };
+    println!("Schedule: {schedule:?}");
+    println!("Timezone: {}", schedule.timezone_str());
+
+    let _ws = WorkflowSchedule::new("daily_finance_report", schedule);
+    println!("WorkflowSchedule built successfully.");
+    println!(
+        "This schedule fires at 9:00 AM Pacific weekdays, year-round, \
+         regardless of DST transitions."
+    );
+}

--- a/autumn-harvest/src/builder.rs
+++ b/autumn-harvest/src/builder.rs
@@ -729,6 +729,7 @@ impl HarvestBuilder {
             self.worker_config.max_local_activity_start_to_close,
         )?;
         validate_dags_do_not_use_local_activities(&self.dags, &self.activities)?;
+        validate_dag_schedules(&self.dags)?;
 
         Ok(BuiltHarvest {
             workflows: self.workflows,
@@ -869,6 +870,26 @@ fn validate_workflow_schedules(
         if let Err(reason) = crate::policy::validate_jitter(&schedule.schedule, schedule.jitter) {
             return Err(HarvestBuilderError::InvalidWorkflowSchedule {
                 workflow_name: schedule.workflow_name.clone(),
+                reason,
+            });
+        }
+    }
+    Ok(())
+}
+
+fn validate_dag_schedules(dags: &[crate::info::DagInfo]) -> Result<(), HarvestBuilderError> {
+    for dag in dags {
+        let Some(schedule) = &dag.schedule else {
+            continue;
+        };
+        if let crate::policy::Schedule::CronInTimezone { tz, .. } = schedule
+            && tz.parse::<chrono_tz::Tz>().is_err()
+        {
+            return Err(HarvestBuilderError::UnknownTimezone { name: tz.clone() });
+        }
+        if let Err(reason) = crate::policy::validate_schedule(schedule) {
+            return Err(HarvestBuilderError::InvalidWorkflowSchedule {
+                workflow_name: dag.name.to_string(),
                 reason,
             });
         }
@@ -1840,6 +1861,61 @@ mod tests {
         assert!(
             result.is_ok(),
             "valid timezone must be accepted: {result:?}"
+        );
+    }
+
+    #[test]
+    fn builder_rejects_unknown_timezone_in_dag_schedule() {
+        fn build(_dag: &mut DagBuilder) {}
+        let dag = DagInfo {
+            name: "daily_etl",
+            module: "test",
+            schedule: Some(Schedule::CronInTimezone {
+                expr: "0 9 * * 1-5".to_string(),
+                tz: "Not/ATimezone".to_string(),
+            }),
+            catchup: false,
+            max_active_runs: 1,
+            default_queue: None,
+            builder: build,
+            workflow_handler: None,
+            jitter: std::time::Duration::ZERO,
+            overlap_policy: crate::policy::OverlapPolicy::Skip,
+            buffer_all_max: 100,
+        };
+        let result = HarvestBuilder::new().dags(vec![dag]).try_build();
+        assert!(
+            matches!(
+                result,
+                Err(HarvestBuilderError::UnknownTimezone { ref name }) if name == "Not/ATimezone"
+            ),
+            "unknown timezone in DAG schedule must be rejected at build time: {result:?}"
+        );
+    }
+
+    #[test]
+    fn builder_accepts_valid_timezone_in_dag_schedule() {
+        fn build(_dag: &mut DagBuilder) {}
+        let dag = DagInfo {
+            name: "daily_etl",
+            module: "test",
+            schedule: Some(Schedule::CronInTimezone {
+                expr: "0 9 * * 1-5".to_string(),
+                tz: "America/New_York".to_string(),
+            }),
+            catchup: false,
+            max_active_runs: 1,
+            default_queue: None,
+            builder: build,
+            workflow_handler: None,
+            jitter: std::time::Duration::ZERO,
+            overlap_policy: crate::policy::OverlapPolicy::Skip,
+            buffer_all_max: 100,
+        };
+        let result = HarvestBuilder::new().dags(vec![dag]).try_build();
+        assert!(
+            result.is_ok(),
+            "valid timezone in DAG schedule must be accepted: {result:?}"
         );
     }
 }

--- a/autumn-harvest/src/builder.rs
+++ b/autumn-harvest/src/builder.rs
@@ -265,6 +265,19 @@ pub enum HarvestBuilderError {
     /// A [`WorkerConfig`] field has an invalid value.
     #[error("invalid worker configuration: {0}")]
     InvalidWorkerConfig(String),
+
+    /// A [`crate::policy::Schedule::CronInTimezone`] variant declares a
+    /// timezone name that is not a valid IANA entry. The name is rejected at
+    /// build time so the operator sees a clear error rather than silently
+    /// misfiring at the wrong time.
+    #[error(
+        "unknown timezone '{name}'; use an IANA timezone name \
+         (e.g. \"America/Los_Angeles\", \"Europe/London\", \"UTC\")"
+    )]
+    UnknownTimezone {
+        /// The unrecognised IANA timezone name.
+        name: String,
+    },
 }
 
 impl BuiltHarvest {
@@ -838,11 +851,20 @@ fn validate_workflow_schedules(
                     reason: "interval must be at least 1 second".to_string(),
                 });
             }
-        } else if let Err(reason) = crate::policy::validate_schedule(&schedule.schedule) {
-            return Err(HarvestBuilderError::InvalidWorkflowSchedule {
-                workflow_name: schedule.workflow_name.clone(),
-                reason,
-            });
+        } else {
+            // Validate timezone names early so operators get a typed error rather
+            // than a silent bad-timezone panic at first scheduler tick.
+            if let crate::policy::Schedule::CronInTimezone { tz, .. } = &schedule.schedule
+                && tz.parse::<chrono_tz::Tz>().is_err()
+            {
+                return Err(HarvestBuilderError::UnknownTimezone { name: tz.clone() });
+            }
+            if let Err(reason) = crate::policy::validate_schedule(&schedule.schedule) {
+                return Err(HarvestBuilderError::InvalidWorkflowSchedule {
+                    workflow_name: schedule.workflow_name.clone(),
+                    reason,
+                });
+            }
         }
         if let Err(reason) = crate::policy::validate_jitter(&schedule.schedule, schedule.jitter) {
             return Err(HarvestBuilderError::InvalidWorkflowSchedule {
@@ -1778,5 +1800,43 @@ mod tests {
             built.max_workflow_execution_timeout_ceiling(),
             Some(ceiling)
         );
+    }
+
+    // ── CronInTimezone builder validation ────────────────────────────────────
+
+    #[test]
+    fn builder_rejects_unknown_timezone_in_workflow_schedule() {
+        let result = HarvestBuilder::new()
+            .workflows(vec![fake_workflow_info()])
+            .workflow_schedule(WorkflowSchedule::new(
+                "test",
+                Schedule::CronInTimezone {
+                    expr: "0 9 * * *".to_string(),
+                    tz: "Not/ATimezone".to_string(),
+                },
+            ))
+            .try_build();
+
+        let err = result.unwrap_err();
+        assert!(
+            matches!(&err, HarvestBuilderError::UnknownTimezone { name } if name == "Not/ATimezone"),
+            "expected UnknownTimezone, got: {err:?}"
+        );
+    }
+
+    #[test]
+    fn builder_accepts_valid_timezone_in_workflow_schedule() {
+        let result = HarvestBuilder::new()
+            .workflows(vec![fake_workflow_info()])
+            .workflow_schedule(WorkflowSchedule::new(
+                "test",
+                Schedule::CronInTimezone {
+                    expr: "0 9 * * 1-5".to_string(),
+                    tz: "America/Los_Angeles".to_string(),
+                },
+            ))
+            .try_build();
+
+        assert!(result.is_ok(), "valid timezone must be accepted: {result:?}");
     }
 }

--- a/autumn-harvest/src/builder.rs
+++ b/autumn-harvest/src/builder.rs
@@ -1837,6 +1837,9 @@ mod tests {
             ))
             .try_build();
 
-        assert!(result.is_ok(), "valid timezone must be accepted: {result:?}");
+        assert!(
+            result.is_ok(),
+            "valid timezone must be accepted: {result:?}"
+        );
     }
 }

--- a/autumn-harvest/src/policy.rs
+++ b/autumn-harvest/src/policy.rs
@@ -259,11 +259,67 @@ impl TriggerRule {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub enum Schedule {
     /// Standard cron expression (e.g., `"0 2 * * *"` for daily at 2 AM).
+    ///
+    /// The cron expression is evaluated in **UTC**. This variant is the
+    /// backward-compatible default; existing schedules continue to fire in
+    /// UTC on upgrade.
     Cron(String),
     /// Fixed interval from the end of the previous run.
     Interval(Duration),
     /// Only runs when triggered manually via API.
     Manual,
+    /// Timezone-aware cron expression.
+    ///
+    /// Identical to `Cron` but the expression is evaluated in the declared
+    /// IANA timezone rather than UTC, so `"0 9 * * 1-5"` in
+    /// `"America/Los_Angeles"` fires at **9:00 AM Pacific year-round**,
+    /// regardless of DST transitions.
+    ///
+    /// ## DST disambiguation
+    ///
+    /// - **Spring-forward (clocks skip an hour):** a cron expression whose
+    ///   local-time resolution falls inside the skipped window is **not**
+    ///   back-fired. The scheduler advances to the first valid local instant
+    ///   on the following day (or the next matching wall-clock time after the
+    ///   gap). No spurious firing occurs at the wrong UTC time.
+    /// - **Fall-back (clocks repeat an hour):** a cron expression whose
+    ///   local-time resolution falls inside the repeated window fires exactly
+    ///   **once** — on the first occurrence of that local time (the pre-rollback
+    ///   instant). The repeated hour does not trigger a second firing.
+    ///
+    /// ## Validation
+    ///
+    /// `tz` must be a valid IANA timezone name (e.g. `"America/Los_Angeles"`,
+    /// `"Europe/London"`, `"Asia/Tokyo"`, `"UTC"`). Unknown names are rejected
+    /// at builder/registration time with
+    /// [`HarvestBuilderError::UnknownTimezone`](crate::builder::HarvestBuilderError::UnknownTimezone),
+    /// not at first scheduler tick.
+    ///
+    /// ## Backward compatibility
+    ///
+    /// `Schedule::Cron(expr)` schedules retain UTC semantics on upgrade; the
+    /// new variant is strictly opt-in. Existing persisted schedules are
+    /// unaffected.
+    CronInTimezone {
+        /// The cron expression (same syntax as `Schedule::Cron`).
+        expr: String,
+        /// IANA timezone name (e.g. `"America/Los_Angeles"`).
+        tz: String,
+    },
+}
+
+impl Schedule {
+    /// Returns the IANA timezone name for this schedule.
+    ///
+    /// `Cron`, `Interval`, and `Manual` return `"UTC"` (backward-compatible
+    /// default). `CronInTimezone` returns its declared timezone.
+    #[must_use]
+    pub const fn timezone_str(&self) -> &str {
+        match self {
+            Self::CronInTimezone { tz, .. } => tz.as_str(),
+            Self::Cron(_) | Self::Interval(_) | Self::Manual => "UTC",
+        }
+    }
 }
 
 /// What happens when a new schedule firing collides with a still-running previous
@@ -548,14 +604,24 @@ impl WorkflowSchedule {
 /// Returns a human-readable error string if the cron expression is
 /// syntactically invalid.
 pub fn validate_schedule(schedule: &Schedule) -> Result<(), String> {
-    if let Schedule::Cron(expr) = schedule {
-        Cron::new(expr)
+    match schedule {
+        Schedule::Cron(expr) => Cron::new(expr)
             .with_seconds_optional()
             .parse()
             .map(|_| ())
-            .map_err(|e| format!("invalid cron expression '{expr}': {e}"))
-    } else {
-        Ok(())
+            .map_err(|e| format!("invalid cron expression '{expr}': {e}")),
+        Schedule::CronInTimezone { expr, tz } => {
+            // Validate the IANA timezone name first so callers get a clear error.
+            if tz.parse::<chrono_tz::Tz>().is_err() {
+                return Err(format!("unknown timezone '{tz}'; use an IANA timezone name (e.g. \"America/Los_Angeles\", \"UTC\")"));
+            }
+            Cron::new(expr)
+                .with_seconds_optional()
+                .parse()
+                .map(|_| ())
+                .map_err(|e| format!("invalid cron expression '{expr}': {e}"))
+        }
+        Schedule::Interval(_) | Schedule::Manual => Ok(()),
     }
 }
 
@@ -587,7 +653,7 @@ pub fn validate_jitter(schedule: &Schedule, jitter: Duration) -> Result<(), Stri
                 ));
             }
         }
-        Schedule::Cron(_) => {
+        Schedule::Cron(_) | Schedule::CronInTimezone { .. } => {
             if jitter > MAX_CRON_JITTER {
                 return Err(format!(
                     "jitter ({jitter:?}) exceeds the 1-hour maximum for cron schedules"
@@ -909,6 +975,69 @@ mod tests {
             let back: OverlapPolicy = serde_json::from_str(&json).expect("deserialize");
             assert_eq!(back, policy, "serde round-trip failed for {policy:?}");
         }
+    }
+
+    // ── CronInTimezone schedule ───────────────────────────────────────────────
+
+    #[test]
+    fn cron_in_timezone_validate_ok() {
+        let sched = Schedule::CronInTimezone {
+            expr: "0 9 * * 1-5".to_string(),
+            tz: "America/Los_Angeles".to_string(),
+        };
+        assert!(validate_schedule(&sched).is_ok());
+    }
+
+    #[test]
+    fn cron_in_timezone_unknown_tz_rejected() {
+        let sched = Schedule::CronInTimezone {
+            expr: "0 9 * * *".to_string(),
+            tz: "Not/ATimezone".to_string(),
+        };
+        let err = validate_schedule(&sched).unwrap_err();
+        assert!(
+            err.contains("Not/ATimezone"),
+            "error should name the bad timezone: {err}"
+        );
+    }
+
+    #[test]
+    fn cron_in_timezone_invalid_expr_rejected() {
+        let sched = Schedule::CronInTimezone {
+            expr: "not a cron".to_string(),
+            tz: "UTC".to_string(),
+        };
+        assert!(validate_schedule(&sched).is_err());
+    }
+
+    #[test]
+    fn cron_in_timezone_validate_jitter_applies_cron_rules() {
+        let sched = Schedule::CronInTimezone {
+            expr: "0 * * * *".to_string(),
+            tz: "Europe/London".to_string(),
+        };
+        assert!(
+            validate_jitter(&sched, Duration::from_secs(3601)).is_err(),
+            "jitter > 1 hour must be rejected for CronInTimezone"
+        );
+        assert!(
+            validate_jitter(&sched, Duration::from_secs(3600)).is_ok(),
+            "jitter == 1 hour must be accepted for CronInTimezone"
+        );
+    }
+
+    #[test]
+    fn cron_in_timezone_serde_round_trips() {
+        let sched = Schedule::CronInTimezone {
+            expr: "30 9 * * 1-5".to_string(),
+            tz: "America/New_York".to_string(),
+        };
+        let json = serde_json::to_string(&sched).expect("serialize");
+        let back: Schedule = serde_json::from_str(&json).expect("deserialize");
+        assert!(
+            matches!(&back, Schedule::CronInTimezone { expr, tz } if expr == "30 9 * * 1-5" && tz == "America/New_York"),
+            "serde round-trip failed: {back:?}"
+        );
     }
 
     // ── compute_retry_delay ───────────────────────────────────────────────────

--- a/autumn-harvest/src/policy.rs
+++ b/autumn-harvest/src/policy.rs
@@ -613,7 +613,9 @@ pub fn validate_schedule(schedule: &Schedule) -> Result<(), String> {
         Schedule::CronInTimezone { expr, tz } => {
             // Validate the IANA timezone name first so callers get a clear error.
             if tz.parse::<chrono_tz::Tz>().is_err() {
-                return Err(format!("unknown timezone '{tz}'; use an IANA timezone name (e.g. \"America/Los_Angeles\", \"UTC\")"));
+                return Err(format!(
+                    "unknown timezone '{tz}'; use an IANA timezone name (e.g. \"America/Los_Angeles\", \"UTC\")"
+                ));
             }
             Cron::new(expr)
                 .with_seconds_optional()

--- a/autumn-harvest/src/scheduler.rs
+++ b/autumn-harvest/src/scheduler.rs
@@ -454,6 +454,8 @@ pub async fn register_workflow_schedules(
     schedules: &[WorkflowSchedule],
 ) -> HarvestResult<()> {
     for ws in schedules {
+        crate::policy::validate_schedule(&ws.schedule)
+            .map_err(crate::error::HarvestError::Config)?;
         upsert_workflow_schedule(conn, ws).await?;
     }
     Ok(())

--- a/autumn-harvest/src/scheduler.rs
+++ b/autumn-harvest/src/scheduler.rs
@@ -421,6 +421,10 @@ pub async fn register_schedules(
     #[cfg(not(feature = "unified-dag-execution"))]
     reject_classic_dags_without_unified_execution(dags)?;
     for dag in dags.values() {
+        if let Some(schedule) = &dag.schedule {
+            crate::policy::validate_schedule(schedule)
+                .map_err(crate::error::HarvestError::Config)?;
+        }
         upsert_schedule(conn, dag).await?;
     }
     Ok(())
@@ -437,6 +441,10 @@ async fn register_schedules_for_shard(
     for dag in dags.values() {
         if router.pick_for_dag(&dag.name) != shard {
             continue;
+        }
+        if let Some(schedule) = &dag.schedule {
+            crate::policy::validate_schedule(schedule)
+                .map_err(crate::error::HarvestError::Config)?;
         }
         upsert_schedule(conn, dag).await?;
     }
@@ -470,6 +478,8 @@ async fn register_workflow_schedules_for_shard(
     for ws in schedules {
         let owning_shard = workflow_schedule_shard(ws, router);
         if owning_shard == shard {
+            crate::policy::validate_schedule(&ws.schedule)
+                .map_err(crate::error::HarvestError::Config)?;
             upsert_workflow_schedule(conn, ws).await?;
         } else if ws.dag_name.is_some() {
             delete_stale_dag_workflow_schedule(conn, ws).await?;

--- a/autumn-harvest/src/scheduler.rs
+++ b/autumn-harvest/src/scheduler.rs
@@ -78,7 +78,7 @@ pub fn plan_backfill_timestamps(
 
     match schedule {
         None | Some(Schedule::Manual) => Ok(vec![]),
-        Some(Schedule::Cron(_)) => {
+        Some(Schedule::Cron(_) | Schedule::CronInTimezone { .. }) => {
             // Find the first cron occurrence at or after `from` by searching from 1 ms before
             // it (cron fires on whole-second boundaries; 1 ms is a safe undercut).
             let reference = from - chrono::Duration::milliseconds(1);
@@ -842,10 +842,11 @@ async fn upsert_schedule(
         } else {
             serde_json::json!([])
         };
+        let tz = dag.schedule.as_ref().map_or("UTC", Schedule::timezone_str);
         diesel::update(dsl::harvest_schedules.find(existing.id))
             .set((
                 dsl::schedule_expr.eq(expr.clone()),
-                dsl::timezone.eq("UTC"),
+                dsl::timezone.eq(tz),
                 dsl::catchup.eq(dag.catchup),
                 dsl::max_active_runs.eq(i32::try_from(dag.max_active_runs).unwrap_or(i32::MAX)),
                 dsl::dag_name.eq(Some(dag.name.as_str())),
@@ -871,7 +872,7 @@ async fn upsert_schedule(
             id: uuid::Uuid::new_v4(),
             dag_name: Some(&dag.name),
             schedule_expr: expr.as_deref(),
-            timezone: "UTC",
+            timezone: dag.schedule.as_ref().map_or("UTC", Schedule::timezone_str),
             catchup: dag.catchup,
             max_active_runs: i32::try_from(dag.max_active_runs).unwrap_or(i32::MAX),
             is_paused: false,
@@ -970,7 +971,7 @@ async fn insert_dag_workflow_schedule_if_missing(
         id: uuid::Uuid::new_v4(),
         dag_name: Some(dag_name),
         schedule_expr: expr,
-        timezone: "UTC",
+        timezone: ws.schedule.timezone_str(),
         catchup: ws.catchup,
         max_active_runs: i32::try_from(ws.max_active_runs).unwrap_or(i32::MAX),
         is_paused: ws.paused,
@@ -1009,7 +1010,7 @@ async fn insert_workflow_schedule_if_missing(
         id: uuid::Uuid::new_v4(),
         dag_name: None,
         schedule_expr: expr,
-        timezone: "UTC",
+        timezone: ws.schedule.timezone_str(),
         catchup: ws.catchup,
         max_active_runs: i32::try_from(ws.max_active_runs).unwrap_or(i32::MAX),
         // is_paused is set on initial insert only; subsequent upserts preserve the
@@ -1108,7 +1109,7 @@ async fn upsert_workflow_schedule(
     diesel::update(dsl::harvest_schedules.find(existing.id))
         .set((
             dsl::schedule_expr.eq(expr),
-            dsl::timezone.eq("UTC"),
+            dsl::timezone.eq(ws.schedule.timezone_str()),
             dsl::catchup.eq(ws.catchup),
             dsl::max_active_runs.eq(i32::try_from(ws.max_active_runs).unwrap_or(i32::MAX)),
             dsl::dag_name.eq(dag_name),
@@ -1222,6 +1223,16 @@ pub fn parse_schedule_from_expr_pub(expr: &str) -> Option<Schedule> {
 }
 
 fn parse_schedule_from_expr(expr: &str) -> Option<Schedule> {
+    if let Some(rest) = expr.strip_prefix("cron_tz:") {
+        // Format: "cron_tz:<tz>:<expr>" where <tz> is an IANA name that may
+        // contain one colon (e.g. nothing — IANA names use '/'). We split on
+        // the first colon after the prefix to separate tz from the cron expr.
+        let (tz, cron_expr) = rest.split_once(':')?;
+        return Some(Schedule::CronInTimezone {
+            expr: cron_expr.to_string(),
+            tz: tz.to_string(),
+        });
+    }
     expr.strip_prefix("cron:").map_or_else(
         || {
             expr.strip_prefix("interval:")
@@ -1673,6 +1684,9 @@ pub use crate::policy::validate_schedule;
 fn schedule_expr(schedule: Option<&Schedule>) -> Option<String> {
     match schedule {
         Some(Schedule::Cron(expr)) => Some(format!("cron:{expr}")),
+        Some(Schedule::CronInTimezone { expr, tz }) => {
+            Some(format!("cron_tz:{tz}:{expr}"))
+        }
         Some(Schedule::Interval(interval)) => Some(format!("interval:{}", interval.as_secs())),
         Some(Schedule::Manual) => Some("manual".to_string()),
         None => None,
@@ -1686,6 +1700,34 @@ fn next_run_after(schedule: Option<&Schedule>, reference: DateTime<Utc>) -> Opti
             .parse()
             .ok()
             .and_then(|cron| cron.find_next_occurrence(&reference, false).ok()),
+        Some(Schedule::CronInTimezone { expr, tz }) => {
+            // Parse the IANA timezone; if it's invalid we return None so the
+            // schedule simply doesn't fire (validation should have caught this).
+            let tz: chrono_tz::Tz = tz.parse().ok()?;
+            let cron = Cron::new(expr).with_seconds_optional().parse().ok()?;
+            // Convert the reference instant into the schedule's local timezone.
+            let local_ref = reference.with_timezone(&tz);
+            // First pass: find the candidate next occurrence strictly after the
+            // reference time.
+            let candidate = cron.find_next_occurrence(&local_ref, false).ok()?;
+            // DST spring-forward correction: when `croner` computes a next
+            // occurrence that falls inside a gap (e.g. "02:30 AM" on a day
+            // where 02:00–03:00 is skipped), `chrono_tz` silently advances the
+            // non-existent local time to the first valid second after the gap
+            // (e.g. 03:00:00 PDT).  That instant does NOT match the cron
+            // pattern, so calling `find_next_occurrence` again with
+            // `include_current = true` from the candidate advances to the
+            // actual next matching wall-clock time (e.g. 02:30 on the next day)
+            // without double-advancing on ordinary (non-gap) results.
+            //
+            // Fall-back is handled correctly by the strict `false` on the first
+            // call: `croner` advances past the first occurrence of the repeated
+            // hour when called from it, producing the next-day result.  Calling
+            // `find_next_occurrence(&candidate, true)` on a genuine match
+            // returns the same instant, preserving that behavior.
+            let local_next = cron.find_next_occurrence(&candidate, true).ok()?;
+            Some(local_next.with_timezone(&Utc))
+        }
         Some(Schedule::Interval(interval)) => chrono::Duration::from_std(*interval)
             .ok()
             .map(|duration| reference + duration),
@@ -2346,5 +2388,78 @@ mod tests {
         let json = buffered_runs_to_json(&runs);
         let parsed = parse_buffered_runs(&json);
         assert_eq!(parsed, runs);
+    }
+
+    // ── Timezone-aware schedule: next_run_after ───────────────────────────────
+
+    #[test]
+    fn next_run_after_spring_forward_skips_nonexistent_local_time() {
+        // America/Los_Angeles spring-forward 2026: 2026-03-08 at 2:00 AM PST → 3:00 AM PDT.
+        // "30 2 * * *" has no valid local instant on 2026-03-08; scheduler must
+        // skip that day and fire at 2026-03-09 02:30 PDT = 09:30 UTC.
+        let schedule = Schedule::CronInTimezone {
+            expr: "30 2 * * *".to_string(),
+            tz: "America/Los_Angeles".to_string(),
+        };
+        // Reference: 2026-03-08 01:50 AM PST = 09:50 UTC (just before the gap)
+        let reference = parse_utc("2026-03-08T09:50:00Z");
+        let next = next_run_after(Some(&schedule), reference)
+            .expect("should produce a next occurrence");
+        // Expected: 2026-03-09 02:30 PDT = 09:30 UTC
+        let expected = parse_utc("2026-03-09T09:30:00Z");
+        assert_eq!(
+            next, expected,
+            "spring-forward: 02:30 must not fire on Mar 8 (gap), must fire on Mar 9 instead"
+        );
+    }
+
+    #[test]
+    fn next_run_after_fall_back_fires_first_occurrence_only() {
+        // America/Los_Angeles fall-back 2026: 2026-11-01 at 2:00 AM PDT → 1:00 AM PST.
+        // 01:30 appears twice; the cron "30 1 * * *" must fire on the FIRST 01:30 (PDT = UTC-7).
+        let schedule = Schedule::CronInTimezone {
+            expr: "30 1 * * *".to_string(),
+            tz: "America/Los_Angeles".to_string(),
+        };
+        // Reference: 2026-11-01 00:50 AM PDT = 07:50 UTC
+        let reference = parse_utc("2026-11-01T07:50:00Z");
+        let first_next = next_run_after(Some(&schedule), reference)
+            .expect("should fire on fall-back day");
+        // First 01:30 PDT (UTC-7) = 2026-11-01T08:30:00Z
+        let expected_first = parse_utc("2026-11-01T08:30:00Z");
+        assert_eq!(
+            first_next, expected_first,
+            "fall-back: 01:30 must fire at first occurrence (PDT)"
+        );
+        // Calling next_run_after again from that instant must NOT return the
+        // same time (no double-fire on the repeated hour).
+        let second_next = next_run_after(Some(&schedule), first_next)
+            .expect("should advance past fall-back");
+        assert_ne!(
+            second_next, first_next,
+            "must not double-fire the repeated fall-back hour"
+        );
+        // Next occurrence is 2026-11-02 01:30 PST (UTC-8) = 09:30 UTC
+        let expected_next_day = parse_utc("2026-11-02T09:30:00Z");
+        assert_eq!(
+            second_next, expected_next_day,
+            "fall-back: after first fire, next must be the following day in PST"
+        );
+    }
+
+    #[test]
+    fn schedule_expr_and_parse_round_trip_cron_in_timezone() {
+        let schedule = Schedule::CronInTimezone {
+            expr: "0 9 * * 1-5".to_string(),
+            tz: "America/Los_Angeles".to_string(),
+        };
+        let expr_str =
+            schedule_expr(Some(&schedule)).expect("should produce expr string");
+        let parsed =
+            parse_schedule_from_expr(&expr_str).expect("should round-trip parse");
+        assert!(
+            matches!(&parsed, Schedule::CronInTimezone { tz, .. } if tz == "America/Los_Angeles"),
+            "round-trip failed: {parsed:?}"
+        );
     }
 }

--- a/autumn-harvest/src/scheduler.rs
+++ b/autumn-harvest/src/scheduler.rs
@@ -1684,9 +1684,7 @@ pub use crate::policy::validate_schedule;
 fn schedule_expr(schedule: Option<&Schedule>) -> Option<String> {
     match schedule {
         Some(Schedule::Cron(expr)) => Some(format!("cron:{expr}")),
-        Some(Schedule::CronInTimezone { expr, tz }) => {
-            Some(format!("cron_tz:{tz}:{expr}"))
-        }
+        Some(Schedule::CronInTimezone { expr, tz }) => Some(format!("cron_tz:{tz}:{expr}")),
         Some(Schedule::Interval(interval)) => Some(format!("interval:{}", interval.as_secs())),
         Some(Schedule::Manual) => Some("manual".to_string()),
         None => None,
@@ -2403,8 +2401,8 @@ mod tests {
         };
         // Reference: 2026-03-08 01:50 AM PST = 09:50 UTC (just before the gap)
         let reference = parse_utc("2026-03-08T09:50:00Z");
-        let next = next_run_after(Some(&schedule), reference)
-            .expect("should produce a next occurrence");
+        let next =
+            next_run_after(Some(&schedule), reference).expect("should produce a next occurrence");
         // Expected: 2026-03-09 02:30 PDT = 09:30 UTC
         let expected = parse_utc("2026-03-09T09:30:00Z");
         assert_eq!(
@@ -2423,8 +2421,8 @@ mod tests {
         };
         // Reference: 2026-11-01 00:50 AM PDT = 07:50 UTC
         let reference = parse_utc("2026-11-01T07:50:00Z");
-        let first_next = next_run_after(Some(&schedule), reference)
-            .expect("should fire on fall-back day");
+        let first_next =
+            next_run_after(Some(&schedule), reference).expect("should fire on fall-back day");
         // First 01:30 PDT (UTC-7) = 2026-11-01T08:30:00Z
         let expected_first = parse_utc("2026-11-01T08:30:00Z");
         assert_eq!(
@@ -2433,8 +2431,8 @@ mod tests {
         );
         // Calling next_run_after again from that instant must NOT return the
         // same time (no double-fire on the repeated hour).
-        let second_next = next_run_after(Some(&schedule), first_next)
-            .expect("should advance past fall-back");
+        let second_next =
+            next_run_after(Some(&schedule), first_next).expect("should advance past fall-back");
         assert_ne!(
             second_next, first_next,
             "must not double-fire the repeated fall-back hour"
@@ -2453,10 +2451,8 @@ mod tests {
             expr: "0 9 * * 1-5".to_string(),
             tz: "America/Los_Angeles".to_string(),
         };
-        let expr_str =
-            schedule_expr(Some(&schedule)).expect("should produce expr string");
-        let parsed =
-            parse_schedule_from_expr(&expr_str).expect("should round-trip parse");
+        let expr_str = schedule_expr(Some(&schedule)).expect("should produce expr string");
+        let parsed = parse_schedule_from_expr(&expr_str).expect("should round-trip parse");
         assert!(
             matches!(&parsed, Schedule::CronInTimezone { tz, .. } if tz == "America/Los_Angeles"),
             "round-trip failed: {parsed:?}"


### PR DESCRIPTION
## Summary

Adds support for timezone-aware cron expressions via a new `Schedule::CronInTimezone` variant, allowing jobs to fire at consistent local times year-round regardless of DST transitions. For example, `"0 9 * * 1-5"` in `"America/Los_Angeles"` now fires at 9:00 AM Pacific every weekday, not at a fixed UTC time that drifts by an hour twice yearly.

## Key Changes

- **New `Schedule` variant**: `CronInTimezone { expr: String, tz: String }` accepts IANA timezone names (e.g., `"America/Los_Angeles"`, `"Europe/London"`, `"UTC"`).

- **DST handling**: 
  - Spring-forward gaps (e.g., 2:00–3:00 AM skipped): non-existent local times are not back-fired; the next matching wall-clock time fires on the following day.
  - Fall-back repetitions (e.g., 1:00–2:00 AM repeated): fires exactly once on the first occurrence (pre-rollback instant); the repeated hour does not trigger a second firing.

- **Validation**: Unknown IANA timezone names are rejected at builder/registration time with `HarvestBuilderError::UnknownTimezone { name }`, not at first scheduler tick, so operators see clear errors immediately.

- **Backward compatibility**: Existing `Schedule::Cron(expr)` schedules retain UTC semantics on upgrade. The new variant is strictly opt-in. The `harvest_schedules.timezone` column (already present) is now written with the schedule's declared timezone instead of hard-coded `"UTC"`.

- **Management API**: 
  - `POST /admin/schedules/workflow` accepts an optional `timezone` field (defaults to `"UTC"`).
  - `GET /admin/schedules` and `GET /admin/schedules/{id}` emit a `timezone` field.
  - `ScheduleEntry` struct includes the timezone for all schedule types.

- **Scheduler implementation**:
  - `next_run_after()` converts the reference instant to the schedule's local timezone, computes the next cron occurrence, and applies DST correction logic (spring-forward re-check, fall-back first-occurrence semantics).
  - `parse_schedule_from_expr()` recognizes `"cron_tz:<tz>:<expr>"` format for round-tripping.
  - `schedule_expr()` emits `"cron_tz:<tz>:<expr>"` for `CronInTimezone` schedules.

- **Builder validation**: `validate_workflow_schedules()` now checks timezone validity early, rejecting unknown IANA names before schedule registration.

- **Tests**: Comprehensive unit tests cover validation, serde round-tripping, DST spring-forward and fall-back scenarios, and API request/response serialization.

- **Example**: New `examples/timezone_cron_schedule.rs` demonstrates the feature with usage patterns and DST guarantees.

- **Dependencies**: Added `chrono-tz = "0.10"` to workspace `Cargo.toml` for IANA timezone parsing and DST-aware local time conversion.

## Implementation Details

The DST correction in `next_run_after()` leverages `croner`'s `find_next_occurrence()` behavior:
- On spring-forward, `chrono_tz` silently advances non-existent local times to the first valid second after the gap. Calling `find_next_occurrence()` again with `include_current = true` from that candidate advances to the actual next matching wall-clock time without double-advancing on ordinary results.
- On fall-back, the strict `false` on the first call ensures `croner` advances past the first occurrence of the repeated hour when called from it, producing the next-day result. Calling with `include_current = true` on a genuine match returns the same instant, preserving correct behavior.

The `timezone_str()` method on `Schedule` returns the declared timezone for `CronInTimezone` and `"UTC"` for all other variants, maintaining backward-compatible defaults.

https://claude.ai/code/session_013suyb6F17pjTxa34QpukNf