### PR TITLE
👺 Havoc: Unbounded Payload Extraction in Management API and Multi-Byte Lexer Panic

### DIFF
--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -13,7 +13,6 @@ use autumn_web::session::Session;
 use axum::Extension;
 use axum::Json;
 use axum::Router;
-use axum::body::Bytes;
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::middleware::{self, Next};
@@ -222,6 +221,9 @@ impl HarvestApiRuntime {
 /// read `X-Harvest-Actor`, otherwise return `"anonymous"`. Using `"anonymous"`
 /// is only acceptable for local or dev deployments.
 pub type ActorExtractorFn = Arc<dyn Fn(&axum::http::HeaderMap) -> String + Send + Sync + 'static>;
+
+/// Maximum payload size (10 MB) to prevent OOM / `DoS` from unbounded buffering.
+pub const MAX_API_PAYLOAD_BYTES: usize = 10 * 1024 * 1024;
 
 #[derive(Clone)]
 pub struct HarvestApiState {
@@ -5199,15 +5201,19 @@ struct QueryWorkflowResponse {
 async fn query_workflow_post(
     Extension(api_state): Extension<HarvestApiState>,
     Path((id, query_name)): Path<(String, String)>,
-    body: Bytes,
+    body: axum::body::Body,
 ) -> Result<Json<QueryWorkflowResponse>, AutumnError> {
+    let body_bytes = axum::body::to_bytes(body, MAX_API_PAYLOAD_BYTES)
+        .await
+        .map_err(|e| AutumnError::bad_request_msg(format!("failed to read body: {e}")))?;
+
     let exec_id = parse_execution_id(&id)?;
     let ctx = hydrate_ctx_for_query(&api_state, exec_id).await?;
     let start = Instant::now(); // measure handler invocation latency, not hydration cost
-    let args: Value = if body.is_empty() {
+    let args: Value = if body_bytes.is_empty() {
         Value::Null
     } else {
-        serde_json::from_slice::<QueryWorkflowRequest>(&body)
+        serde_json::from_slice::<QueryWorkflowRequest>(&body_bytes)
             .map(|r| r.args)
             .map_err(|e| AutumnError::bad_request_msg(format!("invalid JSON body: {e}")))?
     };
@@ -7936,14 +7942,23 @@ fn url_encode_for_redirect(input: &str) -> String {
     out
 }
 
+#[allow(clippy::too_many_lines)]
 async fn bulk_replay_dead_letters_handler(
     Extension(api_state): Extension<HarvestApiState>,
     headers: axum::http::HeaderMap,
-    body: axum::body::Bytes,
+    body: axum::body::Body,
 ) -> axum::response::Response {
     use axum::response::IntoResponse as _;
 
-    let request = match parse_bulk_dlq_request(&headers, &body) {
+    let body_bytes = match axum::body::to_bytes(body, MAX_API_PAYLOAD_BYTES).await {
+        Ok(b) => b,
+        Err(e) => {
+            return AutumnError::bad_request_msg(format!("failed to read body: {e}"))
+                .into_response();
+        }
+    };
+
+    let request = match parse_bulk_dlq_request(&headers, &body_bytes) {
         Ok(request) => request,
         Err(error) => return error.into_response(),
     };
@@ -8044,14 +8059,23 @@ async fn bulk_replay_dead_letters_handler(
     }
 }
 
+#[allow(clippy::too_many_lines)]
 async fn bulk_discard_dead_letters_handler(
     Extension(api_state): Extension<HarvestApiState>,
     headers: axum::http::HeaderMap,
-    body: axum::body::Bytes,
+    body: axum::body::Body,
 ) -> axum::response::Response {
     use axum::response::IntoResponse as _;
 
-    let request = match parse_bulk_dlq_request(&headers, &body) {
+    let body_bytes = match axum::body::to_bytes(body, MAX_API_PAYLOAD_BYTES).await {
+        Ok(b) => b,
+        Err(e) => {
+            return AutumnError::bad_request_msg(format!("failed to read body: {e}"))
+                .into_response();
+        }
+    };
+
+    let request = match parse_bulk_dlq_request(&headers, &body_bytes) {
         Ok(request) => request,
         Err(error) => return error.into_response(),
     };

--- a/autumn-harvest/src/det_check.rs
+++ b/autumn-harvest/src/det_check.rs
@@ -377,7 +377,11 @@ fn extract_workflow_bodies<'a>(lines: &[&'a str]) -> Vec<(String, Vec<(u32, &'a 
 
             if let Some(pos) = scan_braces_outside_literals(line, &mut depth) {
                 // Include any code on the closing-brace line that precedes the `}`
-                let before = &line[..pos];
+                let mut valid_pos = pos;
+                while valid_pos > 0 && !line.is_char_boundary(valid_pos) {
+                    valid_pos -= 1;
+                }
+                let before = &line[..valid_pos];
                 if !before.trim().is_empty() {
                     body.push((line_num, before));
                 }
@@ -468,7 +472,13 @@ fn check_body(wf_name: &str, body_lines: &[(u32, &str)], file: &str) -> DetCheck
 /// Returns the portion of `line` that precedes the first `//` (if any).
 /// This avoids flagging patterns that appear only inside comments.
 fn strip_line_comment(line: &str) -> &str {
-    line_comment_start(line).map_or(line, |pos| &line[..pos])
+    line_comment_start(line).map_or(line, |pos| {
+        let mut valid_pos = pos;
+        while valid_pos > 0 && !line.is_char_boundary(valid_pos) {
+            valid_pos -= 1;
+        }
+        &line[..valid_pos]
+    })
 }
 
 /// Returns the byte position immediately after the closing `*/` of a block
@@ -591,11 +601,14 @@ fn normal_string_end(line: &str, start: usize) -> usize {
 
 fn char_literal_end(line: &str, start: usize) -> Option<usize> {
     let content_start = start + 1;
+    if !line.is_char_boundary(content_start) {
+        return None;
+    }
     let (first, first_end) = next_char(line, content_start)?;
 
     if is_lifetime_start(first) {
         let ident_end = consume_lifetime_ident(line, first_end);
-        if !line[ident_end..].starts_with('\'') {
+        if line.is_char_boundary(ident_end) && !line[ident_end..].starts_with('\'') {
             return None;
         }
     }
@@ -721,8 +734,13 @@ fn strip_unparseable_content(line: &str) -> String {
 /// (no code before `//`). A trailing inline comment on `prev_line` is
 /// scoped to that line only and must not suppress violations on the next line.
 fn find_suppression(rule_id: &str, line: &str, prev_line: &str) -> Option<String> {
-    let prev_is_standalone =
-        line_comment_start(prev_line).is_some_and(|pos| prev_line[..pos].trim().is_empty());
+    let prev_is_standalone = line_comment_start(prev_line).is_some_and(|pos| {
+        let mut valid_pos = pos;
+        while valid_pos > 0 && !prev_line.is_char_boundary(valid_pos) {
+            valid_pos -= 1;
+        }
+        prev_line[..valid_pos].trim().is_empty()
+    });
     if prev_is_standalone {
         parse_suppression_comment(rule_id, prev_line)
     } else {


### PR DESCRIPTION
* 🧨 **The Trigger:** Sending a massive payload to `/dead-letters/replay` or `/dead-letters/discard` causes an Out-Of-Memory (OOM) error because `axum::body::Bytes` buffers the entire request stream into memory without a size limit. Additionally, the `det_check::check_source` lexer panicked when encountering multi-byte emoji characters due to naive byte slicing on non-character boundaries.
* 📉 **The Stack Trace:** Process killed by OOM killer before handler executes. Or `core::panicking::panic_fmt` from `core::str::slice_error_fail`.
* 🧪 **Reproduction:** `curl -X POST http://localhost:8080/dead-letters/replay -d @huge_file.json` and `autumn_harvest::det_check::check_source("#[workflow]\nasync fn test() { let x = 1; \n // harvest-suppress: DET001 \"🔥\" \n}", "test.rs")`.
* 😈 **Comment:** "You assumed attackers would be polite and send small payloads, and that emojis were single bytes. You were wrong."

---
*PR created automatically by Jules for task [12821505730139680799](https://jules.google.com/task/12821505730139680799) started by @madmax983*