### PR TITLE
feat: expose worker-pool scaling endpoints for KEDA (#325)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Worker-pool scaling signal and metrics endpoints** (issue #325).
+  Expose KEDA/HPA compatible worker-pool scaling signal endpoint (`GET /admin/queues/scaling`)
+  and Prometheus metrics scraping endpoint (`GET /admin/metrics`). Per-queue metrics include
+  `backlog` (pending, ready now), `in_flight` (currently running), `scheduled` (pending in future),
+  and `active_workers` (healthy, non-draining). Automatically aggregates across all database shards.
+
 - **Timezone-aware cron schedules** (`Schedule::CronInTimezone`, issue #245).
   A new `Schedule` variant lets schedule authors anchor a cron expression to an
   IANA timezone so that jobs like `"0 9 * * 1-5"` fire at 9 AM local time

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -1563,6 +1563,8 @@ pub fn harvest_api_router(api_state: HarvestApiState) -> Router<AppState> {
         .route("/admin/retention", get(retention_status))
         .route("/admin/retention/run-now", post(retention_run_now))
         .route("/admin/concurrency", get(concurrency_status))
+        .route("/admin/queues/scaling", get(queues_scaling_signal))
+        .route("/admin/metrics", get(prometheus_metrics))
         .route("/admin/history/exports", get(export_workflow_histories))
         .route("/admin/external-handoffs", get(list_external_handoffs))
         .route(
@@ -1741,6 +1743,8 @@ pub const fn management_api_routes() -> &'static [(&'static str, &'static str)] 
         ("GET", "/admin/retention"),
         ("POST", "/admin/retention/run-now"),
         ("GET", "/admin/concurrency"),
+        ("GET", "/admin/queues/scaling"),
+        ("GET", "/admin/metrics"),
         ("GET", "/admin/history/exports"),
         ("GET", "/admin/external-handoffs"),
         ("GET", "/admin/external-handoffs/{token}"),
@@ -2161,6 +2165,8 @@ pub const fn management_api_response_fields()
         ("GET", "/admin/retention", None), // RetentionStatus (external model)
         ("POST", "/admin/retention/run-now", Some(&["ok"])),
         ("GET", "/admin/concurrency", None), // Vec<ConcurrencyKeyStats> (external model)
+        ("GET", "/admin/queues/scaling", None),
+        ("GET", "/admin/metrics", None),
         (
             "GET",
             "/admin/history/exports",
@@ -8475,6 +8481,195 @@ async fn concurrency_status(
     let mut result: Vec<ConcurrencyKeyStats> = merged.into_values().collect();
     result.sort_by(|a, b| a.key.cmp(&b.key).then(a.task_type.cmp(&b.task_type)));
     Ok(Json(result))
+}
+
+// ---------------------------------------------------------------------------
+// Worker-pool scaling signal and Prometheus metrics (KEDA/HPA autoscalers)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct ScalingQuery {
+    format: Option<String>,
+}
+
+async fn queues_scaling_signal(
+    Extension(api_state): Extension<HarvestApiState>,
+    Query(query): Query<ScalingQuery>,
+) -> Result<axum::response::Response, AutumnError> {
+    let signals = get_aggregated_scaling_signals(&api_state).await?;
+
+    if query.format.as_deref() == Some("prometheus") {
+        let body = format_prometheus_metrics(&signals);
+        return Ok((
+            StatusCode::OK,
+            [("content-type", "text/plain; version=0.0.4; charset=utf-8")],
+            body,
+        )
+            .into_response());
+    }
+
+    Ok(Json(signals).into_response())
+}
+
+async fn prometheus_metrics(
+    Extension(api_state): Extension<HarvestApiState>,
+) -> Result<axum::response::Response, AutumnError> {
+    let signals = get_aggregated_scaling_signals(&api_state).await?;
+    let body = format_prometheus_metrics(&signals);
+    Ok((
+        StatusCode::OK,
+        [("content-type", "text/plain; version=0.0.4; charset=utf-8")],
+        body,
+    )
+        .into_response())
+}
+
+fn format_prometheus_metrics(signals: &[::autumn_harvest::queue::QueueScalingSignal]) -> String {
+    let mut out = String::new();
+
+    // 1. backlog
+    writeln!(out, "# HELP harvest_queue_backlog Count of pending tasks ready for execution (scheduled_at <= NOW)").unwrap();
+    writeln!(out, "# TYPE harvest_queue_backlog gauge").unwrap();
+    for sig in signals {
+        writeln!(
+            out,
+            "harvest_queue_backlog{{queue=\"{}\"}} {}",
+            sig.queue, sig.backlog
+        )
+        .unwrap();
+    }
+
+    // 2. in_flight
+    writeln!(
+        out,
+        "# HELP harvest_queue_in_flight Count of currently executing tasks"
+    )
+    .unwrap();
+    writeln!(out, "# TYPE harvest_queue_in_flight gauge").unwrap();
+    for sig in signals {
+        writeln!(
+            out,
+            "harvest_queue_in_flight{{queue=\"{}\"}} {}",
+            sig.queue, sig.in_flight
+        )
+        .unwrap();
+    }
+
+    // 3. scheduled
+    writeln!(
+        out,
+        "# HELP harvest_queue_scheduled Count of future-scheduled tasks (scheduled_at > NOW)"
+    )
+    .unwrap();
+    writeln!(out, "# TYPE harvest_queue_scheduled gauge").unwrap();
+    for sig in signals {
+        writeln!(
+            out,
+            "harvest_queue_scheduled{{queue=\"{}\"}} {}",
+            sig.queue, sig.scheduled
+        )
+        .unwrap();
+    }
+
+    // 4. active_workers
+    writeln!(out, "# HELP harvest_queue_active_workers Count of healthy, non-draining worker processes polling this queue").unwrap();
+    writeln!(out, "# TYPE harvest_queue_active_workers gauge").unwrap();
+    for sig in signals {
+        writeln!(
+            out,
+            "harvest_queue_active_workers{{queue=\"{}\"}} {}",
+            sig.queue, sig.active_workers
+        )
+        .unwrap();
+    }
+
+    out
+}
+
+async fn get_aggregated_scaling_signals(
+    api_state: &HarvestApiState,
+) -> Result<Vec<::autumn_harvest::queue::QueueScalingSignal>, AutumnError> {
+    use ::autumn_harvest::models::HarvestWorker;
+    use ::autumn_harvest::schema::harvest_workers;
+    use diesel::prelude::*;
+    use diesel_async::RunQueryDsl;
+
+    let pool = api_state.storage_pool().map_err(map_error)?;
+    let stale_threshold = api_state.worker_stale_threshold();
+
+    // We'll group stats by queue name in-memory
+    let mut task_stats: std::collections::HashMap<
+        String,
+        ::autumn_harvest::queue::QueueTaskCounts,
+    > = std::collections::HashMap::new();
+    let mut worker_stats: std::collections::HashMap<String, i64> = std::collections::HashMap::new();
+
+    for (_shard, shard_pool) in pool.iter_shards() {
+        let mut conn = acquire_conn(shard_pool).await?;
+
+        // 1. Fetch task counts per queue on this shard
+        let shard_counts = ::autumn_harvest::queue::queue_task_counts(&mut conn)
+            .await
+            .map_err(map_error)?;
+        for stat in shard_counts {
+            let entry = task_stats.entry(stat.queue.clone()).or_insert_with(|| {
+                ::autumn_harvest::queue::QueueTaskCounts {
+                    queue: stat.queue.clone(),
+                    backlog: 0,
+                    in_flight: 0,
+                    scheduled: 0,
+                }
+            });
+            entry.backlog += stat.backlog;
+            entry.in_flight += stat.in_flight;
+            entry.scheduled += stat.scheduled;
+        }
+
+        // 2. Fetch workers on this shard
+        let workers = harvest_workers::table
+            .select(HarvestWorker::as_select())
+            .load::<HarvestWorker>(&mut conn)
+            .await
+            .map_err(|e| map_error(::autumn_harvest::error::database_error(e)))?;
+
+        for w in workers {
+            let health = ::autumn_harvest::workers::WorkerHealth::classify(
+                w.last_heartbeat_at,
+                stale_threshold,
+            );
+            let is_active = w.status == ::autumn_harvest::workers::WorkerStatus::Active.as_str()
+                && health == ::autumn_harvest::workers::WorkerHealth::Healthy;
+            let queues = if is_active { w.queues.as_array() } else { None };
+            if let Some(queues) = queues {
+                for q in queues {
+                    if let Some(name) = q.as_str() {
+                        *worker_stats.entry(name.to_string()).or_default() += 1;
+                    }
+                }
+            }
+        }
+    }
+
+    // Merge task stats and worker stats
+    let mut all_queues: std::collections::HashSet<String> = std::collections::HashSet::new();
+    all_queues.extend(task_stats.keys().cloned());
+    all_queues.extend(worker_stats.keys().cloned());
+
+    let mut signals = Vec::new();
+    for q in all_queues {
+        let task_stat = task_stats.get(&q);
+        let active_workers = worker_stats.get(&q).copied().unwrap_or(0);
+        signals.push(::autumn_harvest::queue::QueueScalingSignal {
+            queue: q.clone(),
+            backlog: task_stat.map_or(0, |s| s.backlog),
+            in_flight: task_stat.map_or(0, |s| s.in_flight),
+            scheduled: task_stat.map_or(0, |s| s.scheduled),
+            active_workers,
+        });
+    }
+
+    signals.sort_by(|a, b| a.queue.cmp(&b.queue));
+    Ok(signals)
 }
 
 // ---------------------------------------------------------------------------

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -8531,10 +8531,11 @@ fn format_prometheus_metrics(signals: &[::autumn_harvest::queue::QueueScalingSig
     writeln!(out, "# HELP harvest_queue_backlog Count of pending tasks ready for execution (scheduled_at <= NOW)").unwrap();
     writeln!(out, "# TYPE harvest_queue_backlog gauge").unwrap();
     for sig in signals {
+        let escaped_queue = sig.queue.replace('\\', "\\\\").replace('"', "\\\"");
         writeln!(
             out,
             "harvest_queue_backlog{{queue=\"{}\"}} {}",
-            sig.queue, sig.backlog
+            escaped_queue, sig.backlog
         )
         .unwrap();
     }
@@ -8547,10 +8548,11 @@ fn format_prometheus_metrics(signals: &[::autumn_harvest::queue::QueueScalingSig
     .unwrap();
     writeln!(out, "# TYPE harvest_queue_in_flight gauge").unwrap();
     for sig in signals {
+        let escaped_queue = sig.queue.replace('\\', "\\\\").replace('"', "\\\"");
         writeln!(
             out,
             "harvest_queue_in_flight{{queue=\"{}\"}} {}",
-            sig.queue, sig.in_flight
+            escaped_queue, sig.in_flight
         )
         .unwrap();
     }
@@ -8563,10 +8565,11 @@ fn format_prometheus_metrics(signals: &[::autumn_harvest::queue::QueueScalingSig
     .unwrap();
     writeln!(out, "# TYPE harvest_queue_scheduled gauge").unwrap();
     for sig in signals {
+        let escaped_queue = sig.queue.replace('\\', "\\\\").replace('"', "\\\"");
         writeln!(
             out,
             "harvest_queue_scheduled{{queue=\"{}\"}} {}",
-            sig.queue, sig.scheduled
+            escaped_queue, sig.scheduled
         )
         .unwrap();
     }
@@ -8575,10 +8578,11 @@ fn format_prometheus_metrics(signals: &[::autumn_harvest::queue::QueueScalingSig
     writeln!(out, "# HELP harvest_queue_active_workers Count of healthy, non-draining worker processes polling this queue").unwrap();
     writeln!(out, "# TYPE harvest_queue_active_workers gauge").unwrap();
     for sig in signals {
+        let escaped_queue = sig.queue.replace('\\', "\\\\").replace('"', "\\\"");
         writeln!(
             out,
             "harvest_queue_active_workers{{queue=\"{}\"}} {}",
-            sig.queue, sig.active_workers
+            escaped_queue, sig.active_workers
         )
         .unwrap();
     }

--- a/autumn-harvest-plugin/tests/scaling_api_tests.rs
+++ b/autumn-harvest-plugin/tests/scaling_api_tests.rs
@@ -261,21 +261,36 @@ async fn single_shard_scaling_signals_endpoint_correctly_categorizes_tasks_and_w
     seed_task(&pool, "queue-b", "PENDING", "NOW() - INTERVAL '3 seconds'").await;
     seed_task(&pool, "queue-b", "RUNNING", "NOW()").await;
 
+    // Escaping test queue:
+    // - 1 Backlog task on queue"\\a (represented in Rust as "queue\"\\\\a")
+    seed_task(
+        &pool,
+        "queue\"\\\\a",
+        "PENDING",
+        "NOW() - INTERVAL '5 seconds'",
+    )
+    .await;
+
     // Register workers:
     // - worker-1: healthy active on queue-a
     // - worker-2: healthy active on queue-a & queue-b
     // - worker-3: draining on queue-a
     // - worker-4: stale on queue-b
+    // - worker-escape: healthy active on queue"\\a
     register_active_worker(&pool, "worker-1", &["queue-a"], &[0]).await;
     register_active_worker(&pool, "worker-2", &["queue-a", "queue-b"], &[0]).await;
     register_active_worker(&pool, "worker-3", &["queue-a"], &[0]).await;
     mark_worker_draining(&pool, "worker-3").await;
     register_active_worker(&pool, "worker-4", &["queue-b"], &[0]).await;
     mark_worker_stale(&pool, "worker-4").await;
+    register_active_worker(&pool, "worker-escape", &["queue\"\\\\a"], &[0]).await;
 
     let state = api_state(
         HarvestDbPool::from(pool),
-        runtime_for(&["queue-a", "queue-b"], ShardRouter::single()),
+        runtime_for(
+            &["queue-a", "queue-b", "queue\"\\\\a"],
+            ShardRouter::single(),
+        ),
     );
     let app = harvest_api_router(state).with_state(AppState::for_test().with_profile("test"));
 
@@ -284,7 +299,7 @@ async fn single_shard_scaling_signals_endpoint_correctly_categorizes_tasks_and_w
     assert_eq!(status, StatusCode::OK);
     assert!(body.is_array());
     let arr = body.as_array().unwrap();
-    assert_eq!(arr.len(), 2);
+    assert_eq!(arr.len(), 3);
 
     let qa = arr
         .iter()
@@ -304,6 +319,15 @@ async fn single_shard_scaling_signals_endpoint_correctly_categorizes_tasks_and_w
     assert_eq!(qb["scheduled"], 0);
     assert_eq!(qb["active_workers"], 1); // only worker-2 is healthy & active on queue-b
 
+    let qescape = arr
+        .iter()
+        .find(|q| q["queue"] == "queue\"\\a")
+        .expect("missing escaped queue");
+    assert_eq!(qescape["backlog"], 1);
+    assert_eq!(qescape["in_flight"], 0);
+    assert_eq!(qescape["scheduled"], 0);
+    assert_eq!(qescape["active_workers"], 1);
+
     // 2. Query format=prometheus
     let (status_prom_q, text_prom_q) =
         get_text(&app, "/admin/queues/scaling?format=prometheus").await;
@@ -316,6 +340,8 @@ async fn single_shard_scaling_signals_endpoint_correctly_categorizes_tasks_and_w
     assert!(text_prom_q.contains("harvest_queue_in_flight{queue=\"queue-b\"} 1"));
     assert!(text_prom_q.contains("harvest_queue_scheduled{queue=\"queue-b\"} 0"));
     assert!(text_prom_q.contains("harvest_queue_active_workers{queue=\"queue-b\"} 1"));
+    assert!(text_prom_q.contains("harvest_queue_backlog{queue=\"queue\\\"\\\\a\"} 1"));
+    assert!(text_prom_q.contains("harvest_queue_active_workers{queue=\"queue\\\"\\\\a\"} 1"));
 
     // 3. /admin/metrics endpoint
     let (status_metrics, text_metrics) = get_text(&app, "/admin/metrics").await;
@@ -328,6 +354,8 @@ async fn single_shard_scaling_signals_endpoint_correctly_categorizes_tasks_and_w
     assert!(text_metrics.contains("harvest_queue_in_flight{queue=\"queue-b\"} 1"));
     assert!(text_metrics.contains("harvest_queue_scheduled{queue=\"queue-b\"} 0"));
     assert!(text_metrics.contains("harvest_queue_active_workers{queue=\"queue-b\"} 1"));
+    assert!(text_metrics.contains("harvest_queue_backlog{queue=\"queue\\\"\\\\a\"} 1"));
+    assert!(text_metrics.contains("harvest_queue_active_workers{queue=\"queue\\\"\\\\a\"} 1"));
 }
 
 #[tokio::test]

--- a/autumn-harvest-plugin/tests/scaling_api_tests.rs
+++ b/autumn-harvest-plugin/tests/scaling_api_tests.rs
@@ -1,0 +1,409 @@
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use autumn_harvest::info::WorkflowInfo;
+use autumn_harvest::retention::RetentionConfig;
+use autumn_harvest::scheduler::DagCatalog;
+use autumn_harvest::shard::{ShardRouter, ShardedDbPool};
+use autumn_harvest::types::ShardId;
+use autumn_harvest::worker::{DbPool, HandlerRegistry};
+use autumn_harvest::workers::{WorkerStatus, register_worker};
+use autumn_harvest_plugin::HarvestDbPool;
+use autumn_harvest_plugin::api::{
+    HarvestApiRuntime, HarvestApiState, HarvestRetentionRuntime, harvest_api_router,
+};
+use autumn_web::AppState;
+use autumn_web::reexports::axum;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use diesel_async::AsyncConnection;
+use diesel_async::AsyncPgConnection;
+use diesel_async::RunQueryDsl;
+use diesel_async::pooled_connection::AsyncDieselConnectionManager;
+use serde_json::Value;
+use testcontainers::ContainerAsync;
+use testcontainers_modules::postgres::Postgres;
+use testcontainers_modules::testcontainers::runners::AsyncRunner;
+use tower::ServiceExt;
+
+type HarvestApiApp = axum::Router;
+
+fn build_test_pool(database_url: &str) -> DbPool {
+    let manager = AsyncDieselConnectionManager::<AsyncPgConnection>::new(database_url);
+    deadpool::managed::Pool::builder(manager)
+        .max_size(4)
+        .build()
+        .expect("failed to build test pool")
+}
+
+async fn setup_database_url_with_migrations() -> (String, ContainerAsync<Postgres>) {
+    let container = Postgres::default()
+        .start()
+        .await
+        .expect("failed to start Postgres container");
+    let host = container
+        .get_host()
+        .await
+        .expect("failed to get container host");
+    let port = container
+        .get_host_port_ipv4(5432)
+        .await
+        .expect("failed to get container port");
+    let url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+    autumn_web::migrate::run_pending(&url, autumn_harvest::MIGRATIONS)
+        .expect("failed to run Harvest migrations");
+    (url, container)
+}
+
+async fn setup_two_shards_with_migrations() -> ((String, String), ContainerAsync<Postgres>) {
+    let container = Postgres::default()
+        .start()
+        .await
+        .expect("failed to start Postgres container");
+    let host = container
+        .get_host()
+        .await
+        .expect("failed to get container host");
+    let port = container
+        .get_host_port_ipv4(5432)
+        .await
+        .expect("failed to get container port");
+    let admin_url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+    let shard0_db = format!("harvest_scaling_shard0_{}", uuid::Uuid::new_v4().simple());
+    let shard1_db = format!("harvest_scaling_shard1_{}", uuid::Uuid::new_v4().simple());
+
+    let mut admin_conn = <AsyncPgConnection as AsyncConnection>::establish(&admin_url)
+        .await
+        .expect("failed to connect to admin database");
+    diesel::sql_query(format!("CREATE DATABASE {shard0_db}"))
+        .execute(&mut admin_conn)
+        .await
+        .expect("failed to create shard 0 database");
+    diesel::sql_query(format!("CREATE DATABASE {shard1_db}"))
+        .execute(&mut admin_conn)
+        .await
+        .expect("failed to create shard 1 database");
+
+    let shard0_url = format!("postgres://postgres:postgres@{host}:{port}/{shard0_db}");
+    let shard1_url = format!("postgres://postgres:postgres@{host}:{port}/{shard1_db}");
+    autumn_web::migrate::run_pending(&shard0_url, autumn_harvest::MIGRATIONS)
+        .expect("failed to migrate shard 0");
+    autumn_web::migrate::run_pending(&shard1_url, autumn_harvest::MIGRATIONS)
+        .expect("failed to migrate shard 1");
+    ((shard0_url, shard1_url), container)
+}
+
+fn build_two_shard_pool(shard0_url: &str, shard1_url: &str) -> HarvestDbPool {
+    let mut pools = BTreeMap::new();
+    pools.insert(ShardId::new(0), build_test_pool(shard0_url));
+    pools.insert(ShardId::new(1), build_test_pool(shard1_url));
+    HarvestDbPool::sharded(ShardedDbPool::from_map(pools, ShardId::new(0)))
+}
+
+fn workflow_info() -> WorkflowInfo {
+    WorkflowInfo {
+        name: "echo_workflow",
+        module: "tests",
+        handler: |_ctx, input| Box::pin(async move { Ok(input) }),
+        execution_timeout: None,
+        concurrency: None,
+        max_input_bytes: None,
+    }
+}
+
+fn runtime_for(queues: &[&str], router: ShardRouter) -> HarvestApiRuntime {
+    HarvestApiRuntime::new(
+        Arc::new(HandlerRegistry::new(vec![workflow_info()], Vec::new())),
+        Arc::new(DagCatalog::new()),
+        Arc::new(Vec::new()),
+        None,
+        queues.iter().map(|queue| (*queue).to_string()).collect(),
+        autumn_harvest::scheduler::SchedulerMonitor::offline(),
+        HarvestRetentionRuntime::disabled(RetentionConfig::default()),
+        router,
+    )
+}
+
+fn api_state(pool: HarvestDbPool, runtime: HarvestApiRuntime) -> HarvestApiState {
+    let state = HarvestApiState::new();
+    state.install_storage_pool(pool);
+    state.install(runtime);
+    state.set_worker_stale_threshold(Duration::from_secs(10));
+    state
+}
+
+async fn register_active_worker(pool: &DbPool, worker_id: &str, queues: &[&str], shards: &[i32]) {
+    let queue_names = queues
+        .iter()
+        .map(|queue| (*queue).to_string())
+        .collect::<Vec<_>>();
+    let mut conn = pool.get().await.expect("worker registration connection");
+    register_worker(
+        &mut conn,
+        worker_id,
+        &queue_names,
+        shards,
+        10,
+        "localhost",
+        Some(env!("CARGO_PKG_VERSION")),
+        "",
+        None,
+    )
+    .await
+    .expect("worker registration should succeed");
+}
+
+async fn mark_worker_stale(pool: &DbPool, worker_id: &str) {
+    let mut conn = pool.get().await.expect("stale update connection");
+    diesel::sql_query(
+        "UPDATE harvest_workers
+         SET last_heartbeat_at = NOW() - INTERVAL '10 minutes'
+         WHERE worker_id = $1",
+    )
+    .bind::<diesel::sql_types::Text, _>(worker_id)
+    .execute(&mut conn)
+    .await
+    .expect("worker should be marked stale");
+}
+
+async fn mark_worker_draining(pool: &DbPool, worker_id: &str) {
+    let mut conn = pool.get().await.expect("draining update connection");
+    diesel::sql_query(
+        "UPDATE harvest_workers
+         SET status = $1
+         WHERE worker_id = $2",
+    )
+    .bind::<diesel::sql_types::Text, _>(WorkerStatus::Draining.as_str())
+    .bind::<diesel::sql_types::Text, _>(worker_id)
+    .execute(&mut conn)
+    .await
+    .expect("worker should be marked draining");
+}
+
+async fn seed_task(pool: &DbPool, queue_name: &str, state: &str, scheduled_at_expr: &str) {
+    let mut conn = pool.get().await.expect("task seeding connection");
+    diesel::sql_query(format!(
+        "INSERT INTO harvest_task_queue (
+            id, queue_name, task_type, input, state, priority, max_attempts, scheduled_at
+         ) VALUES (
+            gen_random_uuid(), '{queue_name}', 'workflow', '{{}}'::jsonb, '{state}', 0, 1, {scheduled_at_expr}
+         )"
+    ))
+    .execute(&mut conn)
+    .await
+    .expect("failed to insert test task");
+}
+
+async fn read_response_body(response: axum::response::Response) -> Vec<u8> {
+    axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("failed to read response body")
+        .to_vec()
+}
+
+async fn get_json(app: &HarvestApiApp, uri: impl Into<String>) -> (StatusCode, Value) {
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(uri.into())
+                .body(Body::empty())
+                .expect("request should build"),
+        )
+        .await
+        .expect("request should complete");
+    let status = response.status();
+    let body_bytes = read_response_body(response).await;
+    let json = serde_json::from_slice(&body_bytes).expect("response must be JSON");
+    (status, json)
+}
+
+async fn get_text(app: &HarvestApiApp, uri: impl Into<String>) -> (StatusCode, String) {
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(uri.into())
+                .body(Body::empty())
+                .expect("request should build"),
+        )
+        .await
+        .expect("request should complete");
+    let status = response.status();
+    let body_bytes = read_response_body(response).await;
+    let text = String::from_utf8(body_bytes).expect("response must be valid UTF-8");
+    (status, text)
+}
+
+#[tokio::test]
+async fn single_shard_scaling_signals_endpoint_correctly_categorizes_tasks_and_workers() {
+    let (database_url, _container) = setup_database_url_with_migrations().await;
+    let pool = build_test_pool(&database_url);
+
+    // Queue A:
+    // - 1 Backlog task (PENDING, scheduled_at <= NOW)
+    // - 1 Scheduled task (PENDING, scheduled_at > NOW)
+    // - 2 In-flight tasks (RUNNING)
+    seed_task(&pool, "queue-a", "PENDING", "NOW() - INTERVAL '5 seconds'").await;
+    seed_task(&pool, "queue-a", "PENDING", "NOW() + INTERVAL '1 hour'").await;
+    seed_task(&pool, "queue-a", "RUNNING", "NOW()").await;
+    seed_task(&pool, "queue-a", "RUNNING", "NOW()").await;
+
+    // Queue B:
+    // - 3 Backlog tasks (PENDING, scheduled_at <= NOW)
+    // - 0 Scheduled tasks
+    // - 1 In-flight task (RUNNING)
+    seed_task(&pool, "queue-b", "PENDING", "NOW() - INTERVAL '1 second'").await;
+    seed_task(&pool, "queue-b", "PENDING", "NOW() - INTERVAL '2 seconds'").await;
+    seed_task(&pool, "queue-b", "PENDING", "NOW() - INTERVAL '3 seconds'").await;
+    seed_task(&pool, "queue-b", "RUNNING", "NOW()").await;
+
+    // Register workers:
+    // - worker-1: healthy active on queue-a
+    // - worker-2: healthy active on queue-a & queue-b
+    // - worker-3: draining on queue-a
+    // - worker-4: stale on queue-b
+    register_active_worker(&pool, "worker-1", &["queue-a"], &[0]).await;
+    register_active_worker(&pool, "worker-2", &["queue-a", "queue-b"], &[0]).await;
+    register_active_worker(&pool, "worker-3", &["queue-a"], &[0]).await;
+    mark_worker_draining(&pool, "worker-3").await;
+    register_active_worker(&pool, "worker-4", &["queue-b"], &[0]).await;
+    mark_worker_stale(&pool, "worker-4").await;
+
+    let state = api_state(
+        HarvestDbPool::from(pool),
+        runtime_for(&["queue-a", "queue-b"], ShardRouter::single()),
+    );
+    let app = harvest_api_router(state).with_state(AppState::for_test().with_profile("test"));
+
+    // 1. JSON scaling API format
+    let (status, body) = get_json(&app, "/admin/queues/scaling").await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(body.is_array());
+    let arr = body.as_array().unwrap();
+    assert_eq!(arr.len(), 2);
+
+    let qa = arr
+        .iter()
+        .find(|q| q["queue"] == "queue-a")
+        .expect("missing queue-a");
+    assert_eq!(qa["backlog"], 1);
+    assert_eq!(qa["in_flight"], 2);
+    assert_eq!(qa["scheduled"], 1);
+    assert_eq!(qa["active_workers"], 2); // worker-1 and worker-2 are healthy & active on queue-a
+
+    let qb = arr
+        .iter()
+        .find(|q| q["queue"] == "queue-b")
+        .expect("missing queue-b");
+    assert_eq!(qb["backlog"], 3);
+    assert_eq!(qb["in_flight"], 1);
+    assert_eq!(qb["scheduled"], 0);
+    assert_eq!(qb["active_workers"], 1); // only worker-2 is healthy & active on queue-b
+
+    // 2. Query format=prometheus
+    let (status_prom_q, text_prom_q) =
+        get_text(&app, "/admin/queues/scaling?format=prometheus").await;
+    assert_eq!(status_prom_q, StatusCode::OK);
+    assert!(text_prom_q.contains("harvest_queue_backlog{queue=\"queue-a\"} 1"));
+    assert!(text_prom_q.contains("harvest_queue_in_flight{queue=\"queue-a\"} 2"));
+    assert!(text_prom_q.contains("harvest_queue_scheduled{queue=\"queue-a\"} 1"));
+    assert!(text_prom_q.contains("harvest_queue_active_workers{queue=\"queue-a\"} 2"));
+    assert!(text_prom_q.contains("harvest_queue_backlog{queue=\"queue-b\"} 3"));
+    assert!(text_prom_q.contains("harvest_queue_in_flight{queue=\"queue-b\"} 1"));
+    assert!(text_prom_q.contains("harvest_queue_scheduled{queue=\"queue-b\"} 0"));
+    assert!(text_prom_q.contains("harvest_queue_active_workers{queue=\"queue-b\"} 1"));
+
+    // 3. /admin/metrics endpoint
+    let (status_metrics, text_metrics) = get_text(&app, "/admin/metrics").await;
+    assert_eq!(status_metrics, StatusCode::OK);
+    assert!(text_metrics.contains("harvest_queue_backlog{queue=\"queue-a\"} 1"));
+    assert!(text_metrics.contains("harvest_queue_in_flight{queue=\"queue-a\"} 2"));
+    assert!(text_metrics.contains("harvest_queue_scheduled{queue=\"queue-a\"} 1"));
+    assert!(text_metrics.contains("harvest_queue_active_workers{queue=\"queue-a\"} 2"));
+    assert!(text_metrics.contains("harvest_queue_backlog{queue=\"queue-b\"} 3"));
+    assert!(text_metrics.contains("harvest_queue_in_flight{queue=\"queue-b\"} 1"));
+    assert!(text_metrics.contains("harvest_queue_scheduled{queue=\"queue-b\"} 0"));
+    assert!(text_metrics.contains("harvest_queue_active_workers{queue=\"queue-b\"} 1"));
+}
+
+#[tokio::test]
+async fn multi_shard_scaling_signals_are_correctly_aggregated_across_shards() {
+    let ((shard0_url, shard1_url), _container) = setup_two_shards_with_migrations().await;
+    let pool = build_two_shard_pool(&shard0_url, &shard1_url);
+
+    // Shard 0:
+    // - 1 Backlog task on queue-a
+    // - 1 healthy active worker on queue-a
+    seed_task(
+        pool.pool_for(ShardId::new(0)),
+        "queue-a",
+        "PENDING",
+        "NOW() - INTERVAL '5 seconds'",
+    )
+    .await;
+    register_active_worker(
+        pool.pool_for(ShardId::new(0)),
+        "worker-shard-0",
+        &["queue-a"],
+        &[0],
+    )
+    .await;
+
+    // Shard 1:
+    // - 2 Backlog tasks on queue-a
+    // - 1 In-flight task on queue-a
+    // - 1 healthy active worker on queue-a
+    seed_task(
+        pool.pool_for(ShardId::new(1)),
+        "queue-a",
+        "PENDING",
+        "NOW() - INTERVAL '10 seconds'",
+    )
+    .await;
+    seed_task(
+        pool.pool_for(ShardId::new(1)),
+        "queue-a",
+        "PENDING",
+        "NOW() - INTERVAL '2 seconds'",
+    )
+    .await;
+    seed_task(
+        pool.pool_for(ShardId::new(1)),
+        "queue-a",
+        "RUNNING",
+        "NOW()",
+    )
+    .await;
+    register_active_worker(
+        pool.pool_for(ShardId::new(1)),
+        "worker-shard-1",
+        &["queue-a"],
+        &[1],
+    )
+    .await;
+
+    let router = ShardRouter::new(
+        vec![ShardId::new(0), ShardId::new(1)],
+        vec![ShardId::new(0), ShardId::new(1)],
+        ShardId::new(0),
+    );
+    let state = api_state(pool, runtime_for(&["queue-a"], router));
+    let app = harvest_api_router(state).with_state(AppState::for_test().with_profile("test"));
+
+    let (status, body) = get_json(&app, "/admin/queues/scaling").await;
+    assert_eq!(status, StatusCode::OK);
+    assert!(body.is_array());
+    let arr = body.as_array().unwrap();
+    assert_eq!(arr.len(), 1);
+
+    let qa = &arr[0];
+    assert_eq!(qa["queue"], "queue-a");
+    assert_eq!(qa["backlog"], 3); // 1 from shard 0 + 2 from shard 1
+    assert_eq!(qa["in_flight"], 1); // 1 from shard 1
+    assert_eq!(qa["scheduled"], 0);
+    assert_eq!(qa["active_workers"], 2); // 1 worker-shard-0 + 1 worker-shard-1
+}

--- a/autumn-harvest/src/executor.rs
+++ b/autumn-harvest/src/executor.rs
@@ -640,6 +640,7 @@ mod tests {
 
         let names = SpanNames::default();
         let subscriber = tracing_subscriber::registry().with(SpanNameLayer(names.clone()));
+        let _guard = tracing::subscriber::set_default(subscriber);
 
         let exec_id = ExecutionId::new();
         let history = vec![WorkflowEvent::WorkflowStarted {
@@ -647,13 +648,11 @@ mod tests {
             timestamp: Utc::now(),
         }];
 
-        tracing::subscriber::with_default(subscriber, || {
-            tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .unwrap()
-                .block_on(run_workflow(exec_id, history, echo_workflow, Value::Null))
-        });
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(run_workflow(exec_id, history, echo_workflow, Value::Null));
 
         assert!(
             names.has("harvest.workflow.execute"),
@@ -672,6 +671,7 @@ mod tests {
 
         let names = SpanNames::default();
         let subscriber = tracing_subscriber::registry().with(SpanNameLayer(names.clone()));
+        let _guard = tracing::subscriber::set_default(subscriber);
 
         let exec_id = ExecutionId::new();
         let history = vec![WorkflowEvent::WorkflowStarted {
@@ -679,13 +679,11 @@ mod tests {
             timestamp: Utc::now(),
         }];
 
-        tracing::subscriber::with_default(subscriber, || {
-            tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .unwrap()
-                .block_on(run_workflow(exec_id, history, echo_workflow, Value::Null))
-        });
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(run_workflow(exec_id, history, echo_workflow, Value::Null));
 
         assert!(
             !names.has("harvest.workflow.run"),
@@ -708,6 +706,7 @@ mod tests {
 
         let fields = SpanFields::default();
         let subscriber = tracing_subscriber::registry().with(SpanFieldLayer(fields.clone()));
+        let _guard = tracing::subscriber::set_default(subscriber);
 
         let exec_id = ExecutionId::new();
         let history = vec![WorkflowEvent::WorkflowStarted {
@@ -715,13 +714,11 @@ mod tests {
             timestamp: Utc::now(),
         }];
 
-        tracing::subscriber::with_default(subscriber, || {
-            tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .unwrap()
-                .block_on(run_workflow(exec_id, history, echo_workflow, Value::Null))
-        });
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(run_workflow(exec_id, history, echo_workflow, Value::Null));
 
         let span_fields = fields.fields_for("harvest.workflow.execute");
         assert!(
@@ -752,6 +749,7 @@ mod tests {
 
         let fields = SpanFields::default();
         let subscriber = tracing_subscriber::registry().with(SpanFieldLayer(fields.clone()));
+        let _guard = tracing::subscriber::set_default(subscriber);
 
         let exec_id = ExecutionId::new();
         // Provide a complete single-event history so the strict executor
@@ -761,19 +759,17 @@ mod tests {
             timestamp: Utc::now(),
         }];
 
-        tracing::subscriber::with_default(subscriber, || {
-            tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .unwrap()
-                .block_on(run_workflow_strict(
-                    exec_id,
-                    history,
-                    echo_workflow,
-                    Value::Null,
-                    empty_shared_state(),
-                ))
-        });
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(run_workflow_strict(
+                exec_id,
+                history,
+                echo_workflow,
+                Value::Null,
+                empty_shared_state(),
+            ));
 
         // 1. Span must be named correctly.
         let span_fields = fields.fields_for("harvest.workflow.execute");
@@ -813,6 +809,7 @@ mod tests {
 
         let fields = SpanFields::default();
         let subscriber = tracing_subscriber::registry().with(SpanFieldLayer(fields.clone()));
+        let _guard = tracing::subscriber::set_default(subscriber);
 
         let exec_id = ExecutionId::new();
         let history = vec![WorkflowEvent::WorkflowStarted {
@@ -820,13 +817,11 @@ mod tests {
             timestamp: Utc::now(),
         }];
 
-        tracing::subscriber::with_default(subscriber, || {
-            tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-                .unwrap()
-                .block_on(run_workflow(exec_id, history, echo_workflow, Value::Null))
-        });
+        tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap()
+            .block_on(run_workflow(exec_id, history, echo_workflow, Value::Null));
 
         let span_fields = fields.fields_for("harvest.workflow.execute");
         let any_has_replay_false = span_fields.iter().any(|field_set| {

--- a/autumn-harvest/src/lib.rs
+++ b/autumn-harvest/src/lib.rs
@@ -258,7 +258,7 @@ pub use store::EventHistory;
 pub use models::{AuditRecord, NewAuditRecord};
 
 #[cfg(feature = "db")]
-pub use queue::ConcurrencyKeyStats;
+pub use queue::{ConcurrencyKeyStats, QueueScalingSignal, QueueTaskCounts, queue_task_counts};
 
 // Allow macro-generated code to use ::autumn_harvest::serde_json
 pub use serde_json;

--- a/autumn-harvest/src/queue.rs
+++ b/autumn-harvest/src/queue.rs
@@ -397,6 +397,83 @@ pub async fn claim_task(
 }
 
 // ---------------------------------------------------------------------------
+// ---------------------------------------------------------------------------
+// Worker-pool scaling signals
+// ---------------------------------------------------------------------------
+
+/// Live scaling signals for a task queue.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct QueueScalingSignal {
+    /// The task queue name.
+    pub queue: String,
+    /// Number of tasks in `PENDING` state with `scheduled_at <= NOW()`.
+    pub backlog: i64,
+    /// Number of tasks in `RUNNING` state.
+    pub in_flight: i64,
+    /// Number of tasks in `PENDING` state with `scheduled_at > NOW()`.
+    pub scheduled: i64,
+    /// Number of active (healthy, non-draining) workers currently polling this queue.
+    pub active_workers: i64,
+}
+
+/// Helper struct for queue task counts.
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize, PartialEq, Eq)]
+pub struct QueueTaskCounts {
+    /// The task queue name.
+    pub queue: String,
+    /// Number of tasks in `PENDING` state with `scheduled_at <= NOW()`.
+    pub backlog: i64,
+    /// Number of tasks in `RUNNING` state.
+    pub in_flight: i64,
+    /// Number of tasks in `PENDING` state with `scheduled_at > NOW()`.
+    pub scheduled: i64,
+}
+
+/// Return backlog, in-flight, and scheduled task counts per queue on this shard.
+///
+/// # Errors
+///
+/// Returns [`crate::error::HarvestError::Database`] on query failure.
+pub async fn queue_task_counts(
+    conn: &mut AsyncPgConnection,
+) -> HarvestResult<Vec<QueueTaskCounts>> {
+    #[derive(diesel::QueryableByName)]
+    struct Row {
+        #[diesel(sql_type = diesel::sql_types::Text)]
+        queue: String,
+        #[diesel(sql_type = diesel::sql_types::BigInt)]
+        backlog: i64,
+        #[diesel(sql_type = diesel::sql_types::BigInt)]
+        in_flight: i64,
+        #[diesel(sql_type = diesel::sql_types::BigInt)]
+        scheduled: i64,
+    }
+
+    let rows: Vec<Row> = diesel::sql_query(
+        "SELECT \
+             queue_name AS queue, \
+             COUNT(*) FILTER (WHERE state = 'PENDING' AND scheduled_at <= $1) AS backlog, \
+             COUNT(*) FILTER (WHERE state = 'RUNNING') AS in_flight, \
+             COUNT(*) FILTER (WHERE state = 'PENDING' AND scheduled_at > $1) AS scheduled \
+         FROM harvest_task_queue \
+         GROUP BY queue_name",
+    )
+    .bind::<diesel::sql_types::Timestamptz, _>(Utc::now())
+    .load(conn)
+    .await
+    .map_err(crate::error::database_error)?;
+
+    Ok(rows
+        .into_iter()
+        .map(|r| QueueTaskCounts {
+            queue: r.queue,
+            backlog: r.backlog,
+            in_flight: r.in_flight,
+            scheduled: r.scheduled,
+        })
+        .collect())
+}
+
 // Concurrency-key stats
 // ---------------------------------------------------------------------------
 

--- a/docs/api-contract.json
+++ b/docs/api-contract.json
@@ -2037,6 +2037,51 @@
     },
     {
       "method": "GET",
+      "path": "/admin/queues/scaling",
+      "category": "admin",
+      "read_only": true,
+      "description": "Return worker-pool scaling signal per-queue statistics, including backlog, in-flight, scheduled, and active worker counts.",
+      "params": [
+        {
+          "name": "format",
+          "in": "query",
+          "required": false,
+          "description": "Output format: json (default) or prometheus plain-text."
+        }
+      ],
+      "request_body": null,
+      "success_response": {
+        "status": 200,
+        "free_form": true
+      },
+      "error_responses": [
+        {
+          "status": 500,
+          "description": "Database or shard error."
+        }
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/admin/metrics",
+      "category": "admin",
+      "read_only": true,
+      "description": "Return Prometheus-compatible metrics scrapable by autoscalers or monitoring systems.",
+      "params": [],
+      "request_body": null,
+      "success_response": {
+        "status": 200,
+        "free_form": true
+      },
+      "error_responses": [
+        {
+          "status": 500,
+          "description": "Database or shard error."
+        }
+      ]
+    },
+    {
+      "method": "GET",
       "path": "/admin/history/exports",
       "category": "admin",
       "read_only": true,


### PR DESCRIPTION
Exposes a worker-pool scaling signal endpoint for KEDA/HPA autoscalers. Closes #325.

### Proposed Changes

#### Core Engine: `autumn-harvest`
- Defined the core data structures `QueueScalingSignal` and `QueueTaskCounts` in `autumn-harvest/src/queue.rs` and re-exported them.
- Implemented `queue_task_counts`, a single-pass optimized SQL query retrieving backlog (ready pending), in-flight (running), and scheduled (future pending) tasks on a per-queue basis.

#### Plugin & API: `autumn-harvest-plugin`
- Mounted and exposed `/admin/queues/scaling` and `/admin/metrics` endpoints.
- Implemented the Axum scaling signal handler, aggregating queue statistics across all shards (`ShardedDbPool`) and resolving active healthy workers using `WorkerHealth::classify` staleness thresholds.
- Exposes plain-text Prometheus formatted scraping metrics natively (via `/admin/metrics` or `/admin/queues/scaling?format=prometheus`).
- Cleaned up clippy warnings (such as `collapsible_if`, `items_after_statements`, `map_unwrap_or`) and ensured warning-free library/test compilations.
- Updated `docs/api-contract.json` to register the new endpoints and pass contract regression checks.

### Verification Plan

- Implemented standard database integration test suite in `autumn-harvest-plugin/tests/scaling_api_tests.rs`.
- Validated single-shard queues, multi-shard aggregation, active vs. stale/draining worker tracking, JSON outputs, and Prometheus format.
- Ran all plugin integration tests sequentially (`api_scheduler_integration`, `contract_regression`, `ui_integration`, etc.) against live PostgreSQL testcontainers.