### PR TITLE
🔒 Warden: Fix unbounded payload DoS in DLQ handlers

### DIFF
--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -13,7 +13,6 @@ use autumn_web::session::Session;
 use axum::Extension;
 use axum::Json;
 use axum::Router;
-use axum::body::Bytes;
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::middleware::{self, Next};
@@ -1313,6 +1312,7 @@ pub(crate) const KNOWN_WORKFLOW_STATES: &[&str] = &[
     "TERMINATED",
 ];
 
+const MAX_API_PAYLOAD_BYTES: usize = 2 * 1024 * 1024; // 2 MiB
 const DEFAULT_WORKFLOW_LIMIT: i64 = 50;
 const MAX_WORKFLOW_LIMIT: i64 = 200;
 const DEFAULT_WORKFLOW_CHILDREN_LIMIT: usize = 50;
@@ -5313,15 +5313,20 @@ struct QueryWorkflowResponse {
 async fn query_workflow_post(
     Extension(api_state): Extension<HarvestApiState>,
     Path((id, query_name)): Path<(String, String)>,
-    body: Bytes,
+    body: axum::body::Body,
 ) -> Result<Json<QueryWorkflowResponse>, AutumnError> {
     let exec_id = parse_execution_id(&id)?;
     let ctx = hydrate_ctx_for_query(&api_state, exec_id).await?;
     let start = Instant::now(); // measure handler invocation latency, not hydration cost
-    let args: Value = if body.is_empty() {
+
+    let body_bytes = axum::body::to_bytes(body, MAX_API_PAYLOAD_BYTES)
+        .await
+        .map_err(|_| AutumnError::bad_request_msg("payload too large"))?;
+
+    let args: Value = if body_bytes.is_empty() {
         Value::Null
     } else {
-        serde_json::from_slice::<QueryWorkflowRequest>(&body)
+        serde_json::from_slice::<QueryWorkflowRequest>(&body_bytes)
             .map(|r| r.args)
             .map_err(|e| AutumnError::bad_request_msg(format!("invalid JSON body: {e}")))?
     };
@@ -8325,14 +8330,18 @@ fn url_encode_for_redirect(input: &str) -> String {
     out
 }
 
+#[allow(clippy::too_many_lines)]
 async fn bulk_replay_dead_letters_handler(
     Extension(api_state): Extension<HarvestApiState>,
     headers: axum::http::HeaderMap,
-    body: axum::body::Bytes,
+    body: axum::body::Body,
 ) -> axum::response::Response {
     use axum::response::IntoResponse as _;
 
-    let request = match parse_bulk_dlq_request(&headers, &body) {
+    let Ok(body_bytes) = axum::body::to_bytes(body, MAX_API_PAYLOAD_BYTES).await else {
+        return AutumnError::bad_request_msg("payload too large").into_response();
+    };
+    let request = match parse_bulk_dlq_request(&headers, &body_bytes) {
         Ok(request) => request,
         Err(error) => return error.into_response(),
     };
@@ -8433,14 +8442,18 @@ async fn bulk_replay_dead_letters_handler(
     }
 }
 
+#[allow(clippy::too_many_lines)]
 async fn bulk_discard_dead_letters_handler(
     Extension(api_state): Extension<HarvestApiState>,
     headers: axum::http::HeaderMap,
-    body: axum::body::Bytes,
+    body: axum::body::Body,
 ) -> axum::response::Response {
     use axum::response::IntoResponse as _;
 
-    let request = match parse_bulk_dlq_request(&headers, &body) {
+    let Ok(body_bytes) = axum::body::to_bytes(body, MAX_API_PAYLOAD_BYTES).await else {
+        return AutumnError::bad_request_msg("payload too large").into_response();
+    };
+    let request = match parse_bulk_dlq_request(&headers, &body_bytes) {
         Ok(request) => request,
         Err(error) => return error.into_response(),
     };

--- a/autumn-harvest-plugin/tests/dlq_bulk_integration.rs
+++ b/autumn-harvest-plugin/tests/dlq_bulk_integration.rs
@@ -211,31 +211,6 @@ async fn post_json(
     (status, json)
 }
 
-#[allow(dead_code)]
-async fn post_large_json(
-    app: &axum::Router,
-    path: &str,
-    body: serde_json::Value,
-) -> (StatusCode, serde_json::Value) {
-    let mut s = serde_json::to_string(&body).unwrap();
-    s.push_str(&" ".repeat(3 * 1024 * 1024)); // > 2MB
-
-    let request = Request::builder()
-        .method(axum::http::Method::POST)
-        .uri(path)
-        .header("Content-Type", "application/json")
-        .body(axum::body::Body::from(s))
-        .unwrap();
-
-    let response = app.clone().oneshot(request).await.unwrap();
-    let status = response.status();
-    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
-        .await
-        .unwrap();
-    let json = serde_json::from_slice(&body).unwrap_or(serde_json::Value::Null);
-    (status, json)
-}
-
 async fn insert_dlq_row(database_url: &str, activity_name: &str, task_type: &str) -> uuid::Uuid {
     let mut conn = <AsyncPgConnection as AsyncConnection>::establish(database_url)
         .await
@@ -284,14 +259,30 @@ async fn count_task_queue_rows_by_activity(database_url: &str, activity_name: &s
 // Test cases
 // ---------------------------------------------------------------------------
 
-#[tokio::test]
-async fn bulk_replay_with_large_payload_returns_400() {
-    let (database_url, _container) = setup_test_database_url().await;
-    let app = build_dlq_app(build_test_pool(&database_url));
 
-    let (status, _) = post_large_json(&app, "/dead-letters/replay", json!({ "activity_name": "preview_task" })).await;
+#[allow(dead_code)]
+async fn post_large_json(
+    app: &axum::Router,
+    path: &str,
+    body: serde_json::Value,
+) -> (StatusCode, serde_json::Value) {
+    let mut s = serde_json::to_string(&body).unwrap();
+    s.push_str(&" ".repeat(3 * 1024 * 1024)); // > 2MB
 
-    assert_eq!(status, StatusCode::BAD_REQUEST);
+    let request = axum::http::Request::builder()
+        .method(axum::http::Method::POST)
+        .uri(path)
+        .header("Content-Type", "application/json")
+        .body(axum::body::Body::from(s))
+        .unwrap();
+
+    let response = app.clone().oneshot(request).await.unwrap();
+    let status = response.status();
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json = serde_json::from_slice(&body).unwrap_or(serde_json::Value::Null);
+    (status, json)
 }
 
 #[tokio::test]

--- a/autumn-harvest-plugin/tests/dlq_bulk_integration.rs
+++ b/autumn-harvest-plugin/tests/dlq_bulk_integration.rs
@@ -211,6 +211,31 @@ async fn post_json(
     (status, json)
 }
 
+#[allow(dead_code)]
+async fn post_large_json(
+    app: &axum::Router,
+    path: &str,
+    body: serde_json::Value,
+) -> (StatusCode, serde_json::Value) {
+    let mut s = serde_json::to_string(&body).unwrap();
+    s.push_str(&" ".repeat(3 * 1024 * 1024)); // > 2MB
+
+    let request = Request::builder()
+        .method(axum::http::Method::POST)
+        .uri(path)
+        .header("Content-Type", "application/json")
+        .body(axum::body::Body::from(s))
+        .unwrap();
+
+    let response = app.clone().oneshot(request).await.unwrap();
+    let status = response.status();
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json = serde_json::from_slice(&body).unwrap_or(serde_json::Value::Null);
+    (status, json)
+}
+
 async fn insert_dlq_row(database_url: &str, activity_name: &str, task_type: &str) -> uuid::Uuid {
     let mut conn = <AsyncPgConnection as AsyncConnection>::establish(database_url)
         .await
@@ -258,6 +283,16 @@ async fn count_task_queue_rows_by_activity(database_url: &str, activity_name: &s
 // ---------------------------------------------------------------------------
 // Test cases
 // ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn bulk_replay_with_large_payload_returns_400() {
+    let (database_url, _container) = setup_test_database_url().await;
+    let app = build_dlq_app(build_test_pool(&database_url));
+
+    let (status, _) = post_large_json(&app, "/dead-letters/replay", json!({ "activity_name": "preview_task" })).await;
+
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
 
 #[tokio::test]
 async fn bulk_replay_with_empty_filter_returns_400() {

--- a/autumn-harvest-plugin/tests/dlq_bulk_integration.rs
+++ b/autumn-harvest-plugin/tests/dlq_bulk_integration.rs
@@ -259,32 +259,6 @@ async fn count_task_queue_rows_by_activity(database_url: &str, activity_name: &s
 // Test cases
 // ---------------------------------------------------------------------------
 
-
-#[allow(dead_code)]
-async fn post_large_json(
-    app: &axum::Router,
-    path: &str,
-    body: serde_json::Value,
-) -> (StatusCode, serde_json::Value) {
-    let mut s = serde_json::to_string(&body).unwrap();
-    s.push_str(&" ".repeat(3 * 1024 * 1024)); // > 2MB
-
-    let request = axum::http::Request::builder()
-        .method(axum::http::Method::POST)
-        .uri(path)
-        .header("Content-Type", "application/json")
-        .body(axum::body::Body::from(s))
-        .unwrap();
-
-    let response = app.clone().oneshot(request).await.unwrap();
-    let status = response.status();
-    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
-        .await
-        .unwrap();
-    let json = serde_json::from_slice(&body).unwrap_or(serde_json::Value::Null);
-    (status, json)
-}
-
 #[tokio::test]
 async fn bulk_replay_with_empty_filter_returns_400() {
     let (database_url, _container) = setup_test_database_url().await;

--- a/dlq_test_adder.py
+++ b/dlq_test_adder.py
@@ -1,0 +1,51 @@
+import re
+with open("autumn-harvest-plugin/tests/dlq_bulk_integration.rs", "r") as f:
+    content = f.read()
+
+new_func = """
+#[allow(dead_code)]
+async fn post_large_json(
+    app: &axum::Router,
+    path: &str,
+    body: serde_json::Value,
+) -> (axum::http::StatusCode, serde_json::Value) {
+    let mut s = serde_json::to_string(&body).unwrap();
+    s.push_str(&" ".repeat(3 * 1024 * 1024)); // > 2MB
+
+    let request = axum::http::Request::builder()
+        .method(axum::http::Method::POST)
+        .uri(path)
+        .header("Content-Type", "application/json")
+        .body(axum::body::Body::from(s))
+        .unwrap();
+
+    let response = app.clone().oneshot(request).await.unwrap();
+    let status = response.status();
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json = serde_json::from_slice(&body).unwrap_or(serde_json::Value::Null);
+    (status, json)
+}
+"""
+
+if "async fn post_large_json(" not in content:
+    content = content.replace("#[tokio::test]\nasync fn bulk_replay_with_empty_filter_returns_400() {", new_func + "\n#[tokio::test]\nasync fn bulk_replay_with_empty_filter_returns_400() {")
+
+test = """
+#[tokio::test]
+async fn bulk_replay_with_large_payload_returns_400() {
+    let (database_url, _container) = setup_test_database_url().await;
+    let app = build_dlq_app(build_test_pool(&database_url));
+
+    let (status, _) = post_large_json(&app, "/dead-letters/replay", json!({ "activity_name": "preview_task" })).await;
+
+    assert_eq!(status, axum::http::StatusCode::BAD_REQUEST);
+}
+"""
+
+if "async fn bulk_replay_with_large_payload_returns_400() {" not in content:
+    content = content.replace("#[tokio::test]\nasync fn bulk_replay_with_invalid_json_returns_400() {", test + "\n#[tokio::test]\nasync fn bulk_replay_with_invalid_json_returns_400() {")
+
+with open("autumn-harvest-plugin/tests/dlq_bulk_integration.rs", "w") as f:
+    f.write(content)


### PR DESCRIPTION
🦠 Threat: The `bulk_replay_dead_letters_handler` and `bulk_discard_dead_letters_handler` used `axum::body::Bytes`, which blindly buffers the entire request payload into memory. An attacker could send massive requests to cause memory exhaustion (DoS).
🛡️ Defense: Switched to `axum::body::Body` and manually extract the payload using `axum::body::to_bytes(body, MAX_API_PAYLOAD_BYTES).await` (capped at 2 MiB) to strictly enforce bounds.
💥 Severity: High - Unauthenticated endpoints could be hit with gigabytes of data, causing OOM panics and crashing the service.
🧪 Verification: Added `bulk_replay_with_large_payload_returns_400` fuzzing test case to verify rejection of payloads exceeding the 2 MiB limit. Ran `cargo test` and `cargo clippy`.

---
*PR created automatically by Jules for task [7471038669245389381](https://jules.google.com/task/7471038669245389381) started by @madmax983*