### PR TITLE
Add schedule next-fires preview API (issue #348)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -269,6 +269,7 @@ dependencies = [
  "autumn-harvest",
  "autumn-web",
  "chrono",
+ "chrono-tz",
  "deadpool",
  "diesel",
  "diesel-async",

--- a/autumn-harvest-plugin/Cargo.toml
+++ b/autumn-harvest-plugin/Cargo.toml
@@ -26,6 +26,7 @@ serde_json = { workspace = true }
 toml = { workspace = true }
 uuid = { workspace = true }
 chrono = { workspace = true }
+chrono-tz = { workspace = true }
 tracing = { workspace = true }
 diesel = { workspace = true }
 diesel-async = { workspace = true }

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -2006,6 +2006,25 @@ pub const fn management_api_request_fields()
             Some(&[]),
         ),
         ("POST", "/admin/build-routing/retire", Some(&["build_id"])),
+        // ── schedule preview (issue #348) ─────────────────────────────────────
+        (
+            "POST",
+            "/admin/schedules/preview",
+            Some(&[
+                "schedule_expr",
+                "timezone",
+                "catchup",
+                "max_active_runs",
+                "paused",
+                "jitter_secs",
+                "overlap_policy",
+                "buffer_all_max",
+                "calendar",
+                "skip_policy",
+                "count",
+                "from",
+            ]),
+        ),
     ]
 }
 
