### PR TITLE
Display history event count and continue-as-new threshold on workflow detail page

### DIFF
--- a/autumn-harvest-plugin/src/ui.rs
+++ b/autumn-harvest-plugin/src/ui.rs
@@ -2767,8 +2767,7 @@ fn render_workflow_detail(
                     (kv("Execution timeout", &format!("{}s", timeout.num_seconds()), false))
                 }
                 @if let Some(threshold) = continue_as_new_threshold {
-                    div.k { "History events" }
-                    div.v { (total_events) " / threshold: " (threshold) }
+                    (kv("History events", &format!("{total_events} / threshold: {threshold}"), false))
                 } @else {
                     (kv("History events", &total_events.to_string(), false))
                 }

--- a/autumn-harvest-plugin/src/ui.rs
+++ b/autumn-harvest-plugin/src/ui.rs
@@ -4812,7 +4812,7 @@ mod tests {
             "label should still appear when threshold is None"
         );
         assert!(
-            html.contains("5"),
+            html.contains('5'),
             "event count 5 should appear even without threshold"
         );
     }
@@ -4836,10 +4836,7 @@ mod tests {
         )
         .into_string();
 
-        assert!(
-            html.contains("300"),
-            "event count 300 must appear in HTML"
-        );
+        assert!(html.contains("300"), "event count 300 must appear in HTML");
         assert!(
             html.contains("500"),
             "custom threshold 500 must appear in HTML"

--- a/autumn-harvest-plugin/src/ui.rs
+++ b/autumn-harvest-plugin/src/ui.rs
@@ -684,6 +684,13 @@ async fn workflow_detail_ui(
     // Load blocked-on data for non-terminal workflows.
     let blocked_on = load_blocked_on_data(&mut conn, exec_uuid, &execution.state).await?;
 
+    // Resolve the continue-as-new threshold from the runtime registry if available.
+    // This is a lightweight read of an in-memory value — no extra DB query.
+    let continue_as_new_threshold = api_state
+        .runtime()
+        .ok()
+        .map(|r| r.registry().history_policy().continue_as_new_threshold());
+
     Ok(render_workflow_detail(
         &execution,
         total_events,
@@ -695,6 +702,7 @@ async fn workflow_detail_ui(
         event_page,
         &blocked_on,
         params.flash.as_deref(),
+        continue_as_new_threshold,
     ))
 }
 
@@ -2611,6 +2619,7 @@ fn render_workflow_detail(
     event_page: i64,
     blocked_on: &BlockedOnData,
     flash: Option<&str>,
+    continue_as_new_threshold: Option<u64>,
 ) -> Markup {
     let exec_id_str = execution.id.to_string();
     let title = format!("{} · Vantage", execution.workflow_name);
@@ -2756,6 +2765,12 @@ fn render_workflow_detail(
                 }
                 @if let Some(timeout) = execution.execution_timeout {
                     (kv("Execution timeout", &format!("{}s", timeout.num_seconds()), false))
+                }
+                @if let Some(threshold) = continue_as_new_threshold {
+                    div.k { "History events" }
+                    div.v { (total_events) " / threshold: " (threshold) }
+                } @else {
+                    (kv("History events", &total_events.to_string(), false))
                 }
             }
         }
@@ -4700,5 +4715,134 @@ mod tests {
             SchedulePausedFilter::Active
         ));
         assert!(SchedulePausedFilter::parse("maybe").is_err());
