### PR TITLE
⚡ Bolt: Use Vec::with_capacity to avoid allocations in worker.rs

### DIFF
--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -558,7 +558,9 @@ fn extract_single_command<T>(
 fn extract_all_scheduled_activities(
     commands: &[WorkflowCommand],
 ) -> Option<Vec<ScheduledActivityCommand>> {
-    let mut scheduled = Vec::new();
+    // ⚡ Bolt: Pre-allocate vector capacity to avoid O(log N) heap reallocations
+    // on the hot path since the number of activities cannot exceed total commands.
+    let mut scheduled = Vec::with_capacity(commands.len());
 
     for cmd in commands {
         match cmd {
@@ -595,7 +597,9 @@ fn extract_all_scheduled_activities(
 }
 
 fn extract_all_activity_waits(commands: &[WorkflowCommand]) -> Option<Vec<ActivityExecId>> {
-    let mut activity_ids = Vec::new();
+    // ⚡ Bolt: Pre-allocate vector capacity to avoid O(log N) heap reallocations
+    // on the hot path since the number of activity waits cannot exceed total commands.
+    let mut activity_ids = Vec::with_capacity(commands.len());
 
     for cmd in commands {
         match cmd {
@@ -867,8 +871,11 @@ fn extract_signal_external_workflow(commands: Vec<WorkflowCommand>) -> Vec<Signa
 fn split_mixed_signal_batch(
     commands: Vec<WorkflowCommand>,
 ) -> (Vec<SignalBatchItem>, Vec<WorkflowCommand>) {
-    let mut signal_items = Vec::new();
-    let mut remaining = Vec::new();
+    // ⚡ Bolt: Pre-allocate vector capacities to avoid O(log N) heap reallocations
+    // on the hot path. Over-allocating slightly (commands.len() for each) is faster
+    // than dynamic reallocation during iteration.
+    let mut signal_items = Vec::with_capacity(commands.len());
+    let mut remaining = Vec::with_capacity(commands.len());
     for cmd in commands {
         match cmd {
             WorkflowCommand::SignalExternalWorkflow {


### PR DESCRIPTION
💡 What: Replaced `Vec::new()` with `Vec::with_capacity(commands.len())` in `extract_all_scheduled_activities`, `extract_all_activity_waits`, and `split_mixed_signal_batch` functions. Added doc comments explaining the optimization.
🎯 Why: Avoids unnecessary vector re-allocations when parsing lists of commands from the workflow, which happens on the hot path for every workflow task.
📊 Impact: Eliminates O(log N) heap allocations when collecting activities or signal batches from large command sequences, reducing memory fragmentation and allocator contention.
🔭 Measurement: Run `cargo test -p autumn-harvest` to verify identical behavior.

---
*PR created automatically by Jules for task [8596940453420623610](https://jules.google.com/task/8596940453420623610) started by @madmax983*