### PR TITLE
👺 Havoc: [Fix det_check panic with emoji]

### DIFF
--- a/autumn-harvest/benches/replay_verifier_bench.rs
+++ b/autumn-harvest/benches/replay_verifier_bench.rs
@@ -5,7 +5,7 @@
 //!
 //! Run with:
 //!   cargo bench -p autumn-harvest --features testing --no-default-features \
-//!     --bench replay_verifier_bench
+//!     --bench `replay_verifier_bench`
 
 use std::future::Future;
 use std::pin::Pin;

--- a/autumn-harvest/src/det_check.rs
+++ b/autumn-harvest/src/det_check.rs
@@ -595,7 +595,7 @@ fn char_literal_end(line: &str, start: usize) -> Option<usize> {
 
     if is_lifetime_start(first) {
         let ident_end = consume_lifetime_ident(line, first_end);
-        if !line[ident_end..].starts_with('\'') {
+        if !line.is_char_boundary(ident_end) || !line[ident_end..].starts_with('\'') {
             return None;
         }
     }
@@ -867,6 +867,13 @@ mod tests {
     #[test]
     fn check_source_no_workflow_annotation_produces_no_findings() {
         let src = "async fn foo() { let _ = std::time::SystemTime::now(); }\n";
+        let report = check_source(src, "test.rs");
+        assert!(report.findings.is_empty());
+    }
+
+    #[test]
+    fn check_source_handles_emojis_in_char_literals_without_panic() {
+        let src = "#[workflow]\nasync fn test() {\n    let x = '🦀';\n}";
         let report = check_source(src, "test.rs");
         assert!(report.findings.is_empty());
     }


### PR DESCRIPTION
🧨 **The Trigger:** The determinism checker lexer panics when encountering multi-byte Unicode characters (like emojis) inside character literals. 
📉 **The Stack Trace:** `byte index 17 is out of bounds of let x = '🦀';` when executing `check_source`. 
🧪 **Reproduction:** Run `check_source` on `let x = '🦀';` or `cargo test check_source_handles_emojis_in_char_literals_without_panic`. 
😈 **Comment:** You assumed the user wouldn't put an emoji inside a char literal! The lexer panicked blindly slicing strings at non-character boundaries. It is fragile. Fix this by adding an `.is_char_boundary(ident_end)` check before string slicing.

---
*PR created automatically by Jules for task [16187644122645470252](https://jules.google.com/task/16187644122645470252) started by @madmax983*