### PR TITLE
⚡ Bolt: Pre-allocate vectors in DagProfiler

### DIFF
--- a/autumn-harvest/src/dag_profiler.rs
+++ b/autumn-harvest/src/dag_profiler.rs
@@ -78,13 +78,16 @@ impl DagProfiler {
             };
         }
 
-        let mut timeline = Vec::new();
+        /// ⚡ Bolt: Pre-allocate vectors to avoid O(log N) intermediate heap reallocations.
+        /// Each task will generate exactly 2 events (start and complete).
+        let mut timeline = Vec::with_capacity(tasks.len() * 2);
         let mut peak_concurrency = 0;
         let mut task_start_times = vec![None; tasks.len()];
         let mut task_end_times = vec![None; tasks.len()];
 
         // Priority queue-like behavior using a sorted vector of (time, kind)
-        let mut event_queue: Vec<(Duration, usize, bool)> = Vec::new(); // bool: true = start, false = end
+        /// ⚡ Bolt: Pre-allocate event queue matching the expected number of events.
+        let mut event_queue: Vec<(Duration, usize, bool)> = Vec::with_capacity(tasks.len() * 2); // bool: true = start, false = end
 
         for level in levels {
             for &task_index in level {


### PR DESCRIPTION
💡 What: Switched `Vec::new()` to `Vec::with_capacity(tasks.len() * 2)` for `timeline` and `event_queue` in `DagProfiler::profile` and added missing doc strings.
🎯 Why: `DagProfiler::profile` collects exactly `tasks.len() * 2` events (a start and complete event for each task). Without `with_capacity`, the vectors undergo multiple heap reallocations as they grow.
📊 Impact: Eliminates `O(log(N))` intermediate heap reallocations per DAG profiling run, making timeline generation faster and zero-allocation beyond the initial buffer.
🔬 Measurement: Run `cargo test -p autumn-harvest` to ensure logic is unaffected. Profiling overhead is reduced.

---
*PR created automatically by Jules for task [9149320157584146949](https://jules.google.com/task/9149320157584146949) started by @madmax983*