### PR TITLE
Add SSE execution event stream endpoint (issue #324)

### DIFF
--- a/autumn-harvest-cli/src/lib.rs
+++ b/autumn-harvest-cli/src/lib.rs
@@ -1173,10 +1173,11 @@ pub async fn run_cli(cli: Cli) -> Result<(), CliError> {
 
     // SSE streaming: bypasses JSON execute path.
     if let Commands::Events {
-        command: EventsCommand::Tail {
-            execution_id,
-            last_event_id,
-        },
+        command:
+            EventsCommand::Tail {
+                execution_id,
+                last_event_id,
+            },
     } = &cli.command
     {
         return run_events_tail(&cli, execution_id, *last_event_id).await;
@@ -1353,9 +1354,7 @@ async fn run_events_tail(
             };
             let line_bytes = &buf[..nl];
             // Strip trailing CR for CRLF line endings.
-            let line_bytes = line_bytes
-                .strip_suffix(b"\r")
-                .unwrap_or(line_bytes);
+            let line_bytes = line_bytes.strip_suffix(b"\r").unwrap_or(line_bytes);
             let line = String::from_utf8_lossy(line_bytes).into_owned();
             buf.drain(..=nl);
 

--- a/autumn-harvest-cli/src/lib.rs
+++ b/autumn-harvest-cli/src/lib.rs
@@ -269,6 +269,13 @@ pub enum CliError {
         /// Last observed lifecycle status.
         last_status: String,
     },
+
+    /// The SSE event stream closed abnormally (e.g. slow consumer).
+    #[error("SSE stream closed by server: {message}")]
+    SseStreamError {
+        /// Server-supplied error detail.
+        message: String,
+    },
 }
 
 impl CliError {
@@ -1369,6 +1376,11 @@ async fn run_events_tail(
                     println!("{display_type}: {ev_data}");
                     if ev_type == "stream-end" {
                         return Ok(());
+                    }
+                    if ev_type == "stream-error" {
+                        return Err(CliError::SseStreamError {
+                            message: ev_data.clone(),
+                        });
                     }
                 }
                 ev_id.clear();

--- a/autumn-harvest-cli/src/lib.rs
+++ b/autumn-harvest-cli/src/lib.rs
@@ -1357,7 +1357,7 @@ async fn run_events_tail(
                 .strip_suffix(b"\r")
                 .unwrap_or(line_bytes);
             let line = String::from_utf8_lossy(line_bytes).into_owned();
-            buf.drain(..nl + 1);
+            buf.drain(..=nl);
 
             if line.is_empty() {
                 // Empty line = dispatch event block.

--- a/autumn-harvest-cli/src/lib.rs
+++ b/autumn-harvest-cli/src/lib.rs
@@ -405,6 +405,12 @@ enum Commands {
         #[command(subcommand)]
         command: WorkerCommand,
     },
+    /// Stream live workflow execution events.
+    #[command(alias = "event")]
+    Events {
+        #[command(subcommand)]
+        command: EventsCommand,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -1050,6 +1056,24 @@ enum WorkerCommand {
     Health,
 }
 
+/// Subcommands for `harvest events`.
+#[derive(Debug, Subcommand)]
+enum EventsCommand {
+    /// Open the SSE stream for a workflow execution and print events to stdout.
+    ///
+    /// Each SSE event block is printed as `<event-type>: <json-data>`.
+    /// The stream terminates when the execution reaches a terminal state
+    /// (`event: stream-end`) or when the connection is closed.
+    Tail {
+        /// Workflow execution ID to watch.
+        execution_id: String,
+        /// Resume from this event row ID (Last-Event-ID header).
+        /// Events with id > this value are replayed before entering live-tail mode.
+        #[arg(long)]
+        last_event_id: Option<i64>,
+    },
+}
+
 impl Cli {
     /// Build the management API request represented by these CLI arguments.
     ///
@@ -1103,6 +1127,7 @@ impl Cli {
                 *shard_id,
             )),
             Commands::Tui => unreachable!("Tui command handles its own requests"),
+            Commands::Events { .. } => unreachable!("Events command handles its own requests"),
         }
     }
 }
@@ -1144,6 +1169,17 @@ pub mod tui;
 pub async fn run_cli(cli: Cli) -> Result<(), CliError> {
     if matches!(cli.command, Commands::Tui) {
         return tui::run_tui(&cli).await;
+    }
+
+    // SSE streaming: bypasses JSON execute path.
+    if let Commands::Events {
+        command: EventsCommand::Tail {
+            execution_id,
+            last_event_id,
+        },
+    } = &cli.command
+    {
+        return run_events_tail(&cli, execution_id, *last_event_id).await;
     }
 
     // --wait mode: issue drain then poll until Stopped or timeout.
@@ -1256,6 +1292,103 @@ pub async fn execute(cli: &Cli) -> Result<Value, CliError> {
     }
 
     serde_json::from_str(&body).map_err(CliError::ParseResponse)
+}
+
+/// Open the SSE stream for `execution_id` and print events to stdout.
+///
+/// Each complete SSE event block is printed as `<event-type>: <data>`.
+/// The function returns when the server sends `event: stream-end` or the
+/// connection closes. SSE comment lines (keepalives) are silently discarded.
+async fn run_events_tail(
+    cli: &Cli,
+    execution_id: &str,
+    last_event_id: Option<i64>,
+) -> Result<(), CliError> {
+    let path = format!("/executions/{}", path_segment(execution_id));
+    let url = format!(
+        "{}{}/events/stream",
+        cli.base_url.trim_end_matches('/'),
+        path
+    );
+
+    let client = reqwest::Client::new();
+    let mut builder = client
+        .get(&url)
+        .header("Accept", "text/event-stream")
+        .header("Cache-Control", "no-cache");
+
+    if let Some(token) = &cli.token {
+        builder = builder.bearer_auth(token);
+    }
+    if let Some(id) = last_event_id {
+        builder = builder.header("Last-Event-ID", id.to_string());
+    }
+
+    let response = builder.send().await?;
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await?;
+        return Err(CliError::Http { status, body });
+    }
+
+    let mut response = response;
+    let mut buf: Vec<u8> = Vec::new();
+    // SSE fields for the current event block.
+    let mut ev_id = String::new();
+    let mut ev_type = String::new();
+    let mut ev_data = String::new();
+
+    loop {
+        let chunk = response.chunk().await?;
+        let Some(bytes) = chunk else {
+            // Server closed the connection.
+            break;
+        };
+        buf.extend_from_slice(&bytes);
+
+        // Process complete lines from buf.
+        loop {
+            let Some(nl) = buf.iter().position(|&b| b == b'\n') else {
+                break;
+            };
+            let line_bytes = &buf[..nl];
+            // Strip trailing CR for CRLF line endings.
+            let line_bytes = line_bytes
+                .strip_suffix(b"\r")
+                .unwrap_or(line_bytes);
+            let line = String::from_utf8_lossy(line_bytes).into_owned();
+            buf.drain(..nl + 1);
+
+            if line.is_empty() {
+                // Empty line = dispatch event block.
+                if !ev_data.is_empty() || !ev_type.is_empty() {
+                    let display_type = if ev_type.is_empty() {
+                        "message"
+                    } else {
+                        &ev_type
+                    };
+                    println!("{display_type}: {ev_data}");
+                    if ev_type == "stream-end" {
+                        return Ok(());
+                    }
+                }
+                ev_id.clear();
+                ev_type.clear();
+                ev_data.clear();
+            } else if line.starts_with(':') {
+                // SSE comment (keepalive ping) — discard silently.
+            } else if let Some(value) = line.strip_prefix("id: ") {
+                ev_id = value.to_string();
+                let _ = &ev_id; // suppress unused warning; stored for protocol correctness
+            } else if let Some(value) = line.strip_prefix("event: ") {
+                ev_type = value.to_string();
+            } else if let Some(value) = line.strip_prefix("data: ") {
+                ev_data = value.to_string();
+            }
+        }
+    }
+
+    Ok(())
 }
 
 /// Issue drain then poll `GET /workers/{id}` until status reaches `Stopped`

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -1609,7 +1609,7 @@ pub fn harvest_api_router(api_state: HarvestApiState) -> Router<AppState> {
         // Gated behind the same mgmt auth provider as other management routes.
         .route(
             "/executions/{exec_id}/events/stream",
-            get(stream_execution_events).route_layer(require_admin.clone()),
+            get(stream_execution_events).route_layer(require_admin),
         )
         .layer(Extension(api_state))
 }
@@ -8858,6 +8858,7 @@ fn terminal_event_type_to_state(event_type: &str) -> &'static str {
 ///
 /// Backpressure: if the client reconnects with a `Last-Event-ID` that implies
 /// more than `sse_buffer_depth` events to replay, returns `409 Conflict`.
+#[allow(clippy::too_many_lines)]
 async fn stream_execution_events(
     Extension(api_state): Extension<HarvestApiState>,
     Path(exec_id_raw): Path<String>,
@@ -8881,12 +8882,28 @@ async fn stream_execution_events(
         return AutumnError::unauthorized_msg("authentication required").into_response();
     }
 
-    // Extract Last-Event-ID for resume (harvest_events.id BIGSERIAL cursor)
-    let last_row_id: i64 = headers
+    // Extract Last-Event-ID for resume (harvest_events.id BIGSERIAL cursor).
+    // An absent header means "start from the beginning" (cursor = -1).
+    // A present but non-parseable value is a client error → 400.
+    let last_row_id: i64 = match headers
         .get("last-event-id")
         .and_then(|v| v.to_str().ok())
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(-1);
+    {
+        None => -1,
+        Some(s) => match s.parse::<i64>() {
+            Ok(n) => n,
+            Err(_) => {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(serde_json::json!({
+                        "error": "invalid_last_event_id",
+                        "message": "Last-Event-ID must be a valid i64"
+                    })),
+                )
+                    .into_response();
+            }
+        },
+    };
 
     // Resolve the LISTEN/NOTIFY database URL for this execution's shard
     let shard = exec_id.shard();
@@ -8914,16 +8931,25 @@ async fn stream_execution_events(
         Err(e) => return map_error(e).into_response(),
     };
 
-    // Load events after last_row_id (backfill for reconnecting clients)
-    let backfill = match store::load_events_after_row_id(&mut conn, exec_id, last_row_id).await {
+    // Load backfill events, capped at buffer_depth + 1. Fetching one extra lets
+    // us distinguish "exactly buffer_depth events" from "client is too far behind"
+    // without loading an unbounded history into memory.
+    let buffer_depth = api_state.sse_buffer_depth();
+    let backfill = match store::load_events_after_row_id(
+        &mut conn,
+        exec_id,
+        last_row_id,
+        i64::try_from(buffer_depth + 1).ok(),
+    )
+    .await
+    {
         Ok(rows) => rows,
         Err(e) => return map_error(e).into_response(),
     };
 
     // Slow-consumer check: if reconnecting client is too far behind, return 409
-    let buffer_depth = api_state.sse_buffer_depth();
     if backfill.len() > buffer_depth {
-        let drop_id = backfill.last().map(|r| r.id).unwrap_or(last_row_id);
+        let drop_id = backfill.last().map_or(last_row_id, |r| r.id);
         return (
             StatusCode::CONFLICT,
             Json(serde_json::json!({
@@ -8938,21 +8964,22 @@ async fn stream_execution_events(
     let execution_state = execution.state.to_lowercase().replace('_', "-");
 
     // Audit stream open (issue #158: only stream open/close are audited, not per-event)
+    // Capture audit context now so the producer task can write stream-close on exit.
+    let (audit_actor, audit_source, audit_request_id) = audit_context(&headers, &api_state);
     {
-        let (actor, source, request_id) = audit_context(&headers, &api_state);
         let target = exec_id.to_string();
         let ar = NewAuditRecord {
-            actor: &actor,
+            actor: &audit_actor,
             operation: OP_EXECUTION_STREAM_OPEN,
             target_type: TARGET_WORKFLOW,
             target_id: Some(target.as_str()),
             route_or_command: "GET /executions/{exec_id}/events/stream",
-            request_id: request_id.as_deref(),
+            request_id: audit_request_id.as_deref(),
             idempotency_key: None,
             status: STATUS_SUCCEEDED,
             error_summary: None,
             shard_id: Some(shard.as_i32()),
-            source: &source,
+            source: &audit_source,
         };
         let _ = audit::insert_audit(&mut conn, &ar).await;
     }
@@ -8970,15 +8997,70 @@ async fn stream_execution_events(
 
     // Producer task: runs independently of the HTTP handler after we return
     tokio::spawn(async move {
+        use autumn_harvest::audit::OP_EXECUTION_STREAM_CLOSE;
+
+        // Helper: extract the inner payload from the adjacently-tagged envelope
+        // `{"type":"...","data":{...}}` — the `event:` field already carries the
+        // type, so `data:` should contain only the payload object.
+        let sse_data = |event_data: &serde_json::Value| -> String {
+            let inner = event_data.get("data").unwrap_or(event_data);
+            serde_json::to_string(inner).unwrap_or_default()
+        };
+
+        // Helper: flush a slice of DB rows into the SSE channel.
+        // Returns the last `row.id` seen and the first terminal state name found,
+        // or breaks early if the channel is full / dropped.
+        // Using a macro-style closure here because closures can't easily `break 'notify`.
+        // We use a boolean return: (last_id, terminal_state, should_break).
+        let send_rows = |rows: &[autumn_harvest::models::HarvestEvent],
+                         mut cur_last_seen: i64,
+                         tx: &mut futures::channel::mpsc::Sender<
+            Result<Event, std::convert::Infallible>,
+        >|
+         -> (i64, Option<&'static str>, bool) {
+            let mut found_terminal: Option<&'static str> = None;
+            for row in rows {
+                let sse_event = Event::default()
+                    .id(row.id.to_string())
+                    .event(row.event_type.as_str())
+                    .data(sse_data(&row.event_data));
+                if tx.try_send(Ok(sse_event)).is_err() {
+                    return (cur_last_seen, None, true);
+                }
+                cur_last_seen = row.id;
+                if is_terminal_event_type(&row.event_type) {
+                    found_terminal = Some(terminal_event_type_to_state(&row.event_type));
+                }
+            }
+            (cur_last_seen, found_terminal, false)
+        };
+
         // ── 1. Send backfill events (events already committed before this request) ──
         for row in &backfill {
-            let data = serde_json::to_string(&row.event_data).unwrap_or_default();
             let sse_event = Event::default()
                 .id(row.id.to_string())
                 .event(row.event_type.as_str())
-                .data(data);
+                .data(sse_data(&row.event_data));
             if tx.send(Ok(sse_event)).await.is_err() {
-                return; // Client disconnected
+                // Client disconnected during backfill — skip straight to close audit
+                if let Ok(mut conn) = db_conn_for_execution(&api_clone, exec_id).await {
+                    let target = exec_id.to_string();
+                    let ar = NewAuditRecord {
+                        actor: &audit_actor,
+                        operation: OP_EXECUTION_STREAM_CLOSE,
+                        target_type: TARGET_WORKFLOW,
+                        target_id: Some(target.as_str()),
+                        route_or_command: "GET /executions/{exec_id}/events/stream",
+                        request_id: audit_request_id.as_deref(),
+                        idempotency_key: None,
+                        status: STATUS_SUCCEEDED,
+                        error_summary: None,
+                        shard_id: Some(shard.as_i32()),
+                        source: &audit_source,
+                    };
+                    let _ = audit::insert_audit(&mut conn, &ar).await;
+                }
+                return;
             }
         }
 
@@ -8988,102 +9070,175 @@ async fn stream_execution_events(
             let _ = tx
                 .send(Ok(Event::default().event("stream-end").data(end_data)))
                 .await;
-            return;
+        } else {
+            // ── 3. Live-tail: LISTEN/NOTIFY loop ─────────────────────────────
+            let mut last_seen_id = backfill.last().map_or(last_row_id, |r| r.id);
+            let mut listener = listener;
+            let buf_limit = i64::try_from(api_clone.sse_buffer_depth()).ok();
+
+            'notify: loop {
+                // Use 2× keepalive as notification timeout so the KeepAlive wrapper
+                // has time to send its ping before this loop wakes and re-checks
+                let wait_timeout = keepalive_interval.saturating_mul(2);
+                match listener
+                    .wait_for_notification_timeout(wait_timeout)
+                    .await
+                {
+                    Ok(WorkflowEventWaitOutcome::Notification(payload)) => {
+                        // The harvest_events channel notifies for ALL executions on
+                        // this shard; filter to ours
+                        if payload.workflow_exec_id != exec_id.as_uuid() {
+                            continue;
+                        }
+
+                        // Load new events from the pool — capped to buffer_depth so
+                        // rapid bursts between notifications stay bounded in memory.
+                        let new_rows =
+                            match db_conn_for_execution(&api_clone, exec_id).await {
+                                Ok(mut conn) => {
+                                    match store::load_events_after_row_id(
+                                        &mut conn,
+                                        exec_id,
+                                        last_seen_id,
+                                        buf_limit,
+                                    )
+                                    .await
+                                    {
+                                        Ok(rows) => rows,
+                                        // DB failure: skip this notification batch.
+                                        // The periodic TimedOut poll will catch missed
+                                        // events if no further notifications arrive.
+                                        Err(_) => continue,
+                                    }
+                                }
+                                Err(_) => continue,
+                            };
+
+                        let (new_id, terminal_state, should_break) =
+                            send_rows(&new_rows, last_seen_id, &mut tx);
+                        last_seen_id = new_id;
+
+                        if should_break {
+                            let err_data = serde_json::json!({
+                                "error": "slow_consumer",
+                                "drop_after_event_id": last_seen_id,
+                            })
+                            .to_string();
+                            let _ = tx.try_send(Ok(Event::default()
+                                .event("stream-error")
+                                .data(err_data)));
+                            break 'notify;
+                        }
+
+                        if let Some(state) = terminal_state {
+                            let end_data =
+                                serde_json::json!({"reason": state}).to_string();
+                            let _ = tx
+                                .send(Ok(
+                                    Event::default().event("stream-end").data(end_data)
+                                ))
+                                .await;
+                            break 'notify;
+                        }
+                    }
+                    Ok(WorkflowEventWaitOutcome::TimedOut) => {
+                        // Check whether the client has disconnected while idle
+                        // (send/try_send only detect disconnect on a write attempt).
+                        if tx.is_closed() {
+                            break 'notify;
+                        }
+                        // Periodic safety-net poll: catch any events missed due to a
+                        // prior DB failure on a notification (e.g. terminal event).
+                        let Ok(mut conn) =
+                            db_conn_for_execution(&api_clone, exec_id).await
+                        else {
+                            continue 'notify;
+                        };
+                        let Ok(missed) = store::load_events_after_row_id(
+                            &mut conn,
+                            exec_id,
+                            last_seen_id,
+                            buf_limit,
+                        )
+                        .await
+                        else {
+                            continue 'notify;
+                        };
+                        let (new_id, terminal_state, should_break) =
+                            send_rows(&missed, last_seen_id, &mut tx);
+                        last_seen_id = new_id;
+                        if should_break {
+                            break 'notify;
+                        }
+                        if let Some(state) = terminal_state {
+                            let end_data = serde_json::json!({"reason": state}).to_string();
+                            let _ = tx
+                                .send(Ok(Event::default().event("stream-end").data(end_data)))
+                                .await;
+                            break 'notify;
+                        }
+                    }
+                    Ok(WorkflowEventWaitOutcome::ChannelClosed) => {
+                        // LISTEN connection dropped; reconnect and backfill any events
+                        // that may have been committed while the connection was down.
+                        let Ok(l) = WorkflowEventListener::connect(&notification_url).await
+                        else {
+                            break 'notify;
+                        };
+                        listener = l;
+                        // Backfill events missed during reconnection window
+                        let Ok(mut conn) =
+                            db_conn_for_execution(&api_clone, exec_id).await
+                        else {
+                            continue 'notify;
+                        };
+                        let Ok(missed) = store::load_events_after_row_id(
+                            &mut conn,
+                            exec_id,
+                            last_seen_id,
+                            buf_limit,
+                        )
+                        .await
+                        else {
+                            continue 'notify;
+                        };
+                        let (new_id, terminal_state, should_break) =
+                            send_rows(&missed, last_seen_id, &mut tx);
+                        last_seen_id = new_id;
+                        if should_break {
+                            break 'notify;
+                        }
+                        if let Some(state) = terminal_state {
+                            let end_data =
+                                serde_json::json!({"reason": state}).to_string();
+                            let _ = tx
+                                .send(Ok(Event::default().event("stream-end").data(end_data)))
+                                .await;
+                            break 'notify;
+                        }
+                    }
+                    Err(_) => break 'notify,
+                }
+            }
         }
 
-        // ── 3. Live-tail: LISTEN/NOTIFY loop ──────────────────────────────────
-        let mut last_seen_id = backfill.last().map(|r| r.id).unwrap_or(last_row_id);
-        let mut listener = listener;
-
-        loop {
-            // Use 2× keepalive as notification timeout so the KeepAlive wrapper
-            // has time to send its ping before this loop wakes and re-checks
-            let wait_timeout = keepalive_interval.saturating_mul(2);
-            match listener
-                .wait_for_notification_timeout(wait_timeout)
-                .await
-            {
-                Ok(WorkflowEventWaitOutcome::Notification(payload)) => {
-                    // The harvest_events channel notifies for ALL executions on this
-                    // shard; filter to ours
-                    if payload.workflow_exec_id != exec_id.as_uuid() {
-                        continue;
-                    }
-
-                    // Load new events from the pool — do not hold conn while waiting
-                    let new_rows =
-                        match db_conn_for_execution(&api_clone, exec_id).await {
-                            Ok(mut conn) => {
-                                match store::load_events_after_row_id(
-                                    &mut conn,
-                                    exec_id,
-                                    last_seen_id,
-                                )
-                                .await
-                                {
-                                    Ok(rows) => rows,
-                                    Err(_) => continue,
-                                }
-                            }
-                            Err(_) => continue,
-                        };
-
-                    let mut found_terminal_type: Option<&'static str> = None;
-
-                    for row in &new_rows {
-                        let data = serde_json::to_string(&row.event_data).unwrap_or_default();
-                        let sse_event = Event::default()
-                            .id(row.id.to_string())
-                            .event(row.event_type.as_str())
-                            .data(data);
-
-                        // Detect slow consumer during live-tail
-                        match tx.try_send(Ok(sse_event)) {
-                            Ok(()) => {}
-                            Err(_) => {
-                                // Buffer full or receiver dropped — close stream
-                                let err_data = serde_json::json!({
-                                    "error": "slow_consumer",
-                                    "drop_after_event_id": last_seen_id,
-                                })
-                                .to_string();
-                                let _ = tx.try_send(Ok(Event::default()
-                                    .event("stream-error")
-                                    .data(err_data)));
-                                return;
-                            }
-                        }
-
-                        last_seen_id = row.id;
-
-                        if is_terminal_event_type(&row.event_type) {
-                            found_terminal_type =
-                                Some(terminal_event_type_to_state(&row.event_type));
-                        }
-                    }
-
-                    if let Some(state) = found_terminal_type {
-                        let end_data =
-                            serde_json::json!({"reason": state}).to_string();
-                        let _ = tx
-                            .send(Ok(Event::default().event("stream-end").data(end_data)))
-                            .await;
-                        return;
-                    }
-                }
-                Ok(WorkflowEventWaitOutcome::TimedOut) => {
-                    // No activity within the timeout window; keepalive pings are
-                    // sent automatically by Sse::keep_alive — nothing to do here
-                }
-                Ok(WorkflowEventWaitOutcome::ChannelClosed) => {
-                    // LISTEN connection dropped; reconnect and continue
-                    match WorkflowEventListener::connect(&notification_url).await {
-                        Ok(l) => listener = l,
-                        Err(_) => return,
-                    }
-                }
-                Err(_) => return,
-            }
+        // Audit stream close (issue #158) — fires on every producer exit path
+        if let Ok(mut conn) = db_conn_for_execution(&api_clone, exec_id).await {
+            let target = exec_id.to_string();
+            let ar = NewAuditRecord {
+                actor: &audit_actor,
+                operation: OP_EXECUTION_STREAM_CLOSE,
+                target_type: TARGET_WORKFLOW,
+                target_id: Some(target.as_str()),
+                route_or_command: "GET /executions/{exec_id}/events/stream",
+                request_id: audit_request_id.as_deref(),
+                idempotency_key: None,
+                status: STATUS_SUCCEEDED,
+                error_summary: None,
+                shard_id: Some(shard.as_i32()),
+                source: &audit_source,
+            };
+            let _ = audit::insert_audit(&mut conn, &ar).await;
         }
     });
 

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -363,8 +363,12 @@ impl HarvestApiState {
     ///
     /// # Panics
     ///
-    /// Panics if the internal mutex is poisoned.
+    /// Panics if `interval` is zero or if the internal mutex is poisoned.
     pub fn set_sse_keepalive_interval(&self, interval: std::time::Duration) {
+        assert!(
+            !interval.is_zero(),
+            "SSE keepalive interval must be non-zero"
+        );
         *self
             .sse_keepalive_interval
             .lock()
@@ -637,17 +641,13 @@ impl HarvestApiState {
     }
 
     /// Return the LISTEN/NOTIFY database URL for the given shard (issue #324).
-    ///
-    /// Falls back to the first configured URL for single-shard deployments.
     pub(crate) fn sse_notification_url(&self, shard: ShardId) -> HarvestResult<String> {
         let urls = self.workflow_result_notification_database_urls()?;
-        if let Some(url) = urls.get(&shard) {
-            return Ok(url.clone());
-        }
-        // Single-shard fallback: use the first available URL
-        urls.into_values()
-            .next()
-            .ok_or_else(|| HarvestError::Config("no SSE notification URL configured".to_string()))
+        urls.get(&shard).cloned().ok_or_else(|| {
+            HarvestError::Config(format!(
+                "no SSE notification URL configured for shard {shard:?}"
+            ))
+        })
     }
 
     fn workflow_handle_client(&self) -> HarvestResult<WorkflowHandleClient> {
@@ -9032,6 +9032,9 @@ async fn stream_execution_events(
             };
 
         // ── 1. Send backfill events (events already committed before this request) ──
+        // Also track whether a terminal event appears in the backfill: the execution
+        // may have transitioned between load_execution and load_events_after_row_id.
+        let mut backfill_terminal: Option<&'static str> = None;
         for row in &backfill {
             let sse_event = Event::default()
                 .id(row.id.to_string())
@@ -9058,11 +9061,23 @@ async fn stream_execution_events(
                 }
                 return;
             }
+            if is_terminal_event_type(&row.event_type) {
+                backfill_terminal = Some(terminal_event_type_to_state(&row.event_type));
+            }
         }
 
-        // ── 2. If already terminal, emit stream-end and close ─────────────────
-        if terminal {
-            let end_data = serde_json::json!({"reason": execution_state}).to_string();
+        // ── 2. If already terminal (or backfill contained a terminal event), emit
+        //       stream-end and close.  Use the backfill-detected state when present
+        //       because it reflects the actual transition even if load_execution ran
+        //       before the row was committed.
+        let effective_terminal: Option<&str> =
+            backfill_terminal.map(|s| s as &str).or(if terminal {
+                Some(execution_state.as_str())
+            } else {
+                None
+            });
+        if let Some(state) = effective_terminal {
+            let end_data = serde_json::json!({"reason": state}).to_string();
             let _ = tx
                 .send(Ok(Event::default().event("stream-end").data(end_data)))
                 .await;
@@ -9155,6 +9170,14 @@ async fn stream_execution_events(
                             send_rows(&missed, last_seen_id, &mut tx);
                         last_seen_id = new_id;
                         if should_break {
+                            let err_data = serde_json::json!({
+                                "error": "slow_consumer",
+                                "drop_after_event_id": last_seen_id,
+                            })
+                            .to_string();
+                            let _ = tx.try_send(Ok(Event::default()
+                                .event("stream-error")
+                                .data(err_data)));
                             break 'notify;
                         }
                         if let Some(state) = terminal_state {
@@ -9190,6 +9213,14 @@ async fn stream_execution_events(
                             send_rows(&missed, last_seen_id, &mut tx);
                         last_seen_id = new_id;
                         if should_break {
+                            let err_data = serde_json::json!({
+                                "error": "slow_consumer",
+                                "drop_after_event_id": last_seen_id,
+                            })
+                            .to_string();
+                            let _ = tx.try_send(Ok(Event::default()
+                                .event("stream-error")
+                                .data(err_data)));
                             break 'notify;
                         }
                         if let Some(state) = terminal_state {

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -8885,10 +8885,7 @@ async fn stream_execution_events(
     // Extract Last-Event-ID for resume (harvest_events.id BIGSERIAL cursor).
     // An absent header means "start from the beginning" (cursor = -1).
     // A present but non-parseable value is a client error → 400.
-    let last_row_id: i64 = match headers
-        .get("last-event-id")
-        .and_then(|v| v.to_str().ok())
-    {
+    let last_row_id: i64 = match headers.get("last-event-id").and_then(|v| v.to_str().ok()) {
         None => -1,
         Some(s) => match s.parse::<i64>() {
             Ok(n) => n,
@@ -9012,28 +9009,27 @@ async fn stream_execution_events(
         // or breaks early if the channel is full / dropped.
         // Using a macro-style closure here because closures can't easily `break 'notify`.
         // We use a boolean return: (last_id, terminal_state, should_break).
-        let send_rows = |rows: &[autumn_harvest::models::HarvestEvent],
-                         mut cur_last_seen: i64,
-                         tx: &mut futures::channel::mpsc::Sender<
-            Result<Event, std::convert::Infallible>,
-        >|
-         -> (i64, Option<&'static str>, bool) {
-            let mut found_terminal: Option<&'static str> = None;
-            for row in rows {
-                let sse_event = Event::default()
-                    .id(row.id.to_string())
-                    .event(row.event_type.as_str())
-                    .data(sse_data(&row.event_data));
-                if tx.try_send(Ok(sse_event)).is_err() {
-                    return (cur_last_seen, None, true);
+        let send_rows =
+            |rows: &[autumn_harvest::models::HarvestEvent],
+             mut cur_last_seen: i64,
+             tx: &mut futures::channel::mpsc::Sender<Result<Event, std::convert::Infallible>>|
+             -> (i64, Option<&'static str>, bool) {
+                let mut found_terminal: Option<&'static str> = None;
+                for row in rows {
+                    let sse_event = Event::default()
+                        .id(row.id.to_string())
+                        .event(row.event_type.as_str())
+                        .data(sse_data(&row.event_data));
+                    if tx.try_send(Ok(sse_event)).is_err() {
+                        return (cur_last_seen, None, true);
+                    }
+                    cur_last_seen = row.id;
+                    if is_terminal_event_type(&row.event_type) {
+                        found_terminal = Some(terminal_event_type_to_state(&row.event_type));
+                    }
                 }
-                cur_last_seen = row.id;
-                if is_terminal_event_type(&row.event_type) {
-                    found_terminal = Some(terminal_event_type_to_state(&row.event_type));
-                }
-            }
-            (cur_last_seen, found_terminal, false)
-        };
+                (cur_last_seen, found_terminal, false)
+            };
 
         // ── 1. Send backfill events (events already committed before this request) ──
         for row in &backfill {
@@ -9080,10 +9076,7 @@ async fn stream_execution_events(
                 // Use 2× keepalive as notification timeout so the KeepAlive wrapper
                 // has time to send its ping before this loop wakes and re-checks
                 let wait_timeout = keepalive_interval.saturating_mul(2);
-                match listener
-                    .wait_for_notification_timeout(wait_timeout)
-                    .await
-                {
+                match listener.wait_for_notification_timeout(wait_timeout).await {
                     Ok(WorkflowEventWaitOutcome::Notification(payload)) => {
                         // The harvest_events channel notifies for ALL executions on
                         // this shard; filter to ours
@@ -9093,26 +9086,25 @@ async fn stream_execution_events(
 
                         // Load new events from the pool — capped to buffer_depth so
                         // rapid bursts between notifications stay bounded in memory.
-                        let new_rows =
-                            match db_conn_for_execution(&api_clone, exec_id).await {
-                                Ok(mut conn) => {
-                                    match store::load_events_after_row_id(
-                                        &mut conn,
-                                        exec_id,
-                                        last_seen_id,
-                                        buf_limit,
-                                    )
-                                    .await
-                                    {
-                                        Ok(rows) => rows,
-                                        // DB failure: skip this notification batch.
-                                        // The periodic TimedOut poll will catch missed
-                                        // events if no further notifications arrive.
-                                        Err(_) => continue,
-                                    }
+                        let new_rows = match db_conn_for_execution(&api_clone, exec_id).await {
+                            Ok(mut conn) => {
+                                match store::load_events_after_row_id(
+                                    &mut conn,
+                                    exec_id,
+                                    last_seen_id,
+                                    buf_limit,
+                                )
+                                .await
+                                {
+                                    Ok(rows) => rows,
+                                    // DB failure: skip this notification batch.
+                                    // The periodic TimedOut poll will catch missed
+                                    // events if no further notifications arrive.
+                                    Err(_) => continue,
                                 }
-                                Err(_) => continue,
-                            };
+                            }
+                            Err(_) => continue,
+                        };
 
                         let (new_id, terminal_state, should_break) =
                             send_rows(&new_rows, last_seen_id, &mut tx);
@@ -9131,12 +9123,9 @@ async fn stream_execution_events(
                         }
 
                         if let Some(state) = terminal_state {
-                            let end_data =
-                                serde_json::json!({"reason": state}).to_string();
+                            let end_data = serde_json::json!({"reason": state}).to_string();
                             let _ = tx
-                                .send(Ok(
-                                    Event::default().event("stream-end").data(end_data)
-                                ))
+                                .send(Ok(Event::default().event("stream-end").data(end_data)))
                                 .await;
                             break 'notify;
                         }
@@ -9149,9 +9138,7 @@ async fn stream_execution_events(
                         }
                         // Periodic safety-net poll: catch any events missed due to a
                         // prior DB failure on a notification (e.g. terminal event).
-                        let Ok(mut conn) =
-                            db_conn_for_execution(&api_clone, exec_id).await
-                        else {
+                        let Ok(mut conn) = db_conn_for_execution(&api_clone, exec_id).await else {
                             continue 'notify;
                         };
                         let Ok(missed) = store::load_events_after_row_id(
@@ -9181,15 +9168,12 @@ async fn stream_execution_events(
                     Ok(WorkflowEventWaitOutcome::ChannelClosed) => {
                         // LISTEN connection dropped; reconnect and backfill any events
                         // that may have been committed while the connection was down.
-                        let Ok(l) = WorkflowEventListener::connect(&notification_url).await
-                        else {
+                        let Ok(l) = WorkflowEventListener::connect(&notification_url).await else {
                             break 'notify;
                         };
                         listener = l;
                         // Backfill events missed during reconnection window
-                        let Ok(mut conn) =
-                            db_conn_for_execution(&api_clone, exec_id).await
-                        else {
+                        let Ok(mut conn) = db_conn_for_execution(&api_clone, exec_id).await else {
                             continue 'notify;
                         };
                         let Ok(missed) = store::load_events_after_row_id(
@@ -9209,8 +9193,7 @@ async fn stream_execution_events(
                             break 'notify;
                         }
                         if let Some(state) = terminal_state {
-                            let end_data =
-                                serde_json::json!({"reason": state}).to_string();
+                            let end_data = serde_json::json!({"reason": state}).to_string();
                             let _ = tx
                                 .send(Ok(Event::default().event("stream-end").data(end_data)))
                                 .await;

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -254,6 +254,10 @@ pub struct HarvestApiState {
     /// Server-side ceiling on `execution_timeout` (issue #243).
     /// `None` = no ceiling enforced.
     max_workflow_execution_timeout: Arc<Mutex<Option<std::time::Duration>>>,
+    /// SSE keepalive comment interval (issue #324). Default 15 s.
+    sse_keepalive_interval: Arc<Mutex<std::time::Duration>>,
+    /// Maximum SSE event buffer depth per stream (issue #324). Default 1024.
+    sse_buffer_depth: Arc<Mutex<usize>>,
 }
 
 impl Default for HarvestApiState {
@@ -273,6 +277,8 @@ impl Default for HarvestApiState {
             workflow_result_max_wait: Arc::new(Mutex::new(std::time::Duration::from_secs(30))),
             query_timeout: Arc::new(Mutex::new(std::time::Duration::from_secs(5))),
             max_workflow_execution_timeout: Arc::new(Mutex::new(None)),
+            sse_keepalive_interval: Arc::new(Mutex::new(std::time::Duration::from_secs(15))),
+            sse_buffer_depth: Arc::new(Mutex::new(1024)),
         }
     }
 }
@@ -349,6 +355,59 @@ impl HarvestApiState {
     pub fn max_workflow_execution_timeout(&self) -> Option<std::time::Duration> {
         *self
             .max_workflow_execution_timeout
+            .lock()
+            .expect("harvest api state lock poisoned")
+    }
+
+    /// Override the SSE keepalive comment interval (default 15 s, issue #324).
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal mutex is poisoned.
+    pub fn set_sse_keepalive_interval(&self, interval: std::time::Duration) {
+        *self
+            .sse_keepalive_interval
+            .lock()
+            .expect("harvest api state lock poisoned") = interval;
+    }
+
+    /// Current SSE keepalive comment interval.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal mutex is poisoned.
+    #[must_use]
+    pub fn sse_keepalive_interval(&self) -> std::time::Duration {
+        *self
+            .sse_keepalive_interval
+            .lock()
+            .expect("harvest api state lock poisoned")
+    }
+
+    /// Override the SSE per-stream event buffer depth (default 1024, issue #324).
+    ///
+    /// When the producer falls behind by more than this many events the stream
+    /// closes with a slow-consumer response.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal mutex is poisoned.
+    pub fn set_sse_buffer_depth(&self, depth: usize) {
+        *self
+            .sse_buffer_depth
+            .lock()
+            .expect("harvest api state lock poisoned") = depth;
+    }
+
+    /// Current SSE per-stream event buffer depth.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal mutex is poisoned.
+    #[must_use]
+    pub fn sse_buffer_depth(&self) -> usize {
+        *self
+            .sse_buffer_depth
             .lock()
             .expect("harvest api state lock poisoned")
     }
@@ -575,6 +634,20 @@ impl HarvestApiState {
             ));
         }
         Ok(urls)
+    }
+
+    /// Return the LISTEN/NOTIFY database URL for the given shard (issue #324).
+    ///
+    /// Falls back to the first configured URL for single-shard deployments.
+    pub(crate) fn sse_notification_url(&self, shard: ShardId) -> HarvestResult<String> {
+        let urls = self.workflow_result_notification_database_urls()?;
+        if let Some(url) = urls.get(&shard) {
+            return Ok(url.clone());
+        }
+        // Single-shard fallback: use the first available URL
+        urls.into_values()
+            .next()
+            .ok_or_else(|| HarvestError::Config("no SSE notification URL configured".to_string()))
     }
 
     fn workflow_handle_client(&self) -> HarvestResult<WorkflowHandleClient> {
@@ -846,7 +919,7 @@ struct RedactedPayloadSummary {
     summary: &'static str,
 }
 
-fn is_terminal_state(state: &str) -> bool {
+pub(crate) fn is_terminal_state(state: &str) -> bool {
     matches!(
         state,
         "COMPLETED" | "FAILED" | "CANCELLED" | "TIMED_OUT" | "CONTINUED_AS_NEW" | "TERMINATED"
@@ -1521,7 +1594,7 @@ pub fn harvest_api_router(api_state: HarvestApiState) -> Router<AppState> {
         .route("/batch-operations", get(list_batch_operations))
         .route(
             "/batch-operations",
-            post(submit_batch_operation).route_layer(require_admin),
+            post(submit_batch_operation).route_layer(require_admin.clone()),
         )
         .route("/batch-operations/{id}", get(get_batch_operation))
         // Task priority management (issue #249): PATCH /tasks/{id} lets
@@ -1532,6 +1605,12 @@ pub fn harvest_api_router(api_state: HarvestApiState) -> Router<AppState> {
         // Audit trail (issue #158): read-only endpoint to query management
         // API mutations. See `audit::ALL_MUTATION_ROUTES` for covered paths.
         .route("/admin/audit", get(list_audit_records))
+        // SSE execution event stream (issue #324): live workflow event tail.
+        // Gated behind the same mgmt auth provider as other management routes.
+        .route(
+            "/executions/{exec_id}/events/stream",
+            get(stream_execution_events).route_layer(require_admin.clone()),
+        )
         .layer(Extension(api_state))
 }
 
@@ -1548,7 +1627,10 @@ pub(crate) async fn require_harvest_admin(
     }
 }
 
-async fn has_harvest_admin_access(api_state: &HarvestApiState, session: Option<Session>) -> bool {
+pub(crate) async fn has_harvest_admin_access(
+    api_state: &HarvestApiState,
+    session: Option<Session>,
+) -> bool {
     if api_state.admin_auth_boundary() {
         return true;
     }
@@ -1639,6 +1721,8 @@ pub const fn management_api_routes() -> &'static [(&'static str, &'static str)] 
         ("DELETE", "/calendars/{name}"),
         // ── audit (issue #158) ────────────────────────────────────────────────
         ("GET", "/admin/audit"),
+        // ── SSE execution event stream (issue #324) ───────────────────────────
+        ("GET", "/executions/{exec_id}/events/stream"),
     ]
 }
 
@@ -2138,6 +2222,8 @@ pub const fn management_api_response_fields()
         ("DELETE", "/calendars/{name}", None), // 204 No Content
         // ── audit ─────────────────────────────────────────────────────────────
         ("GET", "/admin/audit", None), // Vec<AuditRecord> (external model)
+        // ── SSE execution event stream (issue #324) ───────────────────────────
+        ("GET", "/executions/{exec_id}/events/stream", None), // text/event-stream
     ]
 }
 
@@ -2462,7 +2548,7 @@ fn parse_audit_datetime(raw: &str) -> Result<chrono::DateTime<chrono::Utc>, Autu
 // ── Audit emission helpers ─────────────────────────────────────────────────────
 
 /// Extract audit context (`actor`, `source`, `request_id`) from request headers.
-fn audit_context(
+pub(crate) fn audit_context(
     headers: &axum::http::HeaderMap,
     api_state: &HarvestApiState,
 ) -> (String, String, Option<String>) {
@@ -8717,6 +8803,295 @@ fn check_signal_payload_cap(payload: &Value, cap: u64) -> Result<(), AutumnError
         }));
     }
     Ok(())
+}
+
+// ── SSE execution event stream (issue #324) ──────────────────────────────────
+
+/// Whether an event type name signals a terminal lifecycle transition.
+fn is_terminal_event_type(event_type: &str) -> bool {
+    matches!(
+        event_type,
+        "WorkflowCompleted"
+            | "WorkflowFailed"
+            | "WorkflowCancelled"
+            | "WorkflowContinuedAsNew"
+            | "WorkflowResetTerminated"
+            | "WorkflowExecutionTimedOut"
+    )
+}
+
+/// Map a terminal `WorkflowEvent` type name to a short state string.
+fn terminal_event_type_to_state(event_type: &str) -> &'static str {
+    match event_type {
+        "WorkflowCompleted" => "completed",
+        "WorkflowFailed" => "failed",
+        "WorkflowCancelled" => "cancelled",
+        "WorkflowContinuedAsNew" => "continued-as-new",
+        "WorkflowResetTerminated" => "terminated",
+        "WorkflowExecutionTimedOut" => "timed-out",
+        _ => "terminal",
+    }
+}
+
+/// `GET /executions/{exec_id}/events/stream`
+///
+/// Returns a `text/event-stream` response that tails every `WorkflowEvent`
+/// appended to `harvest_events` for the given execution.  Uses Postgres
+/// LISTEN/NOTIFY for sub-second delivery without holding a DB connection
+/// between notifications (issue #324).
+///
+/// SSE wire format:
+/// ```text
+/// id: <harvest_events.id BIGSERIAL>
+/// event: <WorkflowEvent::type_name()>
+/// data: <JSON event value>
+///
+/// ```
+///
+/// Resume: send `Last-Event-ID: <id>` to replay events with `id > n` before
+/// switching to live-tail mode.
+///
+/// Keepalive: `: ping\n\n` comments every `sse_keepalive_interval` (default 15 s).
+///
+/// Stream termination: `event: stream-end` followed by HTTP close when the
+/// execution reaches a terminal state.
+///
+/// Backpressure: if the client reconnects with a `Last-Event-ID` that implies
+/// more than `sse_buffer_depth` events to replay, returns `409 Conflict`.
+async fn stream_execution_events(
+    Extension(api_state): Extension<HarvestApiState>,
+    Path(exec_id_raw): Path<String>,
+    headers: axum::http::HeaderMap,
+    session: Option<axum::extract::Extension<Session>>,
+) -> axum::response::Response {
+    use autumn_harvest::audit::{OP_EXECUTION_STREAM_OPEN, STATUS_SUCCEEDED, TARGET_WORKFLOW};
+    use autumn_harvest::models::NewAuditRecord;
+    use autumn_harvest::notify::{WorkflowEventListener, WorkflowEventWaitOutcome};
+    use axum::response::sse::{Event, KeepAlive, Sse};
+    use futures::SinkExt as _;
+
+    // Parse execution ID
+    let exec_id = match parse_execution_id(&exec_id_raw) {
+        Ok(id) => id,
+        Err(e) => return e.into_response(),
+    };
+
+    // Auth check — rejects unauthenticated requests with 401 (issue #174)
+    if !has_harvest_admin_access(&api_state, session.map(|s| s.0)).await {
+        return AutumnError::unauthorized_msg("authentication required").into_response();
+    }
+
+    // Extract Last-Event-ID for resume (harvest_events.id BIGSERIAL cursor)
+    let last_row_id: i64 = headers
+        .get("last-event-id")
+        .and_then(|v| v.to_str().ok())
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(-1);
+
+    // Resolve the LISTEN/NOTIFY database URL for this execution's shard
+    let shard = exec_id.shard();
+    let notification_url = match api_state.sse_notification_url(shard) {
+        Ok(url) => url,
+        Err(e) => return map_error(e).into_response(),
+    };
+
+    // Establish LISTEN connection before the backfill query to avoid the
+    // race where new events are committed between the query and LISTEN setup
+    let listener = match WorkflowEventListener::connect(&notification_url).await {
+        Ok(l) => l,
+        Err(e) => return map_error(e).into_response(),
+    };
+
+    // Get a pooled connection for the initial verification and backfill
+    let mut conn = match db_conn_for_execution(&api_state, exec_id).await {
+        Ok(c) => c,
+        Err(e) => return e.into_response(),
+    };
+
+    // Verify the execution exists
+    let execution = match load_execution(&mut conn, exec_id).await {
+        Ok(e) => e,
+        Err(e) => return map_error(e).into_response(),
+    };
+
+    // Load events after last_row_id (backfill for reconnecting clients)
+    let backfill = match store::load_events_after_row_id(&mut conn, exec_id, last_row_id).await {
+        Ok(rows) => rows,
+        Err(e) => return map_error(e).into_response(),
+    };
+
+    // Slow-consumer check: if reconnecting client is too far behind, return 409
+    let buffer_depth = api_state.sse_buffer_depth();
+    if backfill.len() > buffer_depth {
+        let drop_id = backfill.last().map(|r| r.id).unwrap_or(last_row_id);
+        return (
+            StatusCode::CONFLICT,
+            Json(serde_json::json!({
+                "error": "slow_consumer",
+                "drop_after_event_id": drop_id,
+            })),
+        )
+            .into_response();
+    }
+
+    let terminal = is_terminal_state(&execution.state);
+    let execution_state = execution.state.to_lowercase().replace('_', "-");
+
+    // Audit stream open (issue #158: only stream open/close are audited, not per-event)
+    {
+        let (actor, source, request_id) = audit_context(&headers, &api_state);
+        let target = exec_id.to_string();
+        let ar = NewAuditRecord {
+            actor: &actor,
+            operation: OP_EXECUTION_STREAM_OPEN,
+            target_type: TARGET_WORKFLOW,
+            target_id: Some(target.as_str()),
+            route_or_command: "GET /executions/{exec_id}/events/stream",
+            request_id: request_id.as_deref(),
+            idempotency_key: None,
+            status: STATUS_SUCCEEDED,
+            error_summary: None,
+            shard_id: Some(shard.as_i32()),
+            source: &source,
+        };
+        let _ = audit::insert_audit(&mut conn, &ar).await;
+    }
+
+    // Release the pooled DB connection — SSE streams must not hold connections while idle
+    drop(conn);
+
+    // Bounded channel: capacity = buffer_depth.  When the receiver (axum SSE) drops,
+    // further sends fail and the producer task shuts down cleanly.
+    let (mut tx, rx) =
+        futures::channel::mpsc::channel::<Result<Event, std::convert::Infallible>>(buffer_depth);
+
+    let keepalive_interval = api_state.sse_keepalive_interval();
+    let api_clone = api_state.clone();
+
+    // Producer task: runs independently of the HTTP handler after we return
+    tokio::spawn(async move {
+        // ── 1. Send backfill events (events already committed before this request) ──
+        for row in &backfill {
+            let data = serde_json::to_string(&row.event_data).unwrap_or_default();
+            let sse_event = Event::default()
+                .id(row.id.to_string())
+                .event(row.event_type.as_str())
+                .data(data);
+            if tx.send(Ok(sse_event)).await.is_err() {
+                return; // Client disconnected
+            }
+        }
+
+        // ── 2. If already terminal, emit stream-end and close ─────────────────
+        if terminal {
+            let end_data = serde_json::json!({"reason": execution_state}).to_string();
+            let _ = tx
+                .send(Ok(Event::default().event("stream-end").data(end_data)))
+                .await;
+            return;
+        }
+
+        // ── 3. Live-tail: LISTEN/NOTIFY loop ──────────────────────────────────
+        let mut last_seen_id = backfill.last().map(|r| r.id).unwrap_or(last_row_id);
+        let mut listener = listener;
+
+        loop {
+            // Use 2× keepalive as notification timeout so the KeepAlive wrapper
+            // has time to send its ping before this loop wakes and re-checks
+            let wait_timeout = keepalive_interval.saturating_mul(2);
+            match listener
+                .wait_for_notification_timeout(wait_timeout)
+                .await
+            {
+                Ok(WorkflowEventWaitOutcome::Notification(payload)) => {
+                    // The harvest_events channel notifies for ALL executions on this
+                    // shard; filter to ours
+                    if payload.workflow_exec_id != exec_id.as_uuid() {
+                        continue;
+                    }
+
+                    // Load new events from the pool — do not hold conn while waiting
+                    let new_rows =
+                        match db_conn_for_execution(&api_clone, exec_id).await {
+                            Ok(mut conn) => {
+                                match store::load_events_after_row_id(
+                                    &mut conn,
+                                    exec_id,
+                                    last_seen_id,
+                                )
+                                .await
+                                {
+                                    Ok(rows) => rows,
+                                    Err(_) => continue,
+                                }
+                            }
+                            Err(_) => continue,
+                        };
+
+                    let mut found_terminal_type: Option<&'static str> = None;
+
+                    for row in &new_rows {
+                        let data = serde_json::to_string(&row.event_data).unwrap_or_default();
+                        let sse_event = Event::default()
+                            .id(row.id.to_string())
+                            .event(row.event_type.as_str())
+                            .data(data);
+
+                        // Detect slow consumer during live-tail
+                        match tx.try_send(Ok(sse_event)) {
+                            Ok(()) => {}
+                            Err(_) => {
+                                // Buffer full or receiver dropped — close stream
+                                let err_data = serde_json::json!({
+                                    "error": "slow_consumer",
+                                    "drop_after_event_id": last_seen_id,
+                                })
+                                .to_string();
+                                let _ = tx.try_send(Ok(Event::default()
+                                    .event("stream-error")
+                                    .data(err_data)));
+                                return;
+                            }
+                        }
+
+                        last_seen_id = row.id;
+
+                        if is_terminal_event_type(&row.event_type) {
+                            found_terminal_type =
+                                Some(terminal_event_type_to_state(&row.event_type));
+                        }
+                    }
+
+                    if let Some(state) = found_terminal_type {
+                        let end_data =
+                            serde_json::json!({"reason": state}).to_string();
+                        let _ = tx
+                            .send(Ok(Event::default().event("stream-end").data(end_data)))
+                            .await;
+                        return;
+                    }
+                }
+                Ok(WorkflowEventWaitOutcome::TimedOut) => {
+                    // No activity within the timeout window; keepalive pings are
+                    // sent automatically by Sse::keep_alive — nothing to do here
+                }
+                Ok(WorkflowEventWaitOutcome::ChannelClosed) => {
+                    // LISTEN connection dropped; reconnect and continue
+                    match WorkflowEventListener::connect(&notification_url).await {
+                        Ok(l) => listener = l,
+                        Err(_) => return,
+                    }
+                }
+                Err(_) => return,
+            }
+        }
+    });
+
+    // Return the SSE response. axum's KeepAlive wrapper sends `: ping\n\n`
+    // comments every keepalive_interval so proxies don't idle the connection.
+    Sse::new(rx)
+        .keep_alive(KeepAlive::new().interval(keepalive_interval).text("ping"))
+        .into_response()
 }
 
 pub(crate) fn map_error(error: HarvestError) -> AutumnError {

--- a/autumn-harvest-plugin/tests/sse_stream_tests.rs
+++ b/autumn-harvest-plugin/tests/sse_stream_tests.rs
@@ -1,0 +1,155 @@
+/// TDD Red Phase — tests for the SSE execution event stream (issue #324).
+///
+/// These tests will FAIL until the SSE stream implementation is in place.
+use autumn_harvest_plugin::api::{HarvestApiState, management_api_routes};
+
+// ── Route registration ────────────────────────────────────────────────────────
+
+#[test]
+fn sse_stream_route_is_registered_in_management_api_routes() {
+    let routes = management_api_routes();
+    assert!(
+        routes.contains(&("GET", "/executions/{exec_id}/events/stream")),
+        "SSE stream route not found in management_api_routes(); \
+         add it to the router and the canonical route list"
+    );
+}
+
+// ── HarvestApiState SSE configuration ────────────────────────────────────────
+
+#[test]
+fn sse_keepalive_interval_default_is_15s() {
+    let state = HarvestApiState::new();
+    assert_eq!(
+        state.sse_keepalive_interval(),
+        std::time::Duration::from_secs(15),
+        "default SSE keepalive interval must be 15 s per issue #324 AC"
+    );
+}
+
+#[test]
+fn sse_buffer_depth_default_is_1024() {
+    let state = HarvestApiState::new();
+    assert_eq!(
+        state.sse_buffer_depth(),
+        1024,
+        "default SSE buffer depth must be 1024 events per issue #324 AC"
+    );
+}
+
+#[test]
+fn sse_keepalive_interval_is_configurable() {
+    let state = HarvestApiState::new();
+    state.set_sse_keepalive_interval(std::time::Duration::from_secs(30));
+    assert_eq!(
+        state.sse_keepalive_interval(),
+        std::time::Duration::from_secs(30)
+    );
+}
+
+#[test]
+fn sse_buffer_depth_is_configurable() {
+    let state = HarvestApiState::new();
+    state.set_sse_buffer_depth(512);
+    assert_eq!(state.sse_buffer_depth(), 512);
+}
+
+// ── Audit constants ───────────────────────────────────────────────────────────
+
+#[test]
+fn audit_op_execution_stream_open_constant_exists() {
+    use autumn_harvest::audit::OP_EXECUTION_STREAM_OPEN;
+    assert_eq!(OP_EXECUTION_STREAM_OPEN, "execution.stream.open");
+}
+
+#[test]
+fn audit_op_execution_stream_close_constant_exists() {
+    use autumn_harvest::audit::OP_EXECUTION_STREAM_CLOSE;
+    assert_eq!(OP_EXECUTION_STREAM_CLOSE, "execution.stream.close");
+}
+
+// ── Route classification ──────────────────────────────────────────────────────
+
+#[test]
+fn sse_stream_route_is_classified_as_read_only() {
+    use autumn_harvest::audit::{CLASSIFIED_ROUTES, RouteClass};
+    let route = "GET /executions/{exec_id}/events/stream";
+    let classification = CLASSIFIED_ROUTES
+        .iter()
+        .find(|(r, _)| *r == route)
+        .map(|(_, c)| c);
+    assert_eq!(
+        classification,
+        Some(&RouteClass::ReadOnly),
+        "SSE stream route '{route}' must be classified as ReadOnly in CLASSIFIED_ROUTES"
+    );
+}
+
+#[test]
+fn sse_stream_route_is_in_all_mutation_routes_as_excluded() {
+    use autumn_harvest::audit::ALL_MUTATION_ROUTES;
+    let route = "GET /executions/{exec_id}/events/stream";
+    let found = ALL_MUTATION_ROUTES.iter().any(|(r, _)| *r == route);
+    assert!(
+        found,
+        "SSE stream route '{route}' must be present in ALL_MUTATION_ROUTES (with None operation)"
+    );
+}
+
+// ── SSE HTTP contract ─────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn sse_stream_returns_service_unavailable_when_not_configured() {
+    use autumn_web::reexports::axum::body::Body;
+    use autumn_web::reexports::http::{Method, Request, StatusCode};
+    use tower::ServiceExt;
+
+    let app =
+        autumn_harvest_plugin::api::harvest_api_router(HarvestApiState::new())
+            .with_state(autumn_web::AppState::for_test());
+
+    let req = Request::builder()
+        .method(Method::GET)
+        .uri("/executions/00000000-0000-0000-0000-000000000001/events/stream")
+        .body(Body::empty())
+        .unwrap();
+
+    let res = app.oneshot(req).await.unwrap();
+    // When no notification URL is configured, the endpoint should return 503 or 404/401.
+    // It must NOT return 200 with no stream configured.
+    assert_ne!(
+        res.status(),
+        StatusCode::OK,
+        "SSE endpoint should not return 200 when notification URL is not configured"
+    );
+}
+
+#[tokio::test]
+async fn sse_stream_route_exists_in_router() {
+    use autumn_web::reexports::axum::body::Body;
+    use autumn_web::reexports::http::{Method, Request, StatusCode};
+    use tower::ServiceExt;
+
+    let app =
+        autumn_harvest_plugin::api::harvest_api_router(HarvestApiState::new())
+            .with_state(autumn_web::AppState::for_test());
+
+    let req = Request::builder()
+        .method(Method::GET)
+        .uri("/executions/00000000-0000-0000-0000-000000000001/events/stream")
+        .body(Body::empty())
+        .unwrap();
+
+    let res = app.oneshot(req).await.unwrap();
+    // The route must be registered — 404 means it's not
+    assert_ne!(
+        res.status(),
+        StatusCode::NOT_FOUND,
+        "SSE stream route not found in router (returns 404). Register the route."
+    );
+    assert_ne!(
+        res.status(),
+        StatusCode::METHOD_NOT_ALLOWED,
+        "SSE stream route registered with wrong HTTP method."
+    );
+}

--- a/autumn-harvest-plugin/tests/sse_stream_tests.rs
+++ b/autumn-harvest-plugin/tests/sse_stream_tests.rs
@@ -104,9 +104,8 @@ async fn sse_stream_returns_service_unavailable_when_not_configured() {
     use autumn_web::reexports::http::{Method, Request, StatusCode};
     use tower::ServiceExt;
 
-    let app =
-        autumn_harvest_plugin::api::harvest_api_router(HarvestApiState::new())
-            .with_state(autumn_web::AppState::for_test());
+    let app = autumn_harvest_plugin::api::harvest_api_router(HarvestApiState::new())
+        .with_state(autumn_web::AppState::for_test());
 
     let req = Request::builder()
         .method(Method::GET)
@@ -130,9 +129,8 @@ async fn sse_stream_route_exists_in_router() {
     use autumn_web::reexports::http::{Method, Request, StatusCode};
     use tower::ServiceExt;
 
-    let app =
-        autumn_harvest_plugin::api::harvest_api_router(HarvestApiState::new())
-            .with_state(autumn_web::AppState::for_test());
+    let app = autumn_harvest_plugin::api::harvest_api_router(HarvestApiState::new())
+        .with_state(autumn_web::AppState::for_test());
 
     let req = Request::builder()
         .method(Method::GET)

--- a/autumn-harvest/src/audit.rs
+++ b/autumn-harvest/src/audit.rs
@@ -72,6 +72,10 @@ pub const OP_EXTERNAL_ACTIVITY_COMPLETE: &str = "external_activity.complete";
 pub const OP_EXTERNAL_ACTIVITY_FAIL: &str = "external_activity.fail";
 /// Audit operation: Initiated draining of a worker fleet.
 pub const OP_WORKER_DRAIN: &str = "worker.drain";
+/// Audit operation: Opened an SSE execution event stream (issue #324).
+pub const OP_EXECUTION_STREAM_OPEN: &str = "execution.stream.open";
+/// Audit operation: Closed an SSE execution event stream (issue #324).
+pub const OP_EXECUTION_STREAM_CLOSE: &str = "execution.stream.close";
 
 // ── Target type constants ─────────────────────────────────────────────────────
 
@@ -216,6 +220,11 @@ pub const CLASSIFIED_ROUTES: &[(&str, RouteClass)] = &[
     ("GET /workers/{worker_id}", RouteClass::ReadOnly),
     ("GET /batch-operations", RouteClass::ReadOnly),
     ("GET /batch-operations/{id}", RouteClass::ReadOnly),
+    // SSE execution event stream (issue #324): read-only long-poll, never mutates state.
+    (
+        "GET /executions/{exec_id}/events/stream",
+        RouteClass::ReadOnly,
+    ),
     // ── Mutating ── modifies workflow execution or system configuration ───────
     // All of these are covered by the audit trail (harvest_audit_log) or are
     // explicitly listed in EXCLUDED_ROUTES with an audit disposition note.
@@ -341,6 +350,8 @@ pub const EXCLUDED_ROUTES: &[&str] = &[
     "GET /batch-operations/{id}",
     // The audit list endpoint itself is read-only.
     "GET /admin/audit",
+    // SSE stream is read-only; stream open/close are audited manually in the handler.
+    "GET /executions/{exec_id}/events/stream",
 ];
 
 /// Declarative manifest of every route in `harvest_api_router`.
@@ -435,6 +446,8 @@ pub const ALL_MUTATION_ROUTES: &[(&str, Option<&str>)] = &[
     ("GET /batch-operations/{id}", None),
     // Audit log (read-only)
     ("GET /admin/audit", None),
+    // SSE execution event stream (issue #324): read-only; open/close audited in handler.
+    ("GET /executions/{exec_id}/events/stream", None),
 ];
 
 // ── Query filters ─────────────────────────────────────────────────────────────

--- a/autumn-harvest/src/store.rs
+++ b/autumn-harvest/src/store.rs
@@ -397,6 +397,31 @@ pub async fn load_history_since(
     })
 }
 
+/// Load raw `harvest_events` rows for `exec_id` with `id > after_row_id`.
+///
+/// Returns rows ordered by `id ASC`. The `id` column is the `BIGSERIAL` primary
+/// key and serves as the SSE resume cursor (`Last-Event-ID`). Pass `-1` for
+/// `after_row_id` to load all events.
+///
+/// # Errors
+///
+/// Returns [`crate::error::HarvestError::Database`] on query failure.
+#[cfg(feature = "db")]
+pub async fn load_events_after_row_id(
+    conn: &mut AsyncPgConnection,
+    exec_id: ExecutionId,
+    after_row_id: i64,
+) -> HarvestResult<Vec<crate::models::HarvestEvent>> {
+    harvest_events::table
+        .filter(harvest_events::workflow_exec_id.eq(exec_id.as_uuid()))
+        .filter(harvest_events::id.gt(after_row_id))
+        .order(harvest_events::id.asc())
+        .select(crate::models::HarvestEvent::as_select())
+        .load(conn)
+        .await
+        .map_err(crate::error::database_error)
+}
+
 /// Load the direct children of `parent_id` from one shard.
 ///
 /// Callers that need cross-shard discovery should call this once per shard and

--- a/autumn-harvest/src/store.rs
+++ b/autumn-harvest/src/store.rs
@@ -411,11 +411,17 @@ pub async fn load_events_after_row_id(
     conn: &mut AsyncPgConnection,
     exec_id: ExecutionId,
     after_row_id: i64,
+    limit: Option<i64>,
 ) -> HarvestResult<Vec<crate::models::HarvestEvent>> {
-    harvest_events::table
+    let mut query = harvest_events::table
         .filter(harvest_events::workflow_exec_id.eq(exec_id.as_uuid()))
         .filter(harvest_events::id.gt(after_row_id))
         .order(harvest_events::id.asc())
+        .into_boxed();
+    if let Some(n) = limit {
+        query = query.limit(n);
+    }
+    query
         .select(crate::models::HarvestEvent::as_select())
         .load(conn)
         .await

--- a/docs/api-contract.json
+++ b/docs/api-contract.json
@@ -2946,6 +2946,56 @@
           "description": "Database error."
         }
       ]
+    },
+    {
+      "method": "GET",
+      "path": "/executions/{exec_id}/events/stream",
+      "category": "workflow",
+      "read_only": true,
+      "description": "Server-Sent Events stream of WorkflowEvent history for one execution. Emits every newly persisted event as id/event/data SSE messages. Resume via Last-Event-ID header. Closes with event:stream-end on terminal state. Keepalive :ping comments every 15 s (default). Returns 409 Conflict when Last-Event-ID implies more than buffer_depth events to replay (slow consumer).",
+      "params": [
+        {
+          "name": "exec_id",
+          "in": "path",
+          "required": true,
+          "description": "Execution UUID."
+        }
+      ],
+      "headers": [
+        {
+          "name": "Last-Event-ID",
+          "required": false,
+          "description": "harvest_events.id BIGSERIAL cursor. When present, the server replays events with id > n before entering live-tail mode."
+        }
+      ],
+      "request_body": null,
+      "success_response": {
+        "status": 200,
+        "note": "Content-Type: text/event-stream. Each SSE message carries id (BIGSERIAL), event (WorkflowEvent type name), and data (JSON event value). A final event:stream-end message signals terminal execution state. Returns 409 Conflict with {error:slow_consumer, drop_after_event_id} when the client is too far behind.",
+        "free_form": true
+      },
+      "error_responses": [
+        {
+          "status": 400,
+          "description": "Invalid execution ID."
+        },
+        {
+          "status": 401,
+          "description": "Unauthenticated request."
+        },
+        {
+          "status": 404,
+          "description": "Execution not found."
+        },
+        {
+          "status": 409,
+          "description": "Slow consumer: too many events to replay. Reconnect with Last-Event-ID: drop_after_event_id."
+        },
+        {
+          "status": 503,
+          "description": "SSE notification URL not configured."
+        }
+      ]
     }
   ]
 }

--- a/docs/management-api.md
+++ b/docs/management-api.md
@@ -1,0 +1,179 @@
+# Management API
+
+This document covers the HTTP management API mounted by `autumn-harvest-plugin`.
+
+## SSE Execution Event Stream
+
+### Endpoint
+
+```
+GET /executions/{exec_id}/events/stream
+```
+
+**Auth**: same bearer-token gate as all other management API routes (issue #174). Returns `401` if the token is missing or invalid.
+
+**Content-Type**: `text/event-stream`
+
+**Category**: read-only; classified as `ReadOnly` in the audit system.
+
+---
+
+### Wire format
+
+Each event arrives as a standard SSE block:
+
+```
+id: <harvest_events.id BIGSERIAL>
+event: <WorkflowEvent type name>
+data: <JSON event payload>
+
+```
+
+- `id` is the row-level `BIGSERIAL` primary key of `harvest_events`, **not** the per-execution sequential event ID. It is monotonically increasing across all executions on the shard and is safe to use as a resume cursor.
+- `event` is the adjacently-tagged type string (`ActivityScheduled`, `SignalReceived`, etc.). New `WorkflowEvent` variants land in the stream automatically without client changes.
+- `data` is the `data` inner object of the adjacently-tagged JSON envelope `{"type":"…","data":{…}}` stored in `harvest_events.event_data`.
+
+#### Keepalive
+
+Between events the server emits an SSE comment line at the configured interval (default 15 s):
+
+```
+: ping
+
+```
+
+Keepalive comments prevent reverse proxies and load balancers from killing idle connections. They carry no semantic content and should be discarded by clients.
+
+#### Terminal marker
+
+When the execution reaches a terminal state (`Completed`, `Failed`, `Cancelled`, `TimedOut`, `ResetTerminated`), the server sends a final event block then closes the stream:
+
+```
+id: <last_row_id>
+event: stream-end
+data: {"reason":"completed","execution_id":"<exec_id>","state":"COMPLETED"}
+
+```
+
+The `reason` field mirrors the terminal event type in lowercase. Receiving `event: stream-end` is the client's signal to **stop reconnecting** — the execution will not produce more events. Contrast this with a transport drop, where the client should reconnect with `Last-Event-ID`.
+
+#### Slow consumer
+
+If the client cannot drain the server-side buffer (default depth 1024 events) before it fills, the server sends a final `event: stream-error` block and closes the stream with HTTP 409:
+
+```
+event: stream-error
+data: {"error":"slow_consumer","drop_after_event_id":<n>}
+
+```
+
+The client may reconnect immediately with `Last-Event-ID: <n>` to resume from where the stream was cut.
+
+---
+
+### Resume protocol (`Last-Event-ID`)
+
+The browser `EventSource` API sends `Last-Event-ID` automatically on reconnect. Curl and custom clients must set it explicitly.
+
+When the server receives `Last-Event-ID: <n>`:
+
+1. It queries `harvest_events` for all rows with `id > n` for this execution (the backfill).
+2. It sends the backfill rows over the stream in ascending `id` order.
+3. It then enters live-tail mode, forwarding new events via LISTEN/NOTIFY.
+
+A client that drops mid-stream and reconnects with the last `id` it saw will receive every event exactly once with no gaps.
+
+**First connection** (no `Last-Event-ID`): the server starts from the beginning — all existing events are backfilled, then live-tail begins.
+
+---
+
+### Sharding
+
+The endpoint resolves `exec_id.shard()` and subscribes to that shard's Postgres LISTEN/NOTIFY channel. Cross-shard fan-out is not required in v1; one stream always maps to one shard.
+
+---
+
+### Concurrency model
+
+The server holds **no database connection while idle**. Each LISTEN/NOTIFY notification triggers a short-lived pooled connection to load new events, which is released immediately after the batch is sent. A single harvest process can sustain ≥ 1,000 concurrent SSE streams within the configured worker DB pool ceiling (DD-2).
+
+---
+
+### Audit trail
+
+Opening a stream records one `execution.stream.open` audit entry with:
+- `actor`: extracted from the auth context
+- `exec_id`: the target execution
+- `last_event_id_seen`: the cursor value from `Last-Event-ID` (or `-1` for a fresh stream)
+
+Per-event audit entries are **not** written — that would amplify writes by 1:N. Stream close is audited as `execution.stream.close` when the producer task exits.
+
+---
+
+### Working `EventSource` example (browser)
+
+```javascript
+const execId = '00000000-0000-0000-0000-000000000001';
+const token  = 'your-mgmt-token';
+
+// EventSource does not support custom headers natively in all browsers.
+// Use a query-param token or an initial cookie exchange instead.
+// For internal tools, a ServiceWorker or fetch-based polyfill handles auth headers.
+const url = `/api/harvest/executions/${execId}/events/stream`;
+
+const es = new EventSource(url);
+
+es.addEventListener('message', (e) => {
+  const payload = JSON.parse(e.data);
+  console.log('event id', e.lastEventId, payload);
+});
+
+es.addEventListener('stream-end', (e) => {
+  const { reason, state } = JSON.parse(e.data);
+  console.log(`execution finished: ${state} (${reason})`);
+  es.close();          // stop reconnecting — execution is terminal
+});
+
+es.addEventListener('stream-error', (e) => {
+  const { drop_after_event_id } = JSON.parse(e.data);
+  console.warn(`slow consumer; resume from ${drop_after_event_id}`);
+  es.close();
+  // reconnect logic: open a new EventSource and the browser will send
+  // Last-Event-ID: <drop_after_event_id> automatically.
+});
+
+es.onerror = (e) => {
+  // transport error or server 4xx/5xx — browser will retry with Last-Event-ID
+  console.error('SSE error', e);
+};
+```
+
+---
+
+### CLI usage
+
+```bash
+# Tail a live execution (Ctrl-C to stop)
+harvest events tail <exec_id>
+
+# Resume from a known cursor (skips events already seen)
+harvest events tail <exec_id> --last-event-id 4200
+```
+
+Each event prints as `<event-type>: <json-data>` to stdout, one per line.
+Keepalive comments are discarded silently.
+The command exits cleanly when the server sends `event: stream-end`.
+
+---
+
+### Reverse-proxy and CDN notes
+
+| Environment | Required config |
+|-------------|----------------|
+| **nginx** | `proxy_set_header X-Accel-Buffering no;` on the upstream location. Without this, nginx buffers the response and the client sees no events until the buffer fills. |
+| **Cloudflare** | No special config required since 2024; Cloudflare proxies SSE transparently. Enterprise plan: disable `rocket_loader` on the management API path if enabled. |
+| **AWS ALB** | Set `idle_timeout` ≥ 65 s. The SSE keepalive fires every 15 s (default), which keeps ALB's 60 s default from killing idle connections. |
+| **HAProxy** | Set `timeout tunnel` on the backend section (e.g. `timeout tunnel 10m`). Without it, HAProxy applies the shorter `timeout server` to streaming connections. |
+| **Traefik** | No special config required. Traefik detects `text/event-stream` and disables response buffering automatically. |
+
+**Important**: SSE requires HTTP/1.1 or HTTP/2. Ensure the proxy does not downgrade the connection to HTTP/1.0, which does not support chunked transfer encoding.

--- a/docs/vantage-ui.md
+++ b/docs/vantage-ui.md
@@ -88,11 +88,40 @@ Event fields are extracted from the inner `data` object of the adjacently-tagged
 | `/schedules` | Cron/interval schedules |
 | `/dlq` | Dead letter queue |
 
+## Live Event Streaming (feature toggle)
+
+The workflow detail page can show events in real-time as they land in `harvest_events`, using the `GET /executions/{exec_id}/events/stream` SSE endpoint.
+
+### Enabling the toggle
+
+Set the `AUTUMN_HARVEST_UI_LIVE_STREAM=true` environment variable (or the equivalent `harvest.ui.live_stream = true` config key) before starting your application. When the toggle is on and the browser supports `EventSource`, the detail page replaces the manual **Refresh** button with a **Live** / **Paused** indicator:
+
+- **Live** (green dot): the `EventSource` connection is open and events are streaming in real time.
+- **Paused** (grey dot): the user clicked the indicator to freeze the view, or `EventSource` is not supported; the existing polled-refresh path is used instead.
+
+When the toggle is **off** (the default), the v1 polled-refresh behaviour is used unchanged — the detail page auto-refreshes at the configured interval and shows the **Refresh** button. No JavaScript is executed in this mode.
+
+### Fallback rules
+
+1. Toggle off → polled refresh (default, no change from v1).
+2. Toggle on, browser lacks `EventSource` → polled refresh.
+3. Toggle on, browser supports `EventSource`, endpoint returns 4xx/5xx → polled refresh with a "stream unavailable" notice.
+4. Execution reaches a terminal state → `event: stream-end` closes the `EventSource`; the page transitions to a static "completed" view without reconnecting.
+
+### Browser / proxy notes
+
+See `docs/management-api.md` for a full list of reverse-proxy and CDN considerations (nginx buffering, Cloudflare, ALB idle timeouts). In short:
+
+- nginx: add `proxy_set_header X-Accel-Buffering no;` on the upstream location block.
+- Cloudflare: SSE is proxied without special configuration since 2024; no extra headers needed.
+- AWS ALB: set idle timeout ≥ 65 s (the SSE keepalive default is 15 s, well inside this window).
+
 ## Accessibility
 
 - Status badges on the detail page include `aria-label` and `role="status"`.
 - All filter and action forms use standard `<form>` / `<button>` elements navigable by keyboard.
-- The dashboard has no JavaScript; all interactions are plain HTTP form submissions or link navigations.
+- The **Live / Paused** SSE indicator is a `<button>` with `aria-label` and `aria-pressed` attributes.
+- When SSE is disabled the dashboard has no JavaScript; all interactions are plain HTTP form submissions or link navigations.
 
 ## Security
 


### PR DESCRIPTION
## Summary

Implements a Server-Sent Events (SSE) endpoint for live-tailing workflow execution events without holding database connections idle. Clients can stream `WorkflowEvent` history in real-time, resume from a cursor using the `Last-Event-ID` header, and receive keepalive pings to prevent proxy timeouts.

## Key Changes

### Core API Endpoint
- **New route**: `GET /executions/{exec_id}/events/stream` returns `text/event-stream` with live workflow events
- **Resume protocol**: `Last-Event-ID` header replays events with `id > n` before entering live-tail mode
- **Terminal marker**: `event: stream-end` signals execution completion; clients stop reconnecting
- **Keepalive**: `: ping` comments every 15 s (configurable) prevent idle connection kills
- **Backpressure**: Returns `409 Conflict` when client is too far behind (slow consumer); includes `drop_after_event_id` for safe reconnect

### HarvestApiState Configuration
- Added `sse_keepalive_interval` (default 15 s) and `sse_buffer_depth` (default 1024 events) as configurable fields
- New methods: `set_sse_keepalive_interval()`, `sse_keepalive_interval()`, `set_sse_buffer_depth()`, `sse_buffer_depth()`
- New helper: `sse_notification_url(shard)` resolves the LISTEN/NOTIFY database URL for a given shard

### Event Stream Implementation
- Producer task spawned per connection; holds no DB connection while idle
- Backfill phase: queries `harvest_events` for rows with `id > last_event_id` (resume cursor)
- Live-tail phase: uses Postgres LISTEN/NOTIFY to detect new events, fetches via pooled connection, sends via bounded channel
- Terminal detection: emits `stream-end` when a terminal `WorkflowEvent` type is observed
- Slow consumer detection: channel full or receiver dropped triggers `stream-error` and HTTP close

### Audit Trail
- Stream open recorded as `execution.stream.open` audit entry with actor, execution ID, and shard
- Per-event audit entries omitted (would amplify writes 1:N)
- Stream close audited as `execution.stream.close` when producer task exits

### CLI Support
- New `harvest events tail <exec_id>` command with optional `--last-event-id` flag
- Prints each SSE event as `<event-type>: <json-data>` to stdout
- Keepalive comments silently discarded; exits cleanly on `event: stream-end`

### Documentation & Testing
- **New file**: `docs/management-api.md` with wire format, resume protocol, slow-consumer handling, reverse-proxy notes, and browser `EventSource` example
- **New file**: `autumn-harvest-plugin/tests/sse_stream_tests.rs` with TDD Red Phase tests for route registration, configuration defaults, and HTTP contract
- Updated `docs/api-contract.json` with endpoint schema
- Updated `docs/vantage-ui.md` with live event streaming feature toggle documentation

### Supporting Changes
- Made `is_terminal_state()`, `audit_context()`, and `has_harvest_admin_access()` public for use in stream handler
- Added `load_events_after_row_id()` query to `store.rs` for backfill
- Added audit operation constants: `OP_EXECUTION_STREAM_OPEN`, `OP_EXECUTION_STREAM_CLOSE`
- Cloned `require_admin` middleware to avoid move issues in router layer composition
- Updated `management_api_routes()` and `management_api_response_fields()` to include the new endpoint

## Implementation Details

- **No connection pooling during idle**: Each LISTEN/NOTIFY notification triggers a short-lived pooled connection to load new events, released immediately after send. Enables ≥1,000 concurrent streams within pool ceiling.
- **Shard-aware**: Resolves `exec_id.shard()` and subscribes to that shard's LISTEN/NOTIFY

https://claude.ai/code/session_0182hP6hiZpchxqBoyzcmc7h