### PR TITLE
Deterministic retry jitter: add `JitterPolicy`, seeded delays, worker seeding, tests, docs and benchmark

### DIFF
--- a/autumn-harvest/benches/retry_jitter_bench.rs
+++ b/autumn-harvest/benches/retry_jitter_bench.rs
@@ -1,0 +1,42 @@
+use autumn_harvest::policy::{JitterPolicy, RetryPolicy};
+use criterion::{Criterion, criterion_group, criterion_main};
+
+fn bench_retry_jitter(c: &mut Criterion) {
+    let base = RetryPolicy::exponential(10, std::time::Duration::from_millis(250));
+    let full = base.clone().with_jitter(JitterPolicy::Full);
+    let equal = base.clone().with_jitter(JitterPolicy::Equal);
+    let deco = base.clone().with_jitter(JitterPolicy::Decorrelated);
+    let seed = 0x1234_5678_9abc_def0_u64;
+
+    c.bench_function("retry_delay_none", |b| {
+        b.iter(|| {
+            for attempt in 1..10 {
+                std::hint::black_box(base.next_delay_with_seed(attempt, seed));
+            }
+        })
+    });
+    c.bench_function("retry_delay_full", |b| {
+        b.iter(|| {
+            for attempt in 1..10 {
+                std::hint::black_box(full.next_delay_with_seed(attempt, seed));
+            }
+        })
+    });
+    c.bench_function("retry_delay_equal", |b| {
+        b.iter(|| {
+            for attempt in 1..10 {
+                std::hint::black_box(equal.next_delay_with_seed(attempt, seed));
+            }
+        })
+    });
+    c.bench_function("retry_delay_decorrelated", |b| {
+        b.iter(|| {
+            for attempt in 1..10 {
+                std::hint::black_box(deco.next_delay_with_seed(attempt, seed));
+            }
+        })
+    });
+}
+
+criterion_group!(benches, bench_retry_jitter);
+criterion_main!(benches);

--- a/autumn-harvest/src/policy.rs
+++ b/autumn-harvest/src/policy.rs
@@ -49,7 +49,7 @@ const fn mix64(mut x: u64) -> u64 {
     x ^ (x >> 31)
 }
 
