### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -546,7 +546,7 @@ fn extract_single_command<T>(
 fn extract_all_scheduled_activities(
     commands: &[WorkflowCommand],
 ) -> Option<Vec<ScheduledActivityCommand>> {
-    let mut scheduled = Vec::new();
+    let mut scheduled = Vec::with_capacity(commands.len());
 
     for cmd in commands {
         match cmd {
@@ -583,7 +583,7 @@ fn extract_all_scheduled_activities(
 }
 
 fn extract_all_activity_waits(commands: &[WorkflowCommand]) -> Option<Vec<ActivityExecId>> {
-    let mut activity_ids = Vec::new();
+    let mut activity_ids = Vec::with_capacity(commands.len());
 
     for cmd in commands {
         match cmd {
@@ -853,8 +853,8 @@ fn extract_signal_external_workflow(commands: Vec<WorkflowCommand>) -> Vec<Signa
 fn split_mixed_signal_batch(
     commands: Vec<WorkflowCommand>,
 ) -> (Vec<SignalBatchItem>, Vec<WorkflowCommand>) {
-    let mut signal_items = Vec::new();
-    let mut remaining = Vec::new();
+    let mut signal_items = Vec::with_capacity(commands.len());
+    let mut remaining = Vec::with_capacity(commands.len());
     for cmd in commands {
         match cmd {
             WorkflowCommand::SignalExternalWorkflow {
@@ -907,7 +907,7 @@ async fn persist_external_signal_inline(
     items: Vec<SignalBatchItem>,
     next_event_id: &mut i32,
 ) -> HarvestResult<Vec<WorkflowEvent>> {
-    let mut new_events: Vec<WorkflowEvent> = Vec::new();
+    let mut new_events: Vec<WorkflowEvent> = Vec::with_capacity(items.len());
 
     for item in items {
         match item {


### PR DESCRIPTION
💡 What: Pre-allocate `Vec` capacity using `Vec::with_capacity` instead of `Vec::new` in multiple worker loops (`extract_all_scheduled_activities`, `extract_all_activity_waits`, `split_mixed_signal_batch`, `persist_external_signal_inline`).
🎯 Why: Avoids multiple heap allocations and reallocations when processing large batches of commands during workflow tasks.
📊 Impact: Eliminates `O(log N)` vector reallocations per function call when dealing with multiple commands, resulting in fewer memory allocations on the hot path.
🔬 Measurement: Run `cargo bench` or profile the workflow execution loops to verify reduced memory allocation traffic during command extraction and signal batching.

---
*PR created automatically by Jules for task [14448823020820651320](https://jules.google.com/task/14448823020820651320) started by @madmax983*