### PR TITLE
Add calendar-aware schedule filtering (issue #337)

### DIFF
--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -1629,6 +1629,13 @@ pub const fn management_api_routes() -> &'static [(&'static str, &'static str)] 
         ("POST", "/admin/schedules/{id}/resume"),
         ("POST", "/admin/schedules/{id}/backfill"),
         ("DELETE", "/admin/schedules/{id}"),
+        ("GET", "/admin/schedules/{id}/preview"),
+        // ── calendars (issue #337) ────────────────────────────────────────────
+        ("GET", "/calendars"),
+        ("GET", "/calendars/{name}"),
+        ("POST", "/calendars"),
+        ("PUT", "/calendars/{name}"),
+        ("DELETE", "/calendars/{name}"),
         // ── audit (issue #158) ────────────────────────────────────────────────
         ("GET", "/admin/audit"),
     ]
@@ -1770,6 +1777,8 @@ pub const fn management_api_request_fields()
                 "catchup",
                 "paused",
                 "queue_name",
+                "calendar",
+                "skip_policy",
             ]),
         ),
         ("POST", "/admin/schedules/{id}/pause", Some(&["reason"])),
@@ -1782,6 +1791,10 @@ pub const fn management_api_request_fields()
             Some(&["from", "to", "dry_run", "include_paused", "max_count"]),
         ),
         ("DELETE", "/admin/schedules/{id}", Some(&[])),
+        // ── calendars (issue #337) ────────────────────────────────────────────
+        ("POST", "/calendars", Some(&["name", "description"])),
+        ("PUT", "/calendars/{name}", Some(&["exclusion_dates"])),
+        ("DELETE", "/calendars/{name}", Some(&[])),
     ]
 }
 
@@ -2094,6 +2107,25 @@ pub const fn management_api_response_fields()
             ]),
         ),
         ("DELETE", "/admin/schedules/{id}", Some(&["ok"])),
+        ("GET", "/admin/schedules/{id}/preview", Some(&["entries"])),
+        // ── calendars (issue #337) ────────────────────────────────────────────
+        ("GET", "/calendars", None), // Vec<CalendarSummary>
+        (
+            "GET",
+            "/calendars/{name}",
+            Some(&["name", "description", "exclusion_dates"]),
+        ),
+        (
+            "POST",
+            "/calendars",
+            Some(&["name", "description", "exclusion_dates"]),
+        ),
+        (
+            "PUT",
+            "/calendars/{name}",
+            Some(&["name", "description", "exclusion_dates"]),
+        ),
+        ("DELETE", "/calendars/{name}", Some(&["ok"])),
         // ── audit ─────────────────────────────────────────────────────────────
         ("GET", "/admin/audit", None), // Vec<AuditRecord> (external model)
     ]
@@ -8857,7 +8889,9 @@ async fn preview_schedule_firings_handler(
         vec![]
     };
 
