### PR TITLE
⚒️ Forge: apply idiomatic traits to parsing and flatten workflow task loop

### DIFF
--- a/autumn-harvest/src/policy.rs
+++ b/autumn-harvest/src/policy.rs
@@ -473,6 +473,12 @@ impl OverlapPolicy {
     /// reading a newer enum value degrades to the safe default.
     #[must_use]
     pub fn from_db(s: &str) -> Self {
+        Self::from(s)
+    }
+}
+
+impl From<&str> for OverlapPolicy {
+    fn from(s: &str) -> Self {
         match s {
             "buffer_one" => Self::BufferOne,
             "buffer_all" => Self::BufferAll,
@@ -481,7 +487,9 @@ impl OverlapPolicy {
             _ => Self::Skip,
         }
     }
+}
 
+impl OverlapPolicy {
     /// Parse an `overlap_policy` value from user-supplied input (e.g. an API request).
     ///
     /// Unlike [`from_db`](Self::from_db) this is strict: an unknown value returns
@@ -539,13 +547,21 @@ impl SkipPolicy {
     /// append-only-schema invariant.
     #[must_use]
     pub fn from_db(s: &str) -> Self {
+        Self::from(s)
+    }
+}
+
+impl From<&str> for SkipPolicy {
+    fn from(s: &str) -> Self {
         match s {
             "run_next_business_day" => Self::RunNextBusinessDay,
             "run_prev_business_day" => Self::RunPrevBusinessDay,
             _ => Self::Skip,
         }
     }
+}
 
+impl SkipPolicy {
     /// Parse a `skip_policy` value from user-supplied input (e.g. an API request).
     ///
     /// # Errors

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -345,11 +345,13 @@ enum ClaimedTaskKind {
     Activity,
 }
 
-impl ClaimedTaskKind {
-    fn from_db(task_type: &str) -> HarvestResult<Self> {
+impl TryFrom<&str> for ClaimedTaskKind {
+    type Error = HarvestError;
+
+    fn try_from(task_type: &str) -> Result<Self, Self::Error> {
         match task_type {
-            task_type if task_type == TaskType::Workflow.as_str() => Ok(Self::Workflow),
-            task_type if task_type == TaskType::Activity.as_str() => Ok(Self::Activity),
+            t if t == TaskType::Workflow.as_str() => Ok(Self::Workflow),
+            t if t == TaskType::Activity.as_str() => Ok(Self::Activity),
             other => Err(HarvestError::Config(format!(
                 "unsupported task type in queue row: {other}"
             ))),
@@ -4151,22 +4153,18 @@ async fn process_workflow_task(
 
                 // If any signal in the batch was not resolved inline (remains pending/suspended),
                 // we must break the loop and suspend the workflow task.
-                let mut all_resolved = true;
-                for item in &items_clone {
-                    if let SignalBatchItem::Signal(run) = item {
-                        let resolved = new_events.iter().any(|e| match e {
-                            WorkflowEvent::ExternalSignalDelivered { signal_id }
-                            | WorkflowEvent::ExternalSignalFailed { signal_id, .. } => {
-                                *signal_id == run.signal_id
-                            }
-                            _ => false,
-                        });
-                        if !resolved {
-                            all_resolved = false;
-                            break;
+                let all_resolved = items_clone.iter().all(|item| {
+                    let SignalBatchItem::Signal(run) = item else {
+                        return true;
+                    };
+                    new_events.iter().any(|e| match e {
+                        WorkflowEvent::ExternalSignalDelivered { signal_id }
+                        | WorkflowEvent::ExternalSignalFailed { signal_id, .. } => {
+                            *signal_id == run.signal_id
                         }
-                    }
-                }
+                        _ => false,
+                    })
+                });
 
                 if !all_resolved {
                     let mut reconstructed_commands = Vec::with_capacity(items_clone.len());
@@ -4431,7 +4429,7 @@ async fn process_task(
 ) -> HarvestResult<()> {
     let mut conn = pool.get().await.map_err(crate::error::database_error)?;
 
-    match ClaimedTaskKind::from_db(&task.task_type)? {
+    match ClaimedTaskKind::try_from(task.task_type.as_str())? {
         ClaimedTaskKind::Workflow => {
             process_workflow_task(
                 &mut conn,
@@ -5237,7 +5235,7 @@ impl Worker {
 
     /// Spawn a bounded Tokio task for the claimed work item.
     fn dispatch_task(&self, task: TaskQueueItem, pool: &DbPool) {
-        let kind = match ClaimedTaskKind::from_db(&task.task_type) {
+        let kind = match ClaimedTaskKind::try_from(task.task_type.as_str()) {
             Ok(kind) => kind,
             Err(error) => {
                 tracing::error!(
@@ -5572,14 +5570,14 @@ mod tests {
     #[test]
     fn claimed_task_kind_uses_lowercase_db_values() -> Result<(), crate::error::HarvestError> {
         assert_eq!(
-            ClaimedTaskKind::from_db("workflow")?,
+            ClaimedTaskKind::try_from("workflow")?,
             ClaimedTaskKind::Workflow
         );
         assert_eq!(
-            ClaimedTaskKind::from_db("activity")?,
+            ClaimedTaskKind::try_from("activity")?,
             ClaimedTaskKind::Activity
         );
-        assert!(ClaimedTaskKind::from_db("WORKFLOW").is_err());
+        assert!(ClaimedTaskKind::try_from("WORKFLOW").is_err());
         Ok(())
     }
 


### PR DESCRIPTION
🚮 Smell: 
- `worker.rs` and `policy.rs` implemented ad-hoc static methods (`from_db`) for parsing values instead of implementing the standard library `From` and `TryFrom` traits.
- `worker.rs` had a deeply nested `for` loop maintaining an `all_resolved` flag with an explicit `break`.

✨ Solution: 
- Implemented `TryFrom<&str>` for `ClaimedTaskKind` in `worker.rs`.
- Implemented `From<&str>` for `OverlapPolicy` and `SkipPolicy` in `policy.rs`.
- Replaced the `for` loop in `worker.rs` (`process_workflow_task`) with a concise `.iter().all(...)` iterator chain, using guard clauses to eliminate multiple levels of indentation.

🧼 Benefit: 
- Adheres to idiomatic Rust trait conventions for type conversions.
- Reduces cognitive load and "Pyramid of Doom" nesting in the critical path of workflow task processing.

🛡️ Verification: 
- Tests passed. No runtime logic was changed. Run `cargo clippy` to ensure no new warnings were introduced.

---
*PR created automatically by Jules for task [15673415665163553584](https://jules.google.com/task/15673415665163553584) started by @madmax983*