### PR TITLE
👺 Havoc: [Fix det_check panics on multi-byte unicode characters]

### DIFF
--- a/autumn-harvest/src/det_check.rs
+++ b/autumn-harvest/src/det_check.rs
@@ -508,8 +508,8 @@ fn scan_braces_outside_literals(line: &str, depth: &mut u32) -> Option<usize> {
             '\'' => {
                 pos = char_literal_end(line, pos).unwrap_or(next_pos);
             }
-            '/' if line[next_pos..].starts_with('/') => break,
-            '/' if line[next_pos..].starts_with('*') => {
+            '/' if line.as_bytes().get(next_pos) == Some(&b'/') => break,
+            '/' if line.as_bytes().get(next_pos) == Some(&b'*') => {
                 pos = block_comment_end(line, next_pos + 1);
             }
             '{' => {
@@ -550,8 +550,8 @@ fn line_comment_start(line: &str) -> Option<usize> {
             '\'' => {
                 pos = char_literal_end(line, pos).unwrap_or(next_pos);
             }
-            '/' if line[next_pos..].starts_with('/') => return Some(pos),
-            '/' if line[next_pos..].starts_with('*') => {
+            '/' if line.as_bytes().get(next_pos) == Some(&b'/') => return Some(pos),
+            '/' if line.as_bytes().get(next_pos) == Some(&b'*') => {
                 pos = block_comment_end(line, next_pos + 1);
             }
             _ => pos = next_pos,
@@ -701,7 +701,7 @@ fn strip_unparseable_content(line: &str) -> String {
         match ch {
             '"' => pos = normal_string_end(code, pos),
             '\'' => pos = char_literal_end(code, pos).unwrap_or(next_pos),
-            '/' if code[next_pos..].starts_with('*') => {
+            '/' if code.as_bytes().get(next_pos) == Some(&b'*') => {
                 pos = block_comment_end(code, next_pos + 1);
             }
             _ => {


### PR DESCRIPTION
🧨 **The Trigger:** Input string with an emoji followed by characters triggering a lookahead (e.g. `\"/💥\"`) caused a panic due to `line[next_pos..]` indexing inside a multi-byte character boundary.
📉 **The Stack Trace:** (Panic: byte index x is not a char boundary; it is inside '💥' (bytes y..z) of `\"/💥\"`)
🧪 **Reproduction:** Run `cargo test -p autumn-harvest --lib det_check::tests`.
😈 **Comment:** You assumed users will only type ASCII in their workflows, or that lookaheads will magically align with byte boundaries. You were wrong.

---
*PR created automatically by Jules for task [18130964606600401314](https://jules.google.com/task/18130964606600401314) started by @madmax983*