### PR TITLE
⚒️ Forge: Flatten nested loops and matches in worker.rs

### DIFF
--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -1294,12 +1294,14 @@ fn find_pending_scheduled_activity(
 
     let mut pending = None;
     for event in history {
-        if let WorkflowEvent::ActivityScheduled {
+        let WorkflowEvent::ActivityScheduled {
             activity_id, name, ..
         } = event
-            && name == activity_name
-            && !terminal_ids.contains(activity_id)
-        {
+        else {
+            continue;
+        };
+
+        if name == activity_name && !terminal_ids.contains(activity_id) {
             if pending.is_some() {
                 return Err(HarvestError::NonDeterministic(format!(
                     "multiple pending scheduled activities named '{activity_name}' found in history"
@@ -1648,16 +1650,16 @@ async fn persist_update_result_commands(
     let events: Vec<WorkflowEvent> = commands
         .iter()
         .filter_map(|cmd| match cmd {
-            WorkflowCommand::RecordUpdateResult { update_id, result } => Some(match result {
-                Ok(output) => WorkflowEvent::UpdateCompleted {
+            WorkflowCommand::RecordUpdateResult { update_id, result } => match result {
+                Ok(output) => Some(WorkflowEvent::UpdateCompleted {
                     update_id: *update_id,
                     output: output.clone(),
-                },
-                Err(error) => WorkflowEvent::UpdateFailed {
+                }),
+                Err(error) => Some(WorkflowEvent::UpdateFailed {
                     update_id: *update_id,
                     error: error.clone(),
-                },
-            }),
+                }),
+            },
             _ => None,
         })
         .collect();


### PR DESCRIPTION
🚮 Smell: Deeply nested `if let` blocks inside loops and nested matches returning `Some` in `autumn-harvest/src/worker.rs`.
✨ Solution: Extracted nested `if let` conditions into `else { continue; }` guard clauses, and flattened nested matches in `filter_map`.
🧼 Benefit: Reduces cognitive load and flattens the structure to improve readability.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [8125370393896900543](https://jules.google.com/task/8125370393896900543) started by @madmax983*