### PR TITLE
⚡ Bolt: [performance improvement] Pre-allocate vectors in workflow worker command extraction

### DIFF
--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -557,7 +557,7 @@ fn extract_single_command<T>(
 fn extract_all_scheduled_activities(
     commands: &[WorkflowCommand],
 ) -> Option<Vec<ScheduledActivityCommand>> {
-    let mut scheduled = Vec::new();
+    let mut scheduled = Vec::with_capacity(commands.len());
 
     for cmd in commands {
         match cmd {
@@ -594,7 +594,7 @@ fn extract_all_scheduled_activities(
 }
 
 fn extract_all_activity_waits(commands: &[WorkflowCommand]) -> Option<Vec<ActivityExecId>> {
-    let mut activity_ids = Vec::new();
+    let mut activity_ids = Vec::with_capacity(commands.len());
 
     for cmd in commands {
         match cmd {
@@ -891,8 +891,8 @@ fn extract_signal_external_workflow(commands: Vec<WorkflowCommand>) -> Vec<Signa
 fn split_mixed_signal_batch(
     commands: Vec<WorkflowCommand>,
 ) -> (Vec<SignalBatchItem>, Vec<WorkflowCommand>) {
-    let mut signal_items = Vec::new();
-    let mut remaining = Vec::new();
+    let mut signal_items = Vec::with_capacity(commands.len());
+    let mut remaining = Vec::with_capacity(commands.len());
     for cmd in commands {
         match cmd {
             WorkflowCommand::SignalExternalWorkflow {


### PR DESCRIPTION
💡 What: Replaced `Vec::new()` with `Vec::with_capacity(commands.len())` in `extract_all_scheduled_activities`, `extract_all_activity_waits`, and `split_mixed_signal_batch` in `autumn-harvest/src/worker.rs`.

🎯 Why: Workflow tasks frequently process batches of commands. By dynamically pre-allocating the vector capacity based on the input slice/vector length, we avoid multiple reallocations on the heap as commands are iterated and collected.

📊 Impact: Reduces heap reallocations per workflow task that emits multiple commands or waits on multiple activities.

🔬 Measurement: Run `cargo test -p autumn-harvest --lib` and observe identical functionality with fewer underlying memory operations.

Assumptions: The length of the `commands` vector/slice is a reasonable upper bound for the resulting collections, and allocating it directly eliminates any risk of intermediate reallocation during the loop.

---
*PR created automatically by Jules for task [15510927275301750121](https://jules.google.com/task/15510927275301750121) started by @madmax983*