+    }
+
+    // -- Issue #279: history event count and continue-as-new threshold --
+
+    fn stub_execution() -> autumn_harvest::models::WorkflowExecution {
+        use chrono::Utc;
+        use uuid::Uuid;
+        autumn_harvest::models::WorkflowExecution {
+            id: Uuid::new_v4(),
+            workflow_name: "test_workflow".to_string(),
+            workflow_id: "wf-1".to_string(),
+            run_id: Uuid::new_v4(),
+            shard_id: 0,
+            state: "RUNNING".to_string(),
+            input: serde_json::json!(null),
+            output: None,
+            error: None,
+            parent_id: None,
+            sticky_worker_id: None,
+            queue_name: "default".to_string(),
+            started_at: Utc::now(),
+            completed_at: None,
+            execution_timeout: None,
+            deadline_at: None,
+            memo: None,
+            search_attrs: None,
+            created_at: Utc::now(),
+            assigned_build_id: None,
+        }
+    }
+
+    fn stub_blocked_on() -> BlockedOnData {
+        BlockedOnData {
+            activities: vec![],
+            external_tasks: vec![],
+            timers: vec![],
+            signals: vec![],
+        }
+    }
+
+    #[test]
+    fn render_detail_shows_history_event_count_with_threshold() {
+        let execution = stub_execution();
+        let blocked = stub_blocked_on();
+        let html = render_workflow_detail(
+            &execution,
+            42,
+            &[],
+            &[],
+            &[],
+            false,
+            &[],
+            0,
+            &blocked,
+            None,
+            Some(10_000),
+        )
+        .into_string();
+
+        assert!(
+            html.contains("History events"),
+            "metadata card must have a 'History events' label"
+        );
+        assert!(
+            html.contains("42"),
+            "metadata card must show the event count 42"
+        );
+        assert!(
+            html.contains("10000") || html.contains("10,000"),
+            "metadata card must show the threshold 10000"
+        );
+    }
+
+    #[test]
+    fn render_detail_shows_threshold_absent_when_none() {
+        let execution = stub_execution();
+        let blocked = stub_blocked_on();
+        let html = render_workflow_detail(
+            &execution,
+            5,
+            &[],
+            &[],
+            &[],
+            false,
+            &[],
+            0,
+            &blocked,
+            None,
+            None,
+        )
+        .into_string();
+
+        assert!(
+            html.contains("History events"),
+            "label should still appear when threshold is None"
+        );
+        assert!(
+            html.contains("5"),
+            "event count 5 should appear even without threshold"
+        );
+    }
+
+    #[test]
+    fn render_detail_shows_custom_threshold() {
+        let execution = stub_execution();
+        let blocked = stub_blocked_on();
+        let html = render_workflow_detail(
+            &execution,
+            300,
+            &[],
+            &[],
+            &[],
+            false,
+            &[],
+            0,
+            &blocked,
+            None,
+            Some(500),
+        )
+        .into_string();
+
+        assert!(
+            html.contains("300"),
+            "event count 300 must appear in HTML"
+        );
+        assert!(
+            html.contains("500"),
+            "custom threshold 500 must appear in HTML"
+        );
     }
 }

--- a/autumn-harvest-plugin/tests/ui_integration.rs
+++ b/autumn-harvest-plugin/tests/ui_integration.rs
@@ -4,6 +4,7 @@ use std::collections::{BTreeMap, HashMap};
 use std::sync::Arc;
 
 use autumn_harvest::builder::WorkerConfig;
+use autumn_harvest::context::{DEFAULT_HISTORY_CONTINUE_AS_NEW_THRESHOLD, WorkflowHistoryPolicy};
 use autumn_harvest::info::WorkflowInfo;
 use autumn_harvest::models::NewHarvestEvent;
 use autumn_harvest::scheduler::SchedulerMonitor;
