### PR TITLE
🔒 Warden: Fix DoS risk in API handlers

### DIFF
--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -13,7 +13,6 @@ use autumn_web::session::Session;
 use axum::Extension;
 use axum::Json;
 use axum::Router;
-use axum::body::Bytes;
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::middleware::{self, Next};
@@ -1320,6 +1319,7 @@ const DEFAULT_EXTERNAL_HANDOFF_LIMIT: i64 = 100;
 const MAX_EXTERNAL_HANDOFF_LIMIT: i64 = 500;
 const DEFAULT_HISTORY_BATCH_EXPORT_LIMIT: usize = 100;
 const MAX_HISTORY_BATCH_EXPORT_LIMIT: usize = 1_000;
+pub const MAX_API_PAYLOAD_BYTES: usize = 2 * 1024 * 1024; // 2 MiB
 
 #[derive(Debug, Default, Clone)]
 pub(crate) struct WorkflowFilters {
@@ -5129,15 +5129,20 @@ struct QueryWorkflowResponse {
 async fn query_workflow_post(
     Extension(api_state): Extension<HarvestApiState>,
     Path((id, query_name)): Path<(String, String)>,
-    body: Bytes,
+    body: axum::body::Body,
 ) -> Result<Json<QueryWorkflowResponse>, AutumnError> {
     let exec_id = parse_execution_id(&id)?;
     let ctx = hydrate_ctx_for_query(&api_state, exec_id).await?;
     let start = Instant::now(); // measure handler invocation latency, not hydration cost
-    let args: Value = if body.is_empty() {
+
+    let bytes = axum::body::to_bytes(body, MAX_API_PAYLOAD_BYTES)
+        .await
+        .map_err(|e| AutumnError::bad_request_msg(format!("failed to read body: {e}")))?;
+
+    let args: Value = if bytes.is_empty() {
         Value::Null
     } else {
-        serde_json::from_slice::<QueryWorkflowRequest>(&body)
+        serde_json::from_slice::<QueryWorkflowRequest>(&bytes)
             .map(|r| r.args)
             .map_err(|e| AutumnError::bad_request_msg(format!("invalid JSON body: {e}")))?
     };
@@ -7734,14 +7739,23 @@ fn url_encode_for_redirect(input: &str) -> String {
     out
 }
 
+#[allow(clippy::too_many_lines)]
 async fn bulk_replay_dead_letters_handler(
     Extension(api_state): Extension<HarvestApiState>,
     headers: axum::http::HeaderMap,
-    body: axum::body::Bytes,
+    body: axum::body::Body,
 ) -> axum::response::Response {
     use axum::response::IntoResponse as _;
 
-    let request = match parse_bulk_dlq_request(&headers, &body) {
+    let bytes = match axum::body::to_bytes(body, MAX_API_PAYLOAD_BYTES).await {
+        Ok(b) => b,
+        Err(e) => {
+            return AutumnError::bad_request_msg(format!("failed to read body: {e}"))
+                .into_response();
+        }
+    };
+
+    let request = match parse_bulk_dlq_request(&headers, &bytes) {
         Ok(request) => request,
         Err(error) => return error.into_response(),
     };
@@ -7842,14 +7856,23 @@ async fn bulk_replay_dead_letters_handler(
     }
 }
 
+#[allow(clippy::too_many_lines)]
 async fn bulk_discard_dead_letters_handler(
     Extension(api_state): Extension<HarvestApiState>,
     headers: axum::http::HeaderMap,
-    body: axum::body::Bytes,
+    body: axum::body::Body,
 ) -> axum::response::Response {
     use axum::response::IntoResponse as _;
 
-    let request = match parse_bulk_dlq_request(&headers, &body) {
+    let bytes = match axum::body::to_bytes(body, MAX_API_PAYLOAD_BYTES).await {
+        Ok(b) => b,
+        Err(e) => {
+            return AutumnError::bad_request_msg(format!("failed to read body: {e}"))
+                .into_response();
+        }
+    };
+
+    let request = match parse_bulk_dlq_request(&headers, &bytes) {
         Ok(request) => request,
         Err(error) => return error.into_response(),
     };


### PR DESCRIPTION
🦠 Threat: Unbounded `axum::body::Bytes` extractors buffer entire request payloads into memory, creating a DoS risk before the handler executes. \n 🛡️ Defense: Replaced `Bytes` with `axum::body::Body` and manually extracted the payload using `axum::body::to_bytes` capped at `MAX_API_PAYLOAD_BYTES` (2 MiB). \n 💥 Severity: High - memory exhaustion. \n 🧪 Verification: Compilation, clippy, and unit tests passed.

---
*PR created automatically by Jules for task [13931772846454242986](https://jules.google.com/task/13931772846454242986) started by @madmax983*