### PR TITLE
⚡ Bolt: [performance improvement] Pre-allocate vectors in workflow worker and scheduler

### DIFF
--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -557,7 +557,7 @@ fn extract_single_command<T>(
 fn extract_all_scheduled_activities(
     commands: &[WorkflowCommand],
 ) -> Option<Vec<ScheduledActivityCommand>> {
-    let mut scheduled = Vec::new();
+    let mut scheduled = Vec::with_capacity(commands.len());
 
     for cmd in commands {
         match cmd {
@@ -594,7 +594,7 @@ fn extract_all_scheduled_activities(
 }
 
 fn extract_all_activity_waits(commands: &[WorkflowCommand]) -> Option<Vec<ActivityExecId>> {
-    let mut activity_ids = Vec::new();
+    let mut activity_ids = Vec::with_capacity(commands.len());
 
     for cmd in commands {
         match cmd {
@@ -891,8 +891,8 @@ fn extract_signal_external_workflow(commands: Vec<WorkflowCommand>) -> Vec<Signa
 fn split_mixed_signal_batch(
     commands: Vec<WorkflowCommand>,
 ) -> (Vec<SignalBatchItem>, Vec<WorkflowCommand>) {
-    let mut signal_items = Vec::new();
-    let mut remaining = Vec::new();
+    let mut signal_items = Vec::with_capacity(commands.len());
+    let mut remaining = Vec::with_capacity(commands.len());
     for cmd in commands {
         match cmd {
             WorkflowCommand::SignalExternalWorkflow {
@@ -945,7 +945,7 @@ async fn persist_external_signal_inline(
     items: Vec<SignalBatchItem>,
     next_event_id: &mut i32,
 ) -> HarvestResult<Vec<WorkflowEvent>> {
-    let mut new_events: Vec<WorkflowEvent> = Vec::new();
+    let mut new_events: Vec<WorkflowEvent> = Vec::with_capacity(items.len());
 
     for item in items {
         match item {


### PR DESCRIPTION
💡 What: Switched `Vec::new()` to `Vec::with_capacity(len)` in multiple workflow extraction/batching functions in `worker.rs` and in `plan_backfill_timestamps` in `scheduler.rs`.
🎯 Why: These functions were previously creating empty vectors and then pushing items into them in a loop where the maximum required capacity is known upfront (the length of the commands array or `max_count`), causing unnecessary heap reallocations.
📊 Impact: Reduces heap reallocations when processing large command batches or backfilling timestamps.
🔬 Measurement: Run `cargo clippy -p autumn-harvest --all-targets --all-features -- -D warnings -W clippy::perf` and `cargo test -p autumn-harvest`.

---
*PR created automatically by Jules for task [15161406090079166474](https://jules.google.com/task/15161406090079166474) started by @madmax983*