@@ -2358,5 +2359,104 @@ async fn detail_page_has_jump_to_event_n_control() {
     assert!(
         html.contains("Jump to") || html.contains("jump") || html.contains("Go"),
         "detail page should have a jump/go button or label for the control: {html}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Issue #279: history event count and continue-as-new threshold on detail page
+// ---------------------------------------------------------------------------
+
+/// The workflow detail page must show the current event count alongside the
+/// configured continue-as-new threshold in the Metadata card.
+#[tokio::test]
+async fn detail_page_shows_history_event_count_and_threshold() {
+    let (database_url, _container) = setup_test_database_url().await;
+    let exec_id =
+        insert_workflow_on_url(&database_url, ShardId::new(0), "hist_wf", "hist-1").await;
+    // Insert 7 events so we have a known, non-zero count.
+    append_test_events(&database_url, exec_id, "hist", 7).await;
+
+    let app = build_single_shard_ui_app(&database_url);
+    let (status, html) = fetch_html(&app, &format!("/workflows/{exec_id}")).await;
+    assert_eq!(status, StatusCode::OK, "detail page must render: {html}");
+
+    // The page must display the event count explicitly in the metadata section.
+    assert!(
+        html.contains("History events"),
+        "metadata card should have a 'History events' label: {html}"
+    );
+    assert!(
+        html.contains("7"),
+        "metadata card should show the count 7: {html}"
+    );
+
+    // The default threshold (10 000) must be visible alongside the count.
+    let threshold_str = DEFAULT_HISTORY_CONTINUE_AS_NEW_THRESHOLD.to_string();
+    assert!(
+        html.contains(&threshold_str),
+        "metadata card should include the continue-as-new threshold ({threshold_str}): {html}"
+    );
+}
+
+/// When the registry is configured with a custom threshold the detail page must
+/// reflect that value rather than the default 10 000.
+#[tokio::test]
+async fn detail_page_shows_custom_continue_as_new_threshold() {
+    let (database_url, _container) = setup_test_database_url().await;
+    let exec_id =
+        insert_workflow_on_url(&database_url, ShardId::new(0), "cust_wf", "cust-1").await;
+    append_test_events(&database_url, exec_id, "cust", 3).await;
+
+    // Build an app whose registry uses a distinctive non-default threshold.
+    const CUSTOM_THRESHOLD: u64 = 500;
+    let pool = build_test_pool(&database_url);
+    let api_state = HarvestApiState::new();
+    api_state.install_storage_pool(HarvestDbPool::from(pool));
+    let registry = Arc::new(
+        HandlerRegistry::new(
+            vec![WorkflowInfo {
+                name: "cust_wf",
+                module: "tests",
+                handler: |_ctx, input| Box::pin(async move { Ok(input) }),
+                execution_timeout: None,
+                concurrency: None,
+                max_input_bytes: None,
+            }],
+            vec![],
+        )
+        .with_history_policy(
+            WorkflowHistoryPolicy::default()
+                .with_continue_as_new_threshold(CUSTOM_THRESHOLD),
+        ),
+    );
+    api_state.install(HarvestApiRuntime::new(
+        registry,
+        Arc::new(HashMap::new()),
+        Arc::new(Vec::new()),
+        None,
+        vec!["default".to_string()],
+        SchedulerMonitor::offline(),
+        HarvestRetentionRuntime::disabled(autumn_harvest::RetentionConfig::default()),
+        ShardRouter::single(),
+    ));
+    let app = harvest_ui_router(api_state).with_state(test_app_state_without_database());
+
+    let (status, html) = fetch_html(&app, &format!("/workflows/{exec_id}")).await;
+    assert_eq!(status, StatusCode::OK, "detail page must render: {html}");
+
+    assert!(
+        html.contains("History events"),
+        "metadata card should have a 'History events' label: {html}"
+    );
+    assert!(
+        html.contains("500"),
+        "metadata card should show the custom threshold 500: {html}"
+    );
+    // The default threshold value must NOT appear as the threshold.
+    // (It could appear elsewhere, e.g. as an event count or ID, so we verify
+    // the custom value is present rather than asserting the default is absent.)
+    assert!(
+        html.contains("3"),
+        "metadata card should show the event count 3: {html}"
     );
 }

--- a/autumn-harvest-plugin/tests/ui_integration.rs
+++ b/autumn-harvest-plugin/tests/ui_integration.rs
@@ -2371,8 +2371,7 @@ async fn detail_page_has_jump_to_event_n_control() {
 #[tokio::test]
 async fn detail_page_shows_history_event_count_and_threshold() {
     let (database_url, _container) = setup_test_database_url().await;
-    let exec_id =
-        insert_workflow_on_url(&database_url, ShardId::new(0), "hist_wf", "hist-1").await;
+    let exec_id = insert_workflow_on_url(&database_url, ShardId::new(0), "hist_wf", "hist-1").await;
     // Insert 7 events so we have a known, non-zero count.
     append_test_events(&database_url, exec_id, "hist", 7).await;
 
@@ -2386,7 +2385,7 @@ async fn detail_page_shows_history_event_count_and_threshold() {
         "metadata card should have a 'History events' label: {html}"
     );
     assert!(
-        html.contains("7"),
+        html.contains('7'),
         "metadata card should show the count 7: {html}"
     );
 
@@ -2402,13 +2401,13 @@ async fn detail_page_shows_history_event_count_and_threshold() {
 /// reflect that value rather than the default 10 000.
 #[tokio::test]
 async fn detail_page_shows_custom_continue_as_new_threshold() {
+    const CUSTOM_THRESHOLD: u64 = 500;
+
     let (database_url, _container) = setup_test_database_url().await;
-    let exec_id =
-        insert_workflow_on_url(&database_url, ShardId::new(0), "cust_wf", "cust-1").await;
+    let exec_id = insert_workflow_on_url(&database_url, ShardId::new(0), "cust_wf", "cust-1").await;
     append_test_events(&database_url, exec_id, "cust", 3).await;
 
     // Build an app whose registry uses a distinctive non-default threshold.
-    const CUSTOM_THRESHOLD: u64 = 500;
     let pool = build_test_pool(&database_url);
     let api_state = HarvestApiState::new();
     api_state.install_storage_pool(HarvestDbPool::from(pool));
@@ -2425,8 +2424,7 @@ async fn detail_page_shows_custom_continue_as_new_threshold() {
             vec![],
         )
         .with_history_policy(
-            WorkflowHistoryPolicy::default()
-                .with_continue_as_new_threshold(CUSTOM_THRESHOLD),
+            WorkflowHistoryPolicy::default().with_continue_as_new_threshold(CUSTOM_THRESHOLD),
         ),
     );
     api_state.install(HarvestApiRuntime::new(
@@ -2456,7 +2454,7 @@ async fn detail_page_shows_custom_continue_as_new_threshold() {
     // (It could appear elsewhere, e.g. as an event count or ID, so we verify
     // the custom value is present rather than asserting the default is absent.)
     assert!(
-        html.contains("3"),
+        html.contains('3'),
         "metadata card should show the event count 3: {html}"
     );
 }


### PR DESCRIPTION
## Summary

Adds visibility of the current workflow history event count alongside the configured continue-as-new threshold in the workflow detail page metadata card. This addresses issue #279 by helping operators monitor when workflows are approaching the threshold that would trigger automatic continuation.

## Changes

- **Threshold resolution**: Modified `workflow_detail_ui` to resolve the `continue_as_new_threshold` from the runtime registry's history policy (lightweight in-memory read, no DB query)
- **UI rendering**: Updated `render_workflow_detail` to accept an optional `continue_as_new_threshold` parameter and display it alongside the event count in the metadata card
  - When threshold is available: shows "History events: {count} / threshold: {threshold}"
  - When threshold is unavailable: falls back to showing just the event count
- **Unit tests**: Added three unit tests to verify rendering behavior with and without threshold values
- **Integration tests**: Added two integration tests to verify the detail page displays:
  - The default threshold (10,000) when using the standard registry configuration
  - Custom thresholds when the registry is configured with non-default values

## Implementation Details

The threshold is resolved from `api_state.runtime().ok().map(|r| r.registry().history_policy().continue_as_new_threshold())`, which safely handles cases where the runtime is not available (returns `None`). The UI gracefully degrades to show only the event count when the threshold cannot be determined.

The integration tests use `WorkflowHistoryPolicy::default().with_continue_as_new_threshold(CUSTOM_THRESHOLD)` to verify that custom thresholds configured on the registry are properly reflected in the rendered page.

https://claude.ai/code/session_01U5mbRCq5MoPae2a68He1E1