### PR TITLE
⚒️ Forge: [Refactoring: Idiomatic Assertions, Clippy Casting, and Guard Clauses]

### DIFF
--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -1002,17 +1002,16 @@ async fn persist_external_signal_inline(
                     }),
                 };
 
-                if let Some(terminal) = terminal_opt {
-                    store::append_events(
-                        conn,
-                        exec_id,
-                        std::slice::from_ref(&terminal),
-                        *next_event_id,
-                    )
-                    .await?;
-                    *next_event_id += 1;
-                    new_events.push(terminal);
-                }
+                let Some(terminal) = terminal_opt else { continue };
+                store::append_events(
+                    conn,
+                    exec_id,
+                    std::slice::from_ref(&terminal),
+                    *next_event_id,
+                )
+                .await?;
+                *next_event_id += 1;
+                new_events.push(terminal);
             }
         }
     }
@@ -1325,23 +1324,22 @@ fn next_retry_delay(
         return Ok(None);
     }
 
-    if let Some(policy) = retry_policy {
-        let typed_error_type = typed.as_ref().map(|f| f.error_type.as_str());
-        if policy.is_non_retryable(typed_error_type, error) {
-            return Ok(None);
+    let Some(policy) = retry_policy else {
+        if task.attempt < task.max_attempts {
+            return Ok(Some(chrono::Duration::seconds(1)));
         }
+        return Ok(None);
+    };
 
-        return policy
-            .next_delay_with_seed(task_attempt(task), retry_stream_seed(task))
-            .map(|delay| chrono_duration_from_std(delay, "retry delay"))
-            .transpose();
+    let typed_error_type = typed.as_ref().map(|f| f.error_type.as_str());
+    if policy.is_non_retryable(typed_error_type, error) {
+        return Ok(None);
     }
 
-    if task.attempt < task.max_attempts {
-        return Ok(Some(chrono::Duration::seconds(1)));
-    }
-
-    Ok(None)
+    policy
+        .next_delay_with_seed(task_attempt(task), retry_stream_seed(task))
+        .map(|delay| chrono_duration_from_std(delay, "retry delay"))
+        .transpose()
 }
 
 fn find_pending_scheduled_activity(


### PR DESCRIPTION
🚮 Smell: Non-idiomatic bool comparisons (assert_eq!(x, true)), clippy casting warnings, and nested if-let guard clauses creating pyramid of doom in worker.rs.
✨ Solution: Converted assert_eq! to assert!, used TryFrom instead of as for truncations, added explicit #[allow(...)] for precision loss casting, and inverted if-let statements into guard clauses in worker.rs.
🧼 Benefit: Reduces cognitive load with flattened nesting, strongly typed truncations instead of silent overflows, and idiomatic test assertions.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [18160807072700518006](https://jules.google.com/task/18160807072700518006) started by @madmax983*