### PR TITLE
🌟 Nova: Mermaid Gantt Chart Exporter for DAG Profiles

### DIFF
--- a/autumn-harvest/src/dag_export.rs
+++ b/autumn-harvest/src/dag_export.rs
@@ -91,6 +91,95 @@ pub fn export_dot(dag: &DagDefinition) -> Result<String, std::fmt::Error> {
     Ok(out)
 }
 
+#[cfg(feature = "testing")]
+use crate::dag_profiler::{DagProfile, ProfilerEventKind};
+
+/// Exports a DAG execution profile to a Mermaid.js Gantt chart.
+///
+/// This provides a visual timeline of task executions, showing concurrency and critical paths.
+/// Since Mermaid Gantt charts require absolute dates, this generator mocks an execution
+/// starting from `2000-01-01T00:00:00`.
+///
+/// # Examples
+///
+/// ```rust
+/// use autumn_harvest::dag::DagBuilder;
+/// use autumn_harvest::dag_profiler::DagProfiler;
+/// use autumn_harvest::dag_export::export_mermaid_gantt;
+/// use std::time::Duration;
+///
+/// fn my_activity() {}
+/// fn my_other_activity() {}
+///
+/// let mut builder = DagBuilder::new();
+/// let a = builder.activity(my_activity);
+/// let b = builder.activity(my_other_activity).upstream(&a);
+/// let dag = builder.build().unwrap();
+///
+/// let profiler = DagProfiler::new(dag).mock_duration("my_activity", Duration::from_secs(5));
+/// let profile = profiler.profile();
+///
+/// let gantt = export_mermaid_gantt(&profile).unwrap();
+/// assert!(gantt.contains("gantt"));
+/// assert!(gantt.contains("my_activity"));
+/// ```
+///
+/// # Errors
+/// Returns `std::fmt::Error` if string formatting fails.
+#[cfg(feature = "testing")]
+pub fn export_mermaid_gantt(profile: &DagProfile) -> Result<String, std::fmt::Error> {
+    use std::collections::HashMap;
+
+    let mut out = String::new();
+    writeln!(out, "gantt")?;
+    writeln!(out, "    title DAG Execution Profile")?;
+    writeln!(out, "    dateFormat YYYY-MM-DDTHH:mm:ss")?;
+    writeln!(out, "    axisFormat %H:%M:%S")?;
+    writeln!(out)?;
+    writeln!(out, "    section Tasks")?;
+
+    // We need to pair TaskStarted and TaskCompleted to get durations.
+    let mut starts = HashMap::new();
+    for event in &profile.timeline {
+        match &event.kind {
+            ProfilerEventKind::TaskStarted(id, name) => {
+                starts.insert(*id, (name.clone(), event.time));
+            }
+            ProfilerEventKind::TaskCompleted(id, _name) => {
+                if let Some((name, start_time)) = starts.remove(id) {
+                    let end_time = event.time;
+                    let start_ts = format_duration_as_timestamp(start_time);
+                    let end_ts = format_duration_as_timestamp(end_time);
+
+                    writeln!(out, "    {name} : t{id}, {start_ts}, {end_ts}")?;
+                }
+            }
+        }
+    }
+
+    Ok(out)
+}
+
+#[cfg(feature = "testing")]
+fn format_duration_as_timestamp(duration: std::time::Duration) -> String {
+    // Mermaid requires valid datetimes. We mock execution starting at 2000-01-01 00:00:00.
+    let total_secs = duration.as_secs();
+    let days = total_secs / 86400;
+    let rem_secs = total_secs % 86400;
+    let hours = rem_secs / 3600;
+    let mins = (rem_secs % 3600) / 60;
+    let secs = rem_secs % 60;
+
+    // Day is 1-indexed, starting from Jan 1
+    format!(
+        "2000-01-{:02}T{:02}:{:02}:{:02}",
+        days + 1,
+        hours,
+        mins,
+        secs
+    )
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -110,6 +199,30 @@ mod tests {
 
         let dot = export_dot(&dag).unwrap();
         assert_eq!(dot, "digraph DAG {\n}\n");
+    }
+
+    #[test]
+    #[cfg(feature = "testing")]
+    fn test_export_gantt_chart() {
+        use crate::dag_profiler::DagProfiler;
+        use std::time::Duration;
+
+        let mut builder = DagBuilder::new();
+        let a = builder.activity(dummy_activity);
+        let _b1 = builder.activity(dummy_activity2).upstream(&a);
+        let dag = builder.build().unwrap();
+
+        let profiler = DagProfiler::new(dag)
+            .mock_duration("dummy_activity", Duration::from_secs(5))
+            .mock_duration("dummy_activity2", Duration::from_secs(10));
+        let profile = profiler.profile();
+
+        let gantt = export_mermaid_gantt(&profile).unwrap();
+
+        assert!(gantt.contains("gantt"));
+        assert!(gantt.contains("title DAG Execution Profile"));
+        assert!(gantt.contains("dummy_activity : t0, 2000-01-01T00:00:00, 2000-01-01T00:00:05"));
+        assert!(gantt.contains("dummy_activity2 : t1, 2000-01-01T00:00:05, 2000-01-01T00:00:15"));
     }
 
     #[test]

--- a/autumn-harvest/src/lib.rs
+++ b/autumn-harvest/src/lib.rs
@@ -172,6 +172,8 @@ pub use context::{
 };
 pub use critical_path::{CriticalPathAnalyzer, CriticalPathResult};
 pub use dag::{DagBuildError, DagBuilder, DagDefinition, DagTask, DagTaskRef};
+#[cfg(feature = "testing")]
+pub use dag_export::export_mermaid_gantt;
 pub use dag_export::{export_dot, export_mermaid};
 pub use dag_linter::{
     DagLinter, DagRule, DagWarning, ExcessiveParallelismRule, MissingRetryPolicyRule,


### PR DESCRIPTION
💡 **The Spark:** I noticed we can profile a DAG's execution timeline and we can export DAGs to Mermaid flowcharts, but we don't visualize the timeline. Can I implement an exporter that takes a `DagProfile` and outputs a Mermaid Gantt Chart?
🚀 **The Feature:** Implemented `export_mermaid_gantt` which converts a `DagProfile` into a Mermaid Gantt chart visualizing task durations and concurrency.
🔮 **The Potential:** Enables developers to easily visualize the critical path and bottlenecks of their DAG execution.
⚠️ **Risk:** Low. Isolated in testing features of `dag_export.rs`.

---
*PR created automatically by Jules for task [15905315927020637010](https://jules.google.com/task/15905315927020637010) started by @madmax983*