-    let entries = preview_schedule_firings(
+    let jitter_secs = schedule.jitter_secs;
+    let schedule_id = schedule.id;
+    let mut entries = preview_schedule_firings(
         sched,
         from,
         count,
@@ -8865,6 +8899,19 @@ async fn preview_schedule_firings_handler(
         &excluded_dates,
         skip_policy,
     );
+
+    // Apply schedule jitter to each effective_at (mirrors effective_fire_time logic).
+    if jitter_secs > 0 {
+        let jitter_window = std::time::Duration::from_secs(jitter_secs.cast_unsigned());
+        for entry in &mut entries {
+            if let Some(t) = entry.effective_at {
+                let offset = compute_jitter_offset(schedule_id, t, jitter_window);
+                if let Ok(d) = chrono::Duration::from_std(offset) {
+                    entry.effective_at = Some(t + d);
+                }
+            }
+        }
+    }
 
     Ok((
         StatusCode::OK,

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -6261,7 +6261,10 @@ async fn schedule_backfill(
     // Dry-run: query current running count and project what would happen.
     if request.dry_run {
         let running = query_running_count_best_effort(&pool, &kind, &name).await;
-        let already_exists = count_existing_in_window(&pool, &kind, &name, &fire_times).await;
+        // Workflow IDs are derived from original_slot (not fire_time), so duplicate
+        // detection must use the same set of timestamps that dispatch will use.
+        let original_slots: Vec<_> = timestamp_pairs.iter().map(|(orig, _)| *orig).collect();
+        let already_exists = count_existing_in_window(&pool, &kind, &name, &original_slots).await;
         let remaining = total.saturating_sub(already_exists);
         let available_slots = usize::try_from((max_active - running).max(0)).unwrap_or(0);
         let would_dispatch = remaining.min(available_slots);
@@ -8899,6 +8902,8 @@ async fn update_calendar_exclusions_handler(
     // Attempt all shards even on error so that a transient failure on one shard
     // does not leave others stale. replace_calendar_exclusions is idempotent
     // (runs in a transaction), so retrying a partial fanout converges correctly.
+    // NotFound from any shard means the calendar does not exist → return 404
+    // immediately so callers fix input rather than retrying.
     let mut shard_errors: Vec<String> = Vec::new();
     for (shard_id, shard_pool) in pool.iter_shards() {
         let mut conn = match acquire_conn(shard_pool).await {
@@ -8908,8 +8913,14 @@ async fn update_calendar_exclusions_handler(
                 continue;
             }
         };
-        if let Err(e) = replace_calendar_exclusions(&mut conn, &name, &body.exclusion_dates).await {
-            shard_errors.push(format!("shard {shard_id}: {e}"));
+        match replace_calendar_exclusions(&mut conn, &name, &body.exclusion_dates).await {
+            Ok(()) => {}
+            Err(autumn_harvest::HarvestError::NotFound(_)) => {
+                return Err(AutumnError::not_found_msg(format!(
+                    "calendar '{name}' not found"
+                )));
+            }
+            Err(e) => shard_errors.push(format!("shard {shard_id}: {e}")),
         }
     }
     if !shard_errors.is_empty() {
@@ -8928,14 +8939,26 @@ async fn delete_calendar_handler(
     Path(name): Path<String>,
 ) -> Result<impl IntoResponse, AutumnError> {
     let pool = api_state.storage_pool().map_err(map_error)?;
+    let mut any_deleted = false;
+    let mut all_not_found = true;
     for (_, shard_pool) in pool.iter_shards() {
         let mut conn = acquire_conn(shard_pool).await?;
-        // NotFound is treated as success so that retries after a partial delete
-        // converge: already-deleted shards no longer hold the calendar row.
         match delete_calendar(&mut conn, &name).await {
-            Ok(()) | Err(autumn_harvest::HarvestError::NotFound(_)) => {}
+            Ok(()) => {
+                any_deleted = true;
+                all_not_found = false;
+            }
+            // NotFound on this shard is idempotent for retry: if at least one shard
+            // deleted successfully, the overall operation succeeded.
+            Err(autumn_harvest::HarvestError::NotFound(_)) => {}
             Err(e) => return Err(map_error(e)),
         }
+    }
+    // If every shard reported not-found the calendar never existed; return 404.
+    if all_not_found && !any_deleted {
+        return Err(AutumnError::not_found_msg(format!(
+            "calendar '{name}' not found"
+        )));
     }
     Ok(StatusCode::NO_CONTENT)
 }

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -1793,7 +1793,7 @@ pub const fn management_api_request_fields()
         ("DELETE", "/admin/schedules/{id}", Some(&[])),
         // ── calendars (issue #337) ────────────────────────────────────────────
         ("POST", "/calendars", Some(&["name", "description"])),
-        ("PUT", "/calendars/{name}", None), // 204 No Content
+        ("PUT", "/calendars/{name}", Some(&["exclusion_dates"])),
         ("DELETE", "/calendars/{name}", Some(&[])),
     ]
 }
@@ -2113,19 +2113,28 @@ pub const fn management_api_response_fields()
         (
             "GET",
             "/calendars/{name}",
-            Some(&["name", "description", "exclusion_dates"]),
+            Some(&[
+                "name",
+                "description",
+                "built_in",
+                "created_at",
+                "updated_at",
+                "exclusion_dates",
+            ]),
         ),
         (
             "POST",
             "/calendars",
-            Some(&["name", "description", "exclusion_dates"]),
+            Some(&[
+                "name",
+                "description",
+                "built_in",
+                "created_at",
+                "updated_at",
+            ]),
         ),
-        (
-            "PUT",
-            "/calendars/{name}",
-            Some(&["name", "description", "exclusion_dates"]),
-        ),
-        ("DELETE", "/calendars/{name}", Some(&["ok"])),
+        ("PUT", "/calendars/{name}", None),    // 204 No Content
+        ("DELETE", "/calendars/{name}", None), // 204 No Content
         // ── audit ─────────────────────────────────────────────────────────────
         ("GET", "/admin/audit", None), // Vec<AuditRecord> (external model)
     ]
@@ -5600,14 +5609,28 @@ async fn create_workflow_schedule(
         }
     };
 
-    // Validate calendar name exists before storing to return a helpful 400 rather than
-    // a generic FK-violation 503 from the database.
+    // Validate calendar name exists before storing. Return 400 for NotFound so
+    // clients distinguish invalid input from transient DB failures (503).
     if let Some(cal_name) = &request.calendar {
-        get_calendar(&mut conn, cal_name).await.map_err(|_| {
-            AutumnError::bad_request_msg(format!(
-                "calendar '{cal_name}' not found; create it first with POST /calendars"
-            ))
-        })?;
+        match get_calendar(&mut conn, cal_name).await {
+            Ok(_) => {}
+            Err(autumn_harvest::HarvestError::NotFound(_)) => {
+                let err_summary = format!(
+                    "calendar '{cal_name}' not found; create it first with POST /calendars"
+                );
+                schedule_create_audit_failed(
+                    &api_state,
+                    &actor,
+                    &source,
+                    request_id.as_deref(),
+                    &request.workflow_name,
+                    &err_summary,
+                )
+                .await;
+                return Err(AutumnError::bad_request_msg(err_summary));
+            }
+            Err(e) => return Err(map_error(e)),
+        }
     }
 
     let ws = WorkflowSchedule {

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -18,7 +18,7 @@ use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::middleware::{self, Next};
 use axum::response::IntoResponse;
-use axum::routing::{delete, get, patch, post};
+use axum::routing::{delete, get, patch, post, put};
 use diesel::ExpressionMethods;
 use diesel::OptionalExtension;
 use diesel::QueryDsl;
@@ -28,6 +28,10 @@ use diesel_async::RunQueryDsl;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
+use autumn_harvest::calendar::{
+    create_calendar, delete_calendar, get_calendar, list_calendars, load_exclusions_for_calendar,
+    preview_schedule_firings, replace_calendar_exclusions,
+};
 use autumn_harvest::audit::{
     self, AuditFilters, HEADER_ACTOR, HEADER_REQUEST_ID, HEADER_SOURCE, OP_BATCH_SUBMIT,
     OP_DAG_PATCH, OP_DAG_TRIGGER, OP_DLQ_DISCARD_BULK, OP_DLQ_REPLAY, OP_DLQ_REPLAY_BULK,
@@ -51,10 +55,10 @@ use autumn_harvest::history_export::{
     HistoryExportRequest, HistoryPayloadPolicy, export_history,
 };
 use autumn_harvest::models::{
-    AuditRecord, BackfillLogRow, DeadLetter, HarvestSchedule, NewAuditRecord, NewBackfillLogRow,
-    WorkflowExecution,
+    AuditRecord, BackfillLogRow, DeadLetter, HarvestCalendar,
+    HarvestSchedule, NewAuditRecord, NewBackfillLogRow, WorkflowExecution,
 };
-use autumn_harvest::policy::{Schedule, WorkflowSchedule, compute_jitter_offset};
+use autumn_harvest::policy::{Schedule, SkipPolicy, WorkflowSchedule, compute_jitter_offset};
 use autumn_harvest::queue::{self, ConcurrencyKeyStats};
 use autumn_harvest::reset::{
     ResetInvalidPoint, ResetResult, WorkflowResetError, WorkflowResetRequest,
@@ -1108,6 +1112,10 @@ struct ScheduleEntry {
     buffered_count: usize,
     /// Maximum buffered slots under `buffer_all`. 0 for other policies.
     buffer_all_max: i32,
+    /// Optional named calendar attached to this schedule (issue #337). `null` = no filtering.
+    calendar_name: Option<String>,
+    /// What to do when the fire date is calendar-excluded (issue #337).
+    skip_policy: String,
 }
 
 /// Optional request body for `POST /admin/schedules/{id}/pause` and `…/resume`.
@@ -1149,6 +1157,13 @@ struct CreateWorkflowScheduleRequest {
     /// Maximum buffered slots under `BufferAll`. Defaults to `100`.
     #[serde(default = "default_buffer_all_max")]
     buffer_all_max: u32,
+    /// Optional named calendar for business-day / holiday filtering (issue #337).
+    #[serde(default)]
+    calendar: Option<String>,
+    /// What to do when the fire date is excluded by the calendar.
+    /// Valid values: `"skip"`, `"run_next_business_day"`, `"run_prev_business_day"`.
+    #[serde(default = "default_skip_policy")]
+    skip_policy: String,
 }
 
 fn default_queue_name() -> String {
@@ -1164,6 +1179,10 @@ const fn default_max_active_runs() -> u32 {
 }
 
 fn default_overlap_policy() -> String {
+    "skip".to_string()
+}
+
+fn default_skip_policy() -> String {
     "skip".to_string()
 }
 
@@ -1450,6 +1469,22 @@ pub fn harvest_api_router(api_state: HarvestApiState) -> Router<AppState> {
         .route("/admin/schedules/{id}/resume", post(resume_schedule))
         .route("/admin/schedules/{id}/backfill", post(schedule_backfill))
         .route("/admin/schedules/{id}", delete(delete_schedule))
+        .route("/admin/schedules/{id}/preview", get(preview_schedule_firings_handler))
+        // Calendar management (issue #337): named exclusion sets for business-day aware scheduling.
+        .route("/calendars", get(list_calendars_handler))
+        .route(
+            "/calendars",
+            post(create_calendar_handler).route_layer(require_admin.clone()),
+        )
+        .route("/calendars/{name}", get(get_calendar_handler))
+        .route(
+            "/calendars/{name}",
+            put(update_calendar_exclusions_handler).route_layer(require_admin.clone()),
+        )
+        .route(
+            "/calendars/{name}",
+            delete(delete_calendar_handler).route_layer(require_admin.clone()),
+        )
         // External activity completion (issue #92): async task-token API.
         .route(
             "/activities/external/{token}/complete",
@@ -5195,9 +5230,11 @@ async fn list_schedules(
                 last_backfill,
                 jitter_secs: s.jitter_secs,
                 effective_fire_time: eft,
-                overlap_policy: s.overlap_policy.clone(),
+                overlap_policy: s.overlap_policy,
                 buffered_count,
                 buffer_all_max: s.buffer_all_max,
+                calendar_name: s.calendar_name,
+                skip_policy: s.skip_policy,
             }
         })
         .collect();
@@ -5266,6 +5303,8 @@ async fn get_schedule(
         overlap_policy: s.overlap_policy.clone(),
         buffered_count,
         buffer_all_max: s.buffer_all_max,
+        calendar_name: s.calendar_name.clone(),
+        skip_policy: s.skip_policy.clone(),
     }))
 }
 
@@ -5427,9 +5466,11 @@ async fn upsert_workflow_schedule_and_read_back(
         max_active_runs: row.max_active_runs,
         catchup: row.catchup,
         last_backfill: None, // newly created; no backfill history yet
-        overlap_policy: row.overlap_policy.clone(),
+        overlap_policy: row.overlap_policy,
         buffered_count,
         buffer_all_max: row.buffer_all_max,
+        calendar_name: row.calendar_name,
+        skip_policy: row.skip_policy,
     })
 }
 
@@ -5505,6 +5546,24 @@ async fn create_workflow_schedule(
             return Err(AutumnError::bad_request_msg(err_summary));
         }
     };
+    let skip_policy = match SkipPolicy::from_user_input(&request.skip_policy) {
+        Ok(p) => p,
+        Err(v) => {
+            let err_summary = format!(
+                "invalid skip_policy '{v}'; valid values: skip, run_next_business_day, run_prev_business_day"
+            );
+            schedule_create_audit_failed(
+                &api_state,
+                &actor,
+                &source,
+                request_id.as_deref(),
+                &request.workflow_name,
+                &err_summary,
+            )
+            .await;
+            return Err(AutumnError::bad_request_msg(err_summary));
+        }
+    };
     let ws = WorkflowSchedule {
         workflow_name: request.workflow_name.clone(),
         dag_name: None,
@@ -5518,6 +5577,8 @@ async fn create_workflow_schedule(
         overlap_policy,
         buffer_all_max: request.buffer_all_max,
         execution_timeout: None,
+        calendar: request.calendar.clone(),
+        skip_policy,
     };
     let entry = match upsert_workflow_schedule_and_read_back(&mut conn, &ws).await {
         Ok(e) => e,
@@ -8604,6 +8665,207 @@ pub(crate) fn map_error(error: HarvestError) -> AutumnError {
         HarvestError::Database(message) => AutumnError::service_unavailable_msg(message),
         other => AutumnError::service_unavailable_msg(other.to_string()),
     }
+}
+
+// ── Calendar management (issue #337) ─────────────────────────────────────────
+
+/// Response body for calendar CRUD endpoints.
+#[derive(Debug, Serialize)]
+struct CalendarResponse {
+    name: String,
+    description: Option<String>,
+    built_in: bool,
+    created_at: chrono::DateTime<chrono::Utc>,
+    updated_at: chrono::DateTime<chrono::Utc>,
+}
+
+impl From<HarvestCalendar> for CalendarResponse {
+    fn from(c: HarvestCalendar) -> Self {
+        Self {
+            name: c.name,
+            description: c.description,
+            built_in: c.built_in,
+            created_at: c.created_at,
+            updated_at: c.updated_at,
+        }
+    }
+}
+
+/// `GET /calendars` — list all calendars.
+async fn list_calendars_handler(
+    Extension(api_state): Extension<HarvestApiState>,
+) -> Result<impl IntoResponse, AutumnError> {
+    let pool = api_state.storage_pool().map_err(map_error)?;
+    let mut conn = acquire_conn(pool.default_pool()).await?;
+    let calendars = list_calendars(&mut conn).await.map_err(map_error)?;
+    let response: Vec<CalendarResponse> = calendars.into_iter().map(Into::into).collect();
+    Ok((StatusCode::OK, Json(response)))
+}
+
+/// `GET /calendars/{name}` — get a single calendar with its exclusions.
+#[derive(Debug, Serialize)]
+struct CalendarDetailResponse {
+    name: String,
+    description: Option<String>,
+    built_in: bool,
+    created_at: chrono::DateTime<chrono::Utc>,
+    updated_at: chrono::DateTime<chrono::Utc>,
+    exclusion_dates: Vec<chrono::NaiveDate>,
+}
+
+async fn get_calendar_handler(
+    Extension(api_state): Extension<HarvestApiState>,
+    Path(name): Path<String>,
+) -> Result<impl IntoResponse, AutumnError> {
+    let pool = api_state.storage_pool().map_err(map_error)?;
+    let mut conn = acquire_conn(pool.default_pool()).await?;
+    let cal = get_calendar(&mut conn, &name).await.map_err(map_error)?;
+    let exclusions = load_exclusions_for_calendar(&mut conn, &name)
+        .await
+        .unwrap_or_default();
+    Ok((
+        StatusCode::OK,
+        Json(CalendarDetailResponse {
+            name: cal.name,
+            description: cal.description,
+            built_in: cal.built_in,
+            created_at: cal.created_at,
+            updated_at: cal.updated_at,
+            exclusion_dates: exclusions,
+        }),
+    ))
+}
+
+/// Request body for `POST /calendars`.
+#[derive(Debug, Deserialize)]
+struct CreateCalendarRequest {
+    name: String,
+    description: Option<String>,
+}
+
+/// `POST /calendars` — create a custom calendar.
+async fn create_calendar_handler(
+    Extension(api_state): Extension<HarvestApiState>,
+    Json(body): Json<CreateCalendarRequest>,
+) -> Result<impl IntoResponse, AutumnError> {
+    let pool = api_state.storage_pool().map_err(map_error)?;
+    let mut conn = acquire_conn(pool.default_pool()).await?;
+    let cal = create_calendar(&mut conn, &body.name, body.description.as_deref())
+        .await
+        .map_err(map_error)?;
+    Ok((StatusCode::CREATED, Json(CalendarResponse::from(cal))))
+}
+
+/// Request body for `PUT /calendars/{name}` — replace exclusion dates.
+#[derive(Debug, Deserialize)]
+struct UpdateCalendarRequest {
+    /// Complete set of exclusion dates (replaces existing). Format: `"YYYY-MM-DD"`.
+    exclusion_dates: Vec<chrono::NaiveDate>,
+}
+
+/// `PUT /calendars/{name}` — replace the exclusion set for a calendar.
+async fn update_calendar_exclusions_handler(
+    Extension(api_state): Extension<HarvestApiState>,
+    Path(name): Path<String>,
+    Json(body): Json<UpdateCalendarRequest>,
+) -> Result<impl IntoResponse, AutumnError> {
+    let pool = api_state.storage_pool().map_err(map_error)?;
+    let mut conn = acquire_conn(pool.default_pool()).await?;
+    replace_calendar_exclusions(&mut conn, &name, &body.exclusion_dates)
+        .await
+        .map_err(map_error)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// `DELETE /calendars/{name}` — delete a custom calendar.
+async fn delete_calendar_handler(
+    Extension(api_state): Extension<HarvestApiState>,
+    Path(name): Path<String>,
+) -> Result<impl IntoResponse, AutumnError> {
+    let pool = api_state.storage_pool().map_err(map_error)?;
+    let mut conn = acquire_conn(pool.default_pool()).await?;
+    delete_calendar(&mut conn, &name)
+        .await
+        .map_err(map_error)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+// ── Schedule preview (issue #337) ─────────────────────────────────────────────
+
+/// Query parameters for `GET /admin/schedules/{id}/preview`.
+#[derive(Debug, Deserialize)]
+struct SchedulePreviewQuery {
+    /// Number of fire-time entries to return. Defaults to 10, max 100.
+    #[serde(default = "default_preview_count")]
+    count: usize,
+}
+
+const fn default_preview_count() -> usize {
+    10
+}
+
+/// `GET /admin/schedules/{id}/preview?count=N` — preview next N fire times.
+async fn preview_schedule_firings_handler(
+    Extension(api_state): Extension<HarvestApiState>,
+    Path(id): Path<uuid::Uuid>,
+    Query(params): Query<SchedulePreviewQuery>,
+) -> Result<impl IntoResponse, AutumnError> {
+    use autumn_harvest::policy::SkipPolicy;
+    use autumn_harvest::scheduler::parse_schedule_from_expr_pub;
+
+    let count = params.count.clamp(1, 100);
+    let pool = api_state.storage_pool().map_err(map_error)?;
+    let mut conn = acquire_conn(pool.default_pool()).await?;
+
+    let schedule = {
+        use autumn_harvest::schema::harvest_schedules;
+        use diesel::{QueryDsl, SelectableHelper};
+        use diesel_async::RunQueryDsl;
+
+        harvest_schedules::table
+            .find(id)
+            .select(HarvestSchedule::as_select())
+            .first(&mut conn)
+            .await
+            .optional()
+            .map_err(database_error)
+            .map_err(map_error)?
+            .ok_or_else(|| AutumnError::not_found_msg("schedule not found"))?
+    };
+
+    let parsed_schedule = schedule
+        .schedule_expr
+        .as_deref()
+        .and_then(parse_schedule_from_expr_pub);
+    let Some(ref sched) = parsed_schedule else {
+        return Ok((
+            StatusCode::OK,
+            Json(serde_json::json!({"entries": [], "reason": "manual or no schedule"})),
+        ));
+    };
+
+    let from = chrono::Utc::now();
+    let calendar_name = schedule.calendar_name.as_deref();
+    let skip_policy = SkipPolicy::from_db(&schedule.skip_policy);
+
+    let excluded_dates = if let Some(cal_name) = calendar_name {
+        load_exclusions_for_calendar(&mut conn, cal_name)
+            .await
+            .unwrap_or_default()
+    } else {
+        vec![]
+    };
+
+    let entries = preview_schedule_firings(
+        sched,
+        from,
+        count,
+        calendar_name,
+        &excluded_dates,
+        skip_policy,
+    );
+
+    Ok((StatusCode::OK, Json(serde_json::json!({"entries": entries}))))
 }
 
 // ── External activity completion (issue #92) ──────────────────────────────────

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -8860,29 +8860,49 @@ async fn create_calendar_handler(
         ));
     }
     let pool = api_state.storage_pool().map_err(map_error)?;
-    let mut first_cal = None;
+    // Track whether at least one shard performed a fresh insert so we can
+    // distinguish a successful new create from a duplicate-name conflict.
+    let mut fresh_insert_cal: Option<_> = None;
+    let mut conflict_cal: Option<_> = None;
     for (_, shard_pool) in pool.iter_shards() {
         let mut conn = acquire_conn(shard_pool).await?;
-        // Treat "already exists" as idempotent so that retries after a partial
-        // shard failure converge rather than returning 400 on already-written shards.
-        let cal = match create_calendar(&mut conn, &body.name, body.description.as_deref()).await {
-            Ok(cal) => cal,
+        match create_calendar(&mut conn, &body.name, body.description.as_deref()).await {
+            Ok(cal) => {
+                if fresh_insert_cal.is_none() {
+                    fresh_insert_cal = Some(cal);
+                }
+            }
+            // "Already exists" on a later shard is an idempotent retry-safe no-op
+            // (the shard already has the calendar from a prior attempt). Record
+            // the existing row so we can return it if no shard performed a fresh
+            // insert.
             Err(autumn_harvest::HarvestError::Config(ref msg))
                 if msg.contains("already exists") =>
             {
-                get_calendar(&mut conn, &body.name)
-                    .await
-                    .map_err(map_error)?
+                if conflict_cal.is_none() {
+                    conflict_cal = Some(
+                        get_calendar(&mut conn, &body.name)
+                            .await
+                            .map_err(map_error)?,
+                    );
+                }
             }
             Err(e) => return Err(map_error(e)),
-        };
-        if first_cal.is_none() {
-            first_cal = Some(cal);
         }
     }
-    let cal =
-        first_cal.ok_or_else(|| AutumnError::service_unavailable_msg("no shards available"))?;
-    Ok((StatusCode::CREATED, Json(CalendarResponse::from(cal))))
+    // At least one shard performed a fresh insert: this was a new calendar.
+    if let Some(cal) = fresh_insert_cal {
+        return Ok((StatusCode::CREATED, Json(CalendarResponse::from(cal))));
+    }
+    // Every shard already had the calendar: the name is taken.
+    if conflict_cal.is_some() {
+        return Err(AutumnError::bad_request_msg(format!(
+            "calendar '{}' already exists",
+            body.name
+        ))
+        .with_status(axum::http::StatusCode::CONFLICT));
+    }
+    Err(AutumnError::service_unavailable_msg("no shards available"))
 }
 
 /// Request body for `PUT /calendars/{name}` — replace exclusion dates.
@@ -8899,11 +8919,24 @@ async fn update_calendar_exclusions_handler(
     Json(body): Json<UpdateCalendarRequest>,
 ) -> Result<impl IntoResponse, AutumnError> {
     let pool = api_state.storage_pool().map_err(map_error)?;
-    // Attempt all shards even on error so that a transient failure on one shard
-    // does not leave others stale. replace_calendar_exclusions is idempotent
-    // (runs in a transaction), so retrying a partial fanout converges correctly.
-    // NotFound from any shard means the calendar does not exist → return 404
-    // immediately so callers fix input rather than retrying.
+    // Preflight: verify the calendar exists on every reachable shard before
+    // writing to any. This ensures a 404 is returned cleanly without leaving
+    // partial exclusion updates on earlier shards.
+    for (_, shard_pool) in pool.iter_shards() {
+        let mut conn = acquire_conn(shard_pool).await?;
+        match get_calendar(&mut conn, &name).await {
+            Ok(_) => {}
+            Err(autumn_harvest::HarvestError::NotFound(_)) => {
+                return Err(AutumnError::not_found_msg(format!(
+                    "calendar '{name}' not found"
+                )));
+            }
+            Err(e) => return Err(map_error(e)),
+        }
+    }
+    // Fanout: attempt all shards; collect failures so retries converge.
+    // replace_calendar_exclusions is transactional so retrying a partial
+    // fanout is safe.
     let mut shard_errors: Vec<String> = Vec::new();
     for (shard_id, shard_pool) in pool.iter_shards() {
         let mut conn = match acquire_conn(shard_pool).await {
@@ -8913,14 +8946,8 @@ async fn update_calendar_exclusions_handler(
                 continue;
             }
         };
-        match replace_calendar_exclusions(&mut conn, &name, &body.exclusion_dates).await {
-            Ok(()) => {}
-            Err(autumn_harvest::HarvestError::NotFound(_)) => {
-                return Err(AutumnError::not_found_msg(format!(
-                    "calendar '{name}' not found"
-                )));
-            }
-            Err(e) => shard_errors.push(format!("shard {shard_id}: {e}")),
+        if let Err(e) = replace_calendar_exclusions(&mut conn, &name, &body.exclusion_dates).await {
+            shard_errors.push(format!("shard {shard_id}: {e}"));
         }
     }
     if !shard_errors.is_empty() {
@@ -8941,23 +8968,42 @@ async fn delete_calendar_handler(
     let pool = api_state.storage_pool().map_err(map_error)?;
     let mut any_deleted = false;
     let mut all_not_found = true;
-    for (_, shard_pool) in pool.iter_shards() {
-        let mut conn = acquire_conn(shard_pool).await?;
+    let mut shard_errors: Vec<String> = Vec::new();
+    for (shard_id, shard_pool) in pool.iter_shards() {
+        let mut conn = match acquire_conn(shard_pool).await {
+            Ok(c) => c,
+            Err(e) => {
+                shard_errors.push(format!("shard {shard_id}: {e}"));
+                all_not_found = false;
+                continue;
+            }
+        };
         match delete_calendar(&mut conn, &name).await {
             Ok(()) => {
                 any_deleted = true;
                 all_not_found = false;
             }
-            // NotFound on this shard is idempotent for retry: if at least one shard
-            // deleted successfully, the overall operation succeeded.
+            // NotFound on this shard is idempotent: a prior partial delete or
+            // the calendar was never on this shard. Continue so all shards
+            // are attempted before deciding the response.
             Err(autumn_harvest::HarvestError::NotFound(_)) => {}
-            Err(e) => return Err(map_error(e)),
+            Err(e) => {
+                shard_errors.push(format!("shard {shard_id}: {e}"));
+                all_not_found = false;
+            }
         }
     }
-    // If every shard reported not-found the calendar never existed; return 404.
-    if all_not_found && !any_deleted {
+    // Every shard reported not-found and no errors: calendar never existed.
+    if all_not_found && !any_deleted && shard_errors.is_empty() {
         return Err(AutumnError::not_found_msg(format!(
             "calendar '{name}' not found"
+        )));
+    }
+    if !shard_errors.is_empty() {
+        return Err(AutumnError::service_unavailable_msg(format!(
+            "calendar delete failed on {} shard(s); retry to converge: {}",
+            shard_errors.len(),
+            shard_errors.join("; ")
         )));
     }
     Ok(StatusCode::NO_CONTENT)

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -43,8 +43,9 @@ use autumn_harvest::batch::{
     BatchSubmission,
 };
 use autumn_harvest::calendar::{
-    create_calendar, delete_calendar, get_calendar, list_calendars, load_exclusions_for_calendar,
-    preview_schedule_firings, replace_calendar_exclusions,
+    calendar_excludes_weekends, create_calendar, delete_calendar, get_calendar, list_calendars,
+    load_exclusions_for_calendar, plan_backfill_with_calendar, preview_schedule_firings,
+    replace_calendar_exclusions,
 };
 use autumn_harvest::context::WorkflowContext;
 use autumn_harvest::dlq;
@@ -6189,17 +6190,37 @@ async fn schedule_backfill(
 
     let max_count = request.max_count.unwrap_or(DEFAULT_BACKFILL_MAX_COUNT);
 
-    let timestamps = plan_backfill_timestamps(
-        parsed_schedule.as_ref(),
-        request.from,
-        request.to,
-        max_count,
-    )
-    .map_err(|e| match e {
+    let limit_err = |e| match e {
         BackfillPlanError::LimitExceeded { limit } => AutumnError::bad_request_msg(format!(
             "backfill window contains more than {limit} timestamps; lower the window or pass a higher max_count"
         )),
-    })?;
+    };
+    let timestamps = if let Some(ref cal_name) = schedule.calendar_name {
+        let mut conn = acquire_conn(pool.default_pool()).await?;
+        let excluded_dates = load_exclusions_for_calendar(&mut conn, cal_name)
+            .await
+            .map_err(map_error)?;
+        let skip_policy = SkipPolicy::from_db(&schedule.skip_policy);
+        let exclude_weekends = calendar_excludes_weekends(cal_name);
+        plan_backfill_with_calendar(
+            parsed_schedule.as_ref(),
+            request.from,
+            request.to,
+            max_count,
+            &excluded_dates,
+            skip_policy,
+            exclude_weekends,
+        )
+        .map_err(limit_err)?
+    } else {
+        plan_backfill_timestamps(
+            parsed_schedule.as_ref(),
+            request.from,
+            request.to,
+            max_count,
+        )
+        .map_err(limit_err)?
+    };
 
     let total = timestamps.len();
     let (kind, name) = if let Some(ref dag_name) = schedule.dag_name {
@@ -8818,10 +8839,18 @@ async fn create_calendar_handler(
     Json(body): Json<CreateCalendarRequest>,
 ) -> Result<impl IntoResponse, AutumnError> {
     let pool = api_state.storage_pool().map_err(map_error)?;
-    let mut conn = acquire_conn(pool.default_pool()).await?;
-    let cal = create_calendar(&mut conn, &body.name, body.description.as_deref())
-        .await
-        .map_err(map_error)?;
+    let mut first_cal = None;
+    for (_, shard_pool) in pool.iter_shards() {
+        let mut conn = acquire_conn(shard_pool).await?;
+        let cal = create_calendar(&mut conn, &body.name, body.description.as_deref())
+            .await
+            .map_err(map_error)?;
+        if first_cal.is_none() {
+            first_cal = Some(cal);
+        }
+    }
+    let cal =
+        first_cal.ok_or_else(|| AutumnError::service_unavailable_msg("no shards available"))?;
     Ok((StatusCode::CREATED, Json(CalendarResponse::from(cal))))
 }
 
@@ -8839,10 +8868,12 @@ async fn update_calendar_exclusions_handler(
     Json(body): Json<UpdateCalendarRequest>,
 ) -> Result<impl IntoResponse, AutumnError> {
     let pool = api_state.storage_pool().map_err(map_error)?;
-    let mut conn = acquire_conn(pool.default_pool()).await?;
-    replace_calendar_exclusions(&mut conn, &name, &body.exclusion_dates)
-        .await
-        .map_err(map_error)?;
+    for (_, shard_pool) in pool.iter_shards() {
+        let mut conn = acquire_conn(shard_pool).await?;
+        replace_calendar_exclusions(&mut conn, &name, &body.exclusion_dates)
+            .await
+            .map_err(map_error)?;
+    }
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -8852,8 +8883,10 @@ async fn delete_calendar_handler(
     Path(name): Path<String>,
 ) -> Result<impl IntoResponse, AutumnError> {
     let pool = api_state.storage_pool().map_err(map_error)?;
-    let mut conn = acquire_conn(pool.default_pool()).await?;
-    delete_calendar(&mut conn, &name).await.map_err(map_error)?;
+    for (_, shard_pool) in pool.iter_shards() {
+        let mut conn = acquire_conn(shard_pool).await?;
+        delete_calendar(&mut conn, &name).await.map_err(map_error)?;
+    }
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -8882,23 +8915,9 @@ async fn preview_schedule_firings_handler(
 
     let count = params.count.clamp(1, 100);
     let pool = api_state.storage_pool().map_err(map_error)?;
+    // load_schedule_by_id fans out across all shards so schedules on any shard are found.
+    let schedule = load_schedule_by_id(&api_state, id).await?;
     let mut conn = acquire_conn(pool.default_pool()).await?;
-
-    let schedule = {
-        use autumn_harvest::schema::harvest_schedules;
-        use diesel::{QueryDsl, SelectableHelper};
-        use diesel_async::RunQueryDsl;
-
-        harvest_schedules::table
-            .find(id)
-            .select(HarvestSchedule::as_select())
-            .first(&mut conn)
-            .await
-            .optional()
-            .map_err(database_error)
-            .map_err(map_error)?
-            .ok_or_else(|| AutumnError::not_found_msg("schedule not found"))?
-    };
 
     let parsed_schedule = schedule
         .schedule_expr

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -28,10 +28,6 @@ use diesel_async::RunQueryDsl;
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 
-use autumn_harvest::calendar::{
-    create_calendar, delete_calendar, get_calendar, list_calendars, load_exclusions_for_calendar,
-    preview_schedule_firings, replace_calendar_exclusions,
-};
 use autumn_harvest::audit::{
     self, AuditFilters, HEADER_ACTOR, HEADER_REQUEST_ID, HEADER_SOURCE, OP_BATCH_SUBMIT,
     OP_DAG_PATCH, OP_DAG_TRIGGER, OP_DLQ_DISCARD_BULK, OP_DLQ_REPLAY, OP_DLQ_REPLAY_BULK,
@@ -46,6 +42,10 @@ use autumn_harvest::batch::{
     self, BatchAction, BatchExecutorConfig, BatchFilter, BatchJobStatus, BatchJobView,
     BatchSubmission,
 };
+use autumn_harvest::calendar::{
+    create_calendar, delete_calendar, get_calendar, list_calendars, load_exclusions_for_calendar,
+    preview_schedule_firings, replace_calendar_exclusions,
+};
 use autumn_harvest::context::WorkflowContext;
 use autumn_harvest::dlq;
 use autumn_harvest::error::{HarvestError, HarvestResult, database_error};
@@ -55,8 +55,8 @@ use autumn_harvest::history_export::{
     HistoryExportRequest, HistoryPayloadPolicy, export_history,
 };
 use autumn_harvest::models::{
-    AuditRecord, BackfillLogRow, DeadLetter, HarvestCalendar,
-    HarvestSchedule, NewAuditRecord, NewBackfillLogRow, WorkflowExecution,
+    AuditRecord, BackfillLogRow, DeadLetter, HarvestCalendar, HarvestSchedule, NewAuditRecord,
+    NewBackfillLogRow, WorkflowExecution,
 };
 use autumn_harvest::policy::{Schedule, SkipPolicy, WorkflowSchedule, compute_jitter_offset};
 use autumn_harvest::queue::{self, ConcurrencyKeyStats};
@@ -1469,7 +1469,10 @@ pub fn harvest_api_router(api_state: HarvestApiState) -> Router<AppState> {
         .route("/admin/schedules/{id}/resume", post(resume_schedule))
         .route("/admin/schedules/{id}/backfill", post(schedule_backfill))
         .route("/admin/schedules/{id}", delete(delete_schedule))
-        .route("/admin/schedules/{id}/preview", get(preview_schedule_firings_handler))
+        .route(
+            "/admin/schedules/{id}/preview",
+            get(preview_schedule_firings_handler),
+        )
         // Calendar management (issue #337): named exclusion sets for business-day aware scheduling.
         .route("/calendars", get(list_calendars_handler))
         .route(
@@ -8784,9 +8787,7 @@ async fn delete_calendar_handler(
 ) -> Result<impl IntoResponse, AutumnError> {
     let pool = api_state.storage_pool().map_err(map_error)?;
     let mut conn = acquire_conn(pool.default_pool()).await?;
-    delete_calendar(&mut conn, &name)
-        .await
-        .map_err(map_error)?;
+    delete_calendar(&mut conn, &name).await.map_err(map_error)?;
     Ok(StatusCode::NO_CONTENT)
 }
 
@@ -8865,7 +8866,10 @@ async fn preview_schedule_firings_handler(
         skip_policy,
     );
 
-    Ok((StatusCode::OK, Json(serde_json::json!({"entries": entries}))))
+    Ok((
+        StatusCode::OK,
+        Json(serde_json::json!({"entries": entries})),
+    ))
 }
 
 // ── External activity completion (issue #92) ──────────────────────────────────
@@ -10532,6 +10536,8 @@ mod tests {
             overlap_policy: "skip".to_string(),
             buffered_count: 0,
             buffer_all_max: 100,
+            calendar_name: None,
+            skip_policy: "skip".to_string(),
         };
         let json = serde_json::to_string(&entry).expect("serialize");
         assert!(

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -43,9 +43,9 @@ use autumn_harvest::batch::{
     BatchSubmission,
 };
 use autumn_harvest::calendar::{
-    calendar_excludes_weekends, create_calendar, delete_calendar, get_calendar, list_calendars,
-    load_exclusions_for_calendar, plan_backfill_with_calendar, preview_schedule_firings,
-    replace_calendar_exclusions,
+    BackfillSlot, calendar_excludes_weekends, create_calendar, delete_calendar, get_calendar,
+    list_calendars, load_exclusions_for_calendar, plan_backfill_with_calendar,
+    preview_schedule_firings, replace_calendar_exclusions,
 };
 use autumn_harvest::context::WorkflowContext;
 use autumn_harvest::dlq;
@@ -6195,7 +6195,11 @@ async fn schedule_backfill(
             "backfill window contains more than {limit} timestamps; lower the window or pass a higher max_count"
         )),
     };
-    let timestamps = if let Some(ref cal_name) = schedule.calendar_name {
+    // Each entry is (original_slot, fire_time). original_slot is the raw cron timestamp
+    // used for deterministic workflow-ID generation so that calendar rebasing (e.g.
+    // RunNextBusinessDay / RunPrevBusinessDay) cannot cause two distinct logical slots
+    // that adjust to the same day to collide on the derived workflow ID.
+    let timestamp_pairs: Vec<BackfillSlot> = if let Some(ref cal_name) = schedule.calendar_name {
         let mut conn = acquire_conn(pool.default_pool()).await?;
         let excluded_dates = load_exclusions_for_calendar(&mut conn, cal_name)
             .await
@@ -6220,9 +6224,15 @@ async fn schedule_backfill(
             max_count,
         )
         .map_err(limit_err)?
+        .into_iter()
+        .map(|ts| (ts, ts))
+        .collect()
     };
+    // fire_times is the calendar-adjusted list used for display and dedup checks.
+    let fire_times: Vec<chrono::DateTime<chrono::Utc>> =
+        timestamp_pairs.iter().map(|(_, ft)| *ft).collect();
 
-    let total = timestamps.len();
+    let total = timestamp_pairs.len();
     let (kind, name) = if let Some(ref dag_name) = schedule.dag_name {
         (ScheduleKind::Dag, dag_name.clone())
     } else if let Some(ref wf_name) = schedule.workflow_name {
@@ -6251,7 +6261,7 @@ async fn schedule_backfill(
     // Dry-run: query current running count and project what would happen.
     if request.dry_run {
         let running = query_running_count_best_effort(&pool, &kind, &name).await;
-        let already_exists = count_existing_in_window(&pool, &kind, &name, &timestamps).await;
+        let already_exists = count_existing_in_window(&pool, &kind, &name, &fire_times).await;
         let remaining = total.saturating_sub(already_exists);
         let available_slots = usize::try_from((max_active - running).max(0)).unwrap_or(0);
         let would_dispatch = remaining.min(available_slots);
@@ -6310,7 +6320,7 @@ async fn schedule_backfill(
             name,
             from: request.from,
             to: request.to,
-            planned_timestamps: timestamps,
+            planned_timestamps: fire_times.clone(),
             total,
             dispatched: would_dispatch,
             skipped: would_skip,
@@ -6397,7 +6407,7 @@ async fn schedule_backfill(
                 name,
                 from: request.from,
                 to: request.to,
-                planned_timestamps: timestamps,
+                planned_timestamps: fire_times.clone(),
                 total,
                 dispatched: 0,
                 skipped: 0,
@@ -6419,7 +6429,7 @@ async fn schedule_backfill(
             // unique index on (workflow_name, workflow_id) prevents the scheduler from
             // creating a second run for the same timestamp after the backfill window.
             let wf_shard_pool = pool.default_pool();
-            for scheduled_for in &timestamps {
+            for (original_slot, _fire_time) in &timestamp_pairs {
                 // Respect max_active_runs: skip if we've already saturated the limit.
                 if running_at_start + dispatched_this_call >= max_active {
                     skipped += 1;
@@ -6429,7 +6439,9 @@ async fn schedule_backfill(
                     continue;
                 }
 
-                let workflow_id = scheduled_workflow_id_pub(&wf_name, *scheduled_for);
+                // Use original_slot (pre-calendar-rebase) for ID so that two distinct
+                // logical slots that calendar-adjust to the same fire_time do not collide.
+                let workflow_id = scheduled_workflow_id_pub(&wf_name, *original_slot);
                 // Match the scheduler: ExecutionId::new() encodes ShardId::UNENCODED so
                 // the execution lands on the default shard, same as tick_one_workflow_schedule.
                 let exec_id = ExecutionId::new();
@@ -6527,7 +6539,7 @@ async fn schedule_backfill(
             let shard_id = runtime.router().pick_for_dag(&dag_name);
             let shard_pool = pool.pool_for(shard_id);
 
-            for scheduled_for in &timestamps {
+            for (original_slot, _fire_time) in &timestamp_pairs {
                 // Respect max_active_runs for DAGs (now counted via workflow executions).
                 if running_at_start + dispatched_this_call >= max_active {
                     skipped += 1;
@@ -6545,7 +6557,8 @@ async fn schedule_backfill(
                     failed += 1;
                     continue;
                 };
-                let workflow_id = scheduled_workflow_id_pub(&dag_name, *scheduled_for);
+                // Use original_slot for ID, same as the workflow path above.
+                let workflow_id = scheduled_workflow_id_pub(&dag_name, *original_slot);
                 let exec_id = autumn_harvest::types::ExecutionId::new_for_shard(shard_id);
                 let dag_queue = schedule
                     .queue_name
@@ -6688,7 +6701,7 @@ async fn schedule_backfill(
         name,
         from: request.from,
         to: request.to,
-        planned_timestamps: timestamps,
+        planned_timestamps: fire_times,
         total,
         dispatched,
         skipped,
@@ -8838,13 +8851,28 @@ async fn create_calendar_handler(
     Extension(api_state): Extension<HarvestApiState>,
     Json(body): Json<CreateCalendarRequest>,
 ) -> Result<impl IntoResponse, AutumnError> {
+    if body.name.is_empty() {
+        return Err(AutumnError::bad_request_msg(
+            "calendar name must not be empty",
+        ));
+    }
     let pool = api_state.storage_pool().map_err(map_error)?;
     let mut first_cal = None;
     for (_, shard_pool) in pool.iter_shards() {
         let mut conn = acquire_conn(shard_pool).await?;
-        let cal = create_calendar(&mut conn, &body.name, body.description.as_deref())
-            .await
-            .map_err(map_error)?;
+        // Treat "already exists" as idempotent so that retries after a partial
+        // shard failure converge rather than returning 400 on already-written shards.
+        let cal = match create_calendar(&mut conn, &body.name, body.description.as_deref()).await {
+            Ok(cal) => cal,
+            Err(autumn_harvest::HarvestError::Config(ref msg))
+                if msg.contains("already exists") =>
+            {
+                get_calendar(&mut conn, &body.name)
+                    .await
+                    .map_err(map_error)?
+            }
+            Err(e) => return Err(map_error(e)),
+        };
         if first_cal.is_none() {
             first_cal = Some(cal);
         }
@@ -8868,11 +8896,28 @@ async fn update_calendar_exclusions_handler(
     Json(body): Json<UpdateCalendarRequest>,
 ) -> Result<impl IntoResponse, AutumnError> {
     let pool = api_state.storage_pool().map_err(map_error)?;
-    for (_, shard_pool) in pool.iter_shards() {
-        let mut conn = acquire_conn(shard_pool).await?;
-        replace_calendar_exclusions(&mut conn, &name, &body.exclusion_dates)
-            .await
-            .map_err(map_error)?;
+    // Attempt all shards even on error so that a transient failure on one shard
+    // does not leave others stale. replace_calendar_exclusions is idempotent
+    // (runs in a transaction), so retrying a partial fanout converges correctly.
+    let mut shard_errors: Vec<String> = Vec::new();
+    for (shard_id, shard_pool) in pool.iter_shards() {
+        let mut conn = match acquire_conn(shard_pool).await {
+            Ok(c) => c,
+            Err(e) => {
+                shard_errors.push(format!("shard {shard_id}: {e}"));
+                continue;
+            }
+        };
+        if let Err(e) = replace_calendar_exclusions(&mut conn, &name, &body.exclusion_dates).await {
+            shard_errors.push(format!("shard {shard_id}: {e}"));
+        }
+    }
+    if !shard_errors.is_empty() {
+        return Err(AutumnError::service_unavailable_msg(format!(
+            "calendar exclusion update failed on {} shard(s); retry to converge: {}",
+            shard_errors.len(),
+            shard_errors.join("; ")
+        )));
     }
     Ok(StatusCode::NO_CONTENT)
 }
@@ -8885,7 +8930,12 @@ async fn delete_calendar_handler(
     let pool = api_state.storage_pool().map_err(map_error)?;
     for (_, shard_pool) in pool.iter_shards() {
         let mut conn = acquire_conn(shard_pool).await?;
-        delete_calendar(&mut conn, &name).await.map_err(map_error)?;
+        // NotFound is treated as success so that retries after a partial delete
+        // converge: already-deleted shards no longer hold the calendar row.
+        match delete_calendar(&mut conn, &name).await {
+            Ok(()) | Err(autumn_harvest::HarvestError::NotFound(_)) => {}
+            Err(e) => return Err(map_error(e)),
+        }
     }
     Ok(StatusCode::NO_CONTENT)
 }

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -8864,8 +8864,17 @@ async fn create_calendar_handler(
     // distinguish a successful new create from a duplicate-name conflict.
     let mut fresh_insert_cal: Option<_> = None;
     let mut conflict_cal: Option<_> = None;
-    for (_, shard_pool) in pool.iter_shards() {
-        let mut conn = acquire_conn(shard_pool).await?;
+    let mut shard_errors: Vec<String> = Vec::new();
+    for (shard_id, shard_pool) in pool.iter_shards() {
+        let mut conn = match acquire_conn(shard_pool).await {
+            Ok(c) => c,
+            Err(e) => {
+                // Connection failure: continue so later shards are attempted;
+                // collect the error so we can surface it if nothing succeeded.
+                shard_errors.push(format!("shard {shard_id}: {e}"));
+                continue;
+            }
+        };
         match create_calendar(&mut conn, &body.name, body.description.as_deref()).await {
             Ok(cal) => {
                 if fresh_insert_cal.is_none() {
@@ -8894,13 +8903,20 @@ async fn create_calendar_handler(
     if let Some(cal) = fresh_insert_cal {
         return Ok((StatusCode::CREATED, Json(CalendarResponse::from(cal))));
     }
-    // Every shard already had the calendar: the name is taken.
+    // Every reachable shard already had the calendar: the name is taken.
     if conflict_cal.is_some() {
         return Err(AutumnError::bad_request_msg(format!(
             "calendar '{}' already exists",
             body.name
         ))
         .with_status(axum::http::StatusCode::CONFLICT));
+    }
+    // Only connection errors (no shard was reached at all).
+    if !shard_errors.is_empty() {
+        return Err(AutumnError::service_unavailable_msg(format!(
+            "calendar create could not reach all shards; retry to converge: {}",
+            shard_errors.join("; ")
+        )));
     }
     Err(AutumnError::service_unavailable_msg("no shards available"))
 }
@@ -8987,6 +9003,11 @@ async fn delete_calendar_handler(
             // the calendar was never on this shard. Continue so all shards
             // are attempted before deciding the response.
             Err(autumn_harvest::HarvestError::NotFound(_)) => {}
+            // Config error means the calendar is built-in and cannot be deleted:
+            // return 400 immediately since this is a client error, not transient.
+            Err(autumn_harvest::HarvestError::Config(msg)) => {
+                return Err(AutumnError::bad_request_msg(msg));
+            }
             Err(e) => {
                 shard_errors.push(format!("shard {shard_id}: {e}"));
                 all_not_found = false;

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -1793,7 +1793,7 @@ pub const fn management_api_request_fields()
         ("DELETE", "/admin/schedules/{id}", Some(&[])),
         // ── calendars (issue #337) ────────────────────────────────────────────
         ("POST", "/calendars", Some(&["name", "description"])),
-        ("PUT", "/calendars/{name}", Some(&["exclusion_dates"])),
+        ("PUT", "/calendars/{name}", None), // 204 No Content
         ("DELETE", "/calendars/{name}", Some(&[])),
     ]
 }
@@ -5599,6 +5599,17 @@ async fn create_workflow_schedule(
             return Err(AutumnError::bad_request_msg(err_summary));
         }
     };
+
+    // Validate calendar name exists before storing to return a helpful 400 rather than
+    // a generic FK-violation 503 from the database.
+    if let Some(cal_name) = &request.calendar {
+        get_calendar(&mut conn, cal_name).await.map_err(|_| {
+            AutumnError::bad_request_msg(format!(
+                "calendar '{cal_name}' not found; create it first with POST /calendars"
+            ))
+        })?;
+    }
+
     let ws = WorkflowSchedule {
         workflow_name: request.workflow_name.clone(),
         dag_name: None,
@@ -8757,7 +8768,7 @@ async fn get_calendar_handler(
     let cal = get_calendar(&mut conn, &name).await.map_err(map_error)?;
     let exclusions = load_exclusions_for_calendar(&mut conn, &name)
         .await
-        .unwrap_or_default();
+        .map_err(map_error)?;
     Ok((
         StatusCode::OK,
         Json(CalendarDetailResponse {
@@ -8884,7 +8895,7 @@ async fn preview_schedule_firings_handler(
     let excluded_dates = if let Some(cal_name) = calendar_name {
         load_exclusions_for_calendar(&mut conn, cal_name)
             .await
-            .unwrap_or_default()
+            .map_err(map_error)?
     } else {
         vec![]
     };

--- a/autumn-harvest-plugin/src/ui.rs
+++ b/autumn-harvest-plugin/src/ui.rs
@@ -4463,6 +4463,8 @@ mod tests {
             overlap_policy: "skip".to_string(),
             buffered_runs: serde_json::json!([]),
             buffer_all_max: 100,
+            calendar_name: None,
+            skip_policy: "skip".to_string(),
         }
     }
 

--- a/autumn-harvest-plugin/tests/api_scheduler_integration.rs
+++ b/autumn-harvest-plugin/tests/api_scheduler_integration.rs
@@ -3755,6 +3755,8 @@ async fn harvest_api_defers_manual_dag_trigger_when_schedule_is_paused() {
         overlap_policy: autumn_harvest::OverlapPolicy::Skip,
         buffer_all_max: 100u32,
         execution_timeout: None,
+        calendar: None,
+        skip_policy: autumn_harvest::policy::SkipPolicy::Skip,
     };
     let registry = Arc::new(HandlerRegistry::new(
         vec![workflow_info_named(dag_name)],
@@ -4223,6 +4225,8 @@ async fn harvest_api_backfill_matches_fractional_legacy_dag_workflow_id() {
         overlap_policy: autumn_harvest::OverlapPolicy::Skip,
         buffer_all_max: 100u32,
         execution_timeout: None,
+        calendar: None,
+        skip_policy: autumn_harvest::policy::SkipPolicy::Skip,
     };
 
     {
@@ -4309,6 +4313,8 @@ async fn harvest_api_rejects_backfill_for_unregistered_dag_schedule_row() {
         overlap_policy: autumn_harvest::OverlapPolicy::Skip,
         buffer_all_max: 100u32,
         execution_timeout: None,
+        calendar: None,
+        skip_policy: autumn_harvest::policy::SkipPolicy::Skip,
     };
 
     {
@@ -4646,6 +4652,8 @@ async fn register_workflow_schedules_accepts_unified_dag_schedule_rows() {
         overlap_policy: autumn_harvest::OverlapPolicy::Skip,
         buffer_all_max: 100u32,
         execution_timeout: None,
+        calendar: None,
+        skip_policy: autumn_harvest::policy::SkipPolicy::Skip,
     };
 
     let mut conn = <AsyncPgConnection as AsyncConnection>::establish(&database_url)
@@ -4679,6 +4687,8 @@ async fn register_workflow_schedules_preserves_existing_dag_marker_for_workflow_
         overlap_policy: autumn_harvest::OverlapPolicy::Skip,
         buffer_all_max: 100u32,
         execution_timeout: None,
+        calendar: None,
+        skip_policy: autumn_harvest::policy::SkipPolicy::Skip,
     };
     let workflow_only_update = WorkflowSchedule::new(
         "preserve_dag_marker",
@@ -4730,6 +4740,8 @@ async fn register_workflow_schedules_migrates_legacy_workflow_only_dag_row() {
         overlap_policy: autumn_harvest::OverlapPolicy::Skip,
         buffer_all_max: 100u32,
         execution_timeout: None,
+        calendar: None,
+        skip_policy: autumn_harvest::policy::SkipPolicy::Skip,
     };
     let unified_dag_row = WorkflowSchedule {
         workflow_name: "legacy_workflow_only_dag".to_string(),
@@ -4744,6 +4756,8 @@ async fn register_workflow_schedules_migrates_legacy_workflow_only_dag_row() {
         overlap_policy: autumn_harvest::OverlapPolicy::Skip,
         buffer_all_max: 100u32,
         execution_timeout: None,
+        calendar: None,
+        skip_policy: autumn_harvest::policy::SkipPolicy::Skip,
     };
 
     let mut conn = <AsyncPgConnection as AsyncConnection>::establish(&database_url)
@@ -4787,6 +4801,8 @@ async fn ensure_dag_schedule_reuses_paused_legacy_workflow_only_dag_row() {
         overlap_policy: autumn_harvest::OverlapPolicy::Skip,
         buffer_all_max: 100u32,
         execution_timeout: None,
+        calendar: None,
+        skip_policy: autumn_harvest::policy::SkipPolicy::Skip,
     };
     let paused_at = chrono::DateTime::parse_from_rfc3339("2026-05-14T02:00:00.123456Z")
         .expect("fixed pause timestamp should parse")
@@ -4894,6 +4910,8 @@ async fn register_workflow_schedules_reuses_existing_dag_schedule_row_on_upgrade
         overlap_policy: autumn_harvest::OverlapPolicy::Skip,
         buffer_all_max: 100u32,
         execution_timeout: None,
+        calendar: None,
+        skip_policy: autumn_harvest::policy::SkipPolicy::Skip,
     };
 
     let mut conn = <AsyncPgConnection as AsyncConnection>::establish(&database_url)
@@ -4958,6 +4976,8 @@ async fn register_workflow_schedules_merges_split_legacy_dag_rows_before_upgrade
         overlap_policy: autumn_harvest::OverlapPolicy::Skip,
         buffer_all_max: 100u32,
         execution_timeout: None,
+        calendar: None,
+        skip_policy: autumn_harvest::policy::SkipPolicy::Skip,
     };
     let unified_dag_row = WorkflowSchedule {
         workflow_name: dag_name.to_string(),
@@ -4972,6 +4992,8 @@ async fn register_workflow_schedules_merges_split_legacy_dag_rows_before_upgrade
         overlap_policy: autumn_harvest::OverlapPolicy::Skip,
         buffer_all_max: 100u32,
         execution_timeout: None,
+        calendar: None,
+        skip_policy: autumn_harvest::policy::SkipPolicy::Skip,
     };
 
     let mut conn = <AsyncPgConnection as AsyncConnection>::establish(&database_url)
@@ -5049,6 +5071,8 @@ async fn register_workflow_schedules_preserves_pause_metadata_when_merging_split
         overlap_policy: autumn_harvest::OverlapPolicy::Skip,
         buffer_all_max: 100u32,
         execution_timeout: None,
+        calendar: None,
+        skip_policy: autumn_harvest::policy::SkipPolicy::Skip,
     };
     let unified_dag_row = WorkflowSchedule {
         workflow_name: dag_name.to_string(),
@@ -5063,6 +5087,8 @@ async fn register_workflow_schedules_preserves_pause_metadata_when_merging_split
         overlap_policy: autumn_harvest::OverlapPolicy::Skip,
         buffer_all_max: 100u32,
         execution_timeout: None,
+        calendar: None,
+        skip_policy: autumn_harvest::policy::SkipPolicy::Skip,
     };
 
     let mut conn = <AsyncPgConnection as AsyncConnection>::establish(&database_url)
@@ -5135,6 +5161,8 @@ async fn scheduler_tick_dispatches_scheduled_unified_dag_on_dag_shard() {
         overlap_policy: autumn_harvest::OverlapPolicy::Skip,
         buffer_all_max: 100u32,
         execution_timeout: None,
+        calendar: None,
+        skip_policy: autumn_harvest::policy::SkipPolicy::Skip,
     };
     let harvest_pool = build_two_shard_pool(&shard0_url, &shard1_url);
     let registry = Arc::new(HandlerRegistry::new(
@@ -5241,6 +5269,8 @@ async fn scheduler_tick_removes_stale_unified_dag_schedule_from_old_shard() {
         overlap_policy: autumn_harvest::OverlapPolicy::Skip,
         buffer_all_max: 100u32,
         execution_timeout: None,
+        calendar: None,
+        skip_policy: autumn_harvest::policy::SkipPolicy::Skip,
     };
     let harvest_pool = build_two_shard_pool(&shard0_url, &shard1_url);
     let registry = Arc::new(HandlerRegistry::new(
@@ -5295,6 +5325,7 @@ async fn scheduler_tick_removes_stale_unified_dag_schedule_from_old_shard() {
 }
 
 #[tokio::test]
+#[allow(clippy::too_many_lines)]
 async fn scheduler_tick_removes_legacy_workflow_only_dag_schedule_from_old_shard() {
     let ((shard0_url, shard1_url), _container) = setup_sharded_test_database_urls().await;
     let router = two_shard_router();
@@ -5333,6 +5364,8 @@ async fn scheduler_tick_removes_legacy_workflow_only_dag_schedule_from_old_shard
         overlap_policy: autumn_harvest::OverlapPolicy::Skip,
         buffer_all_max: 100u32,
         execution_timeout: None,
+        calendar: None,
+        skip_policy: autumn_harvest::policy::SkipPolicy::Skip,
     };
     let harvest_pool = build_two_shard_pool(&shard0_url, &shard1_url);
     let registry = Arc::new(HandlerRegistry::new(
@@ -5355,6 +5388,8 @@ async fn scheduler_tick_removes_legacy_workflow_only_dag_schedule_from_old_shard
             overlap_policy: autumn_harvest::OverlapPolicy::Skip,
             buffer_all_max: 100u32,
             execution_timeout: None,
+            calendar: None,
+            skip_policy: autumn_harvest::policy::SkipPolicy::Skip,
         };
         let mut conn = <AsyncPgConnection as AsyncConnection>::establish(&shard0_url)
             .await
@@ -5437,6 +5472,8 @@ async fn scheduler_tick_removes_stale_classic_dag_schedule_from_old_shard() {
         overlap_policy: autumn_harvest::OverlapPolicy::Skip,
         buffer_all_max: 100u32,
         execution_timeout: None,
+        calendar: None,
+        skip_policy: autumn_harvest::policy::SkipPolicy::Skip,
     };
     let harvest_pool = build_two_shard_pool(&shard0_url, &shard1_url);
     let registry = Arc::new(HandlerRegistry::new(
@@ -5527,6 +5564,8 @@ async fn scheduler_tick_does_not_dispatch_removed_dag_schedule_rows() {
         overlap_policy: autumn_harvest::OverlapPolicy::Skip,
         buffer_all_max: 100u32,
         execution_timeout: None,
+        calendar: None,
+        skip_policy: autumn_harvest::policy::SkipPolicy::Skip,
     };
 
     {

--- a/autumn-harvest-plugin/tests/api_scheduler_integration.rs
+++ b/autumn-harvest-plugin/tests/api_scheduler_integration.rs
@@ -108,6 +108,10 @@ const INIT_SQL: &str = concat!(
     include_str!(
         "../../autumn-harvest/migrations/20260518000000_harvest_workflow_execution_timeout/up.sql"
     ),
+    "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260519000000_harvest_calendar_awareness/up.sql"
+    ),
 );
 type HarvestApiApp = axum::Router;
 

--- a/autumn-harvest/migrations/20260519000000_harvest_calendar_awareness/down.sql
+++ b/autumn-harvest/migrations/20260519000000_harvest_calendar_awareness/down.sql
@@ -1,0 +1,8 @@
+-- Revert calendar-aware schedules (issue #337)
+
+ALTER TABLE harvest_schedules
+    DROP COLUMN IF EXISTS calendar_name,
+    DROP COLUMN IF EXISTS skip_policy;
+
+DROP TABLE IF EXISTS harvest_calendar_exclusions;
+DROP TABLE IF EXISTS harvest_calendars;

--- a/autumn-harvest/migrations/20260519000000_harvest_calendar_awareness/up.sql
+++ b/autumn-harvest/migrations/20260519000000_harvest_calendar_awareness/up.sql
@@ -1,0 +1,108 @@
+-- Calendar-aware schedules (issue #337)
+--
+-- Introduces two new tables:
+--   harvest_calendars            - named exclusion-set registries
+--   harvest_calendar_exclusions  - per-calendar date exclusions
+--
+-- Adds two columns to harvest_schedules:
+--   calendar_name  - references a harvest_calendars.name (nullable)
+--   skip_policy    - what to do when the fire date is excluded (default 'skip')
+--
+-- Three built-in calendars are seeded with holidays for 2025-2026.
+-- Built-in calendars have built_in = TRUE; operators may not delete them.
+
+-- ── Tables ────────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS harvest_calendars (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name        TEXT NOT NULL,
+    description TEXT,
+    built_in    BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT harvest_calendars_name_unique UNIQUE (name)
+);
+
+CREATE TABLE IF NOT EXISTS harvest_calendar_exclusions (
+    id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    calendar_name TEXT NOT NULL REFERENCES harvest_calendars(name) ON DELETE CASCADE,
+    excluded_date DATE NOT NULL,
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+    CONSTRAINT harvest_calendar_exclusions_unique UNIQUE (calendar_name, excluded_date)
+);
+
+CREATE INDEX IF NOT EXISTS harvest_calendar_exclusions_name_idx
+    ON harvest_calendar_exclusions (calendar_name);
+
+-- ── Schedule columns ──────────────────────────────────────────────────────────
+
+ALTER TABLE harvest_schedules
+    ADD COLUMN IF NOT EXISTS calendar_name TEXT
+        REFERENCES harvest_calendars(name) ON DELETE SET NULL,
+    ADD COLUMN IF NOT EXISTS skip_policy TEXT NOT NULL DEFAULT 'skip';
+
+-- ── Built-in calendars ────────────────────────────────────────────────────────
+
+INSERT INTO harvest_calendars (name, description, built_in) VALUES
+    ('weekends-off',          'Excludes Saturdays and Sundays', TRUE),
+    ('us-federal-holidays',   'US federal public holidays (observed dates, 2025-2026)', TRUE),
+    ('nyse',                  'NYSE market holidays (2025-2026)', TRUE)
+ON CONFLICT (name) DO NOTHING;
+
+-- weekends-off: uses a function-based approach; operators load specific dates
+-- via PUT /calendars/weekends-off. The built-in seed only registers the calendar
+-- with a flag so the scheduler can enumerate it; actual weekend exclusion is
+-- handled at query time in the scheduler by inspecting DOW when calendar_name =
+-- 'weekends-off'. No static dates are seeded for this calendar.
+
+-- US federal holidays 2025
+INSERT INTO harvest_calendar_exclusions (calendar_name, excluded_date) VALUES
+    ('us-federal-holidays', '2025-01-01'),
+    ('us-federal-holidays', '2025-01-20'),
+    ('us-federal-holidays', '2025-02-17'),
+    ('us-federal-holidays', '2025-05-26'),
+    ('us-federal-holidays', '2025-06-19'),
+    ('us-federal-holidays', '2025-07-04'),
+    ('us-federal-holidays', '2025-09-01'),
+    ('us-federal-holidays', '2025-10-13'),
+    ('us-federal-holidays', '2025-11-11'),
+    ('us-federal-holidays', '2025-11-27'),
+    ('us-federal-holidays', '2025-12-25'),
+    -- 2026
+    ('us-federal-holidays', '2026-01-01'),
+    ('us-federal-holidays', '2026-01-19'),
+    ('us-federal-holidays', '2026-02-16'),
+    ('us-federal-holidays', '2026-05-25'),
+    ('us-federal-holidays', '2026-06-19'),
+    ('us-federal-holidays', '2026-07-03'),
+    ('us-federal-holidays', '2026-09-07'),
+    ('us-federal-holidays', '2026-10-12'),
+    ('us-federal-holidays', '2026-11-11'),
+    ('us-federal-holidays', '2026-11-26'),
+    ('us-federal-holidays', '2026-12-25')
+ON CONFLICT (calendar_name, excluded_date) DO NOTHING;
+
+-- NYSE holidays 2025
+INSERT INTO harvest_calendar_exclusions (calendar_name, excluded_date) VALUES
+    ('nyse', '2025-01-01'),
+    ('nyse', '2025-01-20'),
+    ('nyse', '2025-02-17'),
+    ('nyse', '2025-04-18'),
+    ('nyse', '2025-05-26'),
+    ('nyse', '2025-06-19'),
+    ('nyse', '2025-07-04'),
+    ('nyse', '2025-09-01'),
+    ('nyse', '2025-11-27'),
+    ('nyse', '2025-12-25'),
+    -- 2026
+    ('nyse', '2026-01-01'),
+    ('nyse', '2026-01-19'),
+    ('nyse', '2026-02-16'),
+    ('nyse', '2026-04-03'),
+    ('nyse', '2026-05-25'),
+    ('nyse', '2026-06-19'),
+    ('nyse', '2026-07-03'),
+    ('nyse', '2026-09-07'),
+    ('nyse', '2026-11-26'),
+    ('nyse', '2026-12-25')
+ON CONFLICT (calendar_name, excluded_date) DO NOTHING;

--- a/autumn-harvest/src/calendar.rs
+++ b/autumn-harvest/src/calendar.rs
@@ -1,0 +1,717 @@
+//! Calendar-aware schedule filtering for business-day and holiday-skip jobs.
+//!
+//! A [`Calendar`] is a named, Postgres-backed set of excluded dates. Schedules
+//! can reference a calendar by name and declare a [`SkipPolicy`] that controls
+//! what happens when a scheduled fire date falls on an excluded day.
+//!
+//! ## Pure helpers (always available)
+//! - [`is_excluded_date`] — O(n) membership check
+//! - [`apply_skip_policy`] — adjusts or suppresses a date
+//!
+//! ## DB-dependent helpers (require the `db` feature)
+//! - [`preview_schedule_firings`] — generates a preview of upcoming fire times
+//! - [`plan_backfill_with_calendar`] — like `plan_backfill_timestamps` but calendar-aware
+
+use chrono::NaiveDate;
+#[cfg(feature = "db")]
+use chrono::TimeZone;
+use serde::{Deserialize, Serialize};
+
+use crate::policy::SkipPolicy;
+
+/// An in-memory representation of a named calendar.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct Calendar {
+    /// Stable string identifier (e.g. `"us-federal-holidays"`, `"nyse"`).
+    pub name: String,
+    /// Human-readable description.
+    pub description: Option<String>,
+    /// `true` for built-in calendars shipped by Harvest; operators cannot delete them.
+    pub built_in: bool,
+}
+
+/// Returns `true` when `date` appears in `excluded_dates`.
+///
+/// The check is O(n) linear scan. For performance-sensitive paths sort
+/// `excluded_dates` and use binary search; the function handles both sorted
+/// and unsorted slices correctly.
+#[must_use]
+pub fn is_excluded_date(date: NaiveDate, excluded_dates: &[NaiveDate]) -> bool {
+    excluded_dates.contains(&date)
+}
+
+/// Adjust a scheduled fire date according to a calendar and skip policy.
+///
+/// - When `date` is not excluded, returns `Some(date)` unchanged.
+/// - `SkipPolicy::Skip` → `None` (firing is suppressed).
+/// - `SkipPolicy::RunNextBusinessDay` → first subsequent non-excluded date.
+/// - `SkipPolicy::RunPrevBusinessDay` → most recent preceding non-excluded date.
+///
+/// Scans up to 365 days in either direction; returns `None` if no non-excluded
+/// day can be found within that window (degenerate calendar with 365 consecutive
+/// exclusions).
+#[must_use]
+pub fn apply_skip_policy(
+    date: NaiveDate,
+    skip_policy: SkipPolicy,
+    excluded_dates: &[NaiveDate],
+) -> Option<NaiveDate> {
+    if !is_excluded_date(date, excluded_dates) {
+        return Some(date);
+    }
+    match skip_policy {
+        SkipPolicy::Skip => None,
+        SkipPolicy::RunNextBusinessDay => {
+            let mut candidate = date + chrono::Duration::days(1);
+            for _ in 0..365 {
+                if !is_excluded_date(candidate, excluded_dates) {
+                    return Some(candidate);
+                }
+                candidate += chrono::Duration::days(1);
+            }
+            None
+        }
+        SkipPolicy::RunPrevBusinessDay => {
+            let mut candidate = date - chrono::Duration::days(1);
+            for _ in 0..365 {
+                if !is_excluded_date(candidate, excluded_dates) {
+                    return Some(candidate);
+                }
+                candidate -= chrono::Duration::days(1);
+            }
+            None
+        }
+    }
+}
+
+/// Rebase a `DateTime<Utc>` to a different date, preserving the time-of-day.
+///
+/// Returns the original datetime if the date cannot be combined with the time.
+#[cfg(feature = "db")]
+#[must_use]
+fn rebase_to_date(ts: chrono::DateTime<chrono::Utc>, date: NaiveDate) -> chrono::DateTime<chrono::Utc> {
+    let naive = date.and_time(ts.time());
+    chrono::Utc.from_utc_datetime(&naive)
+}
+
+/// A single entry in a schedule fire preview.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct ScheduleFirePreview {
+    /// The original (unadjusted) scheduled fire timestamp.
+    pub scheduled_at: chrono::DateTime<chrono::Utc>,
+    /// The effective fire timestamp after calendar + skip policy.
+    ///
+    /// `None` means the firing is suppressed (`SkipPolicy::Skip` on an excluded date).
+    pub effective_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// Human-readable reason.
+    ///
+    /// - `"Fired"` — fires as scheduled.
+    /// - `"SkippedByCalendar:<calendar_name>"` — suppressed by calendar.
+    /// - `"DeferredFrom:<YYYY-MM-DD>"` — moved to a different day.
+    pub reason: String,
+}
+
+/// Generate the next `count` preview entries for a schedule.
+///
+/// Each entry explains whether the firing is suppressed, deferred, or fired as-is.
+/// Pass an empty `excluded_dates` slice (or `calendar_name = None`) to disable
+/// calendar filtering.
+///
+/// The preview does not query the database; supply `excluded_dates` from the DB
+/// calendar helpers.
+#[cfg(feature = "db")]
+#[must_use]
+pub fn preview_schedule_firings(
+    schedule: &crate::policy::Schedule,
+    from: chrono::DateTime<chrono::Utc>,
+    count: usize,
+    calendar_name: Option<&str>,
+    excluded_dates: &[NaiveDate],
+    skip_policy: SkipPolicy,
+) -> Vec<ScheduleFirePreview> {
+    use crate::scheduler::next_run_after_pub;
+
+    let mut entries = Vec::with_capacity(count);
+    let mut cursor = from;
+
+    while entries.len() < count {
+        let Some(fire_time) = next_run_after_pub(Some(schedule), cursor) else {
+            break;
+        };
+        cursor = fire_time;
+        let fire_date = fire_time.date_naive();
+
+        let (effective_at, reason) = calendar_name.map_or_else(
+            || (Some(fire_time), "Fired".to_string()),
+            |cal_name| match apply_skip_policy(fire_date, skip_policy, excluded_dates) {
+                None => (None, format!("SkippedByCalendar:{cal_name}")),
+                Some(adjusted) if adjusted == fire_date => (Some(fire_time), "Fired".to_string()),
+                Some(adjusted) => (
+                    Some(rebase_to_date(fire_time, adjusted)),
+                    format!("DeferredFrom:{}", fire_date.format("%Y-%m-%d")),
+                ),
+            },
+        );
+
+        entries.push(ScheduleFirePreview {
+            scheduled_at: fire_time,
+            effective_at,
+            reason,
+        });
+    }
+
+    entries
+}
+
+/// Like [`crate::scheduler::plan_backfill_timestamps`] but respects a calendar.
+///
+/// Excluded dates are filtered out or adjusted per the skip policy:
+/// - `Skip` → the timestamp is dropped from the result.
+/// - `RunNextBusinessDay` / `RunPrevBusinessDay` → the timestamp is adjusted to
+///   the nearest non-excluded day while preserving the original time-of-day.
+///
+/// # Errors
+///
+/// Returns [`crate::scheduler::BackfillPlanError::LimitExceeded`] when the raw
+/// timestamp window would exceed `max_count` before calendar filtering.
+#[cfg(feature = "db")]
+pub fn plan_backfill_with_calendar(
+    schedule: Option<&crate::policy::Schedule>,
+    from: chrono::DateTime<chrono::Utc>,
+    to: chrono::DateTime<chrono::Utc>,
+    max_count: usize,
+    excluded_dates: &[NaiveDate],
+    skip_policy: SkipPolicy,
+) -> Result<Vec<chrono::DateTime<chrono::Utc>>, crate::scheduler::BackfillPlanError> {
+    let raw = crate::scheduler::plan_backfill_timestamps(schedule, from, to, max_count)?;
+    let adjusted = raw
+        .into_iter()
+        .filter_map(|ts| {
+            let date = ts.date_naive();
+            apply_skip_policy(date, skip_policy, excluded_dates).map(|adj_date| {
+                if adj_date == date {
+                    ts
+                } else {
+                    rebase_to_date(ts, adj_date)
+                }
+            })
+        })
+        .collect();
+    Ok(adjusted)
+}
+
+// ── DB helpers (require `db` feature) ─────────────────────────────────────────
+
+/// Load all exclusion dates for a named calendar from the database.
+///
+/// Returns an empty vec when the calendar name is not found or has no
+/// exclusions. This is intentionally lenient: a misconfigured `calendar_name`
+/// silently disables filtering rather than halting the scheduler.
+///
+/// # Errors
+///
+/// Returns `HarvestError::Database` on connection or query failure.
+#[cfg(feature = "db")]
+pub async fn load_exclusions_for_calendar(
+    conn: &mut diesel_async::AsyncPgConnection,
+    calendar_name: &str,
+) -> crate::error::HarvestResult<Vec<NaiveDate>> {
+    use crate::schema::harvest_calendar_exclusions;
+    use diesel::{ExpressionMethods, QueryDsl};
+    use diesel_async::RunQueryDsl;
+
+    let rows: Vec<chrono::NaiveDate> = harvest_calendar_exclusions::table
+        .filter(harvest_calendar_exclusions::calendar_name.eq(calendar_name))
+        .select(harvest_calendar_exclusions::excluded_date)
+        .load(conn)
+        .await
+        .map_err(crate::error::database_error)?;
+
+    Ok(rows)
+}
+
+/// Load all calendars from the database.
+///
+/// # Errors
+///
+/// Returns `HarvestError::Database` on connection or query failure.
+#[cfg(feature = "db")]
+pub async fn list_calendars(
+    conn: &mut diesel_async::AsyncPgConnection,
+) -> crate::error::HarvestResult<Vec<crate::models::HarvestCalendar>> {
+    use crate::schema::harvest_calendars;
+    use diesel::{ExpressionMethods, QueryDsl, SelectableHelper};
+    use diesel_async::RunQueryDsl;
+
+    harvest_calendars::table
+        .select(crate::models::HarvestCalendar::as_select())
+        .order(harvest_calendars::name.asc())
+        .load(conn)
+        .await
+        .map_err(crate::error::database_error)
+}
+
+/// Get a single calendar by name.
+///
+/// # Errors
+///
+/// Returns `HarvestError::Database` on query failure, or
+/// `HarvestError::NotFound` when no calendar has that name.
+#[cfg(feature = "db")]
+pub async fn get_calendar(
+    conn: &mut diesel_async::AsyncPgConnection,
+    name: &str,
+) -> crate::error::HarvestResult<crate::models::HarvestCalendar> {
+    use crate::schema::harvest_calendars;
+    use diesel::{ExpressionMethods, OptionalExtension, QueryDsl, SelectableHelper};
+    use diesel_async::RunQueryDsl;
+
+    harvest_calendars::table
+        .filter(harvest_calendars::name.eq(name))
+        .select(crate::models::HarvestCalendar::as_select())
+        .first(conn)
+        .await
+        .optional()
+        .map_err(crate::error::database_error)?
+        .ok_or_else(|| crate::error::HarvestError::NotFound(format!("calendar '{name}'")))
+}
+
+/// Create a new custom calendar.
+///
+/// Fails with `HarvestError::Config` if a calendar with the same name already exists.
+///
+/// # Errors
+///
+/// Returns `HarvestError::Database` on query failure, or
+/// `HarvestError::Config` when the name conflicts with an existing calendar.
+#[cfg(feature = "db")]
+pub async fn create_calendar(
+    conn: &mut diesel_async::AsyncPgConnection,
+    name: &str,
+    description: Option<&str>,
+) -> crate::error::HarvestResult<crate::models::HarvestCalendar> {
+    use crate::models::NewHarvestCalendar;
+    use crate::schema::harvest_calendars;
+    use diesel::{ExpressionMethods, QueryDsl, SelectableHelper};
+    use diesel_async::RunQueryDsl;
+
+    let new = NewHarvestCalendar {
+        id: uuid::Uuid::new_v4(),
+        name,
+        description,
+        built_in: false,
+    };
+    diesel::insert_into(harvest_calendars::table)
+        .values(&new)
+        .execute(conn)
+        .await
+        .map_err(|e| {
+            if e.to_string().contains("unique") || e.to_string().contains("duplicate") {
+                crate::error::HarvestError::Config(format!("calendar '{name}' already exists"))
+            } else {
+                crate::error::database_error(e)
+            }
+        })?;
+
+    harvest_calendars::table
+        .filter(harvest_calendars::name.eq(name))
+        .select(crate::models::HarvestCalendar::as_select())
+        .first(conn)
+        .await
+        .map_err(crate::error::database_error)
+}
+
+/// Replace the exclusion set for a calendar (PUT semantics).
+///
+/// Deletes all existing exclusions for `calendar_name`, then inserts `dates`.
+/// Built-in calendars may be updated (operators can extend them).
+///
+/// # Errors
+///
+/// Returns `HarvestError::Database` on query failure, or
+/// `HarvestError::NotFound` when no calendar has that name.
+#[cfg(feature = "db")]
+pub async fn replace_calendar_exclusions(
+    conn: &mut diesel_async::AsyncPgConnection,
+    calendar_name: &str,
+    dates: &[NaiveDate],
+) -> crate::error::HarvestResult<()> {
+    use crate::models::NewHarvestCalendarExclusion;
+    use crate::schema::harvest_calendar_exclusions;
+    use diesel::{ExpressionMethods, QueryDsl};
+    use diesel_async::RunQueryDsl;
+
+    // Validate the calendar exists.
+    get_calendar(conn, calendar_name).await?;
+
+    diesel::delete(
+        harvest_calendar_exclusions::table
+            .filter(harvest_calendar_exclusions::calendar_name.eq(calendar_name)),
+    )
+    .execute(conn)
+    .await
+    .map_err(crate::error::database_error)?;
+
+    let rows: Vec<NewHarvestCalendarExclusion<'_>> = dates
+        .iter()
+        .map(|&excluded_date| NewHarvestCalendarExclusion {
+            calendar_name,
+            excluded_date,
+        })
+        .collect();
+
+    if !rows.is_empty() {
+        diesel::insert_into(harvest_calendar_exclusions::table)
+            .values(&rows)
+            .on_conflict((
+                harvest_calendar_exclusions::calendar_name,
+                harvest_calendar_exclusions::excluded_date,
+            ))
+            .do_nothing()
+            .execute(conn)
+            .await
+            .map_err(crate::error::database_error)?;
+    }
+
+    Ok(())
+}
+
+/// Delete a custom calendar (built-in calendars cannot be deleted).
+///
+/// Exclusions are cascade-deleted by the FK constraint.
+///
+/// # Errors
+///
+/// Returns `HarvestError::NotFound` when the calendar does not exist.
+/// Returns `HarvestError::Config` when attempting to delete a built-in calendar.
+#[cfg(feature = "db")]
+pub async fn delete_calendar(
+    conn: &mut diesel_async::AsyncPgConnection,
+    name: &str,
+) -> crate::error::HarvestResult<()> {
+    use crate::schema::harvest_calendars;
+    use diesel::{ExpressionMethods, QueryDsl};
+    use diesel_async::RunQueryDsl;
+
+    let cal = get_calendar(conn, name).await?;
+    if cal.built_in {
+        return Err(crate::error::HarvestError::Config(format!(
+            "built-in calendar '{name}' cannot be deleted; create a custom calendar with the same name to shadow it"
+        )));
+    }
+
+    diesel::delete(harvest_calendars::table.filter(harvest_calendars::name.eq(name)))
+        .execute(conn)
+        .await
+        .map_err(crate::error::database_error)?;
+    Ok(())
+}
+
+// ── Built-in calendar data ────────────────────────────────────────────────────
+
+/// US federal public holidays for 2025 and 2026 (observed dates).
+///
+/// Used to seed the `"us-federal-holidays"` built-in calendar in the migration.
+/// Operators can shadow this calendar per-deployment by creating a custom
+/// calendar with the same name.
+pub const US_FEDERAL_HOLIDAYS_2025_2026: &[&str] = &[
+    // 2025
+    "2025-01-01", // New Year's Day
+    "2025-01-20", // MLK Day (observed)
+    "2025-02-17", // Presidents' Day (observed)
+    "2025-05-26", // Memorial Day
+    "2025-06-19", // Juneteenth
+    "2025-07-04", // Independence Day
+    "2025-09-01", // Labor Day
+    "2025-10-13", // Columbus Day
+    "2025-11-11", // Veterans Day
+    "2025-11-27", // Thanksgiving
+    "2025-12-25", // Christmas
+    // 2026
+    "2026-01-01", // New Year's Day
+    "2026-01-19", // MLK Day (observed)
+    "2026-02-16", // Presidents' Day (observed)
+    "2026-05-25", // Memorial Day
+    "2026-06-19", // Juneteenth
+    "2026-07-03", // Independence Day (observed, 4th falls on Saturday)
+    "2026-09-07", // Labor Day
+    "2026-10-12", // Columbus Day
+    "2026-11-11", // Veterans Day
+    "2026-11-26", // Thanksgiving
+    "2026-12-25", // Christmas
+];
+
+/// NYSE market holidays for 2025 and 2026.
+pub const NYSE_HOLIDAYS_2025_2026: &[&str] = &[
+    // 2025
+    "2025-01-01", // New Year's Day
+    "2025-01-20", // MLK Day
+    "2025-02-17", // Presidents' Day
+    "2025-04-18", // Good Friday
+    "2025-05-26", // Memorial Day
+    "2025-06-19", // Juneteenth
+    "2025-07-04", // Independence Day
+    "2025-09-01", // Labor Day
+    "2025-11-27", // Thanksgiving
+    "2025-12-25", // Christmas
+    // 2026
+    "2026-01-01", // New Year's Day
+    "2026-01-19", // MLK Day
+    "2026-02-16", // Presidents' Day
+    "2026-04-03", // Good Friday
+    "2026-05-25", // Memorial Day
+    "2026-06-19", // Juneteenth
+    "2026-07-03", // Independence Day (observed)
+    "2026-09-07", // Labor Day
+    "2026-11-26", // Thanksgiving
+    "2026-12-25", // Christmas
+];
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::NaiveDate;
+
+    fn date(s: &str) -> NaiveDate {
+        NaiveDate::parse_from_str(s, "%Y-%m-%d").expect("valid date")
+    }
+
+    fn excluded(dates: &[&str]) -> Vec<NaiveDate> {
+        dates.iter().map(|s| date(s)).collect()
+    }
+
+    // ── is_excluded_date ──────────────────────────────────────────────────────
+
+    #[test]
+    fn is_excluded_date_true_for_excluded() {
+        let exc = excluded(&["2026-07-04", "2026-12-25"]);
+        assert!(is_excluded_date(date("2026-07-04"), &exc));
+        assert!(is_excluded_date(date("2026-12-25"), &exc));
+    }
+
+    #[test]
+    fn is_excluded_date_false_for_non_excluded() {
+        let exc = excluded(&["2026-07-04"]);
+        assert!(!is_excluded_date(date("2026-07-05"), &exc));
+        assert!(!is_excluded_date(date("2026-01-01"), &exc));
+    }
+
+    #[test]
+    fn is_excluded_date_empty_exclusions_always_false() {
+        assert!(!is_excluded_date(date("2026-07-04"), &[]));
+    }
+
+    // ── apply_skip_policy ─────────────────────────────────────────────────────
+
+    #[test]
+    fn apply_skip_policy_non_excluded_returns_same() {
+        let exc = excluded(&["2026-07-04"]);
+        let d = date("2026-07-05");
+        assert_eq!(apply_skip_policy(d, SkipPolicy::Skip, &exc), Some(d));
+        assert_eq!(
+            apply_skip_policy(d, SkipPolicy::RunNextBusinessDay, &exc),
+            Some(d)
+        );
+    }
+
+    #[test]
+    fn apply_skip_policy_skip_suppresses_excluded() {
+        let exc = excluded(&["2026-07-04"]);
+        assert_eq!(
+            apply_skip_policy(date("2026-07-04"), SkipPolicy::Skip, &exc),
+            None
+        );
+    }
+
+    #[test]
+    fn apply_skip_policy_next_business_day_finds_next() {
+        let exc = excluded(&["2026-07-04"]);
+        assert_eq!(
+            apply_skip_policy(date("2026-07-04"), SkipPolicy::RunNextBusinessDay, &exc),
+            Some(date("2026-07-05"))
+        );
+    }
+
+    #[test]
+    fn apply_skip_policy_prev_business_day_finds_prev() {
+        let exc = excluded(&["2026-07-04"]);
+        assert_eq!(
+            apply_skip_policy(date("2026-07-04"), SkipPolicy::RunPrevBusinessDay, &exc),
+            Some(date("2026-07-03"))
+        );
+    }
+
+    #[test]
+    fn apply_skip_policy_chains_through_multiple_consecutive_exclusions() {
+        let exc = excluded(&["2026-08-06", "2026-08-07", "2026-08-08"]);
+        assert_eq!(
+            apply_skip_policy(date("2026-08-06"), SkipPolicy::RunNextBusinessDay, &exc),
+            Some(date("2026-08-09"))
+        );
+    }
+
+    #[test]
+    fn apply_skip_policy_prev_chains_through_multiple_consecutive_exclusions() {
+        let exc = excluded(&["2026-08-06", "2026-08-07", "2026-08-08"]);
+        assert_eq!(
+            apply_skip_policy(date("2026-08-08"), SkipPolicy::RunPrevBusinessDay, &exc),
+            Some(date("2026-08-05"))
+        );
+    }
+
+    // ── preview_schedule_firings ──────────────────────────────────────────────
+
+    #[cfg(feature = "db")]
+    mod db_tests {
+        use super::*;
+        use crate::policy::Schedule;
+        use chrono::Utc;
+
+        #[test]
+        fn preview_firings_no_calendar_all_fired() {
+            let from = "2026-07-01T00:00:00Z".parse::<chrono::DateTime<Utc>>().unwrap();
+            let schedule = Schedule::Cron("0 9 * * *".to_string());
+            let previews =
+                preview_schedule_firings(&schedule, from, 3, None, &[], SkipPolicy::Skip);
+            assert_eq!(previews.len(), 3);
+            for p in &previews {
+                assert_eq!(p.reason, "Fired");
+                assert!(p.effective_at.is_some());
+            }
+        }
+
+        #[test]
+        fn preview_firings_skip_excluded() {
+            let from = "2026-07-03T10:00:00Z"
+                .parse::<chrono::DateTime<Utc>>()
+                .unwrap();
+            let schedule = Schedule::Cron("0 9 * * *".to_string());
+            let exc = excluded(&["2026-07-04"]);
+            let previews = preview_schedule_firings(
+                &schedule,
+                from,
+                3,
+                Some("us-federal-holidays"),
+                &exc,
+                SkipPolicy::Skip,
+            );
+            let skipped = previews
+                .iter()
+                .find(|p| p.scheduled_at.date_naive() == date("2026-07-04"));
+            assert!(skipped.is_some(), "Jul 4 should appear in preview");
+            let skipped = skipped.unwrap();
+            assert_eq!(skipped.effective_at, None);
+            assert!(
+                skipped.reason.starts_with("SkippedByCalendar:"),
+                "reason should start with SkippedByCalendar: got '{}'",
+                skipped.reason
+            );
+        }
+
+        #[test]
+        fn preview_firings_deferred_next() {
+            let from = "2026-07-03T10:00:00Z"
+                .parse::<chrono::DateTime<Utc>>()
+                .unwrap();
+            let schedule = Schedule::Cron("0 9 * * *".to_string());
+            let exc = excluded(&["2026-07-04"]);
+            let previews = preview_schedule_firings(
+                &schedule,
+                from,
+                3,
+                Some("us-federal-holidays"),
+                &exc,
+                SkipPolicy::RunNextBusinessDay,
+            );
+            let deferred = previews
+                .iter()
+                .find(|p| p.scheduled_at.date_naive() == date("2026-07-04"));
+            assert!(deferred.is_some());
+            let deferred = deferred.unwrap();
+            assert!(deferred.effective_at.is_some());
+            assert_eq!(
+                deferred.effective_at.unwrap().date_naive(),
+                date("2026-07-05")
+            );
+            assert!(
+                deferred.reason.starts_with("DeferredFrom:"),
+                "reason should start with DeferredFrom: got '{}'",
+                deferred.reason
+            );
+        }
+
+        // ── plan_backfill_with_calendar ───────────────────────────────────────
+
+        #[test]
+        fn backfill_skip_drops_excluded_dates() {
+            let from = "2026-07-01T09:00:00Z"
+                .parse::<chrono::DateTime<Utc>>()
+                .unwrap();
+            let to = "2026-07-05T09:00:00Z"
+                .parse::<chrono::DateTime<Utc>>()
+                .unwrap();
+            let schedule = Schedule::Cron("0 9 * * *".to_string());
+            let exc = excluded(&["2026-07-04"]);
+            let result = plan_backfill_with_calendar(
+                Some(&schedule),
+                from,
+                to,
+                100,
+                &exc,
+                SkipPolicy::Skip,
+            )
+            .unwrap();
+            let dates: Vec<_> = result.iter().map(|ts| ts.date_naive()).collect();
+            assert!(!dates.contains(&date("2026-07-04")), "Jul 4 should be excluded");
+            assert!(dates.contains(&date("2026-07-05")), "Jul 5 should be present");
+        }
+
+        #[test]
+        fn backfill_next_business_day_adjusts_excluded_date() {
+            let from = "2026-07-01T09:00:00Z"
+                .parse::<chrono::DateTime<Utc>>()
+                .unwrap();
+            let to = "2026-07-05T09:00:00Z"
+                .parse::<chrono::DateTime<Utc>>()
+                .unwrap();
+            let schedule = Schedule::Cron("0 9 * * *".to_string());
+            let exc = excluded(&["2026-07-04"]);
+            let result = plan_backfill_with_calendar(
+                Some(&schedule),
+                from,
+                to,
+                100,
+                &exc,
+                SkipPolicy::RunNextBusinessDay,
+            )
+            .unwrap();
+            let dates: Vec<_> = result.iter().map(|ts| ts.date_naive()).collect();
+            assert!(
+                dates.iter().filter(|&&d| d == date("2026-07-05")).count() >= 1,
+                "Jul 5 should appear (as adjusted Jul 4 and/or natural Jul 5)"
+            );
+            assert!(
+                !dates.contains(&date("2026-07-04")),
+                "raw Jul 4 should not appear"
+            );
+        }
+
+        #[test]
+        fn backfill_no_exclusions_passes_through() {
+            let from = "2026-07-01T09:00:00Z"
+                .parse::<chrono::DateTime<Utc>>()
+                .unwrap();
+            let to = "2026-07-03T09:00:00Z"
+                .parse::<chrono::DateTime<Utc>>()
+                .unwrap();
+            let schedule = Schedule::Cron("0 9 * * *".to_string());
+            let plain =
+                crate::scheduler::plan_backfill_timestamps(Some(&schedule), from, to, 100)
+                    .unwrap();
+            let with_cal =
+                plan_backfill_with_calendar(Some(&schedule), from, to, 100, &[], SkipPolicy::Skip)
+                    .unwrap();
+            assert_eq!(plain, with_cal, "empty exclusion list must not change results");
+        }
+    }
+}

--- a/autumn-harvest/src/calendar.rs
+++ b/autumn-harvest/src/calendar.rs
@@ -107,13 +107,30 @@ pub fn calendar_excludes_weekends(calendar_name: &str) -> bool {
 
 /// Rebase a `DateTime<Utc>` to a different date, preserving the time-of-day.
 ///
+/// For `CronInTimezone` schedules the wall-clock time in the schedule's timezone
+/// is preserved across DST boundaries instead of the raw UTC clock time. Falls
+/// back to naive UTC rebasing for plain `Cron`/`Interval`/`None` schedules.
+///
 /// Returns the original datetime if the date cannot be combined with the time.
 #[cfg(feature = "db")]
 #[must_use]
 fn rebase_to_date(
     ts: chrono::DateTime<chrono::Utc>,
     date: NaiveDate,
+    schedule: Option<&crate::policy::Schedule>,
 ) -> chrono::DateTime<chrono::Utc> {
+    if let Some(crate::policy::Schedule::CronInTimezone { tz, .. }) = schedule
+        && let Ok(tz) = tz.parse::<chrono_tz::Tz>()
+    {
+        let local_ts = ts.with_timezone(&tz);
+        if let Some(local_dt) = date
+            .and_time(local_ts.time())
+            .and_local_timezone(tz)
+            .earliest()
+        {
+            return local_dt.with_timezone(&chrono::Utc);
+        }
+    }
     let naive = date.and_time(ts.time());
     chrono::Utc.from_utc_datetime(&naive)
 }
@@ -177,7 +194,7 @@ pub fn preview_schedule_firings(
                 None => (None, format!("SkippedByCalendar:{cal_name}")),
                 Some(adjusted) if adjusted == fire_date => (Some(fire_time), "Fired".to_string()),
                 Some(adjusted) => (
-                    Some(rebase_to_date(fire_time, adjusted)),
+                    Some(rebase_to_date(fire_time, adjusted, Some(schedule))),
                     format!("DeferredFrom:{}", fire_date.format("%Y-%m-%d")),
                 ),
             },
@@ -223,7 +240,7 @@ pub fn plan_backfill_with_calendar(
                 if adj_date == date {
                     ts
                 } else {
-                    rebase_to_date(ts, adj_date)
+                    rebase_to_date(ts, adj_date, schedule)
                 }
             })
         })

--- a/autumn-harvest/src/calendar.rs
+++ b/autumn-harvest/src/calendar.rs
@@ -210,6 +210,13 @@ pub fn preview_schedule_firings(
     entries
 }
 
+/// Backfill slot returned by [`plan_backfill_with_calendar`]: `(original_slot, fire_time)`.
+///
+/// `original_slot` is the raw cron-generated timestamp used for deterministic
+/// workflow-ID generation. `fire_time` is the calendar-adjusted dispatch time
+/// (may equal `original_slot` when the slot is not excluded).
+pub type BackfillSlot = (chrono::DateTime<chrono::Utc>, chrono::DateTime<chrono::Utc>);
+
 /// Like [`crate::scheduler::plan_backfill_timestamps`] but respects a calendar.
 ///
 /// Excluded dates are filtered out or adjusted per the skip policy:
@@ -222,6 +229,13 @@ pub fn preview_schedule_firings(
 /// Returns [`crate::scheduler::BackfillPlanError::LimitExceeded`] when the raw
 /// timestamp window would exceed `max_count` before calendar filtering.
 #[cfg(feature = "db")]
+/// Returns `(original_slot, fire_time)` pairs.
+///
+/// `original_slot` is the raw cron-generated timestamp used for deterministic
+/// workflow-ID generation. `fire_time` is the calendar-adjusted dispatch time
+/// (may equal `original_slot` for unaffected slots). Keeping both prevents
+/// two logical slots that rebase onto the same calendar day from colliding on
+/// the derived workflow ID.
 pub fn plan_backfill_with_calendar(
     schedule: Option<&crate::policy::Schedule>,
     from: chrono::DateTime<chrono::Utc>,
@@ -230,22 +244,22 @@ pub fn plan_backfill_with_calendar(
     excluded_dates: &[NaiveDate],
     skip_policy: SkipPolicy,
     exclude_weekends: bool,
-) -> Result<Vec<chrono::DateTime<chrono::Utc>>, crate::scheduler::BackfillPlanError> {
+) -> Result<Vec<BackfillSlot>, crate::scheduler::BackfillPlanError> {
     let raw = crate::scheduler::plan_backfill_timestamps(schedule, from, to, max_count)?;
-    let adjusted = raw
+    let pairs = raw
         .into_iter()
         .filter_map(|ts| {
             let date = ts.date_naive();
             apply_skip_policy(date, skip_policy, excluded_dates, exclude_weekends).map(|adj_date| {
                 if adj_date == date {
-                    ts
+                    (ts, ts)
                 } else {
-                    rebase_to_date(ts, adj_date, schedule)
+                    (ts, rebase_to_date(ts, adj_date, schedule))
                 }
             })
         })
         .collect();
-    Ok(adjusted)
+    Ok(pairs)
 }
 
 // ── DB helpers (require `db` feature) ─────────────────────────────────────────

--- a/autumn-harvest/src/calendar.rs
+++ b/autumn-harvest/src/calendar.rs
@@ -89,7 +89,10 @@ pub fn apply_skip_policy(
 /// Returns the original datetime if the date cannot be combined with the time.
 #[cfg(feature = "db")]
 #[must_use]
-fn rebase_to_date(ts: chrono::DateTime<chrono::Utc>, date: NaiveDate) -> chrono::DateTime<chrono::Utc> {
+fn rebase_to_date(
+    ts: chrono::DateTime<chrono::Utc>,
+    date: NaiveDate,
+) -> chrono::DateTime<chrono::Utc> {
     let naive = date.and_time(ts.time());
     chrono::Utc.from_utc_datetime(&naive)
 }
@@ -569,7 +572,9 @@ mod tests {
 
         #[test]
         fn preview_firings_no_calendar_all_fired() {
-            let from = "2026-07-01T00:00:00Z".parse::<chrono::DateTime<Utc>>().unwrap();
+            let from = "2026-07-01T00:00:00Z"
+                .parse::<chrono::DateTime<Utc>>()
+                .unwrap();
             let schedule = Schedule::Cron("0 9 * * *".to_string());
             let previews =
                 preview_schedule_firings(&schedule, from, 3, None, &[], SkipPolicy::Skip);
@@ -652,18 +657,18 @@ mod tests {
                 .unwrap();
             let schedule = Schedule::Cron("0 9 * * *".to_string());
             let exc = excluded(&["2026-07-04"]);
-            let result = plan_backfill_with_calendar(
-                Some(&schedule),
-                from,
-                to,
-                100,
-                &exc,
-                SkipPolicy::Skip,
-            )
-            .unwrap();
-            let dates: Vec<_> = result.iter().map(|ts| ts.date_naive()).collect();
-            assert!(!dates.contains(&date("2026-07-04")), "Jul 4 should be excluded");
-            assert!(dates.contains(&date("2026-07-05")), "Jul 5 should be present");
+            let result =
+                plan_backfill_with_calendar(Some(&schedule), from, to, 100, &exc, SkipPolicy::Skip)
+                    .unwrap();
+            let dates: Vec<_> = result.iter().map(chrono::DateTime::date_naive).collect();
+            assert!(
+                !dates.contains(&date("2026-07-04")),
+                "Jul 4 should be excluded"
+            );
+            assert!(
+                dates.contains(&date("2026-07-05")),
+                "Jul 5 should be present"
+            );
         }
 
         #[test]
@@ -685,7 +690,7 @@ mod tests {
                 SkipPolicy::RunNextBusinessDay,
             )
             .unwrap();
-            let dates: Vec<_> = result.iter().map(|ts| ts.date_naive()).collect();
+            let dates: Vec<_> = result.iter().map(chrono::DateTime::date_naive).collect();
             assert!(
                 dates.iter().filter(|&&d| d == date("2026-07-05")).count() >= 1,
                 "Jul 5 should appear (as adjusted Jul 4 and/or natural Jul 5)"
@@ -706,12 +711,14 @@ mod tests {
                 .unwrap();
             let schedule = Schedule::Cron("0 9 * * *".to_string());
             let plain =
-                crate::scheduler::plan_backfill_timestamps(Some(&schedule), from, to, 100)
-                    .unwrap();
+                crate::scheduler::plan_backfill_timestamps(Some(&schedule), from, to, 100).unwrap();
             let with_cal =
                 plan_backfill_with_calendar(Some(&schedule), from, to, 100, &[], SkipPolicy::Skip)
                     .unwrap();
-            assert_eq!(plain, with_cal, "empty exclusion list must not change results");
+            assert_eq!(
+                plain, with_cal,
+                "empty exclusion list must not change results"
+            );
         }
     }
 }

--- a/autumn-harvest/src/calendar.rs
+++ b/autumn-harvest/src/calendar.rs
@@ -751,7 +751,7 @@ mod tests {
                 false,
             )
             .unwrap();
-            let dates: Vec<_> = result.iter().map(chrono::DateTime::date_naive).collect();
+            let dates: Vec<_> = result.iter().map(|(_, ft)| ft.date_naive()).collect();
             assert!(
                 !dates.contains(&date("2026-07-04")),
                 "Jul 4 should be excluded"
@@ -782,7 +782,7 @@ mod tests {
                 false,
             )
             .unwrap();
-            let dates: Vec<_> = result.iter().map(chrono::DateTime::date_naive).collect();
+            let dates: Vec<_> = result.iter().map(|(_, ft)| ft.date_naive()).collect();
             assert!(
                 dates.iter().filter(|&&d| d == date("2026-07-05")).count() >= 1,
                 "Jul 5 should appear (as adjusted Jul 4 and/or natural Jul 5)"
@@ -814,8 +814,9 @@ mod tests {
                 false,
             )
             .unwrap();
+            let with_cal_times: Vec<_> = with_cal.into_iter().map(|(_, ft)| ft).collect();
             assert_eq!(
-                plain, with_cal,
+                plain, with_cal_times,
                 "empty exclusion list must not change results"
             );
         }

--- a/autumn-harvest/src/calendar.rs
+++ b/autumn-harvest/src/calendar.rs
@@ -12,9 +12,9 @@
 //! - [`preview_schedule_firings`] — generates a preview of upcoming fire times
 //! - [`plan_backfill_with_calendar`] — like `plan_backfill_timestamps` but calendar-aware
 
-use chrono::NaiveDate;
 #[cfg(feature = "db")]
 use chrono::TimeZone;
+use chrono::{Datelike, NaiveDate};
 use serde::{Deserialize, Serialize};
 
 use crate::policy::SkipPolicy;
@@ -40,12 +40,24 @@ pub fn is_excluded_date(date: NaiveDate, excluded_dates: &[NaiveDate]) -> bool {
     excluded_dates.contains(&date)
 }
 
+/// Internal helper: returns `true` if `date` should be treated as excluded,
+/// checking both the explicit exclusion list and the weekend flag.
+fn is_excluded_impl(date: NaiveDate, excluded_dates: &[NaiveDate], exclude_weekends: bool) -> bool {
+    (exclude_weekends && matches!(date.weekday(), chrono::Weekday::Sat | chrono::Weekday::Sun))
+        || excluded_dates.contains(&date)
+}
+
 /// Adjust a scheduled fire date according to a calendar and skip policy.
 ///
 /// - When `date` is not excluded, returns `Some(date)` unchanged.
 /// - `SkipPolicy::Skip` → `None` (firing is suppressed).
-/// - `SkipPolicy::RunNextBusinessDay` → first subsequent non-excluded date.
-/// - `SkipPolicy::RunPrevBusinessDay` → most recent preceding non-excluded date.
+/// - `SkipPolicy::RunNextBusinessDay` → first subsequent non-excluded weekday.
+/// - `SkipPolicy::RunPrevBusinessDay` → most recent preceding non-excluded weekday.
+///
+/// Set `exclude_weekends = true` when the attached calendar is `"weekends-off"`
+/// (or any calendar that implies Saturday/Sunday are always excluded). When
+/// `true`, Saturday and Sunday are treated as excluded regardless of whether they
+/// appear in `excluded_dates`.
 ///
 /// Scans up to 365 days in either direction; returns `None` if no non-excluded
 /// day can be found within that window (degenerate calendar with 365 consecutive
@@ -55,8 +67,9 @@ pub fn apply_skip_policy(
     date: NaiveDate,
     skip_policy: SkipPolicy,
     excluded_dates: &[NaiveDate],
+    exclude_weekends: bool,
 ) -> Option<NaiveDate> {
-    if !is_excluded_date(date, excluded_dates) {
+    if !is_excluded_impl(date, excluded_dates, exclude_weekends) {
         return Some(date);
     }
     match skip_policy {
@@ -64,7 +77,7 @@ pub fn apply_skip_policy(
         SkipPolicy::RunNextBusinessDay => {
             let mut candidate = date + chrono::Duration::days(1);
             for _ in 0..365 {
-                if !is_excluded_date(candidate, excluded_dates) {
+                if !is_excluded_impl(candidate, excluded_dates, exclude_weekends) {
                     return Some(candidate);
                 }
                 candidate += chrono::Duration::days(1);
@@ -74,7 +87,7 @@ pub fn apply_skip_policy(
         SkipPolicy::RunPrevBusinessDay => {
             let mut candidate = date - chrono::Duration::days(1);
             for _ in 0..365 {
-                if !is_excluded_date(candidate, excluded_dates) {
+                if !is_excluded_impl(candidate, excluded_dates, exclude_weekends) {
                     return Some(candidate);
                 }
                 candidate -= chrono::Duration::days(1);
@@ -82,6 +95,14 @@ pub fn apply_skip_policy(
             None
         }
     }
+}
+
+/// Returns `true` when the calendar name implies Saturday/Sunday are always excluded.
+///
+/// Used to derive the `exclude_weekends` flag without a separate DB lookup.
+#[must_use]
+pub fn calendar_excludes_weekends(calendar_name: &str) -> bool {
+    calendar_name == "weekends-off"
 }
 
 /// Rebase a `DateTime<Utc>` to a different date, preserving the time-of-day.
@@ -144,9 +165,15 @@ pub fn preview_schedule_firings(
         cursor = fire_time;
         let fire_date = fire_time.date_naive();
 
+        let exclude_weekends = calendar_name.is_some_and(calendar_excludes_weekends);
         let (effective_at, reason) = calendar_name.map_or_else(
             || (Some(fire_time), "Fired".to_string()),
-            |cal_name| match apply_skip_policy(fire_date, skip_policy, excluded_dates) {
+            |cal_name| match apply_skip_policy(
+                fire_date,
+                skip_policy,
+                excluded_dates,
+                exclude_weekends,
+            ) {
                 None => (None, format!("SkippedByCalendar:{cal_name}")),
                 Some(adjusted) if adjusted == fire_date => (Some(fire_time), "Fired".to_string()),
                 Some(adjusted) => (
@@ -185,13 +212,14 @@ pub fn plan_backfill_with_calendar(
     max_count: usize,
     excluded_dates: &[NaiveDate],
     skip_policy: SkipPolicy,
+    exclude_weekends: bool,
 ) -> Result<Vec<chrono::DateTime<chrono::Utc>>, crate::scheduler::BackfillPlanError> {
     let raw = crate::scheduler::plan_backfill_timestamps(schedule, from, to, max_count)?;
     let adjusted = raw
         .into_iter()
         .filter_map(|ts| {
             let date = ts.date_naive();
-            apply_skip_policy(date, skip_policy, excluded_dates).map(|adj_date| {
+            apply_skip_policy(date, skip_policy, excluded_dates, exclude_weekends).map(|adj_date| {
                 if adj_date == date {
                     ts
                 } else {
@@ -342,18 +370,10 @@ pub async fn replace_calendar_exclusions(
     use crate::models::NewHarvestCalendarExclusion;
     use crate::schema::harvest_calendar_exclusions;
     use diesel::{ExpressionMethods, QueryDsl};
-    use diesel_async::RunQueryDsl;
+    use diesel_async::{AsyncConnection, RunQueryDsl};
 
-    // Validate the calendar exists.
+    // Validate the calendar exists before opening a transaction.
     get_calendar(conn, calendar_name).await?;
-
-    diesel::delete(
-        harvest_calendar_exclusions::table
-            .filter(harvest_calendar_exclusions::calendar_name.eq(calendar_name)),
-    )
-    .execute(conn)
-    .await
-    .map_err(crate::error::database_error)?;
 
     let rows: Vec<NewHarvestCalendarExclusion<'_>> = dates
         .iter()
@@ -363,20 +383,33 @@ pub async fn replace_calendar_exclusions(
         })
         .collect();
 
-    if !rows.is_empty() {
-        diesel::insert_into(harvest_calendar_exclusions::table)
-            .values(&rows)
-            .on_conflict((
-                harvest_calendar_exclusions::calendar_name,
-                harvest_calendar_exclusions::excluded_date,
-            ))
-            .do_nothing()
-            .execute(conn)
+    conn.transaction(|tx| {
+        Box::pin(async move {
+            diesel::delete(
+                harvest_calendar_exclusions::table
+                    .filter(harvest_calendar_exclusions::calendar_name.eq(calendar_name)),
+            )
+            .execute(tx)
             .await
             .map_err(crate::error::database_error)?;
-    }
 
-    Ok(())
+            if !rows.is_empty() {
+                diesel::insert_into(harvest_calendar_exclusions::table)
+                    .values(&rows)
+                    .on_conflict((
+                        harvest_calendar_exclusions::calendar_name,
+                        harvest_calendar_exclusions::excluded_date,
+                    ))
+                    .do_nothing()
+                    .execute(tx)
+                    .await
+                    .map_err(crate::error::database_error)?;
+            }
+
+            Ok(())
+        })
+    })
+    .await
 }
 
 /// Delete a custom calendar (built-in calendars cannot be deleted).
@@ -510,9 +543,9 @@ mod tests {
     fn apply_skip_policy_non_excluded_returns_same() {
         let exc = excluded(&["2026-07-04"]);
         let d = date("2026-07-05");
-        assert_eq!(apply_skip_policy(d, SkipPolicy::Skip, &exc), Some(d));
+        assert_eq!(apply_skip_policy(d, SkipPolicy::Skip, &exc, false), Some(d));
         assert_eq!(
-            apply_skip_policy(d, SkipPolicy::RunNextBusinessDay, &exc),
+            apply_skip_policy(d, SkipPolicy::RunNextBusinessDay, &exc, false),
             Some(d)
         );
     }
@@ -521,7 +554,7 @@ mod tests {
     fn apply_skip_policy_skip_suppresses_excluded() {
         let exc = excluded(&["2026-07-04"]);
         assert_eq!(
-            apply_skip_policy(date("2026-07-04"), SkipPolicy::Skip, &exc),
+            apply_skip_policy(date("2026-07-04"), SkipPolicy::Skip, &exc, false),
             None
         );
     }
@@ -530,7 +563,12 @@ mod tests {
     fn apply_skip_policy_next_business_day_finds_next() {
         let exc = excluded(&["2026-07-04"]);
         assert_eq!(
-            apply_skip_policy(date("2026-07-04"), SkipPolicy::RunNextBusinessDay, &exc),
+            apply_skip_policy(
+                date("2026-07-04"),
+                SkipPolicy::RunNextBusinessDay,
+                &exc,
+                false
+            ),
             Some(date("2026-07-05"))
         );
     }
@@ -539,7 +577,12 @@ mod tests {
     fn apply_skip_policy_prev_business_day_finds_prev() {
         let exc = excluded(&["2026-07-04"]);
         assert_eq!(
-            apply_skip_policy(date("2026-07-04"), SkipPolicy::RunPrevBusinessDay, &exc),
+            apply_skip_policy(
+                date("2026-07-04"),
+                SkipPolicy::RunPrevBusinessDay,
+                &exc,
+                false
+            ),
             Some(date("2026-07-03"))
         );
     }
@@ -548,7 +591,12 @@ mod tests {
     fn apply_skip_policy_chains_through_multiple_consecutive_exclusions() {
         let exc = excluded(&["2026-08-06", "2026-08-07", "2026-08-08"]);
         assert_eq!(
-            apply_skip_policy(date("2026-08-06"), SkipPolicy::RunNextBusinessDay, &exc),
+            apply_skip_policy(
+                date("2026-08-06"),
+                SkipPolicy::RunNextBusinessDay,
+                &exc,
+                false
+            ),
             Some(date("2026-08-09"))
         );
     }
@@ -557,7 +605,12 @@ mod tests {
     fn apply_skip_policy_prev_chains_through_multiple_consecutive_exclusions() {
         let exc = excluded(&["2026-08-06", "2026-08-07", "2026-08-08"]);
         assert_eq!(
-            apply_skip_policy(date("2026-08-08"), SkipPolicy::RunPrevBusinessDay, &exc),
+            apply_skip_policy(
+                date("2026-08-08"),
+                SkipPolicy::RunPrevBusinessDay,
+                &exc,
+                false
+            ),
             Some(date("2026-08-05"))
         );
     }
@@ -657,9 +710,16 @@ mod tests {
                 .unwrap();
             let schedule = Schedule::Cron("0 9 * * *".to_string());
             let exc = excluded(&["2026-07-04"]);
-            let result =
-                plan_backfill_with_calendar(Some(&schedule), from, to, 100, &exc, SkipPolicy::Skip)
-                    .unwrap();
+            let result = plan_backfill_with_calendar(
+                Some(&schedule),
+                from,
+                to,
+                100,
+                &exc,
+                SkipPolicy::Skip,
+                false,
+            )
+            .unwrap();
             let dates: Vec<_> = result.iter().map(chrono::DateTime::date_naive).collect();
             assert!(
                 !dates.contains(&date("2026-07-04")),
@@ -688,6 +748,7 @@ mod tests {
                 100,
                 &exc,
                 SkipPolicy::RunNextBusinessDay,
+                false,
             )
             .unwrap();
             let dates: Vec<_> = result.iter().map(chrono::DateTime::date_naive).collect();
@@ -712,9 +773,16 @@ mod tests {
             let schedule = Schedule::Cron("0 9 * * *".to_string());
             let plain =
                 crate::scheduler::plan_backfill_timestamps(Some(&schedule), from, to, 100).unwrap();
-            let with_cal =
-                plan_backfill_with_calendar(Some(&schedule), from, to, 100, &[], SkipPolicy::Skip)
-                    .unwrap();
+            let with_cal = plan_backfill_with_calendar(
+                Some(&schedule),
+                from,
+                to,
+                100,
+                &[],
+                SkipPolicy::Skip,
+                false,
+            )
+            .unwrap();
             assert_eq!(
                 plain, with_cal,
                 "empty exclusion list must not change results"

--- a/autumn-harvest/src/info.rs
+++ b/autumn-harvest/src/info.rs
@@ -246,6 +246,8 @@ impl DagInfo {
             overlap_policy: self.overlap_policy,
             buffer_all_max: self.buffer_all_max,
             execution_timeout: None,
+            calendar: None,
+            skip_policy: crate::policy::SkipPolicy::Skip,
         })
     }
 

--- a/autumn-harvest/src/lib.rs
+++ b/autumn-harvest/src/lib.rs
@@ -19,6 +19,9 @@ pub mod analyzer;
 /// Audit trail for management API mutations (issue #158).
 #[cfg(feature = "db")]
 pub mod audit;
+/// Calendar-aware schedule filtering: named exclusion sets, skip policies, and
+/// schedule preview generation (issue #337).
+pub mod calendar;
 /// Batch operations for fleet-wide workflow cancel/terminate/signal (issue #102).
 pub mod batch;
 /// Worker build-id routing for safe rolling deploys (issue #171).
@@ -184,8 +187,17 @@ pub use info::{
     UpdateHandlerInfo, UpdateValidatorFn, WorkflowHandlerFn, WorkflowInfo,
 };
 pub use payload_codec::{CodecError, IdentityCodec, PayloadCodec, PayloadCodecs};
+pub use calendar::{Calendar, ScheduleFirePreview, apply_skip_policy, is_excluded_date};
+#[cfg(feature = "db")]
+pub use calendar::{
+    create_calendar, delete_calendar, get_calendar, list_calendars,
+    load_exclusions_for_calendar, plan_backfill_with_calendar, preview_schedule_firings,
+    replace_calendar_exclusions,
+};
 pub use policy::validate_schedule;
-pub use policy::{OverlapPolicy, RetryPolicy, Schedule, TaskStatus, TriggerRule, WorkflowSchedule};
+pub use policy::{
+    OverlapPolicy, RetryPolicy, Schedule, SkipPolicy, TaskStatus, TriggerRule, WorkflowSchedule,
+};
 pub use pool::{HarvestPoolConfig, compute_pool_sizes};
 pub use query::QueryRegistry;
 pub use replay::{HistoryMatch, HistoryMatcher};

--- a/autumn-harvest/src/lib.rs
+++ b/autumn-harvest/src/lib.rs
@@ -19,9 +19,6 @@ pub mod analyzer;
 /// Audit trail for management API mutations (issue #158).
 #[cfg(feature = "db")]
 pub mod audit;
-/// Calendar-aware schedule filtering: named exclusion sets, skip policies, and
-/// schedule preview generation (issue #337).
-pub mod calendar;
 /// Batch operations for fleet-wide workflow cancel/terminate/signal (issue #102).
 pub mod batch;
 /// Worker build-id routing for safe rolling deploys (issue #171).
@@ -29,6 +26,9 @@ pub mod batch;
 pub mod build_routing;
 pub mod builder;
 pub mod cache;
+/// Calendar-aware schedule filtering: named exclusion sets, skip policies, and
+/// schedule preview generation (issue #337).
+pub mod calendar;
 /// Per-key concurrency limits for tenant fair-share scheduling (issue #247).
 pub mod concurrency;
 pub mod context;
@@ -139,6 +139,12 @@ pub use builder::{
     BuiltHarvest, HarvestBuilder, HarvestBuilderError, StickyRoutingConfig, WorkerConfig,
 };
 pub use cache::{CachedWorkflowState, WorkflowCache};
+pub use calendar::{Calendar, ScheduleFirePreview, apply_skip_policy, is_excluded_date};
+#[cfg(feature = "db")]
+pub use calendar::{
+    create_calendar, delete_calendar, get_calendar, list_calendars, load_exclusions_for_calendar,
+    plan_backfill_with_calendar, preview_schedule_firings, replace_calendar_exclusions,
+};
 pub use context::{
     ActivityContext, DEFAULT_HISTORY_CONTINUE_AS_NEW_THRESHOLD, WorkflowCommand, WorkflowContext,
     WorkflowHistoryPolicy,
@@ -187,13 +193,6 @@ pub use info::{
     UpdateHandlerInfo, UpdateValidatorFn, WorkflowHandlerFn, WorkflowInfo,
 };
 pub use payload_codec::{CodecError, IdentityCodec, PayloadCodec, PayloadCodecs};
-pub use calendar::{Calendar, ScheduleFirePreview, apply_skip_policy, is_excluded_date};
-#[cfg(feature = "db")]
-pub use calendar::{
-    create_calendar, delete_calendar, get_calendar, list_calendars,
-    load_exclusions_for_calendar, plan_backfill_with_calendar, preview_schedule_firings,
-    replace_calendar_exclusions,
-};
 pub use policy::validate_schedule;
 pub use policy::{
     OverlapPolicy, RetryPolicy, Schedule, SkipPolicy, TaskStatus, TriggerRule, WorkflowSchedule,

--- a/autumn-harvest/src/lib.rs
+++ b/autumn-harvest/src/lib.rs
@@ -139,7 +139,9 @@ pub use builder::{
     BuiltHarvest, HarvestBuilder, HarvestBuilderError, StickyRoutingConfig, WorkerConfig,
 };
 pub use cache::{CachedWorkflowState, WorkflowCache};
-pub use calendar::{Calendar, ScheduleFirePreview, apply_skip_policy, is_excluded_date};
+pub use calendar::{
+    Calendar, ScheduleFirePreview, apply_skip_policy, calendar_excludes_weekends, is_excluded_date,
+};
 #[cfg(feature = "db")]
 pub use calendar::{
     create_calendar, delete_calendar, get_calendar, list_calendars, load_exclusions_for_calendar,

--- a/autumn-harvest/src/lib.rs
+++ b/autumn-harvest/src/lib.rs
@@ -139,13 +139,14 @@ pub use builder::{
     BuiltHarvest, HarvestBuilder, HarvestBuilderError, StickyRoutingConfig, WorkerConfig,
 };
 pub use cache::{CachedWorkflowState, WorkflowCache};
-pub use calendar::{
-    Calendar, ScheduleFirePreview, apply_skip_policy, calendar_excludes_weekends, is_excluded_date,
-};
 #[cfg(feature = "db")]
 pub use calendar::{
-    create_calendar, delete_calendar, get_calendar, list_calendars, load_exclusions_for_calendar,
-    plan_backfill_with_calendar, preview_schedule_firings, replace_calendar_exclusions,
+    BackfillSlot, create_calendar, delete_calendar, get_calendar, list_calendars,
+    load_exclusions_for_calendar, plan_backfill_with_calendar, preview_schedule_firings,
+    replace_calendar_exclusions,
+};
+pub use calendar::{
+    Calendar, ScheduleFirePreview, apply_skip_policy, calendar_excludes_weekends, is_excluded_date,
 };
 pub use context::{
     ActivityContext, DEFAULT_HISTORY_CONTINUE_AS_NEW_THRESHOLD, WorkflowCommand, WorkflowContext,

--- a/autumn-harvest/src/models.rs
+++ b/autumn-harvest/src/models.rs
@@ -11,10 +11,59 @@ use uuid::Uuid;
 
 use crate::schema::{
     harvest_audit_log, harvest_backfill_log, harvest_batch_jobs, harvest_build_compat,
-    harvest_build_policies, harvest_dead_letters, harvest_events, harvest_external_tasks,
-    harvest_schedules, harvest_signals, harvest_task_queue, harvest_timers, harvest_workers,
-    harvest_workflow_executions,
+    harvest_build_policies, harvest_calendar_exclusions, harvest_calendars, harvest_dead_letters,
+    harvest_events, harvest_external_tasks, harvest_schedules, harvest_signals, harvest_task_queue,
+    harvest_timers, harvest_workers, harvest_workflow_executions,
 };
+
+// ── Calendar ──────────────────────────────────────────────────────────────────
+
+/// A named calendar row from `harvest_calendars`.
+#[derive(
+    Debug, Clone, Queryable, Selectable, Identifiable, serde::Serialize, serde::Deserialize,
+)]
+#[diesel(table_name = harvest_calendars)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct HarvestCalendar {
+    pub id: Uuid,
+    pub name: String,
+    pub description: Option<String>,
+    /// `true` for built-in calendars that operators cannot delete.
+    pub built_in: bool,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+/// Insert struct for creating a new calendar.
+#[derive(Debug, Insertable, serde::Serialize, serde::Deserialize)]
+#[diesel(table_name = harvest_calendars)]
+pub struct NewHarvestCalendar<'a> {
+    pub id: Uuid,
+    pub name: &'a str,
+    pub description: Option<&'a str>,
+    pub built_in: bool,
+}
+
+/// A single date exclusion row from `harvest_calendar_exclusions`.
+#[derive(
+    Debug, Clone, Queryable, Selectable, Identifiable, serde::Serialize, serde::Deserialize,
+)]
+#[diesel(table_name = harvest_calendar_exclusions)]
+#[diesel(check_for_backend(diesel::pg::Pg))]
+pub struct HarvestCalendarExclusion {
+    pub id: Uuid,
+    pub calendar_name: String,
+    pub excluded_date: chrono::NaiveDate,
+    pub created_at: DateTime<Utc>,
+}
+
+/// Insert struct for adding a date to a calendar's exclusion set.
+#[derive(Debug, Insertable, serde::Serialize, serde::Deserialize)]
+#[diesel(table_name = harvest_calendar_exclusions)]
+pub struct NewHarvestCalendarExclusion<'a> {
+    pub calendar_name: &'a str,
+    pub excluded_date: chrono::NaiveDate,
+}
 
 // ── WorkflowExecution ─────────────────────────────────────────────────────────
 
@@ -220,6 +269,10 @@ pub struct HarvestSchedule {
     pub buffered_runs: serde_json::Value,
     /// Maximum buffered slots under `BufferAll` (issue #241). Default 100.
     pub buffer_all_max: i32,
+    /// Optional named calendar for this schedule (issue #337). NULL = no filtering.
+    pub calendar_name: Option<String>,
+    /// What to do when the fire date is calendar-excluded (issue #337).
+    pub skip_policy: String,
 }
 
 /// Insert struct for registering a new schedule (DAG or workflow).
@@ -247,6 +300,10 @@ pub struct NewHarvestSchedule<'a> {
     pub buffered_runs: serde_json::Value,
     /// Maximum buffered slots under `BufferAll` (issue #241).
     pub buffer_all_max: i32,
+    /// Optional named calendar for this schedule (issue #337).
+    pub calendar_name: Option<&'a str>,
+    /// What to do when the fire date is calendar-excluded (issue #337).
+    pub skip_policy: &'a str,
 }
 
 // ── Signal ────────────────────────────────────────────────────────────────────

--- a/autumn-harvest/src/policy.rs
+++ b/autumn-harvest/src/policy.rs
@@ -410,6 +410,64 @@ impl OverlapPolicy {
     }
 }
 
+/// What the scheduler does when a fire date falls on a calendar-excluded day.
+///
+/// Calendars are sets of dates (e.g. federal holidays) that a schedule should
+/// avoid. `SkipPolicy` declares the fallback when the natural fire date is one
+/// of those excluded days.
+///
+/// See [`crate::calendar`] for the [`crate::calendar::apply_skip_policy`] implementation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum SkipPolicy {
+    /// Suppress the firing entirely (increment `harvest.schedule.skipped`).
+    #[default]
+    Skip,
+    /// Defer to the first subsequent non-excluded day.
+    RunNextBusinessDay,
+    /// Advance to the most recent preceding non-excluded day.
+    RunPrevBusinessDay,
+}
+
+impl SkipPolicy {
+    /// The `snake_case` string used to store this policy in `harvest_schedules`.
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::Skip => "skip",
+            Self::RunNextBusinessDay => "run_next_business_day",
+            Self::RunPrevBusinessDay => "run_prev_business_day",
+        }
+    }
+
+    /// Parse a `skip_policy` column value from the database.
+    ///
+    /// Unknown values fall back to [`Skip`](Self::Skip) to preserve the
+    /// append-only-schema invariant.
+    #[must_use]
+    pub fn from_db(s: &str) -> Self {
+        match s {
+            "run_next_business_day" => Self::RunNextBusinessDay,
+            "run_prev_business_day" => Self::RunPrevBusinessDay,
+            _ => Self::Skip,
+        }
+    }
+
+    /// Parse a `skip_policy` value from user-supplied input (e.g. an API request).
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(s)` when `s` is not a recognised variant name.
+    pub fn from_user_input(s: &str) -> Result<Self, &str> {
+        match s {
+            "skip" => Ok(Self::Skip),
+            "run_next_business_day" => Ok(Self::RunNextBusinessDay),
+            "run_prev_business_day" => Ok(Self::RunPrevBusinessDay),
+            _ => Err(s),
+        }
+    }
+}
+
 /// Per-workflow cron/interval schedule — the lightweight alternative to a
 /// single-node DAG when all you need is "run this workflow on a schedule."
 ///
@@ -488,6 +546,20 @@ pub struct WorkflowSchedule {
     /// schedule. `None` = no deadline enforced (today's behaviour).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub execution_timeout: Option<std::time::Duration>,
+    /// Optional named calendar to consult before each firing.
+    ///
+    /// When `Some("us-federal-holidays")`, the scheduler looks up the
+    /// `harvest_calendars` row with that name and applies [`skip_policy`](Self::skip_policy)
+    /// on fire dates that fall on an excluded day. `None` = today's behaviour
+    /// (no calendar filtering).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub calendar: Option<String>,
+    /// What to do when the fire date falls on a calendar-excluded day.
+    ///
+    /// Ignored when [`calendar`](Self::calendar) is `None`.
+    /// Default: [`SkipPolicy::Skip`] (suppress the firing).
+    #[serde(default)]
+    pub skip_policy: SkipPolicy,
 }
 
 const fn default_buffer_all_max() -> u32 {
@@ -499,7 +571,7 @@ impl WorkflowSchedule {
     ///
     /// Defaults: `input = null`, `catchup = false`, `max_active_runs = 1`,
     /// `paused = false`, `queue_name = "default"`, `overlap_policy = Skip`,
-    /// `buffer_all_max = 100`.
+    /// `buffer_all_max = 100`, `calendar = None`, `skip_policy = Skip`.
     #[must_use]
     pub fn new(workflow_name: impl Into<String>, schedule: Schedule) -> Self {
         Self {
@@ -515,6 +587,8 @@ impl WorkflowSchedule {
             overlap_policy: OverlapPolicy::Skip,
             buffer_all_max: 100,
             execution_timeout: None,
+            calendar: None,
+            skip_policy: SkipPolicy::Skip,
         }
     }
 
@@ -589,6 +663,27 @@ impl WorkflowSchedule {
     #[must_use]
     pub const fn with_jitter(mut self, jitter: Duration) -> Self {
         self.jitter = jitter;
+        self
+    }
+
+    /// Attach a named calendar to this schedule.
+    ///
+    /// On each firing the scheduler consults the `harvest_calendars` table for
+    /// a calendar with this name and applies [`skip_policy`](Self::skip_policy)
+    /// when the fire date is excluded. Pass `None` to remove a previously set
+    /// calendar (disables calendar filtering).
+    #[must_use]
+    pub fn with_calendar(mut self, calendar: impl Into<Option<String>>) -> Self {
+        self.calendar = calendar.into();
+        self
+    }
+
+    /// Set the skip policy applied when the fire date falls on an excluded calendar day.
+    ///
+    /// Has no effect when [`calendar`](Self::calendar) is `None`.
+    #[must_use]
+    pub const fn with_skip_policy(mut self, policy: SkipPolicy) -> Self {
+        self.skip_policy = policy;
         self
     }
 }
@@ -904,6 +999,76 @@ mod tests {
         // All rules fire vacuously when there are no upstreams
         assert!(TriggerRule::AllSuccess.should_run(&[]));
         assert!(TriggerRule::AllDone.should_run(&[]));
+    }
+
+    // ── SkipPolicy ────────────────────────────────────────────────────────────
+
+    #[test]
+    fn skip_policy_default_is_skip() {
+        assert_eq!(SkipPolicy::default(), SkipPolicy::Skip);
+    }
+
+    #[test]
+    fn skip_policy_as_str_round_trips() {
+        let cases = [
+            (SkipPolicy::Skip, "skip"),
+            (SkipPolicy::RunNextBusinessDay, "run_next_business_day"),
+            (SkipPolicy::RunPrevBusinessDay, "run_prev_business_day"),
+        ];
+        for (policy, s) in cases {
+            assert_eq!(policy.as_str(), s, "as_str mismatch for {policy:?}");
+            assert_eq!(
+                SkipPolicy::from_db(s),
+                policy,
+                "from_db mismatch for {s}"
+            );
+        }
+    }
+
+    #[test]
+    fn skip_policy_from_db_unknown_defaults_to_skip() {
+        assert_eq!(SkipPolicy::from_db("unknown"), SkipPolicy::Skip);
+        assert_eq!(SkipPolicy::from_db(""), SkipPolicy::Skip);
+    }
+
+    #[test]
+    fn skip_policy_serde_round_trips() {
+        let policies = [
+            SkipPolicy::Skip,
+            SkipPolicy::RunNextBusinessDay,
+            SkipPolicy::RunPrevBusinessDay,
+        ];
+        for policy in policies {
+            let json = serde_json::to_string(&policy).expect("serialize");
+            let back: SkipPolicy = serde_json::from_str(&json).expect("deserialize");
+            assert_eq!(back, policy, "serde round-trip failed for {policy:?}");
+        }
+    }
+
+    #[test]
+    fn workflow_schedule_calendar_defaults_to_none() {
+        let sched = WorkflowSchedule::new("my_wf", Schedule::Manual);
+        assert!(sched.calendar.is_none());
+    }
+
+    #[test]
+    fn workflow_schedule_with_calendar_sets_field() {
+        let sched = WorkflowSchedule::new("my_wf", Schedule::Manual)
+            .with_calendar("us-federal-holidays".to_string());
+        assert_eq!(sched.calendar.as_deref(), Some("us-federal-holidays"));
+    }
+
+    #[test]
+    fn workflow_schedule_skip_policy_defaults_to_skip() {
+        let sched = WorkflowSchedule::new("my_wf", Schedule::Manual);
+        assert_eq!(sched.skip_policy, SkipPolicy::Skip);
+    }
+
+    #[test]
+    fn workflow_schedule_with_skip_policy_sets_field() {
+        let sched = WorkflowSchedule::new("my_wf", Schedule::Manual)
+            .with_skip_policy(SkipPolicy::RunNextBusinessDay);
+        assert_eq!(sched.skip_policy, SkipPolicy::RunNextBusinessDay);
     }
 
     // ── OverlapPolicy ─────────────────────────────────────────────────────────

--- a/autumn-harvest/src/policy.rs
+++ b/autumn-harvest/src/policy.rs
@@ -1017,11 +1017,7 @@ mod tests {
         ];
         for (policy, s) in cases {
             assert_eq!(policy.as_str(), s, "as_str mismatch for {policy:?}");
-            assert_eq!(
-                SkipPolicy::from_db(s),
-                policy,
-                "from_db mismatch for {s}"
-            );
+            assert_eq!(SkipPolicy::from_db(s), policy, "from_db mismatch for {s}");
         }
     }
 

--- a/autumn-harvest/src/prelude.rs
+++ b/autumn-harvest/src/prelude.rs
@@ -16,7 +16,8 @@ pub use crate::handle::{
     WorkflowResultState, start_or_load_workflow_execution_with_handle,
 };
 pub use crate::info::{ActivityInfo, DagInfo, QueryHandlerInfo, UpdateHandlerInfo, WorkflowInfo};
-pub use crate::policy::{RetryPolicy, Schedule, TaskStatus, TriggerRule};
+pub use crate::calendar::{Calendar, ScheduleFirePreview, apply_skip_policy, is_excluded_date};
+pub use crate::policy::{OverlapPolicy, RetryPolicy, Schedule, SkipPolicy, TaskStatus, TriggerRule, WorkflowSchedule};
 pub use crate::query::QueryRegistry;
 pub use crate::saga::Saga;
 #[cfg(feature = "db")]

--- a/autumn-harvest/src/prelude.rs
+++ b/autumn-harvest/src/prelude.rs
@@ -5,6 +5,7 @@
 //! ```
 
 pub use crate::builder::{HarvestBuilder, WorkerConfig};
+pub use crate::calendar::{Calendar, ScheduleFirePreview, apply_skip_policy, is_excluded_date};
 pub use crate::context::{ActivityContext, WorkflowContext};
 pub use crate::dag::{DagBuildError, DagBuilder, DagDefinition, DagTask, DagTaskRef};
 pub use crate::error::{HarvestError, HarvestResult, TimeoutType};
@@ -16,8 +17,9 @@ pub use crate::handle::{
     WorkflowResultState, start_or_load_workflow_execution_with_handle,
 };
 pub use crate::info::{ActivityInfo, DagInfo, QueryHandlerInfo, UpdateHandlerInfo, WorkflowInfo};
-pub use crate::calendar::{Calendar, ScheduleFirePreview, apply_skip_policy, is_excluded_date};
-pub use crate::policy::{OverlapPolicy, RetryPolicy, Schedule, SkipPolicy, TaskStatus, TriggerRule, WorkflowSchedule};
+pub use crate::policy::{
+    OverlapPolicy, RetryPolicy, Schedule, SkipPolicy, TaskStatus, TriggerRule, WorkflowSchedule,
+};
 pub use crate::query::QueryRegistry;
 pub use crate::saga::Saga;
 #[cfg(feature = "db")]

--- a/autumn-harvest/src/prelude.rs
+++ b/autumn-harvest/src/prelude.rs
@@ -5,7 +5,9 @@
 //! ```
 
 pub use crate::builder::{HarvestBuilder, WorkerConfig};
-pub use crate::calendar::{Calendar, ScheduleFirePreview, apply_skip_policy, is_excluded_date};
+pub use crate::calendar::{
+    Calendar, ScheduleFirePreview, apply_skip_policy, calendar_excludes_weekends, is_excluded_date,
+};
 pub use crate::context::{ActivityContext, WorkflowContext};
 pub use crate::dag::{DagBuildError, DagBuilder, DagDefinition, DagTask, DagTaskRef};
 pub use crate::error::{HarvestError, HarvestResult, TimeoutType};

--- a/autumn-harvest/src/scheduler.rs
+++ b/autumn-harvest/src/scheduler.rs
@@ -1654,6 +1654,10 @@ async fn tick_one_workflow_schedule(
 
     let mut dispatched: u32 = 0;
     let mut last_dispatched_at: Option<DateTime<Utc>> = None;
+    // Tracks the pre-rebase original slot of the last dispatched run. Used to
+    // anchor next_run_at when a calendar rebases the fire time forward, so the
+    // natural next cron slot after the original due slot is not skipped.
+    let mut last_original_slot_dispatched: Option<DateTime<Utc>> = None;
     // Set to the first slot we could not dispatch due to max_active_runs or jitter; if Some,
     // it becomes next_run_at so catchup slots are not silently dropped.
     let mut deferred_next_run_at: Option<DateTime<Utc>> = None;
@@ -1662,20 +1666,26 @@ async fn tick_one_workflow_schedule(
         // the pre-loop check no longer rebases `logical_date`).
         let effective_scheduled_for = if schedule.calendar_name.is_some() {
             let slot_date = original_slot.date_naive();
-            match crate::calendar::apply_skip_policy(
+            let Some(adjusted) = crate::calendar::apply_skip_policy(
                 slot_date,
                 calendar_skip_policy,
                 &calendar_excluded,
                 calendar_exclude_weekends,
-            ) {
-                None => {
-                    metrics.record_schedule_skipped("workflow", wf_name, "calendar");
+            ) else {
+                metrics.record_schedule_skipped("workflow", wf_name, "calendar");
+                continue;
+            };
+            if adjusted == slot_date {
+                *original_slot
+            } else {
+                let rebased = rebase_logical_date(*original_slot, adjusted, parsed_schedule);
+                // RunPrevBusinessDay can shift backward into the past. Skip such
+                // slots to avoid firing a retroactive run on an excluded day.
+                if rebased < now {
+                    metrics.record_schedule_skipped("workflow", wf_name, "calendar_prev_expired");
                     continue;
                 }
-                Some(adjusted) if adjusted != slot_date => {
-                    rebase_logical_date(*original_slot, adjusted, parsed_schedule)
-                }
-                Some(_) => *original_slot,
+                rebased
             }
         } else {
             *original_slot
@@ -1761,6 +1771,7 @@ async fn tick_one_workflow_schedule(
             Ok(outcome) => {
                 dispatched += 1;
                 last_dispatched_at = Some(*scheduled_for);
+                last_original_slot_dispatched = Some(*original_slot);
                 if outcome.created() {
                     metrics.record_schedule_run("workflow", wf_name);
                 }
@@ -1787,7 +1798,20 @@ async fn tick_one_workflow_schedule(
     // Deferred catchup slots become next_run_at so the next tick retries them.
     // last_run_at only advances to the last slot actually started.
     let effective_last_run_at = last_dispatched_at.or(schedule.last_run_at);
-    let effective_next_run_at = deferred_next_run_at.or(next_run_after_plan);
+    // When calendar rebasing is active, next_run_after_plan was anchored to the
+    // original due slot and its `filter(t > now)` guard can spuriously fail when
+    // `now` has advanced past the rebased fire time, causing the natural next
+    // cron slot to be skipped. Re-anchor from the last original (pre-rebase)
+    // slot to guarantee the correct successor slot.
+    let effective_next_run_at = deferred_next_run_at.or_else(|| {
+        if schedule.calendar_name.is_some() {
+            last_original_slot_dispatched
+                .and_then(|slot| next_run_after(parsed_schedule, slot))
+                .or(next_run_after_plan)
+        } else {
+            next_run_after_plan
+        }
+    });
     diesel::update(dsl::harvest_schedules.find(schedule.id))
         .set((
             dsl::last_run_at.eq(effective_last_run_at),

--- a/autumn-harvest/src/scheduler.rs
+++ b/autumn-harvest/src/scheduler.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
-use chrono::{DateTime, Utc};
+use chrono::{DateTime, TimeZone, Utc};
 use croner::Cron;
 use diesel::OptionalExtension;
 use diesel::QueryDsl;
@@ -1459,6 +1459,10 @@ async fn tick_one_workflow_schedule(
     use crate::execution::StartWorkflowParams;
     use crate::schema::harvest_schedules::dsl;
 
+    // Calendar adjustment may shift the logical fire date; shadow the parameter
+    // as mutable so the calendar block can rebase it when needed.
+    let mut logical_date = logical_date;
+
     // Compute jitter window once so it can be reused in the dispatch loop below.
     let jitter_window =
         std::time::Duration::from_secs(u64::try_from(schedule.jitter_secs.max(0)).unwrap_or(0));
@@ -1478,17 +1482,40 @@ async fn tick_one_workflow_schedule(
     // If the schedule has a named calendar, load its exclusion dates and apply
     // the skip policy to the logical fire date. Suppressed firings (SkipPolicy::Skip)
     // are recorded as skipped with `reason = "calendar"` and the scheduler advances
-    // past this slot. Deferred firings are allowed through with the adjusted date.
-    if let Some(ref cal_name) = schedule.calendar_name {
+    // past this slot. Deferred firings proceed with the adjusted date.
+    //
+    // `excluded` and `exclude_weekends` are kept for re-use in the dispatch loop
+    // below so that individual catchup slots are also calendar-filtered.
+    let (calendar_excluded, calendar_exclude_weekends, calendar_skip_policy) = if let Some(
+        ref cal_name,
+    ) =
+        schedule.calendar_name
+    {
         let excluded = crate::calendar::load_exclusions_for_calendar(conn, cal_name)
-            .await
-            .unwrap_or_default();
-        let fire_date = logical_date.date_naive();
+                .await
+                .map_err(|e| {
+                    tracing::error!(
+                        workflow_name = %wf_name,
+                        calendar = %cal_name,
+                        error = %e,
+                        "harvest: failed to load calendar exclusions; aborting tick to preserve calendar guarantees"
+                    );
+                    e
+                })?;
+        let exclude_weekends = crate::calendar::calendar_excludes_weekends(cal_name);
         let skip_policy = crate::policy::SkipPolicy::from_db(&schedule.skip_policy);
 
-        match crate::calendar::apply_skip_policy(fire_date, skip_policy, &excluded) {
+        let fire_date = logical_date.date_naive();
+        match crate::calendar::apply_skip_policy(
+            fire_date,
+            skip_policy,
+            &excluded,
+            exclude_weekends,
+        ) {
             None => {
-                // Firing is suppressed. Advance past this slot.
+                // Firing is suppressed. For catchup schedules advance to the next
+                // slot after the excluded date so overdue non-excluded slots are
+                // not dropped; for non-catchup schedules advance from now.
                 tracing::info!(
                     workflow_name = %wf_name,
                     calendar = %cal_name,
@@ -1496,7 +1523,11 @@ async fn tick_one_workflow_schedule(
                     "harvest: workflow schedule firing suppressed by calendar"
                 );
                 metrics.record_schedule_skipped("workflow", wf_name, "calendar");
-                let next = next_run_after(parsed_schedule, now);
+                let next = if catchup {
+                    next_run_after(parsed_schedule, logical_date)
+                } else {
+                    next_run_after(parsed_schedule, now)
+                };
                 diesel::update(dsl::harvest_schedules.find(schedule.id))
                     .set((dsl::next_run_at.eq(next), dsl::updated_at.eq(now)))
                     .execute(conn)
@@ -1504,13 +1535,18 @@ async fn tick_one_workflow_schedule(
                     .map_err(crate::error::database_error)?;
                 return Ok(());
             }
-            Some(_adjusted) => {
-                // Firing proceeds (possibly with an adjusted date — the workflow
-                // gets the original `logical_date`; the calendar adjustment only
-                // affects the fire-date check, not the scheduled run ID).
+            Some(adjusted) => {
+                // Firing proceeds. If the adjusted date differs from the original,
+                // rebase logical_date so downstream dispatch uses the correct day.
+                if adjusted != fire_date {
+                    logical_date = rebase_logical_date(logical_date, adjusted);
+                }
             }
         }
-    }
+        (excluded, exclude_weekends, skip_policy)
+    } else {
+        (vec![], false, crate::policy::SkipPolicy::Skip)
+    };
 
     let mut running: i64 = harvest_workflow_executions::table
         .filter(harvest_workflow_executions::workflow_name.eq(wf_name))
@@ -1626,6 +1662,31 @@ async fn tick_one_workflow_schedule(
     // it becomes next_run_at so catchup slots are not silently dropped.
     let mut deferred_next_run_at: Option<DateTime<Utc>> = None;
     for scheduled_for in &run_dates {
+        // Re-apply calendar filtering for each catchup slot.  The pre-loop check
+        // already handled `logical_date` (the first slot); subsequent catchup slots
+        // are independent fire times and must be filtered independently.
+        let effective_scheduled_for = if schedule.calendar_name.is_some() && run_dates.len() > 1 {
+            let slot_date = scheduled_for.date_naive();
+            match crate::calendar::apply_skip_policy(
+                slot_date,
+                calendar_skip_policy,
+                &calendar_excluded,
+                calendar_exclude_weekends,
+            ) {
+                None => {
+                    metrics.record_schedule_skipped("workflow", wf_name, "calendar");
+                    continue;
+                }
+                Some(adjusted) if adjusted != slot_date => {
+                    rebase_logical_date(*scheduled_for, adjusted)
+                }
+                Some(_) => *scheduled_for,
+            }
+        } else {
+            *scheduled_for
+        };
+        let scheduled_for = &effective_scheduled_for;
+
         if running + i64::from(dispatched) >= i64::from(schedule.max_active_runs) {
             deferred_next_run_at = Some(*scheduled_for);
             tracing::info!(
@@ -1762,6 +1823,14 @@ fn schedule_expr(schedule: Option<&Schedule>) -> Option<String> {
         Some(Schedule::Manual) => Some("manual".to_string()),
         None => None,
     }
+}
+
+/// Rebase a `DateTime<Utc>` to a different date while preserving the time-of-day.
+/// Used by the calendar check to shift `logical_date` when a skip policy defers
+/// the fire to a different day.
+fn rebase_logical_date(ts: DateTime<Utc>, date: chrono::NaiveDate) -> DateTime<Utc> {
+    let naive = date.and_time(ts.time());
+    chrono::Utc.from_utc_datetime(&naive)
 }
 
 fn next_run_after(schedule: Option<&Schedule>, reference: DateTime<Utc>) -> Option<DateTime<Utc>> {

--- a/autumn-harvest/src/scheduler.rs
+++ b/autumn-harvest/src/scheduler.rs
@@ -1678,14 +1678,7 @@ async fn tick_one_workflow_schedule(
             if adjusted == slot_date {
                 *original_slot
             } else {
-                let rebased = rebase_logical_date(*original_slot, adjusted, parsed_schedule);
-                // RunPrevBusinessDay can shift backward into the past. Skip such
-                // slots to avoid firing a retroactive run on an excluded day.
-                if rebased < now {
-                    metrics.record_schedule_skipped("workflow", wf_name, "calendar_prev_expired");
-                    continue;
-                }
-                rebased
+                rebase_logical_date(*original_slot, adjusted, parsed_schedule)
             }
         } else {
             *original_slot

--- a/autumn-harvest/src/scheduler.rs
+++ b/autumn-harvest/src/scheduler.rs
@@ -1459,10 +1459,6 @@ async fn tick_one_workflow_schedule(
     use crate::execution::StartWorkflowParams;
     use crate::schema::harvest_schedules::dsl;
 
-    // Calendar adjustment may shift the logical fire date; shadow the parameter
-    // as mutable so the calendar block can rebase it when needed.
-    let mut logical_date = logical_date;
-
     // Compute jitter window once so it can be reused in the dispatch loop below.
     let jitter_window =
         std::time::Duration::from_secs(u64::try_from(schedule.jitter_secs.max(0)).unwrap_or(0));
@@ -1535,12 +1531,12 @@ async fn tick_one_workflow_schedule(
                     .map_err(crate::error::database_error)?;
                 return Ok(());
             }
-            Some(adjusted) => {
-                // Firing proceeds. If the adjusted date differs from the original,
-                // rebase logical_date so downstream dispatch uses the correct day.
-                if adjusted != fire_date {
-                    logical_date = rebase_logical_date(logical_date, adjusted, parsed_schedule);
-                }
+            Some(_adjusted) => {
+                // Firing proceeds on `_adjusted` day. Do NOT rebase `logical_date`
+                // here — `due_run_plan` must start from the original slot so that
+                // catchup planning covers the full overdue window. Per-slot
+                // adjustment happens in the dispatch loop below for every slot
+                // (including this first one) via `effective_scheduled_for`.
             }
         }
         (excluded, exclude_weekends, skip_policy)
@@ -1662,10 +1658,9 @@ async fn tick_one_workflow_schedule(
     // it becomes next_run_at so catchup slots are not silently dropped.
     let mut deferred_next_run_at: Option<DateTime<Utc>> = None;
     for original_slot in &run_dates {
-        // Re-apply calendar filtering for each catchup slot.  The pre-loop check
-        // already handled `logical_date` (the first slot); subsequent catchup slots
-        // are independent fire times and must be filtered independently.
-        let effective_scheduled_for = if schedule.calendar_name.is_some() && run_dates.len() > 1 {
+        // Apply calendar filtering for every slot (including the first one, since
+        // the pre-loop check no longer rebases `logical_date`).
+        let effective_scheduled_for = if schedule.calendar_name.is_some() {
             let slot_date = original_slot.date_naive();
             match crate::calendar::apply_skip_policy(
                 slot_date,

--- a/autumn-harvest/src/scheduler.rs
+++ b/autumn-harvest/src/scheduler.rs
@@ -1484,8 +1484,7 @@ async fn tick_one_workflow_schedule(
             .await
             .unwrap_or_default();
         let fire_date = logical_date.date_naive();
-        let skip_policy =
-            crate::policy::SkipPolicy::from_db(&schedule.skip_policy);
+        let skip_policy = crate::policy::SkipPolicy::from_db(&schedule.skip_policy);
 
         match crate::calendar::apply_skip_policy(fire_date, skip_policy, &excluded) {
             None => {

--- a/autumn-harvest/src/scheduler.rs
+++ b/autumn-harvest/src/scheduler.rs
@@ -1795,11 +1795,14 @@ async fn tick_one_workflow_schedule(
     // original due slot and its `filter(t > now)` guard can spuriously fail when
     // `now` has advanced past the rebased fire time, causing the natural next
     // cron slot to be skipped. Re-anchor from the last original (pre-rebase)
-    // slot to guarantee the correct successor slot.
+    // slot instead, but preserve the non-catchup skip-overdue semantics by
+    // filtering out past successors and falling back to next_run_after_plan
+    // (which already contains the `or_else(next_run_after(now))` fallback).
     let effective_next_run_at = deferred_next_run_at.or_else(|| {
         if schedule.calendar_name.is_some() {
             last_original_slot_dispatched
                 .and_then(|slot| next_run_after(parsed_schedule, slot))
+                .filter(|&t| t > now)
                 .or(next_run_after_plan)
         } else {
             next_run_after_plan

--- a/autumn-harvest/src/scheduler.rs
+++ b/autumn-harvest/src/scheduler.rs
@@ -1539,7 +1539,7 @@ async fn tick_one_workflow_schedule(
                 // Firing proceeds. If the adjusted date differs from the original,
                 // rebase logical_date so downstream dispatch uses the correct day.
                 if adjusted != fire_date {
-                    logical_date = rebase_logical_date(logical_date, adjusted);
+                    logical_date = rebase_logical_date(logical_date, adjusted, parsed_schedule);
                 }
             }
         }
@@ -1661,12 +1661,12 @@ async fn tick_one_workflow_schedule(
     // Set to the first slot we could not dispatch due to max_active_runs or jitter; if Some,
     // it becomes next_run_at so catchup slots are not silently dropped.
     let mut deferred_next_run_at: Option<DateTime<Utc>> = None;
-    for scheduled_for in &run_dates {
+    for original_slot in &run_dates {
         // Re-apply calendar filtering for each catchup slot.  The pre-loop check
         // already handled `logical_date` (the first slot); subsequent catchup slots
         // are independent fire times and must be filtered independently.
         let effective_scheduled_for = if schedule.calendar_name.is_some() && run_dates.len() > 1 {
-            let slot_date = scheduled_for.date_naive();
+            let slot_date = original_slot.date_naive();
             match crate::calendar::apply_skip_policy(
                 slot_date,
                 calendar_skip_policy,
@@ -1678,17 +1678,17 @@ async fn tick_one_workflow_schedule(
                     continue;
                 }
                 Some(adjusted) if adjusted != slot_date => {
-                    rebase_logical_date(*scheduled_for, adjusted)
+                    rebase_logical_date(*original_slot, adjusted, parsed_schedule)
                 }
-                Some(_) => *scheduled_for,
+                Some(_) => *original_slot,
             }
         } else {
-            *scheduled_for
+            *original_slot
         };
         let scheduled_for = &effective_scheduled_for;
 
         if running + i64::from(dispatched) >= i64::from(schedule.max_active_runs) {
-            deferred_next_run_at = Some(*scheduled_for);
+            deferred_next_run_at = Some(*original_slot);
             tracing::info!(
                 workflow_name = %wf_name,
                 max_active_runs = schedule.max_active_runs,
@@ -1709,7 +1709,7 @@ async fn tick_one_workflow_schedule(
         });
         let effective_fire_time = *scheduled_for + chrono_jitter;
         if now < effective_fire_time {
-            deferred_next_run_at = Some(*scheduled_for);
+            deferred_next_run_at = Some(*original_slot);
             tracing::debug!(
                 workflow_name = %wf_name,
                 logical_date = %scheduled_for,
@@ -1718,7 +1718,7 @@ async fn tick_one_workflow_schedule(
             );
             break;
         }
-        let workflow_id = scheduled_workflow_id(wf_name, *scheduled_for);
+        let workflow_id = scheduled_workflow_id(wf_name, *original_slot);
         let exec_id = if schedule.dag_name.is_some() {
             ExecutionId::new_for_shard(current_shard)
         } else {
@@ -1828,7 +1828,25 @@ fn schedule_expr(schedule: Option<&Schedule>) -> Option<String> {
 /// Rebase a `DateTime<Utc>` to a different date while preserving the time-of-day.
 /// Used by the calendar check to shift `logical_date` when a skip policy defers
 /// the fire to a different day.
-fn rebase_logical_date(ts: DateTime<Utc>, date: chrono::NaiveDate) -> DateTime<Utc> {
+fn rebase_logical_date(
+    ts: DateTime<Utc>,
+    date: chrono::NaiveDate,
+    schedule: Option<&Schedule>,
+) -> DateTime<Utc> {
+    // For timezone-aware schedules preserve the wall-clock time in the schedule's
+    // timezone so DST transitions don't shift the effective dispatch hour.
+    if let Some(Schedule::CronInTimezone { tz, .. }) = schedule
+        && let Ok(tz) = tz.parse::<chrono_tz::Tz>()
+    {
+        let local_ts = ts.with_timezone(&tz);
+        if let Some(local_dt) = date
+            .and_time(local_ts.time())
+            .and_local_timezone(tz)
+            .earliest()
+        {
+            return local_dt.with_timezone(&Utc);
+        }
+    }
     let naive = date.and_time(ts.time());
     chrono::Utc.from_utc_datetime(&naive)
 }

--- a/autumn-harvest/src/scheduler.rs
+++ b/autumn-harvest/src/scheduler.rs
@@ -870,6 +870,8 @@ async fn upsert_schedule(
                 dsl::overlap_policy.eq(dag.overlap_policy.as_str()),
                 dsl::buffer_all_max.eq(i32::try_from(dag.buffer_all_max).unwrap_or(i32::MAX)),
                 dsl::buffered_runs.eq(new_buffered_runs),
+                // calendar_name and skip_policy are not set by DAG registration;
+                // they are operator-managed via the CRUD API.
             ))
             .execute(conn)
             .await
@@ -897,6 +899,8 @@ async fn upsert_schedule(
             overlap_policy: dag.overlap_policy.as_str(),
             buffered_runs: serde_json::json!([]),
             buffer_all_max: i32::try_from(dag.buffer_all_max).unwrap_or(i32::MAX),
+            calendar_name: None,
+            skip_policy: crate::policy::SkipPolicy::Skip.as_str(),
         };
         diesel::insert_into(harvest_schedules::table)
             .values(&row)
@@ -996,6 +1000,8 @@ async fn insert_dag_workflow_schedule_if_missing(
         overlap_policy: ws.overlap_policy.as_str(),
         buffered_runs: serde_json::json!([]),
         buffer_all_max: i32::try_from(ws.buffer_all_max).unwrap_or(i32::MAX),
+        calendar_name: ws.calendar.as_deref(),
+        skip_policy: ws.skip_policy.as_str(),
     };
     diesel::insert_into(harvest_schedules::table)
         .values(&row)
@@ -1037,6 +1043,8 @@ async fn insert_workflow_schedule_if_missing(
         overlap_policy: ws.overlap_policy.as_str(),
         buffered_runs: serde_json::json!([]),
         buffer_all_max: i32::try_from(ws.buffer_all_max).unwrap_or(i32::MAX),
+        calendar_name: ws.calendar.as_deref(),
+        skip_policy: ws.skip_policy.as_str(),
     };
     diesel::insert_into(harvest_schedules::table)
         .values(&row)
@@ -1136,6 +1144,8 @@ async fn upsert_workflow_schedule(
             dsl::overlap_policy.eq(ws.overlap_policy.as_str()),
             dsl::buffer_all_max.eq(i32::try_from(ws.buffer_all_max).unwrap_or(i32::MAX)),
             dsl::buffered_runs.eq(new_buffered_runs),
+            dsl::calendar_name.eq(ws.calendar.as_deref()),
+            dsl::skip_policy.eq(ws.skip_policy.as_str()),
         ))
         .execute(conn)
         .await
@@ -1172,6 +1182,15 @@ fn scheduled_workflow_id(workflow_name: &str, scheduled_for: DateTime<Utc>) -> S
 #[must_use]
 pub fn scheduled_workflow_id_pub(workflow_name: &str, scheduled_for: DateTime<Utc>) -> String {
     scheduled_workflow_id(workflow_name, scheduled_for)
+}
+
+/// Public re-export of `next_run_after` for use in [`crate::calendar`] preview helpers.
+#[must_use]
+pub fn next_run_after_pub(
+    schedule: Option<&Schedule>,
+    reference: DateTime<Utc>,
+) -> Option<DateTime<Utc>> {
+    next_run_after(schedule, reference)
 }
 
 const fn scheduled_workflow_reuse_policy() -> WorkflowIdReusePolicy {
@@ -1452,6 +1471,45 @@ async fn tick_one_workflow_schedule(
             logical_date + chrono::Duration::from_std(jitter_offset).unwrap_or_default();
         if now < effective_fire_time {
             return Ok(());
+        }
+    }
+
+    // ── Calendar check ────────────────────────────────────────────────────────
+    // If the schedule has a named calendar, load its exclusion dates and apply
+    // the skip policy to the logical fire date. Suppressed firings (SkipPolicy::Skip)
+    // are recorded as skipped with `reason = "calendar"` and the scheduler advances
+    // past this slot. Deferred firings are allowed through with the adjusted date.
+    if let Some(ref cal_name) = schedule.calendar_name {
+        let excluded = crate::calendar::load_exclusions_for_calendar(conn, cal_name)
+            .await
+            .unwrap_or_default();
+        let fire_date = logical_date.date_naive();
+        let skip_policy =
+            crate::policy::SkipPolicy::from_db(&schedule.skip_policy);
+
+        match crate::calendar::apply_skip_policy(fire_date, skip_policy, &excluded) {
+            None => {
+                // Firing is suppressed. Advance past this slot.
+                tracing::info!(
+                    workflow_name = %wf_name,
+                    calendar = %cal_name,
+                    fire_date = %fire_date,
+                    "harvest: workflow schedule firing suppressed by calendar"
+                );
+                metrics.record_schedule_skipped("workflow", wf_name, "calendar");
+                let next = next_run_after(parsed_schedule, now);
+                diesel::update(dsl::harvest_schedules.find(schedule.id))
+                    .set((dsl::next_run_at.eq(next), dsl::updated_at.eq(now)))
+                    .execute(conn)
+                    .await
+                    .map_err(crate::error::database_error)?;
+                return Ok(());
+            }
+            Some(_adjusted) => {
+                // Firing proceeds (possibly with an adjusted date — the workflow
+                // gets the original `logical_date`; the calendar adjustment only
+                // affects the fire-date check, not the scheduled run ID).
+            }
         }
     }
 

--- a/autumn-harvest/src/schema.rs
+++ b/autumn-harvest/src/schema.rs
@@ -91,6 +91,31 @@ diesel::table! {
 diesel::table! {
     use diesel::sql_types::*;
 
+    harvest_calendars (id) {
+        id -> Uuid,
+        name -> Text,
+        description -> Nullable<Text>,
+        /// `true` for built-in calendars that operators cannot delete.
+        built_in -> Bool,
+        created_at -> Timestamptz,
+        updated_at -> Timestamptz,
+    }
+}
+
+diesel::table! {
+    use diesel::sql_types::*;
+
+    harvest_calendar_exclusions (id) {
+        id -> Uuid,
+        calendar_name -> Text,
+        excluded_date -> Date,
+        created_at -> Timestamptz,
+    }
+}
+
+diesel::table! {
+    use diesel::sql_types::*;
+
     harvest_schedules (id) {
         id -> Uuid,
         dag_name -> Nullable<Text>,
@@ -116,6 +141,10 @@ diesel::table! {
         buffered_runs -> Jsonb,
         /// Maximum buffered slots under `BufferAll` (issue #241).
         buffer_all_max -> Int4,
+        /// Optional named calendar for this schedule (issue #337). NULL = no filtering.
+        calendar_name -> Nullable<Text>,
+        /// What to do when the fire date is calendar-excluded (issue #337).
+        skip_policy -> Text,
     }
 }
 
@@ -301,6 +330,8 @@ diesel::joinable!(harvest_task_queue -> harvest_workflow_executions (workflow_ex
 diesel::joinable!(harvest_signals -> harvest_workflow_executions (workflow_exec_id));
 diesel::joinable!(harvest_timers -> harvest_workflow_executions (workflow_exec_id));
 diesel::joinable!(harvest_external_tasks -> harvest_workflow_executions (workflow_exec_id));
+// harvest_calendar_exclusions references harvest_calendars(name), not the PK(id),
+// so diesel::joinable! cannot be used here. Queries use explicit filter conditions.
 
 diesel::allow_tables_to_appear_in_same_query!(
     harvest_workflow_executions,
@@ -317,4 +348,6 @@ diesel::allow_tables_to_appear_in_same_query!(
     harvest_build_policies,
     harvest_build_compat,
     harvest_backfill_log,
+    harvest_calendars,
+    harvest_calendar_exclusions,
 );

--- a/autumn-harvest/tests/integration_e2e.rs
+++ b/autumn-harvest/tests/integration_e2e.rs
@@ -90,6 +90,8 @@ const INIT_SQL: &str = concat!(
     include_str!("../migrations/20260517000001_harvest_schedule_overlap_policy/up.sql"),
     "\n",
     include_str!("../migrations/20260518000000_harvest_workflow_execution_timeout/up.sql"),
+    "\n",
+    include_str!("../migrations/20260519000000_harvest_calendar_awareness/up.sql"),
 );
 
 /// The minimal "legacy" migration set used by the upgrade-path regression

--- a/docs/api-contract.json
+++ b/docs/api-contract.json
@@ -2617,6 +2617,193 @@
     },
     {
       "method": "GET",
+      "path": "/admin/schedules/{id}/preview",
+      "category": "schedule",
+      "read_only": true,
+      "description": "Preview the next N fire times for a schedule, applying calendar exclusions and skip policy. Does not trigger any executions.",
+      "params": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Schedule UUID."
+        },
+        {
+          "name": "count",
+          "in": "query",
+          "required": false,
+          "description": "Number of fire-time entries to return. Defaults to 10, max 100."
+        }
+      ],
+      "request_body": null,
+      "success_response": {
+        "status": 200,
+        "free_form": false,
+        "fields": [
+          {
+            "name": "entries",
+            "type": "array",
+            "description": "Array of ScheduleFirePreview objects, each with scheduled_at, effective_at (null if suppressed), and reason."
+          }
+        ]
+      },
+      "error_responses": [
+        {
+          "status": 404,
+          "description": "Schedule not found."
+        },
+        {
+          "status": 500,
+          "description": "Database error."
+        }
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/calendars",
+      "category": "calendar",
+      "read_only": true,
+      "description": "List all named calendars (exclusion sets) available for schedule filtering.",
+      "params": [],
+      "request_body": null,
+      "success_response": {
+        "status": 200,
+        "free_form": true
+      },
+      "error_responses": [
+        {
+          "status": 500,
+          "description": "Database error."
+        }
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/calendars/{name}",
+      "category": "calendar",
+      "read_only": true,
+      "description": "Get a named calendar including its exclusion date list.",
+      "params": [
+        {
+          "name": "name",
+          "in": "path",
+          "required": true,
+          "description": "Calendar name."
+        }
+      ],
+      "request_body": null,
+      "success_response": {
+        "status": 200,
+        "free_form": false,
+        "fields": [
+          { "name": "name", "type": "string", "description": "Calendar name." },
+          { "name": "description", "type": "string", "description": "Optional description." },
+          { "name": "exclusion_dates", "type": "array", "description": "List of excluded dates (YYYY-MM-DD)." }
+        ]
+      },
+      "error_responses": [
+        { "status": 404, "description": "Calendar not found." },
+        { "status": 500, "description": "Database error." }
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/calendars",
+      "category": "calendar",
+      "read_only": false,
+      "description": "Create a new named calendar.",
+      "params": [],
+      "request_body": {
+        "required": true,
+        "free_form": false,
+        "fields": [
+          { "name": "name", "type": "string", "required": true, "description": "Unique calendar name." },
+          { "name": "description", "type": "string", "required": false, "description": "Optional description." }
+        ]
+      },
+      "success_response": {
+        "status": 201,
+        "free_form": false,
+        "fields": [
+          { "name": "name", "type": "string", "description": "Calendar name." },
+          { "name": "description", "type": "string", "description": "Optional description." },
+          { "name": "exclusion_dates", "type": "array", "description": "Initially empty." }
+        ]
+      },
+      "error_responses": [
+        { "status": 409, "description": "Calendar name already exists." },
+        { "status": 500, "description": "Database error." }
+      ]
+    },
+    {
+      "method": "PUT",
+      "path": "/calendars/{name}",
+      "category": "calendar",
+      "read_only": false,
+      "description": "Replace the exclusion date list for a calendar.",
+      "params": [
+        {
+          "name": "name",
+          "in": "path",
+          "required": true,
+          "description": "Calendar name."
+        }
+      ],
+      "request_body": {
+        "required": true,
+        "free_form": false,
+        "fields": [
+          {
+            "name": "exclusion_dates",
+            "type": "array",
+            "required": true,
+            "description": "New full list of excluded dates (YYYY-MM-DD strings). Replaces the existing list atomically."
+          }
+        ]
+      },
+      "success_response": {
+        "status": 200,
+        "free_form": false,
+        "fields": [
+          { "name": "name", "type": "string", "description": "Calendar name." },
+          { "name": "description", "type": "string", "description": "Optional description." },
+          { "name": "exclusion_dates", "type": "array", "description": "Updated exclusion dates." }
+        ]
+      },
+      "error_responses": [
+        { "status": 404, "description": "Calendar not found." },
+        { "status": 500, "description": "Database error." }
+      ]
+    },
+    {
+      "method": "DELETE",
+      "path": "/calendars/{name}",
+      "category": "calendar",
+      "read_only": false,
+      "description": "Delete a named calendar. Schedules referencing this calendar will no longer be filtered.",
+      "params": [
+        {
+          "name": "name",
+          "in": "path",
+          "required": true,
+          "description": "Calendar name."
+        }
+      ],
+      "request_body": null,
+      "success_response": {
+        "status": 200,
+        "free_form": false,
+        "fields": [
+          { "name": "ok", "type": "boolean", "description": "true on success." }
+        ]
+      },
+      "error_responses": [
+        { "status": 404, "description": "Calendar not found." },
+        { "status": 500, "description": "Database error." }
+      ]
+    },
+    {
+      "method": "GET",
       "path": "/admin/audit",
       "category": "audit",
       "read_only": true,

--- a/docs/api-contract.json
+++ b/docs/api-contract.json
@@ -753,7 +753,9 @@
       },
       "success_response": {
         "status": 200,
-        "fields": ["result"]
+        "fields": [
+          "result"
+        ]
       },
       "error_responses": [
         {
@@ -2696,14 +2698,47 @@
         "status": 200,
         "free_form": false,
         "fields": [
-          { "name": "name", "type": "string", "description": "Calendar name." },
-          { "name": "description", "type": "string", "description": "Optional description." },
-          { "name": "exclusion_dates", "type": "array", "description": "List of excluded dates (YYYY-MM-DD)." }
+          {
+            "name": "name",
+            "type": "string",
+            "description": "Calendar name."
+          },
+          {
+            "name": "description",
+            "type": "string",
+            "description": "Optional description."
+          },
+          {
+            "name": "built_in",
+            "type": "boolean",
+            "description": "True for built-in calendars that cannot be deleted."
+          },
+          {
+            "name": "created_at",
+            "type": "string",
+            "description": "ISO 8601 creation timestamp."
+          },
+          {
+            "name": "updated_at",
+            "type": "string",
+            "description": "ISO 8601 last-updated timestamp."
+          },
+          {
+            "name": "exclusion_dates",
+            "type": "array",
+            "description": "List of excluded dates (YYYY-MM-DD)."
+          }
         ]
       },
       "error_responses": [
-        { "status": 404, "description": "Calendar not found." },
-        { "status": 500, "description": "Database error." }
+        {
+          "status": 404,
+          "description": "Calendar not found."
+        },
+        {
+          "status": 500,
+          "description": "Database error."
+        }
       ]
     },
     {
@@ -2717,22 +2752,60 @@
         "required": true,
         "free_form": false,
         "fields": [
-          { "name": "name", "type": "string", "required": true, "description": "Unique calendar name." },
-          { "name": "description", "type": "string", "required": false, "description": "Optional description." }
+          {
+            "name": "name",
+            "type": "string",
+            "required": true,
+            "description": "Unique calendar name."
+          },
+          {
+            "name": "description",
+            "type": "string",
+            "required": false,
+            "description": "Optional description."
+          }
         ]
       },
       "success_response": {
         "status": 201,
         "free_form": false,
         "fields": [
-          { "name": "name", "type": "string", "description": "Calendar name." },
-          { "name": "description", "type": "string", "description": "Optional description." },
-          { "name": "exclusion_dates", "type": "array", "description": "Initially empty." }
+          {
+            "name": "name",
+            "type": "string",
+            "description": "Calendar name."
+          },
+          {
+            "name": "description",
+            "type": "string",
+            "description": "Optional description."
+          },
+          {
+            "name": "built_in",
+            "type": "boolean",
+            "description": "Always false for user-created calendars."
+          },
+          {
+            "name": "created_at",
+            "type": "string",
+            "description": "ISO 8601 creation timestamp."
+          },
+          {
+            "name": "updated_at",
+            "type": "string",
+            "description": "ISO 8601 last-updated timestamp."
+          }
         ]
       },
       "error_responses": [
-        { "status": 409, "description": "Calendar name already exists." },
-        { "status": 500, "description": "Database error." }
+        {
+          "status": 409,
+          "description": "Calendar name already exists."
+        },
+        {
+          "status": 500,
+          "description": "Database error."
+        }
       ]
     },
     {
@@ -2766,8 +2839,14 @@
         "free_form": true
       },
       "error_responses": [
-        { "status": 404, "description": "Calendar not found." },
-        { "status": 500, "description": "Database error." }
+        {
+          "status": 404,
+          "description": "Calendar not found."
+        },
+        {
+          "status": 500,
+          "description": "Database error."
+        }
       ]
     },
     {
@@ -2786,15 +2865,18 @@
       ],
       "request_body": null,
       "success_response": {
-        "status": 200,
-        "free_form": false,
-        "fields": [
-          { "name": "ok", "type": "boolean", "description": "true on success." }
-        ]
+        "status": 204,
+        "free_form": true
       },
       "error_responses": [
-        { "status": 404, "description": "Calendar not found." },
-        { "status": 500, "description": "Database error." }
+        {
+          "status": 404,
+          "description": "Calendar not found."
+        },
+        {
+          "status": 500,
+          "description": "Database error."
+        }
       ]
     },
     {

--- a/docs/api-contract.json
+++ b/docs/api-contract.json
@@ -2762,13 +2762,8 @@
         ]
       },
       "success_response": {
-        "status": 200,
-        "free_form": false,
-        "fields": [
-          { "name": "name", "type": "string", "description": "Calendar name." },
-          { "name": "description", "type": "string", "description": "Optional description." },
-          { "name": "exclusion_dates", "type": "array", "description": "Updated exclusion dates." }
-        ]
+        "status": 204,
+        "free_form": true
       },
       "error_responses": [
         { "status": 404, "description": "Calendar not found." },

--- a/docs/calendars.md
+++ b/docs/calendars.md
@@ -1,0 +1,180 @@
+# Calendar-Aware Schedules (issue #337)
+
+Harvest schedules can be attached to a **named calendar** — a set of excluded dates (holidays, maintenance windows, shutdown days) — so that fires landing on excluded dates are handled according to a configurable **skip policy** instead of being silently dispatched or silently skipped with no visibility into why.
+
+---
+
+## Built-in Calendars
+
+Three calendars are seeded by the `20260519000000_harvest_calendar_awareness` migration:
+
+| Name | Description |
+|------|-------------|
+| `weekends-off` | Saturday and Sunday (rolling; no fixed exclusion rows — handled by day-of-week logic built into `apply_skip_policy`) |
+| `us-federal-holidays` | US federal public holidays for 2025–2026 |
+| `nyse` | NYSE market holidays for 2025–2026 |
+
+Built-in calendars (`built_in = true`) cannot be deleted via `DELETE /calendars/{name}`. Operators can extend them by calling `PUT /calendars/{name}` to replace the exclusion set.
+
+---
+
+## Skip Policies
+
+| Value | Behaviour when fire date is excluded |
+|-------|--------------------------------------|
+| `skip` (default) | Drop the firing; record `harvest.schedule.skipped` metric with `reason = "calendar"`. The schedule advances to the next computed fire time. |
+| `run_next_business_day` | Advance to the nearest non-excluded weekday **after** the excluded date (scans forward up to 365 days). |
+| `run_prev_business_day` | Retreat to the nearest non-excluded weekday **before** the excluded date (scans backward up to 365 days). |
+
+---
+
+## Attaching a Calendar to a Schedule
+
+### Via the management API
+
+```http
+POST /api/harvest/admin/schedules/workflow
+Content-Type: application/json
+
+{
+  "workflow_name": "generate_payroll",
+  "schedule_expr": "cron:0 9 * * 1",
+  "timezone": "America/New_York",
+  "calendar": "us-federal-holidays",
+  "skip_policy": "run_next_business_day"
+}
+```
+
+When `calendar` is `null` (the default) no filtering is applied and all fires dispatch as usual.
+
+### Via `WorkflowSchedule` builder
+
+```rust
+use autumn_harvest::prelude::*;
+
+let schedule = WorkflowSchedule::new("generate_payroll", Schedule::Cron("0 9 * * 1".into()))
+    .with_timezone("America/New_York")
+    .with_calendar(Some("us-federal-holidays".into()))
+    .with_skip_policy(SkipPolicy::RunNextBusinessDay);
+```
+
+---
+
+## Calendar CRUD API
+
+### List calendars
+
+```http
+GET /api/harvest/calendars
+```
+
+Response: array of `{ name, description, built_in, created_at, updated_at }`.
+
+### Get calendar with exclusions
+
+```http
+GET /api/harvest/calendars/{name}
+```
+
+Response: `{ name, description, built_in, created_at, updated_at, exclusion_dates: ["YYYY-MM-DD", ...] }`.
+
+### Create a custom calendar
+
+```http
+POST /api/harvest/calendars          (admin required)
+Content-Type: application/json
+
+{ "name": "plant-shutdown", "description": "Annual factory downtime" }
+```
+
+Response: `201 Created` with the calendar object.
+
+### Replace exclusion dates
+
+```http
+PUT /api/harvest/calendars/{name}    (admin required)
+Content-Type: application/json
+
+{
+  "exclusion_dates": ["2026-12-24", "2026-12-25", "2026-12-26"]
+}
+```
+
+Response: `204 No Content`. The call **replaces** the full set; omitting a date removes it.
+
+### Delete a calendar
+
+```http
+DELETE /api/harvest/calendars/{name}  (admin required)
+```
+
+Returns `204 No Content`. Fails with `409 Conflict` if the calendar is `built_in`.
+
+---
+
+## Schedule Fire Preview
+
+Preview the next N effective fire times for any schedule, respecting its calendar and skip policy:
+
+```http
+GET /api/harvest/admin/schedules/{id}/preview?count=10
+```
+
+Response:
+
+```json
+{
+  "entries": [
+    { "scheduled_at": "2026-01-05T09:00:00Z", "effective_at": "2026-01-05T09:00:00Z", "reason": "on schedule" },
+    { "scheduled_at": "2026-01-19T09:00:00Z", "effective_at": null,                    "reason": "excluded by calendar (skip)" },
+    { "scheduled_at": "2026-01-26T09:00:00Z", "effective_at": "2026-01-26T09:00:00Z", "reason": "on schedule" }
+  ]
+}
+```
+
+`effective_at: null` means the fire is suppressed (`skip` policy). `effective_at` differs from `scheduled_at` when the date was shifted by a `run_next_business_day` / `run_prev_business_day` policy.
+
+---
+
+## Programmatic Helpers
+
+Pure functions are available without the `db` feature:
+
+```rust
+use autumn_harvest::calendar::{is_excluded_date, apply_skip_policy};
+use autumn_harvest::policy::SkipPolicy;
+use chrono::NaiveDate;
+
+let excluded = vec![
+    NaiveDate::from_ymd_opt(2026, 1, 19).unwrap(), // MLK Day
+];
+
+let fire_date = NaiveDate::from_ymd_opt(2026, 1, 19).unwrap();
+
+// Returns None → skip
+assert!(apply_skip_policy(fire_date, SkipPolicy::Skip, &excluded).is_none());
+
+// Returns Some(2026-01-20) → Tuesday after the holiday
+let next = apply_skip_policy(fire_date, SkipPolicy::RunNextBusinessDay, &excluded);
+assert_eq!(next, NaiveDate::from_ymd_opt(2026, 1, 20));
+```
+
+---
+
+## Observability
+
+When a firing is suppressed by the calendar, the scheduler emits:
+
+```
+harvest.schedule.skipped{workflow="generate_payroll", queue="default", reason="calendar"}
+```
+
+This is separate from `reason="overlap"` skips (overlap policy) so dashboards can distinguish holiday-driven suppression from concurrency-driven suppression.
+
+---
+
+## Notes
+
+- Calendar filtering happens **after** jitter is applied and **before** overlap policy evaluation. The effective fire time shown in the preview already includes jitter.
+- `weekends-off` is enforced by `apply_skip_policy` checking `weekday()` on the candidate date directly; Saturday and Sunday are never "business days" regardless of what exclusion rows say.
+- If a calendar is deleted while schedules still reference it, those schedules degrade gracefully to no filtering (the calendar lookup returns an empty exclusion set).


### PR DESCRIPTION
## Summary

Introduces calendar-aware scheduling to Harvest, allowing schedules to reference named calendars (sets of excluded dates like holidays) and apply configurable skip policies when fire dates fall on excluded days. This enables business-day-aware job scheduling with visibility into why firings are suppressed or deferred.

## Key Changes

### Core Calendar Module (`autumn-harvest/src/calendar.rs`)
- **Pure helpers** (no DB required):
  - `is_excluded_date()` — O(n) membership check for a date in an exclusion set
  - `apply_skip_policy()` — adjusts or suppresses a fire date based on `SkipPolicy` (Skip, RunNextBusinessDay, RunPrevBusinessDay); scans up to 365 days in either direction
  
- **DB-dependent helpers** (require `db` feature):
  - `preview_schedule_firings()` — generates preview of next N fire times with calendar + skip policy applied
  - `plan_backfill_with_calendar()` — calendar-aware variant of `plan_backfill_timestamps`
  - Calendar CRUD: `list_calendars()`, `get_calendar()`, `create_calendar()`, `replace_calendar_exclusions()`, `delete_calendar()`, `load_exclusions_for_calendar()`
  - Built-in calendar data: `US_FEDERAL_HOLIDAYS_2025_2026`, `NYSE_HOLIDAYS_2025_2026`

### Policy & Models
- **`SkipPolicy` enum** (`autumn-harvest/src/policy.rs`):
  - `Skip` (default) — suppress firing entirely
  - `RunNextBusinessDay` — defer to first subsequent non-excluded day
  - `RunPrevBusinessDay` — advance to most recent preceding non-excluded day
  - Includes `from_db()` (lenient fallback to Skip) and `from_user_input()` (strict validation)

- **`WorkflowSchedule` extensions** (`autumn-harvest/src/policy.rs`):
  - New fields: `calendar: Option<String>`, `skip_policy: SkipPolicy`
  - Builder methods: `with_calendar()`, `with_skip_policy()`

- **Database models** (`autumn-harvest/src/models.rs`):
  - `HarvestCalendar` — queryable row from `harvest_calendars` table
  - `NewHarvestCalendar` — insert struct for creating calendars
  - `HarvestCalendarExclusion` — queryable row from `harvest_calendar_exclusions` table
  - `NewHarvestCalendarExclusion` — insert struct for exclusion dates

### Database Schema
- **Migration** (`20260519000000_harvest_calendar_awareness`):
  - `harvest_calendars` table: `id`, `name` (unique), `description`, `built_in`, `created_at`, `updated_at`
  - `harvest_calendar_exclusions` table: `id`, `calendar_name` (FK), `excluded_date`, `created_at`; unique constraint on `(calendar_name, excluded_date)`
  - Adds `calendar_name` (nullable FK) and `skip_policy` (default 'skip') columns to `harvest_schedules`
  - Seeds three built-in calendars: `weekends-off`, `us-federal-holidays`, `nyse`

### Management API (`autumn-harvest-plugin/src/api.rs`)
- **Calendar CRUD endpoints**:
  - `GET /calendars` — list all calendars
  - `GET /calendars/{name}` — get calendar with exclusion dates
  - `POST /calendars` (admin) — create custom calendar
  - `PUT /calendars/{name}` (admin) — replace exclusion dates (PUT semantics)
  - `DELETE /calendars/{name}` (admin) — delete custom calendar (fails for built-in)

- **Schedule preview endpoint**:
  - `GET /admin/schedules/{id}/preview?count=N` — preview next N fire times with calendar + skip policy applied; returns `scheduled_at`, `effective_at`, and human-readable `reason`

- **Schedule

https://claude.ai/code/session_01UxffvALvPSGmHEL2uCB84J