@@ -10781,9 +10800,14 @@ struct CandidateSchedulePreviewRequest {
 /// Convert a raw `ScheduleFirePreview` (from calendar.rs) into the enriched API entry
 /// format required by issue #348. This is the pure transformation function that tests
 /// exercise directly.
+///
+/// `pre_jitter_base` is the calendar-adjusted fire time BEFORE jitter was applied
+/// (i.e., `effective_at` from the original unmodified entry). Jitter bounds are
+/// computed from this base so that deferred-calendar entries report bounds on the
+/// correct (adjusted) day, not the original excluded date.
 fn build_preview_entry(
     raw: &autumn_harvest::calendar::ScheduleFirePreview,
-    _schedule_id: uuid::Uuid,
+    pre_jitter_base: Option<chrono::DateTime<chrono::Utc>>,
     jitter_secs: i64,
     timezone: &str,
     overlap_policy: &str,
@@ -10802,10 +10826,14 @@ fn build_preview_entry(
         "cron".to_string()
     };
 
-    // Jitter bounds: [scheduled_at, scheduled_at + jitter_window].
-    let (jitter_earliest_at, jitter_latest_at) = if has_jitter && raw.effective_at.is_some() {
-        let latest = raw.scheduled_at + chrono::Duration::seconds(jitter_secs);
-        (Some(raw.scheduled_at), Some(latest))
+    // Jitter bounds: [pre_jitter_base, pre_jitter_base + jitter_window].
+    // Using the calendar-adjusted base (not raw.scheduled_at) ensures deferred
+    // entries show bounds on the correct day, not the original excluded date.
+    let (jitter_earliest_at, jitter_latest_at) = if has_jitter {
+        pre_jitter_base.map_or((None, None), |base| {
+            let latest = base + chrono::Duration::seconds(jitter_secs);
+            (Some(base), Some(latest))
+        })
     } else {
         (None, None)
     };
@@ -10927,6 +10955,11 @@ async fn preview_schedule_firings_handler(
         skip_policy,
     );
 
+    // Capture pre-jitter calendar-adjusted bases before modifying entries in-place.
+    // These become the lower bound of the jitter window for deferred-calendar entries.
+    let pre_jitter_bases: Vec<Option<chrono::DateTime<chrono::Utc>>> =
+        raw_entries.iter().map(|e| e.effective_at).collect();
+
     // Apply jitter to each effective_at (mirrors effective_fire_time logic).
     if jitter_secs > 0 {
         let jitter_window = std::time::Duration::from_secs(jitter_secs.cast_unsigned());
@@ -10942,10 +10975,11 @@ async fn preview_schedule_firings_handler(
 
     let entries: Vec<ScheduleFirePreviewEntry> = raw_entries
         .iter()
-        .map(|r| {
+        .zip(pre_jitter_bases.iter())
+        .map(|(r, &base)| {
             build_preview_entry(
                 r,
-                schedule_id,
+                base,
                 jitter_secs,
                 timezone,
                 &schedule.overlap_policy,
@@ -10959,6 +10993,7 @@ async fn preview_schedule_firings_handler(
         Json(serde_json::json!({
             "entries": entries,
             "is_paused": false,
+            "pause_reason": serde_json::Value::Null,
             "from": from,
             "count_requested": count,
         })),
@@ -11076,9 +11111,16 @@ async fn preview_candidate_schedule_handler(
     } else {
         vec![]
     };
+    // When schedule_expr embeds a timezone (cron_tz:<tz>:<expr>), use that
+    // timezone for local_at formatting rather than the body's separate `timezone`
+    // field, which defaults to "UTC" and would produce misleading local times.
+    let effective_timezone: &str = match &schedule {
+        autumn_harvest::policy::Schedule::CronInTimezone { tz, .. } => tz.as_str(),
+        _ => &body.timezone,
+    };
+
     // Use a deterministic placeholder UUID so jitter offsets are stable per request.
     let schedule_id = uuid::Uuid::nil();
-    let timezone = &body.timezone;
 
     let mut raw_entries = preview_schedule_firings(
         &schedule,
@@ -11088,6 +11130,10 @@ async fn preview_candidate_schedule_handler(
         &excluded_dates,
         skip_policy,
     );
+
+    // Capture pre-jitter calendar-adjusted bases before modifying entries in-place.
+    let pre_jitter_bases: Vec<Option<chrono::DateTime<chrono::Utc>>> =
+        raw_entries.iter().map(|e| e.effective_at).collect();
 
     if jitter_secs > 0 {
         let jitter_window = std::time::Duration::from_secs(body.jitter_secs);
@@ -11104,12 +11150,13 @@ async fn preview_candidate_schedule_handler(
     let max_active_runs = i32::try_from(body.max_active_runs).unwrap_or(i32::MAX);
     let entries: Vec<ScheduleFirePreviewEntry> = raw_entries
         .iter()
-        .map(|r| {
+        .zip(pre_jitter_bases.iter())
+        .map(|(r, &base)| {
             build_preview_entry(
                 r,
-                schedule_id,
+                base,
                 jitter_secs,
-                timezone,
+                effective_timezone,
                 &body.overlap_policy,
                 max_active_runs,
             )
@@ -11121,6 +11168,7 @@ async fn preview_candidate_schedule_handler(
         Json(serde_json::json!({
             "entries": entries,
             "is_paused": false,
+            "pause_reason": serde_json::Value::Null,
             "from": from,
             "count_requested": count,
         })),
@@ -13648,7 +13696,8 @@ mod tests {
             effective_at: Some(fire),
             reason: "Fired".to_string(),
         };
-        let entry = build_preview_entry(&preview, uuid::Uuid::nil(), 0, "UTC", "skip", 1);
+        // pre_jitter_base = Some(fire) — no calendar adjustment, no jitter.
+        let entry = build_preview_entry(&preview, Some(fire), 0, "UTC", "skip", 1);
         assert_eq!(entry.reason, "cron", "no-jitter reason must be 'cron'");
         assert!(entry.jitter_earliest_at.is_none());
         assert!(entry.jitter_latest_at.is_none());
@@ -13662,10 +13711,11 @@ mod tests {
         let effective = fire + chrono::Duration::seconds(120);
         let preview = ScheduleFirePreview {
             scheduled_at: fire,
-            effective_at: Some(effective),
+            effective_at: Some(effective), // post-jitter effective_at
             reason: "Fired".to_string(),
         };
-        let entry = build_preview_entry(&preview, uuid::Uuid::nil(), 300, "UTC", "skip", 1);
+        // pre_jitter_base = Some(fire) — calendar-adjusted base BEFORE jitter.
+        let entry = build_preview_entry(&preview, Some(fire), 300, "UTC", "skip", 1);
         assert_eq!(
             entry.reason, "cron+jitter",
             "jitter reason must be 'cron+jitter'"
@@ -13681,12 +13731,39 @@ mod tests {
         assert_eq!(
             entry.jitter_earliest_at.unwrap(),
             fire,
-            "jitter_earliest_at must equal scheduled_at"
+            "jitter_earliest_at must equal pre-jitter base"
         );
         assert_eq!(
             entry.jitter_latest_at.unwrap(),
             fire + chrono::Duration::seconds(300),
-            "jitter_latest_at must equal scheduled_at + jitter_secs"
+            "jitter_latest_at must equal pre_jitter_base + jitter_secs"
+        );
+    }
+
+    #[test]
+    fn build_preview_entry_jitter_bounds_use_deferred_date_not_original() {
+        use autumn_harvest::calendar::ScheduleFirePreview;
+        use chrono::TimeZone as _;
+        // Simulates a July 4 holiday deferred to July 5 with jitter applied.
+        let original = chrono::Utc.with_ymd_and_hms(2026, 7, 4, 9, 0, 0).unwrap();
+        let deferred_base = chrono::Utc.with_ymd_and_hms(2026, 7, 5, 9, 0, 0).unwrap();
+        let deferred_jittered = deferred_base + chrono::Duration::seconds(42);
+        let preview = ScheduleFirePreview {
+            scheduled_at: original,
+            effective_at: Some(deferred_jittered), // calendar-adjusted + jitter
+            reason: "DeferredFrom:2026-07-04".to_string(),
+        };
+        // pre_jitter_base = Some(deferred_base) — calendar-adjusted BEFORE jitter.
+        let entry = build_preview_entry(&preview, Some(deferred_base), 300, "UTC", "skip", 1);
+        assert_eq!(
+            entry.jitter_earliest_at.unwrap(),
+            deferred_base,
+            "jitter_earliest_at must be the deferred date, not the original excluded date"
+        );
+        assert_eq!(
+            entry.jitter_latest_at.unwrap(),
+            deferred_base + chrono::Duration::seconds(300),
+            "jitter_latest_at must be deferred_base + jitter_secs"
         );
     }
 
@@ -13700,7 +13777,8 @@ mod tests {
             effective_at: None,
             reason: "SkippedByCalendar:us-holidays".to_string(),
         };
-        let entry = build_preview_entry(&preview, uuid::Uuid::nil(), 0, "UTC", "skip", 1);
+        // pre_jitter_base = None — suppressed entries have no base.
+        let entry = build_preview_entry(&preview, None, 0, "UTC", "skip", 1);
         assert_eq!(
             entry.reason, "skipped:calendar-excluded",
             "calendar-suppressed reason must be 'skipped:calendar-excluded'"
@@ -13719,7 +13797,7 @@ mod tests {
             effective_at: Some(deferred),
             reason: "DeferredFrom:2026-07-04".to_string(),
         };
-        let entry = build_preview_entry(&preview, uuid::Uuid::nil(), 0, "UTC", "skip", 1);
+        let entry = build_preview_entry(&preview, Some(deferred), 0, "UTC", "skip", 1);
         assert_eq!(
             entry.reason, "deferred:calendar",
             "calendar-deferred reason must be 'deferred:calendar'"
@@ -13736,7 +13814,7 @@ mod tests {
             effective_at: Some(fire),
             reason: "Fired".to_string(),
         };
-        let entry = build_preview_entry(&preview, uuid::Uuid::nil(), 0, "UTC", "skip", 1);
+        let entry = build_preview_entry(&preview, Some(fire), 0, "UTC", "skip", 1);
         assert!(
             entry.would_skip_if_active,
             "skip overlap policy must set would_skip_if_active=true"
@@ -13753,7 +13831,7 @@ mod tests {
             effective_at: Some(fire),
             reason: "Fired".to_string(),
         };
-        let entry = build_preview_entry(&preview, uuid::Uuid::nil(), 0, "UTC", "cancel_other", 1);
+        let entry = build_preview_entry(&preview, Some(fire), 0, "UTC", "cancel_other", 1);
         assert!(
             !entry.would_skip_if_active,
             "cancel_other overlap policy must set would_skip_if_active=false"
@@ -13771,7 +13849,7 @@ mod tests {
             reason: "SkippedByCalendar:us-holidays".to_string(),
         };
         // Even with skip policy, a suppressed entry cannot be skipped-if-active.
-        let entry = build_preview_entry(&preview, uuid::Uuid::nil(), 0, "UTC", "skip", 1);
+        let entry = build_preview_entry(&preview, None, 0, "UTC", "skip", 1);
         assert!(
             !entry.would_skip_if_active,
             "suppressed entries (effective_at=None) must not set would_skip_if_active"

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -61,7 +61,9 @@ use autumn_harvest::models::{
     AuditRecord, BackfillLogRow, DeadLetter, HarvestCalendar, HarvestSchedule, NewAuditRecord,
     NewBackfillLogRow, RateLimitBucket, ScheduleDecision, WorkflowExecution,
 };
-use autumn_harvest::policy::{Schedule, SkipPolicy, WorkflowSchedule, compute_jitter_offset};
+use autumn_harvest::policy::{
+    Schedule, SkipPolicy, WorkflowSchedule, compute_jitter_offset, validate_jitter,
+};
 use autumn_harvest::queue::{self, ConcurrencyKeyStats};
 use autumn_harvest::reset::{
     ResetInvalidPoint, ResetResult, WorkflowResetError, WorkflowResetRequest,
@@ -10968,6 +10970,7 @@ async fn preview_schedule_firings_handler(
 ///
 /// Returns `400 Bad Request` when the `schedule_expr` or `timezone` is invalid,
 /// so operators get an actionable parse error before committing the config.
+#[allow(clippy::too_many_lines)]
 async fn preview_candidate_schedule_handler(
     Extension(api_state): Extension<HarvestApiState>,
     Json(body): Json<CandidateSchedulePreviewRequest>,
@@ -10978,15 +10981,48 @@ async fn preview_candidate_schedule_handler(
     let from = parse_from_param(body.from.as_deref()).map_err(AutumnError::bad_request_msg)?;
 
     // Validate and parse the schedule expression; return 400 on error.
+    // Infer `field` from the error message so timezone parse failures are
+    // correctly attributed to the `timezone` field, not `schedule_expr`.
     let schedule = match parse_schedule_expr_with_tz(&body.schedule_expr, &body.timezone) {
         Ok(s) => s,
         Err(e) => {
+            let field = if e.to_lowercase().contains("timezone") || e.to_lowercase().contains("tz")
+            {
+                "timezone"
+            } else {
+                "schedule_expr"
+            };
             return Ok((
                 StatusCode::BAD_REQUEST,
-                Json(serde_json::json!({"error": e, "field": "schedule_expr"})),
+                Json(serde_json::json!({"error": e, "field": field})),
             ));
         }
     };
+
+    // Validate skip_policy strictly — from_db silently falls back to Skip.
+    let skip_policy = match SkipPolicy::from_user_input(&body.skip_policy) {
+        Ok(p) => p,
+        Err(bad) => {
+            return Ok((
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "error": format!("unknown skip_policy '{bad}'; valid: skip, run_next_business_day, run_prev_business_day"),
+                    "field": "skip_policy"
+                })),
+            ));
+        }
+    };
+
+    // Validate overlap_policy strictly before it is used in build_preview_entry.
+    if let Err(bad) = autumn_harvest::OverlapPolicy::from_user_input(&body.overlap_policy) {
+        return Ok((
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "error": format!("unknown overlap_policy '{bad}'; valid: skip, buffer_one, buffer_all, cancel_other, terminate_other"),
+                "field": "overlap_policy"
+            })),
+        ));
+    }
 
     // Paused candidate schedules return no entries.
     if body.paused {
@@ -11002,20 +11038,44 @@ async fn preview_candidate_schedule_handler(
         ));
     }
 
-    let calendar_name = body.calendar.as_deref();
-    let skip_policy = SkipPolicy::from_db(&body.skip_policy);
+    // Validate jitter before i64 conversion; body.jitter_secs is u64 so an
+    // overly large value would overflow chrono::Duration::seconds and panic.
+    let jitter_duration = std::time::Duration::from_secs(body.jitter_secs);
+    if let Err(e) = validate_jitter(&schedule, jitter_duration) {
+        return Ok((
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": e, "field": "jitter_secs"})),
+        ));
+    }
+    // Safe after validate_jitter: valid jitter is at most 3600 s for cron,
+    // or less than the interval period, both well within i64 range.
+    let jitter_secs = i64::try_from(body.jitter_secs).unwrap_or(i64::MAX);
 
+    let calendar_name = body.calendar.as_deref();
     let excluded_dates = if let Some(cal_name) = calendar_name {
         let pool = api_state.storage_pool().map_err(map_error)?;
         let mut conn = acquire_conn(pool.default_pool()).await?;
+        // Verify the calendar exists; silently-empty exclusions on a typo would
+        // confuse operators into thinking the config is valid.
+        match get_calendar(&mut conn, cal_name).await {
+            Ok(_) => {}
+            Err(autumn_harvest::HarvestError::NotFound(_)) => {
+                return Ok((
+                    StatusCode::BAD_REQUEST,
+                    Json(serde_json::json!({
+                        "error": format!("calendar '{cal_name}' not found; create it first with POST /calendars"),
+                        "field": "calendar"
+                    })),
+                ));
+            }
+            Err(e) => return Err(map_error(e)),
+        }
         load_exclusions_for_calendar(&mut conn, cal_name)
             .await
             .map_err(map_error)?
     } else {
         vec![]
     };
-
-    let jitter_secs = i64::try_from(body.jitter_secs).unwrap_or(i64::MAX);
     // Use a deterministic placeholder UUID so jitter offsets are stable per request.
     let schedule_id = uuid::Uuid::nil();
     let timezone = &body.timezone;
@@ -13735,6 +13795,72 @@ mod tests {
                 .iter()
                 .any(|(m, p, _)| *m == "POST" && *p == "/admin/schedules/preview"),
             "POST /admin/schedules/preview must be listed in management_api_response_fields"
+        );
+    }
+
+    // ── Candidate preview handler validation (issue #348 follow-up) ──────────
+
+    #[test]
+    fn candidate_request_invalid_skip_policy_fails_deserialization_gracefully() {
+        // The struct accepts any string (validated at handler time), so
+        // deserialization itself must succeed — handler rejects the bad value.
+        let json = r#"{"schedule_expr":"0 9 * * *","skip_policy":"never"}"#;
+        let req: CandidateSchedulePreviewRequest =
+            serde_json::from_str(json).expect("struct accepts any string for skip_policy");
+        assert_eq!(req.skip_policy, "never");
+    }
+
+    #[test]
+    fn candidate_request_invalid_overlap_policy_fails_deserialization_gracefully() {
+        let json = r#"{"schedule_expr":"0 9 * * *","overlap_policy":"unknown"}"#;
+        let req: CandidateSchedulePreviewRequest =
+            serde_json::from_str(json).expect("struct accepts any string for overlap_policy");
+        assert_eq!(req.overlap_policy, "unknown");
+    }
+
+    #[test]
+    fn candidate_request_large_jitter_u64_parses_into_struct() {
+        // u64::MAX is representable in JSON and should parse into the struct;
+        // the handler rejects it via validate_jitter (not a parse error).
+        let json = format!(
+            r#"{{"schedule_expr":"0 9 * * *","jitter_secs":{}}}"#,
+            u64::MAX
+        );
+        let req: CandidateSchedulePreviewRequest =
+            serde_json::from_str(&json).expect("u64::MAX must parse into the struct");
+        assert_eq!(req.jitter_secs, u64::MAX);
+    }
+
+    #[test]
+    fn parse_schedule_error_timezone_field_attributed_correctly() {
+        // "Not/ATimezone" error message from validate_schedule contains "timezone".
+        let result = parse_schedule_expr_with_tz("0 9 * * *", "Not/ATimezone");
+        let err = result.unwrap_err();
+        let field = if err.to_lowercase().contains("timezone") || err.to_lowercase().contains("tz")
+        {
+            "timezone"
+        } else {
+            "schedule_expr"
+        };
+        assert_eq!(
+            field, "timezone",
+            "timezone parse error must be attributed to 'timezone' field, not 'schedule_expr': {err}"
+        );
+    }
+
+    #[test]
+    fn parse_schedule_error_bad_cron_attributed_to_schedule_expr() {
+        let result = parse_schedule_expr_with_tz("not a cron", "UTC");
+        let err = result.unwrap_err();
+        let field = if err.to_lowercase().contains("timezone") || err.to_lowercase().contains("tz")
+        {
+            "timezone"
+        } else {
+            "schedule_expr"
+        };
+        assert_eq!(
+            field, "schedule_expr",
+            "cron parse error must be attributed to 'schedule_expr': {err}"
         );
     }
 }

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -10874,14 +10874,24 @@ fn format_in_timezone(utc: chrono::DateTime<chrono::Utc>, tz_name: &str) -> Stri
 
 /// Parse an optional ISO-8601 `from` string. Returns the parsed instant when
 /// present, `Utc::now()` when absent, and `Err(String)` when the string is
-/// malformed (caller maps this to a 400 response).
+/// malformed or too far in the future (caller maps this to a 400 response).
+///
+/// Years above 9000 are rejected: interval schedules compute `from + period`
+/// repeatedly, and very large `from` values can overflow `DateTime` arithmetic or
+/// produce RFC 3339 strings (year > 9999) that most clients cannot parse.
 fn parse_from_param(from: Option<&str>) -> Result<chrono::DateTime<chrono::Utc>, String> {
     from.map_or_else(
         || Ok(chrono::Utc::now()),
         |s| {
-            chrono::DateTime::parse_from_rfc3339(s)
+            let dt = chrono::DateTime::parse_from_rfc3339(s)
                 .map(|dt| dt.with_timezone(&chrono::Utc))
-                .map_err(|e| format!("invalid `from` timestamp '{s}': {e}"))
+                .map_err(|e| format!("invalid `from` timestamp '{s}': {e}"))?;
+            if chrono::Datelike::year(&dt) > 9000 {
+                return Err(format!(
+                    "invalid `from` timestamp '{s}': year must be \u{2264} 9000"
+                ));
+            }
+            Ok(dt)
         },
     )
 }
@@ -13656,6 +13666,34 @@ mod tests {
         let q: SchedulePreviewQuery =
             serde_json::from_str(r#"{"count": 10}"#).expect("should deserialize");
         assert!(q.from.is_none(), "missing `from` must default to None");
+    }
+
+    #[test]
+    fn parse_from_param_accepts_valid_timestamp() {
+        let result = parse_from_param(Some("2026-06-01T09:00:00Z"));
+        assert!(result.is_ok(), "valid RFC3339 must parse successfully");
+    }
+
+    #[test]
+    fn parse_from_param_rejects_far_future_year() {
+        let result = parse_from_param(Some("9001-01-01T00:00:00Z"));
+        assert!(
+            result.is_err(),
+            "year 9001 must be rejected to prevent DateTime overflow in schedule expansion"
+        );
+        assert!(
+            result.unwrap_err().contains("year must be"),
+            "error message must mention the year limit"
+        );
+    }
+
+    #[test]
+    fn parse_from_param_accepts_year_9000() {
+        let result = parse_from_param(Some("9000-12-31T23:59:59Z"));
+        assert!(
+            result.is_ok(),
+            "year 9000 is the boundary and must be accepted"
+        );
     }
 
     #[test]

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -10775,6 +10775,7 @@ struct CandidateSchedulePreviewRequest {
     #[allow(dead_code)] // part of the public request shape; included for spec completeness
     catchup: bool,
     #[serde(default = "default_max_active_runs")]
+    #[allow(dead_code)] // part of the public request shape; included for spec completeness
     max_active_runs: u32,
     #[serde(default)]
     paused: bool,
@@ -10811,7 +10812,6 @@ fn build_preview_entry(
     jitter_secs: i64,
     timezone: &str,
     overlap_policy: &str,
-    max_active_runs: i32,
 ) -> ScheduleFirePreviewEntry {
     let has_jitter = jitter_secs > 0;
 
@@ -10829,10 +10829,13 @@ fn build_preview_entry(
     // Jitter bounds: [pre_jitter_base, pre_jitter_base + jitter_window].
     // Using the calendar-adjusted base (not raw.scheduled_at) ensures deferred
     // entries show bounds on the correct day, not the original excluded date.
+    // try_seconds + checked_add_signed guard against oversized stored values
+    // (e.g. a saturated i64::MAX written by the schedule create path).
     let (jitter_earliest_at, jitter_latest_at) = if has_jitter {
         pre_jitter_base.map_or((None, None), |base| {
-            let latest = base + chrono::Duration::seconds(jitter_secs);
-            (Some(base), Some(latest))
+            let latest =
+                chrono::Duration::try_seconds(jitter_secs).and_then(|d| base.checked_add_signed(d));
+            (Some(base), latest)
         })
     } else {
         (None, None)
@@ -10842,10 +10845,11 @@ fn build_preview_entry(
     let effective_local_at = raw.effective_at.map(|t| format_in_timezone(t, timezone));
 
     // would_skip_if_active: advisory flag set when the overlap policy can silently
-    // drop a firing if max_active_runs are running at dispatch time.
-    let would_skip_if_active = (overlap_policy == "skip" || overlap_policy == "buffer_one")
-        && raw.effective_at.is_some()
-        && max_active_runs > 0;
+    // drop a firing if capacity is saturated at dispatch time. The `max_active_runs > 0`
+    // guard is intentionally absent: max_active_runs = 0 means the scheduler's
+    // `running >= max_active_runs` check is always true, so every firing is dropped.
+    let would_skip_if_active =
+        (overlap_policy == "skip" || overlap_policy == "buffer_one") && raw.effective_at.is_some();
 
     ScheduleFirePreviewEntry {
         scheduled_at: raw.scheduled_at,
@@ -10922,7 +10926,7 @@ async fn preview_schedule_firings_handler(
             Json(serde_json::json!({
                 "entries": [],
                 "is_paused": false,
-                "reason": "manual or no schedule",
+                "pause_reason": serde_json::Value::Null,
                 "from": from,
                 "count_requested": count,
             })),
@@ -10977,14 +10981,7 @@ async fn preview_schedule_firings_handler(
         .iter()
         .zip(pre_jitter_bases.iter())
         .map(|(r, &base)| {
-            build_preview_entry(
-                r,
-                base,
-                jitter_secs,
-                timezone,
-                &schedule.overlap_policy,
-                schedule.max_active_runs,
-            )
+            build_preview_entry(r, base, jitter_secs, timezone, &schedule.overlap_policy)
         })
         .collect();
 
@@ -11111,12 +11108,14 @@ async fn preview_candidate_schedule_handler(
     } else {
         vec![]
     };
-    // When schedule_expr embeds a timezone (cron_tz:<tz>:<expr>), use that
-    // timezone for local_at formatting rather than the body's separate `timezone`
-    // field, which defaults to "UTC" and would produce misleading local times.
+    // Use the timezone embedded in the schedule variant so local_at always
+    // reflects what the DB will store after saving. CronInTimezone carries the
+    // timezone explicitly; Interval and Manual are always UTC-based (Schedule::timezone_str()
+    // returns "UTC" for those variants), so using body.timezone there would show a
+    // timezone that the persisted schedule would not honour.
     let effective_timezone: &str = match &schedule {
         autumn_harvest::policy::Schedule::CronInTimezone { tz, .. } => tz.as_str(),
-        _ => &body.timezone,
+        _ => "UTC",
     };
 
     // Use a deterministic placeholder UUID so jitter offsets are stable per request.
@@ -11147,7 +11146,6 @@ async fn preview_candidate_schedule_handler(
         }
     }
 
-    let max_active_runs = i32::try_from(body.max_active_runs).unwrap_or(i32::MAX);
     let entries: Vec<ScheduleFirePreviewEntry> = raw_entries
         .iter()
         .zip(pre_jitter_bases.iter())
@@ -11158,7 +11156,6 @@ async fn preview_candidate_schedule_handler(
                 jitter_secs,
                 effective_timezone,
                 &body.overlap_policy,
-                max_active_runs,
             )
         })
         .collect();
@@ -13697,7 +13694,7 @@ mod tests {
             reason: "Fired".to_string(),
         };
         // pre_jitter_base = Some(fire) — no calendar adjustment, no jitter.
-        let entry = build_preview_entry(&preview, Some(fire), 0, "UTC", "skip", 1);
+        let entry = build_preview_entry(&preview, Some(fire), 0, "UTC", "skip");
         assert_eq!(entry.reason, "cron", "no-jitter reason must be 'cron'");
         assert!(entry.jitter_earliest_at.is_none());
         assert!(entry.jitter_latest_at.is_none());
@@ -13715,7 +13712,7 @@ mod tests {
             reason: "Fired".to_string(),
         };
         // pre_jitter_base = Some(fire) — calendar-adjusted base BEFORE jitter.
-        let entry = build_preview_entry(&preview, Some(fire), 300, "UTC", "skip", 1);
+        let entry = build_preview_entry(&preview, Some(fire), 300, "UTC", "skip");
         assert_eq!(
             entry.reason, "cron+jitter",
             "jitter reason must be 'cron+jitter'"
@@ -13754,7 +13751,7 @@ mod tests {
             reason: "DeferredFrom:2026-07-04".to_string(),
         };
         // pre_jitter_base = Some(deferred_base) — calendar-adjusted BEFORE jitter.
-        let entry = build_preview_entry(&preview, Some(deferred_base), 300, "UTC", "skip", 1);
+        let entry = build_preview_entry(&preview, Some(deferred_base), 300, "UTC", "skip");
         assert_eq!(
             entry.jitter_earliest_at.unwrap(),
             deferred_base,
@@ -13778,7 +13775,7 @@ mod tests {
             reason: "SkippedByCalendar:us-holidays".to_string(),
         };
         // pre_jitter_base = None — suppressed entries have no base.
-        let entry = build_preview_entry(&preview, None, 0, "UTC", "skip", 1);
+        let entry = build_preview_entry(&preview, None, 0, "UTC", "skip");
         assert_eq!(
             entry.reason, "skipped:calendar-excluded",
             "calendar-suppressed reason must be 'skipped:calendar-excluded'"
@@ -13797,7 +13794,7 @@ mod tests {
             effective_at: Some(deferred),
             reason: "DeferredFrom:2026-07-04".to_string(),
         };
-        let entry = build_preview_entry(&preview, Some(deferred), 0, "UTC", "skip", 1);
+        let entry = build_preview_entry(&preview, Some(deferred), 0, "UTC", "skip");
         assert_eq!(
             entry.reason, "deferred:calendar",
             "calendar-deferred reason must be 'deferred:calendar'"
@@ -13814,7 +13811,7 @@ mod tests {
             effective_at: Some(fire),
             reason: "Fired".to_string(),
         };
-        let entry = build_preview_entry(&preview, Some(fire), 0, "UTC", "skip", 1);
+        let entry = build_preview_entry(&preview, Some(fire), 0, "UTC", "skip");
         assert!(
             entry.would_skip_if_active,
             "skip overlap policy must set would_skip_if_active=true"
@@ -13831,7 +13828,7 @@ mod tests {
             effective_at: Some(fire),
             reason: "Fired".to_string(),
         };
-        let entry = build_preview_entry(&preview, Some(fire), 0, "UTC", "cancel_other", 1);
+        let entry = build_preview_entry(&preview, Some(fire), 0, "UTC", "cancel_other");
         assert!(
             !entry.would_skip_if_active,
             "cancel_other overlap policy must set would_skip_if_active=false"
@@ -13849,10 +13846,51 @@ mod tests {
             reason: "SkippedByCalendar:us-holidays".to_string(),
         };
         // Even with skip policy, a suppressed entry cannot be skipped-if-active.
-        let entry = build_preview_entry(&preview, None, 0, "UTC", "skip", 1);
+        let entry = build_preview_entry(&preview, None, 0, "UTC", "skip");
         assert!(
             !entry.would_skip_if_active,
             "suppressed entries (effective_at=None) must not set would_skip_if_active"
+        );
+    }
+
+    #[test]
+    fn build_preview_entry_would_skip_true_when_max_active_runs_is_zero() {
+        use autumn_harvest::calendar::ScheduleFirePreview;
+        use chrono::TimeZone as _;
+        let fire = chrono::Utc.with_ymd_and_hms(2026, 6, 1, 9, 0, 0).unwrap();
+        let preview = ScheduleFirePreview {
+            scheduled_at: fire,
+            effective_at: Some(fire),
+            reason: "Fired".to_string(),
+        };
+        // max_active_runs = 0 means the scheduler's running >= max_active_runs check is
+        // always true, so every firing is dropped. The advisory must fire.
+        let entry = build_preview_entry(&preview, Some(fire), 0, "UTC", "skip");
+        assert!(
+            entry.would_skip_if_active,
+            "max_active_runs=0 with skip policy must set would_skip_if_active=true"
+        );
+    }
+
+    #[test]
+    fn build_preview_entry_jitter_latest_at_is_none_for_oversized_jitter() {
+        use autumn_harvest::calendar::ScheduleFirePreview;
+        use chrono::TimeZone as _;
+        let fire = chrono::Utc.with_ymd_and_hms(2026, 6, 1, 9, 0, 0).unwrap();
+        let preview = ScheduleFirePreview {
+            scheduled_at: fire,
+            effective_at: Some(fire),
+            reason: "Fired".to_string(),
+        };
+        // i64::MAX seconds overflows chrono Duration creation; must not panic.
+        let entry = build_preview_entry(&preview, Some(fire), i64::MAX, "UTC", "skip");
+        assert!(
+            entry.jitter_earliest_at.is_some(),
+            "jitter_earliest_at must still be present"
+        );
+        assert!(
+            entry.jitter_latest_at.is_none(),
+            "jitter_latest_at must be None when jitter_secs overflows DateTime"
         );
     }
 

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -11056,20 +11056,6 @@ async fn preview_candidate_schedule_handler(
         ));
     }
 
-    // Paused candidate schedules return no entries.
-    if body.paused {
-        return Ok((
-            StatusCode::OK,
-            Json(serde_json::json!({
-                "entries": [],
-                "is_paused": true,
-                "pause_reason": serde_json::Value::Null,
-                "from": from,
-                "count_requested": count,
-            })),
-        ));
-    }
-
     // Validate jitter before i64 conversion; body.jitter_secs is u64 so an
     // overly large value would overflow chrono::Duration::seconds and panic.
     let jitter_duration = std::time::Duration::from_secs(body.jitter_secs);
@@ -11083,12 +11069,13 @@ async fn preview_candidate_schedule_handler(
     // or less than the interval period, both well within i64 range.
     let jitter_secs = i64::try_from(body.jitter_secs).unwrap_or(i64::MAX);
 
+    // Verify the calendar exists before returning any result so that a typo
+    // here gets a 400 even when the schedule is paused.  Exclusion dates are
+    // only loaded for active schedules further below.
     let calendar_name = body.calendar.as_deref();
-    let excluded_dates = if let Some(cal_name) = calendar_name {
+    if let Some(cal_name) = calendar_name {
         let pool = api_state.storage_pool().map_err(map_error)?;
         let mut conn = acquire_conn(pool.default_pool()).await?;
-        // Verify the calendar exists; silently-empty exclusions on a typo would
-        // confuse operators into thinking the config is valid.
         match get_calendar(&mut conn, cal_name).await {
             Ok(_) => {}
             Err(autumn_harvest::HarvestError::NotFound(_)) => {
@@ -11102,6 +11089,28 @@ async fn preview_candidate_schedule_handler(
             }
             Err(e) => return Err(map_error(e)),
         }
+    }
+
+    // Paused candidate schedules return no entries. All validations above
+    // (schedule_expr, timezone, skip_policy, overlap_policy, jitter, calendar)
+    // run first so the preview rejects the same configs that POST /admin/schedules/workflow
+    // would reject, regardless of pause state.
+    if body.paused {
+        return Ok((
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "entries": [],
+                "is_paused": true,
+                "pause_reason": serde_json::Value::Null,
+                "from": from,
+                "count_requested": count,
+            })),
+        ));
+    }
+
+    let excluded_dates = if let Some(cal_name) = calendar_name {
+        let pool = api_state.storage_pool().map_err(map_error)?;
+        let mut conn = acquire_conn(pool.default_pool()).await?;
         load_exclusions_for_calendar(&mut conn, cal_name)
             .await
             .map_err(map_error)?

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -1597,6 +1597,10 @@ pub fn harvest_api_router(api_state: HarvestApiState) -> Router<AppState> {
             "/admin/schedules/{id}/preview",
             get(preview_schedule_firings_handler),
         )
+        .route(
+            "/admin/schedules/preview",
+            post(preview_candidate_schedule_handler),
+        )
         // Calendar management (issue #337): named exclusion sets for business-day aware scheduling.
         .route("/calendars", get(list_calendars_handler))
         .route(
@@ -1793,6 +1797,7 @@ pub const fn management_api_routes() -> &'static [(&'static str, &'static str)] 
         ("POST", "/admin/schedules/{id}/trigger"),
         ("DELETE", "/admin/schedules/{id}"),
         ("GET", "/admin/schedules/{id}/preview"),
+        ("POST", "/admin/schedules/preview"),
         // ── calendars (issue #337) ────────────────────────────────────────────
         ("GET", "/calendars"),
         ("GET", "/calendars/{name}"),
@@ -2333,7 +2338,28 @@ pub const fn management_api_response_fields()
             Some(&["execution_id", "workflow_id", "triggered_at", "outcome"]),
         ),
         ("DELETE", "/admin/schedules/{id}", Some(&["ok"])),
-        ("GET", "/admin/schedules/{id}/preview", Some(&["entries"])),
+        (
+            "GET",
+            "/admin/schedules/{id}/preview",
+            Some(&[
+                "entries",
+                "is_paused",
+                "pause_reason",
+                "from",
+                "count_requested",
+            ]),
+        ),
+        (
+            "POST",
+            "/admin/schedules/preview",
+            Some(&[
+                "entries",
+                "is_paused",
+                "pause_reason",
+                "from",
+                "count_requested",
+            ]),
+        ),
         // ── calendars (issue #337) ────────────────────────────────────────────
         ("GET", "/calendars", None), // Vec<CalendarSummary>
         (
@@ -10664,7 +10690,7 @@ async fn delete_calendar_handler(
     Ok(StatusCode::NO_CONTENT)
 }
 
-// ── Schedule preview (issue #337) ─────────────────────────────────────────────
+// ── Schedule next-fires preview API (issues #337, #348) ──────────────────────
 
 /// Query parameters for `GET /admin/schedules/{id}/preview`.
 #[derive(Debug, Deserialize)]
@@ -10672,13 +10698,162 @@ struct SchedulePreviewQuery {
     /// Number of fire-time entries to return. Defaults to 10, max 100.
     #[serde(default = "default_preview_count")]
     count: usize,
+    /// ISO-8601 UTC instant to start the preview from. Defaults to now.
+    #[serde(default)]
+    from: Option<String>,
 }
 
 const fn default_preview_count() -> usize {
     10
 }
 
-/// `GET /admin/schedules/{id}/preview?count=N` — preview next N fire times.
+/// A single enriched entry in the schedule next-fires preview (issue #348).
+#[derive(Debug, Serialize)]
+struct ScheduleFirePreviewEntry {
+    /// UTC wall-clock instant the cron/interval computed.
+    scheduled_at: chrono::DateTime<chrono::Utc>,
+    /// `scheduled_at` rendered in the schedule's configured timezone (RFC 3339).
+    local_at: String,
+    /// Effective fire time after calendar adjustment and jitter application.
+    /// `None` means the firing is suppressed (calendar exclusion with `skip` policy).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    effective_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// `effective_at` rendered in the schedule's timezone. Omitted when `effective_at` is `None`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    effective_local_at: Option<String>,
+    /// Human-readable reason for this instant:
+    /// - `"cron"` — fires as scheduled.
+    /// - `"cron+jitter"` — fires at `effective_at` after deterministic jitter.
+    /// - `"skipped:calendar-excluded"` — suppressed by calendar exclusion.
+    /// - `"deferred:calendar"` — moved to a different day by calendar skip-policy.
+    reason: String,
+    /// Earliest possible fire time when jitter is enabled (`= scheduled_at`).
+    /// Omitted when `jitter_secs = 0`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    jitter_earliest_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// Latest possible fire time when jitter is enabled (`= scheduled_at + jitter_secs`).
+    /// Omitted when `jitter_secs = 0`.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    jitter_latest_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// `true` when the overlap policy (`"skip"` or `"buffer_one"`) could silently drop this
+    /// firing if `max_active_runs` is already running at dispatch time. Preview is stateless
+    /// and cannot know the future run count; treat this as an advisory warning.
+    would_skip_if_active: bool,
+}
+
+/// Request body for `POST /admin/schedules/preview` — validate a candidate schedule
+/// config and preview its next N fire times without persisting anything.
+///
+/// Same field set as `CreateWorkflowScheduleRequest` (issue #348).
+#[derive(Debug, Deserialize)]
+struct CandidateSchedulePreviewRequest {
+    schedule_expr: String,
+    #[serde(default = "default_timezone")]
+    timezone: String,
+    #[serde(default)]
+    #[allow(dead_code)] // part of the public request shape; included for spec completeness
+    catchup: bool,
+    #[serde(default = "default_max_active_runs")]
+    max_active_runs: u32,
+    #[serde(default)]
+    paused: bool,
+    #[serde(default)]
+    jitter_secs: u64,
+    #[serde(default = "default_overlap_policy")]
+    overlap_policy: String,
+    #[serde(default = "default_buffer_all_max")]
+    #[allow(dead_code)] // part of the public request shape; included for spec completeness
+    buffer_all_max: u32,
+    #[serde(default)]
+    calendar: Option<String>,
+    #[serde(default = "default_skip_policy")]
+    skip_policy: String,
+    /// Number of entries to return. Defaults to 10, max 100.
+    #[serde(default = "default_preview_count")]
+    count: usize,
+    /// ISO-8601 UTC instant to start the preview from. Defaults to now.
+    #[serde(default)]
+    from: Option<String>,
+}
+
+/// Convert a raw `ScheduleFirePreview` (from calendar.rs) into the enriched API entry
+/// format required by issue #348. This is the pure transformation function that tests
+/// exercise directly.
+fn build_preview_entry(
+    raw: &autumn_harvest::calendar::ScheduleFirePreview,
+    _schedule_id: uuid::Uuid,
+    jitter_secs: i64,
+    timezone: &str,
+    overlap_policy: &str,
+    max_active_runs: i32,
+) -> ScheduleFirePreviewEntry {
+    let has_jitter = jitter_secs > 0;
+
+    // Map old calendar.rs reason strings to the v2 reason vocabulary.
+    let reason = if raw.reason.starts_with("SkippedByCalendar:") {
+        "skipped:calendar-excluded".to_string()
+    } else if raw.reason.starts_with("DeferredFrom:") {
+        "deferred:calendar".to_string()
+    } else if has_jitter {
+        "cron+jitter".to_string()
+    } else {
+        "cron".to_string()
+    };
+
+    // Jitter bounds: [scheduled_at, scheduled_at + jitter_window].
+    let (jitter_earliest_at, jitter_latest_at) = if has_jitter && raw.effective_at.is_some() {
+        let latest = raw.scheduled_at + chrono::Duration::seconds(jitter_secs);
+        (Some(raw.scheduled_at), Some(latest))
+    } else {
+        (None, None)
+    };
+
+    let local_at = format_in_timezone(raw.scheduled_at, timezone);
+    let effective_local_at = raw.effective_at.map(|t| format_in_timezone(t, timezone));
+
+    // would_skip_if_active: advisory flag set when the overlap policy can silently
+    // drop a firing if max_active_runs are running at dispatch time.
+    let would_skip_if_active = (overlap_policy == "skip" || overlap_policy == "buffer_one")
+        && raw.effective_at.is_some()
+        && max_active_runs > 0;
+
+    ScheduleFirePreviewEntry {
+        scheduled_at: raw.scheduled_at,
+        local_at,
+        effective_at: raw.effective_at,
+        effective_local_at,
+        reason,
+        jitter_earliest_at,
+        jitter_latest_at,
+        would_skip_if_active,
+    }
+}
+
+/// Format a UTC timestamp in the given IANA timezone as RFC 3339.
+/// Falls back to UTC representation when the timezone name is unknown.
+fn format_in_timezone(utc: chrono::DateTime<chrono::Utc>, tz_name: &str) -> String {
+    tz_name.parse::<chrono_tz::Tz>().map_or_else(
+        |_| utc.to_rfc3339(),
+        |tz| utc.with_timezone(&tz).to_rfc3339(),
+    )
+}
+
+/// Parse an optional ISO-8601 `from` string. Returns the parsed instant when
+/// present, `Utc::now()` when absent, and `Err(String)` when the string is
+/// malformed (caller maps this to a 400 response).
+fn parse_from_param(from: Option<&str>) -> Result<chrono::DateTime<chrono::Utc>, String> {
+    from.map_or_else(
+        || Ok(chrono::Utc::now()),
+        |s| {
+            chrono::DateTime::parse_from_rfc3339(s)
+                .map(|dt| dt.with_timezone(&chrono::Utc))
+                .map_err(|e| format!("invalid `from` timestamp '{s}': {e}"))
+        },
+    )
+}
+
+/// `GET /admin/schedules/{id}/preview?count=N&from=<ISO8601>` — preview the next N
+/// planned firing instants for a saved schedule (issue #348 supersedes issue #337).
 async fn preview_schedule_firings_handler(
     Extension(api_state): Extension<HarvestApiState>,
     Path(id): Path<uuid::Uuid>,
@@ -10688,10 +10863,24 @@ async fn preview_schedule_firings_handler(
     use autumn_harvest::scheduler::parse_schedule_from_expr_pub;
 
     let count = params.count.clamp(1, 100);
-    let pool = api_state.storage_pool().map_err(map_error)?;
+    let from = parse_from_param(params.from.as_deref()).map_err(AutumnError::bad_request_msg)?;
+
     // load_schedule_by_id fans out across all shards so schedules on any shard are found.
     let schedule = load_schedule_by_id(&api_state, id).await?;
-    let mut conn = acquire_conn(pool.default_pool()).await?;
+
+    // Paused schedules return zero entries with a paused reason summary.
+    if schedule.is_paused {
+        return Ok((
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "entries": [],
+                "is_paused": true,
+                "pause_reason": schedule.pause_reason,
+                "from": from,
+                "count_requested": count,
+            })),
+        ));
+    }
 
     let parsed_schedule = schedule
         .schedule_expr
@@ -10700,11 +10889,18 @@ async fn preview_schedule_firings_handler(
     let Some(ref sched) = parsed_schedule else {
         return Ok((
             StatusCode::OK,
-            Json(serde_json::json!({"entries": [], "reason": "manual or no schedule"})),
+            Json(serde_json::json!({
+                "entries": [],
+                "is_paused": false,
+                "reason": "manual or no schedule",
+                "from": from,
+                "count_requested": count,
+            })),
         ));
     };
 
-    let from = chrono::Utc::now();
+    let pool = api_state.storage_pool().map_err(map_error)?;
+    let mut conn = acquire_conn(pool.default_pool()).await?;
     let calendar_name = schedule.calendar_name.as_deref();
     let skip_policy = SkipPolicy::from_db(&schedule.skip_policy);
 
@@ -10718,7 +10914,9 @@ async fn preview_schedule_firings_handler(
 
     let jitter_secs = schedule.jitter_secs;
     let schedule_id = schedule.id;
-    let mut entries = preview_schedule_firings(
+    let timezone = &schedule.timezone;
+
+    let mut raw_entries = preview_schedule_firings(
         sched,
         from,
         count,
@@ -10727,10 +10925,10 @@ async fn preview_schedule_firings_handler(
         skip_policy,
     );
 
-    // Apply schedule jitter to each effective_at (mirrors effective_fire_time logic).
+    // Apply jitter to each effective_at (mirrors effective_fire_time logic).
     if jitter_secs > 0 {
         let jitter_window = std::time::Duration::from_secs(jitter_secs.cast_unsigned());
-        for entry in &mut entries {
+        for entry in &mut raw_entries {
             if let Some(t) = entry.effective_at {
                 let offset = compute_jitter_offset(schedule_id, t, jitter_window);
                 if let Ok(d) = chrono::Duration::from_std(offset) {
@@ -10740,9 +10938,132 @@ async fn preview_schedule_firings_handler(
         }
     }
 
+    let entries: Vec<ScheduleFirePreviewEntry> = raw_entries
+        .iter()
+        .map(|r| {
+            build_preview_entry(
+                r,
+                schedule_id,
+                jitter_secs,
+                timezone,
+                &schedule.overlap_policy,
+                schedule.max_active_runs,
+            )
+        })
+        .collect();
+
     Ok((
         StatusCode::OK,
-        Json(serde_json::json!({"entries": entries})),
+        Json(serde_json::json!({
+            "entries": entries,
+            "is_paused": false,
+            "from": from,
+            "count_requested": count,
+        })),
+    ))
+}
+
+/// `POST /admin/schedules/preview` — validate a candidate schedule config and return
+/// the next N firing instants without persisting anything (issue #348).
+///
+/// Returns `400 Bad Request` when the `schedule_expr` or `timezone` is invalid,
+/// so operators get an actionable parse error before committing the config.
+async fn preview_candidate_schedule_handler(
+    Extension(api_state): Extension<HarvestApiState>,
+    Json(body): Json<CandidateSchedulePreviewRequest>,
+) -> Result<impl IntoResponse, AutumnError> {
+    use autumn_harvest::policy::SkipPolicy;
+
+    let count = body.count.clamp(1, 100);
+    let from = parse_from_param(body.from.as_deref()).map_err(AutumnError::bad_request_msg)?;
+
+    // Validate and parse the schedule expression; return 400 on error.
+    let schedule = match parse_schedule_expr_with_tz(&body.schedule_expr, &body.timezone) {
+        Ok(s) => s,
+        Err(e) => {
+            return Ok((
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({"error": e, "field": "schedule_expr"})),
+            ));
+        }
+    };
+
+    // Paused candidate schedules return no entries.
+    if body.paused {
+        return Ok((
+            StatusCode::OK,
+            Json(serde_json::json!({
+                "entries": [],
+                "is_paused": true,
+                "pause_reason": serde_json::Value::Null,
+                "from": from,
+                "count_requested": count,
+            })),
+        ));
+    }
+
+    let calendar_name = body.calendar.as_deref();
+    let skip_policy = SkipPolicy::from_db(&body.skip_policy);
+
+    let excluded_dates = if let Some(cal_name) = calendar_name {
+        let pool = api_state.storage_pool().map_err(map_error)?;
+        let mut conn = acquire_conn(pool.default_pool()).await?;
+        load_exclusions_for_calendar(&mut conn, cal_name)
+            .await
+            .map_err(map_error)?
+    } else {
+        vec![]
+    };
+
+    let jitter_secs = i64::try_from(body.jitter_secs).unwrap_or(i64::MAX);
+    // Use a deterministic placeholder UUID so jitter offsets are stable per request.
+    let schedule_id = uuid::Uuid::nil();
+    let timezone = &body.timezone;
+
+    let mut raw_entries = preview_schedule_firings(
+        &schedule,
+        from,
+        count,
+        calendar_name,
+        &excluded_dates,
+        skip_policy,
+    );
+
+    if jitter_secs > 0 {
+        let jitter_window = std::time::Duration::from_secs(body.jitter_secs);
+        for entry in &mut raw_entries {
+            if let Some(t) = entry.effective_at {
+                let offset = compute_jitter_offset(schedule_id, t, jitter_window);
+                if let Ok(d) = chrono::Duration::from_std(offset) {
+                    entry.effective_at = Some(t + d);
+                }
+            }
+        }
+    }
+
+    let max_active_runs = i32::try_from(body.max_active_runs).unwrap_or(i32::MAX);
+    let entries: Vec<ScheduleFirePreviewEntry> = raw_entries
+        .iter()
+        .map(|r| {
+            build_preview_entry(
+                r,
+                schedule_id,
+                jitter_secs,
+                timezone,
+                &body.overlap_policy,
+                max_active_runs,
+            )
+        })
+        .collect();
+
+    Ok((
+        StatusCode::OK,
+        Json(serde_json::json!({
+            "entries": entries,
+            "is_paused": false,
+            "from": from,
+            "count_requested": count,
+        })),
     ))
 }
 
@@ -13202,6 +13523,218 @@ mod tests {
         assert!(
             json.contains("\"timezone\":\"Asia/Tokyo\""),
             "timezone field must be present in JSON: {json}"
+        );
+    }
+
+    // ── Schedule next-fires preview API (issue #348) ─────────────────────────
+
+    #[test]
+    fn schedule_preview_query_accepts_from_parameter() {
+        let q: SchedulePreviewQuery =
+            serde_json::from_str(r#"{"count": 5, "from": "2026-06-01T09:00:00Z"}"#)
+                .expect("should deserialize");
+        assert_eq!(q.count, 5);
+        assert_eq!(q.from.as_deref(), Some("2026-06-01T09:00:00Z"));
+    }
+
+    #[test]
+    fn schedule_preview_query_from_defaults_to_none() {
+        let q: SchedulePreviewQuery =
+            serde_json::from_str(r#"{"count": 10}"#).expect("should deserialize");
+        assert!(q.from.is_none(), "missing `from` must default to None");
+    }
+
+    #[test]
+    fn candidate_schedule_preview_request_parses_minimal() {
+        let json = r#"{"schedule_expr":"0 9 * * 1-5"}"#;
+        let req: CandidateSchedulePreviewRequest =
+            serde_json::from_str(json).expect("should deserialize minimal body");
+        assert_eq!(req.schedule_expr, "0 9 * * 1-5");
+        assert_eq!(req.timezone, "UTC");
+        assert_eq!(req.jitter_secs, 0);
+        assert_eq!(req.overlap_policy, "skip");
+        assert_eq!(req.count, 10);
+        assert!(req.from.is_none());
+    }
+
+    #[test]
+    fn candidate_schedule_preview_request_parses_full_body() {
+        let json = r#"{
+            "schedule_expr": "0 9 * * 1-5",
+            "timezone": "America/Los_Angeles",
+            "jitter_secs": 300,
+            "overlap_policy": "cancel_other",
+            "count": 20,
+            "from": "2026-06-01T09:00:00Z",
+            "paused": true
+        }"#;
+        let req: CandidateSchedulePreviewRequest =
+            serde_json::from_str(json).expect("should deserialize full body");
+        assert_eq!(req.timezone, "America/Los_Angeles");
+        assert_eq!(req.jitter_secs, 300);
+        assert_eq!(req.overlap_policy, "cancel_other");
+        assert_eq!(req.count, 20);
+        assert_eq!(req.from.as_deref(), Some("2026-06-01T09:00:00Z"));
+        assert!(req.paused);
+    }
+
+    #[test]
+    fn build_preview_entry_reason_is_cron_without_jitter() {
+        use autumn_harvest::calendar::ScheduleFirePreview;
+        use chrono::TimeZone as _;
+        let fire = chrono::Utc.with_ymd_and_hms(2026, 6, 1, 9, 0, 0).unwrap();
+        let preview = ScheduleFirePreview {
+            scheduled_at: fire,
+            effective_at: Some(fire),
+            reason: "Fired".to_string(),
+        };
+        let entry = build_preview_entry(&preview, uuid::Uuid::nil(), 0, "UTC", "skip", 1);
+        assert_eq!(entry.reason, "cron", "no-jitter reason must be 'cron'");
+        assert!(entry.jitter_earliest_at.is_none());
+        assert!(entry.jitter_latest_at.is_none());
+    }
+
+    #[test]
+    fn build_preview_entry_reason_is_cron_plus_jitter_with_jitter() {
+        use autumn_harvest::calendar::ScheduleFirePreview;
+        use chrono::TimeZone as _;
+        let fire = chrono::Utc.with_ymd_and_hms(2026, 6, 1, 9, 0, 0).unwrap();
+        let effective = fire + chrono::Duration::seconds(120);
+        let preview = ScheduleFirePreview {
+            scheduled_at: fire,
+            effective_at: Some(effective),
+            reason: "Fired".to_string(),
+        };
+        let entry = build_preview_entry(&preview, uuid::Uuid::nil(), 300, "UTC", "skip", 1);
+        assert_eq!(
+            entry.reason, "cron+jitter",
+            "jitter reason must be 'cron+jitter'"
+        );
+        assert!(
+            entry.jitter_earliest_at.is_some(),
+            "must have jitter_earliest_at"
+        );
+        assert!(
+            entry.jitter_latest_at.is_some(),
+            "must have jitter_latest_at"
+        );
+        assert_eq!(
+            entry.jitter_earliest_at.unwrap(),
+            fire,
+            "jitter_earliest_at must equal scheduled_at"
+        );
+        assert_eq!(
+            entry.jitter_latest_at.unwrap(),
+            fire + chrono::Duration::seconds(300),
+            "jitter_latest_at must equal scheduled_at + jitter_secs"
+        );
+    }
+
+    #[test]
+    fn build_preview_entry_reason_is_skipped_calendar_excluded() {
+        use autumn_harvest::calendar::ScheduleFirePreview;
+        use chrono::TimeZone as _;
+        let fire = chrono::Utc.with_ymd_and_hms(2026, 7, 4, 9, 0, 0).unwrap();
+        let preview = ScheduleFirePreview {
+            scheduled_at: fire,
+            effective_at: None,
+            reason: "SkippedByCalendar:us-holidays".to_string(),
+        };
+        let entry = build_preview_entry(&preview, uuid::Uuid::nil(), 0, "UTC", "skip", 1);
+        assert_eq!(
+            entry.reason, "skipped:calendar-excluded",
+            "calendar-suppressed reason must be 'skipped:calendar-excluded'"
+        );
+        assert!(entry.effective_at.is_none());
+    }
+
+    #[test]
+    fn build_preview_entry_reason_is_deferred_calendar() {
+        use autumn_harvest::calendar::ScheduleFirePreview;
+        use chrono::TimeZone as _;
+        let fire = chrono::Utc.with_ymd_and_hms(2026, 7, 4, 9, 0, 0).unwrap();
+        let deferred = chrono::Utc.with_ymd_and_hms(2026, 7, 5, 9, 0, 0).unwrap();
+        let preview = ScheduleFirePreview {
+            scheduled_at: fire,
+            effective_at: Some(deferred),
+            reason: "DeferredFrom:2026-07-04".to_string(),
+        };
+        let entry = build_preview_entry(&preview, uuid::Uuid::nil(), 0, "UTC", "skip", 1);
+        assert_eq!(
+            entry.reason, "deferred:calendar",
+            "calendar-deferred reason must be 'deferred:calendar'"
+        );
+    }
+
+    #[test]
+    fn build_preview_entry_would_skip_true_when_overlap_is_skip() {
+        use autumn_harvest::calendar::ScheduleFirePreview;
+        use chrono::TimeZone as _;
+        let fire = chrono::Utc.with_ymd_and_hms(2026, 6, 1, 9, 0, 0).unwrap();
+        let preview = ScheduleFirePreview {
+            scheduled_at: fire,
+            effective_at: Some(fire),
+            reason: "Fired".to_string(),
+        };
+        let entry = build_preview_entry(&preview, uuid::Uuid::nil(), 0, "UTC", "skip", 1);
+        assert!(
+            entry.would_skip_if_active,
+            "skip overlap policy must set would_skip_if_active=true"
+        );
+    }
+
+    #[test]
+    fn build_preview_entry_would_skip_false_when_overlap_is_cancel_other() {
+        use autumn_harvest::calendar::ScheduleFirePreview;
+        use chrono::TimeZone as _;
+        let fire = chrono::Utc.with_ymd_and_hms(2026, 6, 1, 9, 0, 0).unwrap();
+        let preview = ScheduleFirePreview {
+            scheduled_at: fire,
+            effective_at: Some(fire),
+            reason: "Fired".to_string(),
+        };
+        let entry = build_preview_entry(&preview, uuid::Uuid::nil(), 0, "UTC", "cancel_other", 1);
+        assert!(
+            !entry.would_skip_if_active,
+            "cancel_other overlap policy must set would_skip_if_active=false"
+        );
+    }
+
+    #[test]
+    fn build_preview_entry_would_skip_false_when_suppressed_by_calendar() {
+        use autumn_harvest::calendar::ScheduleFirePreview;
+        use chrono::TimeZone as _;
+        let fire = chrono::Utc.with_ymd_and_hms(2026, 7, 4, 9, 0, 0).unwrap();
+        let preview = ScheduleFirePreview {
+            scheduled_at: fire,
+            effective_at: None, // suppressed
+            reason: "SkippedByCalendar:us-holidays".to_string(),
+        };
+        // Even with skip policy, a suppressed entry cannot be skipped-if-active.
+        let entry = build_preview_entry(&preview, uuid::Uuid::nil(), 0, "UTC", "skip", 1);
+        assert!(
+            !entry.would_skip_if_active,
+            "suppressed entries (effective_at=None) must not set would_skip_if_active"
+        );
+    }
+
+    #[test]
+    fn management_api_routes_includes_post_schedule_preview() {
+        let routes = management_api_routes();
+        assert!(
+            routes.contains(&("POST", "/admin/schedules/preview")),
+            "POST /admin/schedules/preview must be listed in management_api_routes; found: {routes:?}"
+        );
+    }
+
+    #[test]
+    fn management_api_response_fields_includes_post_schedule_preview() {
+        let fields = management_api_response_fields();
+        assert!(
+            fields
+                .iter()
+                .any(|(m, p, _)| *m == "POST" && *p == "/admin/schedules/preview"),
+            "POST /admin/schedules/preview must be listed in management_api_response_fields"
         );
     }
 }

--- a/docs/api-contract.json
+++ b/docs/api-contract.json
@@ -2839,7 +2839,7 @@
       "path": "/admin/schedules/{id}/preview",
       "category": "schedule",
       "read_only": true,
-      "description": "Preview the next N fire times for a schedule, applying calendar exclusions and skip policy. Does not trigger any executions.",
+      "description": "Preview the next N planned firing instants for a saved schedule (issue #348). Applies calendar exclusions, skip policy, and jitter. Returns enriched entries with UTC and local-timezone timestamps and advisory would_skip_if_active flag. Does not trigger any executions.",
       "params": [
         {
           "name": "id",
@@ -2852,6 +2852,12 @@
           "in": "query",
           "required": false,
           "description": "Number of fire-time entries to return. Defaults to 10, max 100."
+        },
+        {
+          "name": "from",
+          "in": "query",
+          "required": false,
+          "description": "ISO-8601 UTC instant to start the preview from. Defaults to now."
         }
       ],
       "request_body": null,
@@ -2862,14 +2868,106 @@
           {
             "name": "entries",
             "type": "array",
-            "description": "Array of ScheduleFirePreview objects, each with scheduled_at, effective_at (null if suppressed), and reason."
+            "description": "Array of enriched ScheduleFirePreviewEntry objects, each with scheduled_at, local_at, effective_at, effective_local_at, reason, jitter_earliest_at, jitter_latest_at, and would_skip_if_active."
+          },
+          {
+            "name": "is_paused",
+            "type": "boolean",
+            "description": "true when the schedule is paused; entries will be empty."
+          },
+          {
+            "name": "pause_reason",
+            "type": "string",
+            "description": "Human-readable pause reason, or null when not paused."
+          },
+          {
+            "name": "from",
+            "type": "string",
+            "description": "RFC 3339 timestamp used as the preview start time."
+          },
+          {
+            "name": "count_requested",
+            "type": "integer",
+            "description": "Effective count requested (clamped to [1, 100])."
           }
         ]
       },
       "error_responses": [
         {
+          "status": 400,
+          "description": "Invalid from timestamp."
+        },
+        {
           "status": 404,
           "description": "Schedule not found."
+        },
+        {
+          "status": 500,
+          "description": "Database error."
+        }
+      ]
+    },
+    {
+      "method": "POST",
+      "path": "/admin/schedules/preview",
+      "category": "schedule",
+      "read_only": true,
+      "post_for_body_only": true,
+      "description": "Validate a candidate schedule config and preview the next N firing instants without persisting anything (issue #348). Returns 400 with a parseable field-attributed error for invalid cron, timezone, skip_policy, overlap_policy, jitter_secs, or calendar.",
+      "idempotency": "Fully idempotent read-only operation; no state is written.",
+      "params": [],
+      "request_body": {
+        "free_form": false,
+        "fields": [
+          { "name": "schedule_expr", "type": "string", "description": "Cron, interval, or manual expression (same format as POST /admin/schedules/workflow)." },
+          { "name": "timezone", "type": "string", "description": "IANA timezone for cron evaluation. Defaults to UTC." },
+          { "name": "catchup", "type": "boolean", "description": "Whether missed fires should be caught up. Informational only in preview; defaults to false." },
+          { "name": "max_active_runs", "type": "integer", "description": "Maximum concurrent runs. Used to set would_skip_if_active. Defaults to 1." },
+          { "name": "paused", "type": "boolean", "description": "If true, returns empty entries with is_paused=true." },
+          { "name": "jitter_secs", "type": "integer", "description": "Jitter window in seconds. 0 disables jitter. Validated via validate_jitter." },
+          { "name": "overlap_policy", "type": "string", "description": "One of: skip, buffer_one, buffer_all, cancel_other, terminate_other. Defaults to skip." },
+          { "name": "buffer_all_max", "type": "integer", "description": "Max buffered slots under buffer_all. Defaults to 100." },
+          { "name": "calendar", "type": "string", "description": "Optional named calendar for exclusion filtering. Returns 400 if not found." },
+          { "name": "skip_policy", "type": "string", "description": "One of: skip, run_next_business_day, run_prev_business_day. Defaults to skip." },
+          { "name": "count", "type": "integer", "description": "Number of entries to return. Defaults to 10, max 100." },
+          { "name": "from", "type": "string", "description": "ISO-8601 UTC start instant. Defaults to now." }
+        ]
+      },
+      "success_response": {
+        "status": 200,
+        "free_form": false,
+        "fields": [
+          {
+            "name": "entries",
+            "type": "array",
+            "description": "Array of enriched ScheduleFirePreviewEntry objects."
+          },
+          {
+            "name": "is_paused",
+            "type": "boolean",
+            "description": "true when the candidate config has paused=true."
+          },
+          {
+            "name": "pause_reason",
+            "type": "string",
+            "description": "Always null for candidate previews (no saved pause metadata)."
+          },
+          {
+            "name": "from",
+            "type": "string",
+            "description": "RFC 3339 timestamp used as the preview start time."
+          },
+          {
+            "name": "count_requested",
+            "type": "integer",
+            "description": "Effective count requested (clamped to [1, 100])."
+          }
+        ]
+      },
+      "error_responses": [
+        {
+          "status": 400,
+          "description": "Invalid schedule_expr, timezone, jitter_secs, skip_policy, overlap_policy, calendar, or from."
         },
         {
           "status": 500,

--- a/docs/runbooks/schedule-preview.md
+++ b/docs/runbooks/schedule-preview.md
@@ -1,0 +1,237 @@
+# Schedule Next-Fires Preview
+
+> **Issue #348** — Read-only endpoint for pre-commit cron validation and incident response.
+
+The schedule preview API lets operators verify that a cron expression, timezone, jitter window, overlap policy, and calendar all combine to produce the firing pattern they intend — **before persisting the config or unpausing a schedule during an incident**.
+
+---
+
+## Endpoints
+
+### `GET /admin/schedules/{id}/preview`
+
+Preview the next N firing instants for an **existing, saved** schedule.
+
+**Query parameters**
+
+| Parameter | Default | Max | Description |
+|-----------|---------|-----|-------------|
+| `count` | `10` | `100` | Number of firing instants to return |
+| `from` | now (UTC) | — | ISO-8601 UTC start instant, e.g. `2026-06-01T09:00:00Z` |
+
+**Example request**
+
+```
+GET /api/harvest/admin/schedules/3f7a1b2c-…/preview?count=5&from=2026-06-01T00:00:00Z
+```
+
+---
+
+### `POST /admin/schedules/preview`
+
+Validate a **candidate** schedule config and preview its next N firings **without writing to `harvest_schedules`**. Use this to catch bad cron expressions before committing.
+
+**Request body** — same shape as `POST /admin/schedules/workflow`:
+
+```json
+{
+  "schedule_expr": "0 9 * * 1-5",
+  "timezone": "America/Los_Angeles",
+  "jitter_secs": 300,
+  "overlap_policy": "skip",
+  "calendar": "us-federal-holidays",
+  "skip_policy": "run_next_business_day",
+  "max_active_runs": 1,
+  "paused": false,
+  "count": 10,
+  "from": "2026-06-01T00:00:00Z"
+}
+```
+
+Returns `400 Bad Request` when `schedule_expr` or `timezone` is invalid, with a JSON body pointing at the offending token:
+
+```json
+{"error": "unknown timezone 'America/Bogus'", "field": "schedule_expr"}
+```
+
+---
+
+## Response format
+
+Both endpoints return the same JSON envelope:
+
+```json
+{
+  "entries": [ ... ],
+  "is_paused": false,
+  "pause_reason": null,
+  "from": "2026-06-01T00:00:00Z",
+  "count_requested": 10
+}
+```
+
+### Entry fields
+
+| Field | Always present | Description |
+|-------|---------------|-------------|
+| `scheduled_at` | ✓ | UTC wall-clock instant the cron/interval computed |
+| `local_at` | ✓ | `scheduled_at` in the schedule's configured timezone (RFC 3339) |
+| `effective_at` | when not suppressed | After calendar adjustment and jitter application |
+| `effective_local_at` | when `effective_at` is present | `effective_at` in the schedule's timezone |
+| `reason` | ✓ | See [Reason codes](#reason-codes) |
+| `jitter_earliest_at` | when jitter enabled | Earliest possible fire = `scheduled_at` |
+| `jitter_latest_at` | when jitter enabled | Latest possible fire = `scheduled_at + jitter_secs` |
+| `would_skip_if_active` | ✓ | Advisory: `true` when overlap policy could silently drop this firing |
+
+### Reason codes
+
+| Code | Meaning |
+|------|---------|
+| `cron` | Fires as scheduled (no jitter applied) |
+| `cron+jitter` | Fires at `effective_at` after deterministic jitter |
+| `skipped:calendar-excluded` | Suppressed by calendar exclusion + `skip` policy |
+| `deferred:calendar` | Moved to a different day by calendar `run_next_business_day` / `run_prev_business_day` |
+
+### Paused schedules
+
+When a schedule is paused (`is_paused: true`), `entries` is always empty and a `pause_reason` summary is included at the top level.
+
+```json
+{
+  "entries": [],
+  "is_paused": true,
+  "pause_reason": "Paused for DST rollover maintenance",
+  "from": "2026-11-02T00:00:00Z",
+  "count_requested": 10
+}
+```
+
+### `would_skip_if_active` advisory
+
+The preview is **stateless** — it does not query how many runs are currently active. When the overlap policy is `skip` or `buffer_one`, a firing will be silently dropped at dispatch time if `max_active_runs` is already running. The `would_skip_if_active: true` flag is an advisory warning that the operator should account for run duration when unpausing.
+
+Policies that **never** produce advisory warnings:
+
+| Policy | `would_skip_if_active` |
+|--------|----------------------|
+| `cancel_other` | always `false` |
+| `terminate_other` | always `false` |
+| `buffer_all` | always `false` |
+
+Policies that **always** produce advisory warnings when `effective_at` is non-null:
+
+| Policy | `would_skip_if_active` |
+|--------|----------------------|
+| `skip` | always `true` |
+| `buffer_one` | always `true` |
+
+---
+
+## Example: verify a timezone-aware cron before committing
+
+```bash
+curl -s -X POST https://your-app/api/harvest/admin/schedules/preview \
+  -H "Content-Type: application/json" \
+  -d '{
+    "schedule_expr": "0 9 * * 1-5",
+    "timezone": "America/Los_Angeles",
+    "count": 5
+  }' | jq '.entries[] | {scheduled_at, local_at, reason}'
+```
+
+Sample output (week of 2026-06-01):
+
+```json
+{"scheduled_at": "2026-06-01T16:00:00Z", "local_at": "2026-06-01T09:00:00-07:00", "reason": "cron"}
+{"scheduled_at": "2026-06-02T16:00:00Z", "local_at": "2026-06-02T09:00:00-07:00", "reason": "cron"}
+{"scheduled_at": "2026-06-03T16:00:00Z", "local_at": "2026-06-03T09:00:00-07:00", "reason": "cron"}
+{"scheduled_at": "2026-06-04T16:00:00Z", "local_at": "2026-06-04T09:00:00-07:00", "reason": "cron"}
+{"scheduled_at": "2026-06-05T16:00:00Z", "local_at": "2026-06-05T09:00:00-07:00", "reason": "cron"}
+```
+
+---
+
+## Example: inspect jitter window bounds
+
+```bash
+curl -s -X POST https://your-app/api/harvest/admin/schedules/preview \
+  -H "Content-Type: application/json" \
+  -d '{
+    "schedule_expr": "0 * * * *",
+    "jitter_secs": 300,
+    "count": 3
+  }' | jq '.entries[] | {scheduled_at, effective_at, jitter_earliest_at, jitter_latest_at, reason}'
+```
+
+Sample output:
+
+```json
+{
+  "scheduled_at": "2026-06-01T10:00:00Z",
+  "effective_at": "2026-06-01T10:02:43Z",
+  "jitter_earliest_at": "2026-06-01T10:00:00Z",
+  "jitter_latest_at": "2026-06-01T10:05:00Z",
+  "reason": "cron+jitter"
+}
+```
+
+---
+
+## Example: preview calendar exclusions
+
+```bash
+curl -s -X POST https://your-app/api/harvest/admin/schedules/preview \
+  -H "Content-Type: application/json" \
+  -d '{
+    "schedule_expr": "0 9 * * *",
+    "calendar": "us-federal-holidays",
+    "skip_policy": "run_next_business_day",
+    "count": 5,
+    "from": "2026-07-03T00:00:00Z"
+  }' | jq '.entries[] | {scheduled_at, effective_at, reason}'
+```
+
+Sample output (July 4th deferred to July 5th):
+
+```json
+{"scheduled_at": "2026-07-03T09:00:00Z", "effective_at": "2026-07-03T09:00:00Z", "reason": "cron"}
+{"scheduled_at": "2026-07-04T09:00:00Z", "effective_at": "2026-07-05T09:00:00Z", "reason": "deferred:calendar"}
+{"scheduled_at": "2026-07-05T09:00:00Z", "effective_at": "2026-07-05T09:00:00Z", "reason": "cron"}
+```
+
+---
+
+## Incident response checklist
+
+When validating a schedule before unpausing during an incident:
+
+1. **Fetch current schedule state** → `GET /admin/schedules/{id}` (check `is_paused`, `pause_reason`, `next_run_at`).
+2. **Preview next 10 fires from now** → `GET /admin/schedules/{id}/preview?count=10`.
+3. **Confirm local-timezone times** — check `local_at` matches expected fire times in your timezone.
+4. **Check `would_skip_if_active`** — if `true`, verify there are no lingering active runs before resuming.
+5. **Resume** → `POST /admin/schedules/{id}/resume`.
+
+Target MTTR for the "is this config safe?" decision: **< 60 seconds** (see `synthetic-incident-drills.md`).
+
+---
+
+## Rate limiting
+
+The preview endpoints are read-only and require the same auth posture as `GET /admin/schedules`. Infrastructure-level rate limiting of **30 req/min per embedder** is recommended to prevent expensive cron expansion (large `count` + complex timezone) from being weaponized. Configure this at your reverse proxy or API gateway layer.
+
+---
+
+## Determinism contract
+
+- **Jitter disabled** (`jitter_secs = 0`): responses are fully deterministic for a given `(schedule_config, from)` pair.
+- **Jitter enabled**: `effective_at` is deterministic (seahash of `schedule_id ‖ fire_time`). The `jitter_earliest_at` and `jitter_latest_at` bounds describe the full window so operators can reason about worst-case timing.
+- **`POST /admin/schedules/preview`**: uses `uuid::Uuid::nil()` as a placeholder `schedule_id` for jitter hashing, so repeated calls with the same body produce identical `effective_at` values.
+
+---
+
+## Related runbooks
+
+- [`schedule-backfill.md`](schedule-backfill.md) — recover missed runs after unpausing.
+- [`schedule-trigger-now.md`](schedule-trigger-now.md) — manually fire a schedule once.
+- [`synthetic-incident-drills.md`](synthetic-incident-drills.md) — MTTR drill playbook.
+- [`harvest-alerts.md`](harvest-alerts.md) — alert conditions for `schedule.runs` / `schedule.skipped`.


### PR DESCRIPTION
## Summary

Implements a read-only schedule preview API that allows operators to validate cron expressions, timezones, jitter windows, overlap policies, and calendar configurations before persisting or unpausing schedules. This addresses issue #348 and supersedes the earlier issue #337 preview endpoint.

## Key Changes

- **New `POST /admin/schedules/preview` endpoint**: Validates a candidate schedule configuration and returns the next N firing instants without writing to the database. Returns `400 Bad Request` with actionable parse errors when `schedule_expr` or `timezone` is invalid.

- **Enhanced `GET /admin/schedules/{id}/preview` endpoint**: 
  - Added `from` query parameter (ISO-8601 UTC instant, defaults to now) to allow previewing from arbitrary points in time
  - Now returns paused schedule state with `is_paused` and `pause_reason` fields
  - Includes `from` and `count_requested` in response envelope for clarity

- **New `ScheduleFirePreviewEntry` struct**: Enriched preview entry format with:
  - `scheduled_at` (UTC wall-clock instant)
  - `local_at` (rendered in schedule's configured timezone)
  - `effective_at` (after calendar adjustment and jitter, `None` if suppressed)
  - `effective_local_at` (effective time in schedule's timezone)
  - `reason` codes: `"cron"`, `"cron+jitter"`, `"skipped:calendar-excluded"`, `"deferred:calendar"`
  - `jitter_earliest_at` / `jitter_latest_at` (bounds when jitter enabled)
  - `would_skip_if_active` (advisory flag for overlap policy `skip`/`buffer_one`)

- **New `CandidateSchedulePreviewRequest` struct**: Request body matching `CreateWorkflowScheduleRequest` shape with all schedule configuration fields plus `count` and `from` parameters.

- **Helper functions**:
  - `build_preview_entry()`: Transforms raw `ScheduleFirePreview` into enriched API entry format with timezone rendering and reason mapping
  - `format_in_timezone()`: Renders UTC timestamps in IANA timezone as RFC 3339, falls back to UTC on unknown timezone
  - `parse_from_param()`: Parses optional ISO-8601 `from` string with proper error handling

- **API route registration**: Added both endpoints to `management_api_routes()` and `management_api_response_fields()` for spec completeness.

- **Comprehensive test coverage**: 16 new unit tests covering:
  - Query parameter deserialization (with/without `from`)
  - Request body parsing (minimal and full)
  - Reason code mapping (cron, jitter, calendar exclusions, deferrals)
  - `would_skip_if_active` logic for different overlap policies
  - Route registration in management API metadata

- **Documentation**: New `docs/runbooks/schedule-preview.md` runbook with:
  - Endpoint reference and query parameters
  - Response format and reason codes
  - Practical examples (timezone validation, jitter inspection, calendar exclusions)
  - Incident response checklist for safe schedule resumption
  - Rate limiting and determinism contract guidance

## Notable Implementation Details

- **Paused schedules**: Return empty `entries` array with `is_paused: true` and `pause_reason` summary, allowing operators to understand why a schedule is paused before resuming.

- **Deterministic jitter**: `POST /admin/schedules/preview` uses `uuid::Uuid::nil()` as a placeholder schedule ID for jitter hashing, ensuring repeated calls with the same body produce identical `effective_at` values.

- **Stateless preview**: The preview is read-only and does not query active run counts. The `would_skip_if_active` flag is an advisory warning that operators should account for when unpausing during incidents.

- **Timezone handling**: Uses `chrono-tz` crate (added to workspace dependencies) to render timestamps in the schedule's configured timezone, with graceful fallback to UTC for unknown timezone names.

- **Error handling**: `POST /admin/schedules/preview` returns `400

https://claude.ai/code/session_01MdJtF7m6PjcgcBB1x9p1jN