-fn uniform_inclusive(seed: u64, lo: u64, hi: u64) -> u64 {
+const fn uniform_inclusive(seed: u64, lo: u64, hi: u64) -> u64 {
     let range = hi.wrapping_sub(lo).wrapping_add(1);
     let offset = if range == 0 {
         mix64(seed)

--- a/autumn-harvest/src/policy.rs
+++ b/autumn-harvest/src/policy.rs
@@ -49,6 +49,16 @@ fn mix64(mut x: u64) -> u64 {
     x ^ (x >> 31)
 }
 
+fn uniform_inclusive(seed: u64, lo: u64, hi: u64) -> u64 {
+    let range = hi.wrapping_sub(lo).wrapping_add(1);
+    let offset = if range == 0 {
+        mix64(seed)
+    } else {
+        mix64(seed) % range
+    };
+    lo.wrapping_add(offset)
+}
+
 /// Compute deterministic retry delay with jitter.
 #[must_use]
 pub fn compute_retry_delay_with_seed(
@@ -65,19 +75,19 @@ pub fn compute_retry_delay_with_seed(
     match policy.jitter {
         JitterPolicy::None => base,
         JitterPolicy::Full => {
-            let span = u64::try_from(base.as_nanos()).unwrap_or(u64::MAX);
-            if span == 0 {
+            let hi = u64::try_from(base.as_nanos()).unwrap_or(u64::MAX);
+            if hi == 0 {
                 return Duration::ZERO;
             }
-            Duration::from_nanos(mix64(stream_seed ^ u64::from(attempt)) % span)
+            Duration::from_nanos(uniform_inclusive(stream_seed ^ u64::from(attempt), 0, hi))
         }
         JitterPolicy::Equal => {
-            let span = u64::try_from(base.as_nanos()).unwrap_or(u64::MAX);
-            if span <= 1 {
+            let hi = u64::try_from(base.as_nanos()).unwrap_or(u64::MAX);
+            if hi <= 1 {
                 return base;
             }
-            let half = span / 2;
-            Duration::from_nanos(half + (mix64(stream_seed ^ u64::from(attempt)) % (span - half)))
+            let lo = hi / 2;
+            Duration::from_nanos(uniform_inclusive(stream_seed ^ u64::from(attempt), lo, hi))
         }
         JitterPolicy::Decorrelated => {
             let prev = if attempt <= 1 {
@@ -96,7 +106,7 @@ pub fn compute_retry_delay_with_seed(
             }
             let lo = u64::try_from(policy.initial_interval.as_nanos()).unwrap_or(u64::MAX);
             let hi = u64::try_from(upper.as_nanos()).unwrap_or(u64::MAX);
-            Duration::from_nanos(lo + (mix64(stream_seed ^ u64::from(attempt)) % (hi - lo + 1)))
+            Duration::from_nanos(uniform_inclusive(stream_seed ^ u64::from(attempt), lo, hi))
         }
     }
 }
@@ -124,6 +134,7 @@ pub struct RetryPolicy {
     pub max_interval: Duration,
     /// Error type names that must not be retried.
     pub non_retryable_errors: Vec<String>,
+    #[serde(default)]
     pub jitter: JitterPolicy,
 }
 
@@ -1041,17 +1052,20 @@ mod tests {
             let base_delay = base.next_delay(attempt).unwrap();
             for seed in 0..10_000_u64 {
                 let full = base
+                    .clone()
                     .with_jitter(JitterPolicy::Full)
                     .next_delay_with_seed(attempt, seed)
                     .unwrap();
                 assert!(full <= base_delay);
                 let equal = base
+                    .clone()
                     .with_jitter(JitterPolicy::Equal)
                     .next_delay_with_seed(attempt, seed)
                     .unwrap();
                 assert!(equal >= base_delay / 2);
                 assert!(equal <= base_delay);
                 let deco = base
+                    .clone()
                     .with_jitter(JitterPolicy::Decorrelated)
                     .next_delay_with_seed(attempt, seed)
                     .unwrap();

--- a/autumn-harvest/src/policy.rs
+++ b/autumn-harvest/src/policy.rs
@@ -41,7 +41,7 @@ pub enum JitterPolicy {
     Decorrelated,
 }
 
-fn mix64(mut x: u64) -> u64 {
+const fn mix64(mut x: u64) -> u64 {
     x ^= x >> 30;
     x = x.wrapping_mul(0xbf58_476d_1ce4_e5b9);
     x ^= x >> 27;

--- a/autumn-harvest/src/policy.rs
+++ b/autumn-harvest/src/policy.rs
@@ -31,6 +31,76 @@ pub fn compute_retry_delay(
     delay.min(max_interval)
 }
 
+/// Retry jitter strategy.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub enum JitterPolicy {
+    #[default]
+    None,
+    Full,
+    Equal,
+    Decorrelated,
+}
+
+fn mix64(mut x: u64) -> u64 {
+    x ^= x >> 30;
+    x = x.wrapping_mul(0xbf58_476d_1ce4_e5b9);
+    x ^= x >> 27;
+    x = x.wrapping_mul(0x94d0_49bb_1331_11eb);
+    x ^ (x >> 31)
+}
+
+/// Compute deterministic retry delay with jitter.
+#[must_use]
+pub fn compute_retry_delay_with_seed(
+    policy: &RetryPolicy,
+    attempt: u32,
+    stream_seed: u64,
+) -> Duration {
+    let base = compute_retry_delay(
+        policy.initial_interval,
+        policy.backoff_coefficient,
+        policy.max_interval,
+        attempt,
+    );
+    match policy.jitter {
+        JitterPolicy::None => base,
+        JitterPolicy::Full => {
+            let span = u64::try_from(base.as_nanos()).unwrap_or(u64::MAX);
+            if span == 0 {
+                return Duration::ZERO;
+            }
+            Duration::from_nanos(mix64(stream_seed ^ u64::from(attempt)) % span)
+        }
+        JitterPolicy::Equal => {
+            let span = u64::try_from(base.as_nanos()).unwrap_or(u64::MAX);
+            if span <= 1 {
+                return base;
+            }
+            let half = span / 2;
+            Duration::from_nanos(half + (mix64(stream_seed ^ u64::from(attempt)) % (span - half)))
+        }
+        JitterPolicy::Decorrelated => {
+            let prev = if attempt <= 1 {
+                policy.initial_interval
+            } else {
+                compute_retry_delay(
+                    policy.initial_interval,
+                    policy.backoff_coefficient,
+                    policy.max_interval,
+                    attempt - 1,
+                )
+            };
+            let upper = prev.saturating_mul(3).min(policy.max_interval);
+            if upper <= policy.initial_interval {
+                return upper;
+            }
+            let lo = u64::try_from(policy.initial_interval.as_nanos()).unwrap_or(u64::MAX);
+            let hi = u64::try_from(upper.as_nanos()).unwrap_or(u64::MAX);
+            Duration::from_nanos(lo + (mix64(stream_seed ^ u64::from(attempt)) % (hi - lo + 1)))
+        }
+    }
+}
+
 /// How an activity failure is retried.
 ///
 /// ## Examples
@@ -54,6 +124,7 @@ pub struct RetryPolicy {
     pub max_interval: Duration,
     /// Error type names that must not be retried.
     pub non_retryable_errors: Vec<String>,
+    pub jitter: JitterPolicy,
 }
 
 impl RetryPolicy {
@@ -77,6 +148,7 @@ impl RetryPolicy {
             backoff_coefficient: 2.0,
             max_interval: Duration::from_secs(300),
             non_retryable_errors: vec![],
+            jitter: JitterPolicy::None,
         }
     }
 
@@ -100,6 +172,7 @@ impl RetryPolicy {
             backoff_coefficient: 1.0,
             max_interval: interval,
             non_retryable_errors: vec![],
+            jitter: JitterPolicy::None,
         }
     }
 
@@ -122,12 +195,21 @@ impl RetryPolicy {
         if attempt >= self.max_attempts {
             return None;
         }
-        Some(compute_retry_delay(
-            self.initial_interval,
-            self.backoff_coefficient,
-            self.max_interval,
-            attempt,
-        ))
+        Some(compute_retry_delay_with_seed(self, attempt, 0))
+    }
+
+    #[must_use]
+    pub const fn with_jitter(mut self, jitter: JitterPolicy) -> Self {
+        self.jitter = jitter;
+        self
+    }
+
+    #[must_use]
+    pub fn next_delay_with_seed(&self, attempt: u32, stream_seed: u64) -> Option<Duration> {
+        if attempt >= self.max_attempts {
+            return None;
+        }
+        Some(compute_retry_delay_with_seed(self, attempt, stream_seed))
     }
 
     /// Returns `true` when a failure should skip remaining retries because it
@@ -942,6 +1024,50 @@ mod tests {
     }
 
     #[test]
+    fn retry_jitter_none_is_bit_identical_default() {
+        let policy = RetryPolicy::exponential(5, Duration::from_secs(1));
+        for attempt in 1..5 {
+            assert_eq!(
+                policy.next_delay(attempt),
+                policy.next_delay_with_seed(attempt, 123_456_789)
+            );
+        }
+    }
+
+    #[test]
+    fn retry_jitter_bounds_over_10k_seeds() {
+        let base = RetryPolicy::exponential(8, Duration::from_millis(200));
+        for attempt in 1..6 {
+            let base_delay = base.next_delay(attempt).unwrap();
+            for seed in 0..10_000_u64 {
+                let full = base
+                    .with_jitter(JitterPolicy::Full)
+                    .next_delay_with_seed(attempt, seed)
+                    .unwrap();
+                assert!(full <= base_delay);
+                let equal = base
+                    .with_jitter(JitterPolicy::Equal)
+                    .next_delay_with_seed(attempt, seed)
+                    .unwrap();
+                assert!(equal >= base_delay / 2);
+                assert!(equal <= base_delay);
+                let deco = base
+                    .with_jitter(JitterPolicy::Decorrelated)
+                    .next_delay_with_seed(attempt, seed)
+                    .unwrap();
+                let prev = if attempt == 1 {
+                    base.initial_interval
+                } else {
+                    base.next_delay(attempt - 1).unwrap()
+                };
+                let upper = prev.saturating_mul(3).min(base.max_interval);
+                assert!(deco >= base.initial_interval);
+                assert!(deco <= upper);
+            }
+        }
+    }
+
+    #[test]
     fn exponential_caps_at_max_interval() -> Result<(), String> {
         let policy = RetryPolicy {
             max_attempts: 10,
@@ -949,6 +1075,7 @@ mod tests {
             backoff_coefficient: 2.0,
             max_interval: Duration::from_secs(120),
             non_retryable_errors: vec![],
+            jitter: JitterPolicy::None,
         };
         assert_eq!(
             policy.next_delay(6).ok_or("no delay")?,

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -1256,11 +1256,17 @@ fn task_attempt(task: &TaskQueueItem) -> u32 {
 fn retry_stream_seed(task: &TaskQueueItem) -> u64 {
     let mut seed = 0xcbf2_9ce4_8422_2325_u64;
     if let Some(exec) = task.workflow_exec_id {
-        seed ^= u64::from_le_bytes(exec.as_bytes()[..8].try_into().unwrap_or([0_u8; 8]));
+        let raw = exec.as_u128();
+        seed ^= (raw >> 64) as u64;
+        seed = seed.wrapping_mul(0x1000_0000_01b3);
+        seed ^= raw as u64;
         seed = seed.wrapping_mul(0x1000_0000_01b3);
     }
     if let Some(activity) = task.activity_id {
-        seed ^= u64::from_le_bytes(activity.as_bytes()[..8].try_into().unwrap_or([0_u8; 8]));
+        let raw = activity.as_u128();
+        seed ^= (raw >> 64) as u64;
+        seed = seed.wrapping_mul(0x1000_0000_01b3);
+        seed ^= raw as u64;
         seed = seed.wrapping_mul(0x1000_0000_01b3);
     }
     seed

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -1253,6 +1253,19 @@ fn task_attempt(task: &TaskQueueItem) -> u32 {
     u32::try_from(task.attempt.max(1)).unwrap_or(1)
 }
 
+fn retry_stream_seed(task: &TaskQueueItem) -> u64 {
+    let mut seed = 0xcbf2_9ce4_8422_2325_u64;
+    if let Some(exec) = task.workflow_exec_id {
+        seed ^= u64::from_le_bytes(exec.as_bytes()[..8].try_into().unwrap_or([0_u8; 8]));
+        seed = seed.wrapping_mul(0x1000_0000_01b3);
+    }
+    if let Some(activity) = task.activity_id {
+        seed ^= u64::from_le_bytes(activity.as_bytes()[..8].try_into().unwrap_or([0_u8; 8]));
+        seed = seed.wrapping_mul(0x1000_0000_01b3);
+    }
+    seed
+}
+
 pub(crate) fn chrono_duration_from_secs(
     seconds: u64,
     field_name: &str,
@@ -1288,7 +1301,7 @@ fn next_retry_delay(
         }
 
         return policy
-            .next_delay(task_attempt(task))
+            .next_delay_with_seed(task_attempt(task), retry_stream_seed(task))
             .map(|delay| chrono_duration_from_std(delay, "retry delay"))
             .transpose();
     }

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -1253,20 +1253,21 @@ fn task_attempt(task: &TaskQueueItem) -> u32 {
     u32::try_from(task.attempt.max(1)).unwrap_or(1)
 }
 
+#[allow(clippy::missing_const_for_fn)]
 fn retry_stream_seed(task: &TaskQueueItem) -> u64 {
     let mut seed = 0xcbf2_9ce4_8422_2325_u64;
     if let Some(exec) = task.workflow_exec_id {
-        let raw = exec.as_u128();
-        seed ^= (raw >> 64) as u64;
+        let raw = exec.as_u128().to_le_bytes();
+        seed ^= u64::from_le_bytes(raw[..8].try_into().unwrap_or([0_u8; 8]));
         seed = seed.wrapping_mul(0x1000_0000_01b3);
-        seed ^= raw as u64;
+        seed ^= u64::from_le_bytes(raw[8..].try_into().unwrap_or([0_u8; 8]));
         seed = seed.wrapping_mul(0x1000_0000_01b3);
     }
     if let Some(activity) = task.activity_id {
-        let raw = activity.as_u128();
-        seed ^= (raw >> 64) as u64;
+        let raw = activity.as_u128().to_le_bytes();
+        seed ^= u64::from_le_bytes(raw[..8].try_into().unwrap_or([0_u8; 8]));
         seed = seed.wrapping_mul(0x1000_0000_01b3);
-        seed ^= raw as u64;
+        seed ^= u64::from_le_bytes(raw[8..].try_into().unwrap_or([0_u8; 8]));
         seed = seed.wrapping_mul(0x1000_0000_01b3);
     }
     seed

--- a/autumn-harvest/tests/metrics_integration.rs
+++ b/autumn-harvest/tests/metrics_integration.rs
@@ -992,18 +992,20 @@ async fn workflow_hard_cap_dlq_preserves_terminal_attempt_count() {
         .expect("failed to force attempt");
 
     let policy = WorkflowHistoryPolicy::default().with_event_hard_cap(2);
-    let registry = Arc::new(HandlerRegistry::with_history_policy(
-        vec![WorkflowInfo {
-            name: "history_cap_violator",
-            module: "metrics_integration",
-            handler: history_cap_violator,
-            execution_timeout: None,
-            concurrency: None,
-            max_input_bytes: None,
-        }],
-        vec![],
-        policy,
-    ));
+    let registry = Arc::new(
+        HandlerRegistry::new(
+            vec![WorkflowInfo {
+                name: "history_cap_violator",
+                module: "metrics_integration",
+                handler: history_cap_violator,
+                execution_timeout: None,
+                concurrency: None,
+                max_input_bytes: None,
+            }],
+            vec![],
+        )
+        .with_history_policy(policy),
+    );
 
     let worker = build_worker("metrics-worker-hard-cap-attempt", registry);
     let pool = build_test_pool(&database_url);

--- a/autumn-harvest/tests/metrics_integration.rs
+++ b/autumn-harvest/tests/metrics_integration.rs
@@ -22,6 +22,7 @@ use autumn_harvest::event::WorkflowEvent;
 use autumn_harvest::info::{ActivityInfo, WorkflowInfo};
 use autumn_harvest::models::{NewWorkflowExecution, WorkflowExecution};
 use autumn_harvest::queue::{self as queue_mod, EnqueueParams, TaskType};
+use autumn_harvest::schema::harvest_task_queue::dsl as queue_dsl;
 use autumn_harvest::schema::harvest_workflow_executions;
 use autumn_harvest::store;
 use autumn_harvest::telemetry::{
@@ -811,6 +812,7 @@ async fn continue_as_new_records_history_size_and_rotation_metrics() {
     );
 }
 
+#[allow(clippy::too_many_lines)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn workflow_hard_cap_moves_offender_to_dlq() {
     let (database_url, _container) = setup_test_database_url().await;
@@ -984,7 +986,6 @@ async fn workflow_hard_cap_dlq_preserves_terminal_attempt_count() {
         .await
         .expect("enqueue failed");
 
-    use autumn_harvest::schema::harvest_task_queue::dsl as queue_dsl;
     diesel::update(queue_dsl::harvest_task_queue.find(task_id))
         .set(queue_dsl::attempt.eq(3))
         .execute(&mut conn)

--- a/autumn-harvest/tests/metrics_integration.rs
+++ b/autumn-harvest/tests/metrics_integration.rs
@@ -921,6 +921,113 @@ async fn workflow_hard_cap_moves_offender_to_dlq() {
         "DLQ reason should identify hard cap, got: {}",
         dlq_row.error
     );
+    assert_eq!(
+        dlq_row.attempts, 1,
+        "DLQ attempts must match the terminal task attempt"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn workflow_hard_cap_dlq_preserves_terminal_attempt_count() {
+    let (database_url, _container) = setup_test_database_url().await;
+    let mut conn = AsyncPgConnection::establish(&database_url)
+        .await
+        .expect("failed to connect");
+
+    let exec_id = ExecutionId::new_for_shard(ShardId::new(0));
+    let workflow_input = serde_json::json!({"case":"attempt-regression"});
+    let workflow_id = format!("hard-cap-attempt-{}", Uuid::new_v4());
+
+    diesel::insert_into(harvest_workflow_executions::table)
+        .values(NewWorkflowExecution {
+            id: exec_id.as_uuid(),
+            workflow_name: "history_cap_violator",
+            workflow_id: &workflow_id,
+            run_id: Uuid::new_v4(),
+            shard_id: 0,
+            input: workflow_input.clone(),
+            parent_id: None,
+            queue_name: "default",
+            execution_timeout: None,
+            deadline_at: None,
+            memo: None,
+            search_attrs: None,
+            assigned_build_id: None,
+        })
+        .execute(&mut conn)
+        .await
+        .expect("failed to insert workflow execution row");
+
+    store::append_events(
+        &mut conn,
+        exec_id,
+        &[
+            WorkflowEvent::WorkflowStarted {
+                input: workflow_input.clone(),
+                timestamp: Utc::now(),
+            },
+            WorkflowEvent::MarkerRecorded {
+                name: "already-large".into(),
+                details: serde_json::json!({}),
+            },
+        ],
+        0,
+    )
+    .await
+    .expect("append initial history failed");
+
+    let mut enqueue_params =
+        EnqueueParams::new("default", TaskType::Workflow, workflow_input.clone());
+    enqueue_params.workflow_exec_id = Some(exec_id.as_uuid());
+    enqueue_params.scheduled_at = Utc::now() - chrono::Duration::seconds(1);
+    let task_id = queue_mod::enqueue(&mut conn, &enqueue_params)
+        .await
+        .expect("enqueue failed");
+
+    use autumn_harvest::schema::harvest_task_queue::dsl as queue_dsl;
+    diesel::update(queue_dsl::harvest_task_queue.find(task_id))
+        .set(queue_dsl::attempt.eq(3))
+        .execute(&mut conn)
+        .await
+        .expect("failed to force attempt");
+
+    let policy = WorkflowHistoryPolicy::default().with_event_hard_cap(2);
+    let registry = Arc::new(HandlerRegistry::with_history_policy(
+        vec![WorkflowInfo {
+            name: "history_cap_violator",
+            module: "metrics_integration",
+            handler: history_cap_violator,
+            execution_timeout: None,
+            concurrency: None,
+            max_input_bytes: None,
+        }],
+        vec![],
+        policy,
+    ));
+
+    let worker = build_worker("metrics-worker-hard-cap-attempt", registry);
+    let pool = build_test_pool(&database_url);
+    let runner = Arc::clone(&worker);
+    let pool_for_run = pool.clone();
+    let handle = tokio::spawn(async move {
+        runner.run(&pool_for_run).await;
+    });
+
+    let _execution = wait_for_state(&database_url, exec_id, "FAILED").await;
+    worker.shutdown();
+    handle.await.expect("worker task should join cleanly");
+
+    let dead_letters = dlq::list_dead_letters(&mut conn, 10)
+        .await
+        .expect("failed to list DLQ rows");
+    let dlq_row = dead_letters
+        .iter()
+        .find(|row| row.workflow_exec_id == Some(exec_id.as_uuid()))
+        .expect("hard-cap offender must be moved to DLQ");
+    assert_eq!(
+        dlq_row.attempts, 3,
+        "DLQ attempts must preserve terminal task attempt count"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/autumn-harvest/tests/replayer_tests.rs
+++ b/autumn-harvest/tests/replayer_tests.rs
@@ -12,6 +12,7 @@ use std::pin::Pin;
 
 use autumn_harvest::context::WorkflowContext;
 use autumn_harvest::event::WorkflowEvent;
+use autumn_harvest::policy::{JitterPolicy, RetryPolicy};
 use autumn_harvest::testing::{
     HistorySnapshot, NonDeterminismKind, ReplayStatus, WorkflowReplayer,
 };
@@ -126,6 +127,28 @@ fn timer_first_workflow<'a>(
     })
 }
 
+/// Workflow that derives a timer duration from deterministic retry-jitter math.
+fn jitter_timer_workflow<'a>(
+    ctx: &'a WorkflowContext,
+    input: Value,
+) -> Pin<Box<dyn Future<Output = Result<Value, String>> + Send + 'a>> {
+    Box::pin(async move {
+        let attempt = input["attempt"].as_u64().unwrap_or(1) as u32;
+        let seed = input["seed"].as_u64().unwrap_or(0);
+        let policy = RetryPolicy::exponential(8, std::time::Duration::from_secs(2))
+            .with_jitter(JitterPolicy::Equal);
+        let delay = policy
+            .next_delay_with_seed(attempt, seed)
+            .ok_or_else(|| "no delay for attempt".to_string())?;
+        let secs = delay.as_secs().max(1);
+        let timer_name = format!("retry_jitter_{attempt}_{seed}");
+        ctx.timer(&timer_name, secs)
+            .await
+            .map_err(|e| e.to_string())?;
+        Ok(serde_json::json!({"timer_secs": secs, "timer_name": timer_name}))
+    })
+}
+
 // ---------------------------------------------------------------------------
 // Helper: build canonical event history
 // ---------------------------------------------------------------------------
@@ -176,6 +199,7 @@ fn build_replayer() -> WorkflowReplayer {
         .register_fn("versioned_workflow_fenced", versioned_workflow_fenced)
         .register_fn("versioned_workflow_unfenced", versioned_workflow_unfenced)
         .register_fn("timer_first_workflow", timer_first_workflow)
+        .register_fn("jitter_timer_workflow", jitter_timer_workflow)
 }
 
 /// Build a snapshot from a `(exec_id, events)` pair with a given workflow name.
@@ -233,6 +257,69 @@ async fn replay_reordered_activities_detects_non_determinism() {
         }
         other => panic!("expected NonDeterminismDetected, got: {other:?}\nreport: {report}"),
     }
+}
+
+#[tokio::test]
+async fn replay_jitter_timer_is_exact_and_deterministic() {
+    let replayer = build_replayer();
+    let exec_id = ExecutionId::new();
+    let attempt = 3u32;
+    let seed = 0xfeed_beefu64;
+    let policy = RetryPolicy::exponential(8, std::time::Duration::from_secs(2))
+        .with_jitter(JitterPolicy::Equal);
+    let expected_delay = policy
+        .next_delay_with_seed(attempt, seed)
+        .expect("delay must exist");
+    let timer_secs = expected_delay.as_secs().max(1);
+    let timer_id = TimerId::new(format!("retry_jitter_{attempt}_{seed}"));
+    let input = serde_json::json!({"attempt": attempt, "seed": seed});
+
+    let ok_history = vec![
+        WorkflowEvent::WorkflowStarted {
+            input: input.clone(),
+            timestamp: Utc::now(),
+        },
+        WorkflowEvent::TimerStarted {
+            timer_id: timer_id.clone(),
+            duration_secs: timer_secs,
+        },
+        WorkflowEvent::TimerFired { timer_id },
+    ];
+    let ok = replayer
+        .replay_from_snapshot(make_snapshot("jitter_timer_workflow", exec_id, ok_history))
+        .await;
+    assert!(matches!(ok.status, ReplayStatus::ReplaySucceeded), "{ok}");
+
+    let bad_history = vec![
+        WorkflowEvent::WorkflowStarted {
+            input,
+            timestamp: Utc::now(),
+        },
+        WorkflowEvent::TimerStarted {
+            timer_id: TimerId::new(format!("retry_jitter_{attempt}_{seed}")),
+            duration_secs: timer_secs.saturating_add(1),
+        },
+        WorkflowEvent::TimerFired {
+            timer_id: TimerId::new(format!("retry_jitter_{attempt}_{seed}")),
+        },
+    ];
+    let bad = replayer
+        .replay_from_snapshot(make_snapshot(
+            "jitter_timer_workflow",
+            ExecutionId::new(),
+            bad_history,
+        ))
+        .await;
+    assert!(
+        matches!(
+            bad.status,
+            ReplayStatus::NonDeterminismDetected {
+                kind: NonDeterminismKind::TimerMismatch,
+                ..
+            }
+        ),
+        "timer duration mismatch must be detected as TimerMismatch, got: {bad}"
+    );
 }
 
 // ---------------------------------------------------------------------------

--- a/autumn-harvest/tests/replayer_tests.rs
+++ b/autumn-harvest/tests/replayer_tests.rs
@@ -133,7 +133,7 @@ fn jitter_timer_workflow<'a>(
     input: Value,
 ) -> Pin<Box<dyn Future<Output = Result<Value, String>> + Send + 'a>> {
     Box::pin(async move {
-        let attempt = input["attempt"].as_u64().unwrap_or(1) as u32;
+        let attempt = u32::try_from(input["attempt"].as_u64().unwrap_or(1)).unwrap_or(1);
         let seed = input["seed"].as_u64().unwrap_or(0);
         let policy = RetryPolicy::exponential(8, std::time::Duration::from_secs(2))
             .with_jitter(JitterPolicy::Equal);

--- a/docs/retry-jitter.md
+++ b/docs/retry-jitter.md
@@ -1,0 +1,56 @@
+# Retry jitter (issue #342)
+
+Harvest supports deterministic, opt-in retry jitter for activity retries via
+`RetryPolicy::jitter`.
+
+## Why deterministic jitter
+
+Retry delays are part of workflow replay behavior. Harvest therefore computes
+jittered delays from a stable seed derived from workflow/task identity, so the
+same history and code produce the same timer behavior across worker restarts.
+
+## Strategy guidance
+
+- `None` (default): classic deterministic backoff; use when exact legacy timing
+  compatibility is required.
+- `Full`: uniform random in `[0, base]`; strongest spread, highest tail
+  variability.
+- `Equal`: uniform random in `[base/2, base]`; good spread while preserving
+  minimum pacing.
+- `Decorrelated`: random in `[initial, min(prev*3, max)]`; useful to avoid lock
+  step on long retries while remaining bounded.
+
+## Example
+
+```rust
+use std::time::Duration;
+use autumn_harvest::policy::{JitterPolicy, RetryPolicy};
+
+let retry = RetryPolicy::exponential(6, Duration::from_secs(1))
+    .with_jitter(JitterPolicy::Equal);
+let delay = retry.next_delay_with_seed(3, 0xdecafbad).unwrap();
+assert!(delay >= Duration::from_secs(2));
+```
+
+A runnable example is available:
+
+```bash
+cargo run -p quickstart --bin retry-jitter-example
+```
+
+## Determinism validation
+
+Replay determinism for jitter-derived timer durations is covered by
+`replay_jitter_timer_is_exact_and_deterministic` in
+`autumn-harvest/tests/replayer_tests.rs`.
+
+## Benchmark success metric
+
+Measure overhead of jitter calculation with:
+
+```bash
+cargo bench -p autumn-harvest --bench retry_jitter_bench --features testing --no-default-features
+```
+
+Success metric: p95 latency for `next_delay_with_seed` remains under **250ns**
+for `None` and under **500ns** for jittered modes on a laptop-class CPU.

--- a/examples/quickstart/Cargo.toml
+++ b/examples/quickstart/Cargo.toml
@@ -11,3 +11,7 @@ autumn-harvest-plugin = { version = "0.3.0", path = "../../autumn-harvest-plugin
 autumn-web = "0.4"
 serde_json = { workspace = true }
 tracing = { workspace = true }
+
+[[bin]]
+name = "retry-jitter-example"
+path = "src/retry_jitter_example.rs"

--- a/examples/quickstart/src/retry_jitter_example.rs
+++ b/examples/quickstart/src/retry_jitter_example.rs
@@ -1,0 +1,16 @@
+use autumn_harvest::policy::{JitterPolicy, RetryPolicy};
+
+fn main() {
+    let seed = 0xdecafbad_u64;
+    let policy = RetryPolicy::exponential(6, std::time::Duration::from_secs(1))
+        .with_jitter(JitterPolicy::Equal);
+
+    println!("retry-jitter-example");
+    println!("seed={seed}");
+    for attempt in 1..policy.max_attempts {
+        let delay = policy
+            .next_delay_with_seed(attempt, seed)
+            .expect("attempt is in range");
+        println!("attempt={attempt} delay_ms={}", delay.as_millis());
+    }
+}


### PR DESCRIPTION
### Motivation

- Provide deterministic, opt-in jitter for retry delays so workflows can benefit from randomized backoffs while preserving replay determinism. 
- Preserve legacy timing by keeping `None` as the default jitter behavior to remain bit-identical with prior behavior.

### Description

- Add `JitterPolicy` enum (`None`, `Full`, `Equal`, `Decorrelated`) and attach it to `RetryPolicy` with a builder `with_jitter` and default `None` value. 
- Implement deterministic jitter math: `mix64` as a small mixing PRNG and `compute_retry_delay_with_seed` to compute jittered delays for each strategy, plus `RetryPolicy::next_delay_with_seed` which mirrors `next_delay` but accepts a `stream_seed`. 
- Preserve former `next_delay` semantics by delegating to the seeded path with a zero seed, and add `retry_stream_seed` in `worker.rs` to derive a stable seed from `workflow_exec_id` and `activity_id` so runtime timers remain deterministic. 
- Add benchmarks (`benches/retry_jitter_bench.rs`), documentation (`docs/retry-jitter.md`), an example binary (`examples/quickstart/src/retry_jitter_example.rs`) and replayer + unit/integration tests that validate bounds and determinism (`replayer_tests.rs`, new tests in `policy` and `metrics_integration.rs`).

### Testing

- Ran the crate test suite with `cargo test -p autumn-harvest`, which exercised the new unit tests including `retry_jitter_none_is_bit_identical_default` and `retry_jitter_bounds_over_10k_seeds`, and the integration replayer test `replay_jitter_timer_is_exact_and_deterministic`, and the run succeeded. 
- Exercised integration coverage for DLQ behavior by running the modified `metrics_integration` tests including `workflow_hard_cap_dlq_preserves_terminal_attempt_count`, which passed under the test harness. 
- Added a micro-benchmark `retry_jitter_bench` and validated it with `cargo bench -p autumn-harvest --bench retry_jitter_bench` to measure jitter overhead (bench executed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a113db1c9c8832a8bc37b2b9d9c9da5)