### PR TITLE
Add transactional activities (issue #352)

### DIFF
--- a/autumn-harvest/Cargo.toml
+++ b/autumn-harvest/Cargo.toml
@@ -109,6 +109,10 @@ required-features = ["db"]
 name = "cross_workflow_signal_tests"
 required-features = ["db"]
 
+[[test]]
+name = "transactional_activity_tests"
+required-features = ["db"]
+
 [[example]]
 name = "timezone_cron_schedule"
 

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -3675,6 +3675,12 @@ impl ActivityContext {
                 let output = serde_json::to_value(&user_result)
                     .map_err(HarvestError::Serialization)?;
 
+                // Lock the execution row first (consistent with the rest of the
+                // codebase: harvest_workflow_executions → harvest_task_queue)
+                // and load history so we can compute the next sequential
+                // event_id before appending.
+                let history = crate::store::lock_and_load_history(conn, exec_id).await?;
+
                 // Idempotency guard: verify the task is still RUNNING before
                 // we commit.  If it's already COMPLETED (e.g. this is a
                 // crash-recovery attempt where the first transaction succeeded)
@@ -3696,10 +3702,6 @@ impl ActivityContext {
                         )));
                     }
                 }
-
-                // Lock the execution row and load history so we can compute the
-                // next sequential event_id before appending.
-                let history = crate::store::lock_and_load_history(conn, exec_id).await?;
 
                 // Append ActivityCompleted within the same transaction.
                 let completion_event = crate::event::WorkflowEvent::ActivityCompleted {

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -3600,6 +3600,13 @@ impl ActivityContext {
     /// * **DB must be the same cluster.** The connection comes from harvest's
     ///   own worker pool.  Cross-cluster atomicity is not possible — use the
     ///   traditional idempotency-key pattern for that case.
+    /// * **Must be the final expression.** Once `run_transactional` returns
+    ///   `Ok`, harvest has already committed `ActivityCompleted` and marked
+    ///   the task `COMPLETED`.  Any fallible work done by the activity *after*
+    ///   this call cannot roll back the committed event — if it fails, the
+    ///   workflow still observes success.  Always return the result of
+    ///   `run_transactional` directly; do not use `?` on it and then do more
+    ///   work.
     /// * **Keep bodies short.** The Postgres row lock held during `f` blocks
     ///   concurrent event appends for the same workflow execution.  Long-running
     ///   bodies (> a few seconds) will delay other activities and should use

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -3643,6 +3643,26 @@ impl ActivityContext {
             + Send,
         T: serde::Serialize + Send,
     {
+        // Two-level error type so the user's original Err(String) propagates
+        // unchanged.  Wrapping it in HarvestError::Config would stringify as
+        // "invalid configuration: …" which breaks non_retryable_errors matching
+        // and corrupts the ActivityFailed payload seen by the retry policy.
+        // Defined before any statements to satisfy clippy::items_after_statements.
+        enum TxError {
+            User(String),
+            Harvest(HarvestError),
+        }
+        impl From<HarvestError> for TxError {
+            fn from(e: HarvestError) -> Self {
+                Self::Harvest(e)
+            }
+        }
+        impl From<diesel::result::Error> for TxError {
+            fn from(e: diesel::result::Error) -> Self {
+                Self::Harvest(crate::error::database_error(e))
+            }
+        }
+
         use diesel_async::AsyncConnection as _;
         use scoped_futures::ScopedFutureExt as _;
 
@@ -3660,20 +3680,19 @@ impl ActivityContext {
         let activity_id = txn.activity_id;
         let task_id = txn.task_id;
 
-        let mut conn = txn.pool.get().await.map_err(|e| {
-            format!("transactional activity failed to acquire DB connection: {e}")
-        })?;
+        let mut conn =
+            txn.pool.get().await.map_err(|e| {
+                format!("transactional activity failed to acquire DB connection: {e}")
+            })?;
 
-        conn.transaction::<T, HarvestError, _>(|conn| {
+        conn.transaction::<T, TxError, _>(|conn| {
             async move {
                 // Run user domain writes.
-                let user_result = f(conn)
-                    .await
-                    .map_err(HarvestError::Config)?;
+                let user_result = f(conn).await.map_err(TxError::User)?;
 
                 // Serialize the result for the event log.
-                let output = serde_json::to_value(&user_result)
-                    .map_err(HarvestError::Serialization)?;
+                let output =
+                    serde_json::to_value(&user_result).map_err(HarvestError::Serialization)?;
 
                 // Lock the execution row first (consistent with the rest of the
                 // codebase: harvest_workflow_executions → harvest_task_queue)
@@ -3689,17 +3708,17 @@ impl ActivityContext {
                 match crate::queue::task_state_for_update(conn, task_id).await? {
                     Some(ref s) if s == "RUNNING" => {}
                     Some(other) => {
-                        return Err(HarvestError::Config(format!(
+                        return Err(TxError::Harvest(HarvestError::Config(format!(
                             "transactional activity task {task_id} is in state '{other}', \
                              not RUNNING; rolling back user writes (the ActivityCompleted \
                              event was already committed by a prior attempt)"
-                        )));
+                        ))));
                     }
                     None => {
-                        return Err(HarvestError::Config(format!(
+                        return Err(TxError::Harvest(HarvestError::Config(format!(
                             "transactional activity task {task_id} no longer exists; \
                              rolling back user writes"
-                        )));
+                        ))));
                     }
                 }
 
@@ -3728,7 +3747,10 @@ impl ActivityContext {
             .scope_boxed()
         })
         .await
-        .map_err(|e| e.to_string())
+        .map_err(|e| match e {
+            TxError::User(s) => s,
+            TxError::Harvest(he) => he.to_string(),
+        })
     }
 
     /// Constructor for testing -- no heartbeat channel, default cancel token.

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -115,6 +115,10 @@ pub struct TransactionalState {
     pub(crate) activity_id: crate::types::ActivityExecId,
     /// Task queue row ID — used to lock and complete the task atomically.
     pub(crate) task_id: uuid::Uuid,
+    /// Maximum serialized result size in bytes (0 = unlimited).  Checked
+    /// inside the transaction so an oversized result is caught before
+    /// `ActivityCompleted` is committed.
+    pub(crate) max_result_bytes: u64,
 }
 const LOCAL_ACTIVITY_HEARTBEAT_REASON: &str =
     "local activities do not support heartbeats; use a regular activity";
@@ -3656,8 +3660,14 @@ impl ActivityContext {
         // and corrupts the ActivityFailed payload seen by the retry policy.
         // Defined before any statements to satisfy clippy::items_after_statements.
         enum TxError {
+            /// User closure returned Err — propagated verbatim.
             User(String),
+            /// Internal harvest error (lock, append, DB).
             Harvest(HarvestError),
+            /// Structured `ActivityFailure` JSON payload (e.g. `PayloadTooLarge`)
+            /// that must reach `handle_activity_result` as-is so the failure
+            /// parser can mark it non-retryable.
+            Payload(String),
         }
         impl From<HarvestError> for TxError {
             fn from(e: HarvestError) -> Self {
@@ -3686,6 +3696,7 @@ impl ActivityContext {
         let exec_id = txn.exec_id;
         let activity_id = txn.activity_id;
         let task_id = txn.task_id;
+        let max_result_bytes = txn.max_result_bytes;
 
         let mut conn =
             txn.pool.get().await.map_err(|e| {
@@ -3700,6 +3711,27 @@ impl ActivityContext {
                 // Serialize the result for the event log.
                 let output =
                     serde_json::to_value(&user_result).map_err(HarvestError::Serialization)?;
+
+                // Enforce the result-size cap before committing.  The worker's
+                // post-handler cap check runs after the handler returns, which
+                // is too late for transactional activities — the event would
+                // already be committed.  Rolling back here ensures an oversized
+                // result never lands in harvest_events.
+                if max_result_bytes > 0 {
+                    let observed = serde_json::to_string(&output).map_or(0, |s| s.len() as u64);
+                    if observed > max_result_bytes {
+                        use crate::failure::IntoActivityErrorString as _;
+                        let payload = crate::failure::ActivityFailure::non_retryable(
+                            "PayloadTooLarge",
+                            format!(
+                                "transactional activity result exceeds cap: \
+                                 {observed} bytes (cap {max_result_bytes} bytes)"
+                            ),
+                        )
+                        .into_error_payload();
+                        return Err(TxError::Payload(payload));
+                    }
+                }
 
                 // Lock the execution row first (consistent with the rest of the
                 // codebase: harvest_workflow_executions → harvest_task_queue)
@@ -3757,6 +3789,7 @@ impl ActivityContext {
         .map_err(|e| match e {
             TxError::User(s) => s,
             TxError::Harvest(he) => he.to_string(),
+            TxError::Payload(p) => p,
         })
     }
 

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -97,6 +97,25 @@ type ActivityCancellationPool =
 const DURABLE_CANCELLATION_CHECK_INTERVAL: Duration = Duration::from_secs(1);
 
 const NO_HEARTBEAT_FLUSHER_REASON: &str = "heartbeats are not supported for this activity context because no heartbeat flusher is attached";
+
+/// State needed by [`ActivityContext::run_transactional`] to bind user writes
+/// to the same Postgres transaction as the `ActivityCompleted` event.
+///
+/// Attached to a regular (non-local) activity context by the worker before
+/// dispatching the activity handler.  `None` on test contexts and local
+/// activity contexts; calling `run_transactional` without this state returns
+/// a descriptive error.
+#[cfg(feature = "db")]
+pub struct TransactionalState {
+    /// Pool to acquire the transactional connection from.
+    pub(crate) pool: ActivityCancellationPool,
+    /// Workflow execution that owns this activity invocation.
+    pub(crate) exec_id: crate::types::ExecutionId,
+    /// Unique ID of this activity invocation attempt.
+    pub(crate) activity_id: crate::types::ActivityExecId,
+    /// Task queue row ID — used to lock and complete the task atomically.
+    pub(crate) task_id: uuid::Uuid,
+}
 const LOCAL_ACTIVITY_HEARTBEAT_REASON: &str =
     "local activities do not support heartbeats; use a regular activity";
 
@@ -3197,6 +3216,12 @@ pub struct ActivityContext {
     /// Which attempt of the logical activity invocation this context represents.
     /// `1` for the first attempt. Stable retries share a key but differ here.
     attempt: Option<u32>,
+    /// State needed by [`Self::run_transactional`].
+    ///
+    /// `None` for test contexts, local activity contexts, and any context that
+    /// was not constructed by the worker's regular activity dispatch path.
+    #[cfg(feature = "db")]
+    transactional_state: Option<TransactionalState>,
 }
 
 impl ActivityContext {
@@ -3223,6 +3248,8 @@ impl ActivityContext {
             trace_context: None,
             idempotency_key: None,
             attempt: None,
+            #[cfg(feature = "db")]
+            transactional_state: None,
         }
     }
 
@@ -3254,6 +3281,7 @@ impl ActivityContext {
             trace_context: None,
             idempotency_key: None,
             attempt: None,
+            transactional_state: None,
         }
     }
 
@@ -3273,6 +3301,8 @@ impl ActivityContext {
             trace_context: None,
             idempotency_key: None,
             attempt: None,
+            #[cfg(feature = "db")]
+            transactional_state: None,
         }
     }
 
@@ -3314,6 +3344,18 @@ impl ActivityContext {
     #[must_use]
     pub const fn with_attempt(mut self, attempt: u32) -> Self {
         self.attempt = Some(attempt);
+        self
+    }
+
+    /// Attach the transactional state needed by [`Self::run_transactional`].
+    ///
+    /// Called by the worker after the `ActivityStarted` event is committed so
+    /// the `activity_id` is stable.  Not available on test or local-activity
+    /// contexts.
+    #[cfg(feature = "db")]
+    #[must_use]
+    pub(crate) fn with_transactional_state(mut self, state: TransactionalState) -> Self {
+        self.transactional_state = Some(state);
         self
     }
 
@@ -3523,6 +3565,168 @@ impl ActivityContext {
                 check.task_id
             ))),
         }
+    }
+
+    /// Run user domain writes and commit the `ActivityCompleted` event in a
+    /// single atomic Postgres transaction.
+    ///
+    /// This is the primary API for transactional activities (issue #352).  When
+    /// your activity body and harvest share the same Postgres cluster, wrapping
+    /// domain writes in `run_transactional` eliminates the dual-write problem:
+    /// if the worker crashes between "did the work" and "recorded the work" no
+    /// duplicate effects are produced on retry, even without idempotency keys.
+    ///
+    /// # How it works
+    ///
+    /// `f` receives a `&mut AsyncPgConnection` that is inside the same
+    /// transaction harvest will use to append `ActivityCompleted` and mark the
+    /// task complete.  If `f` returns `Ok(value)`:
+    ///
+    /// * harvest appends `ActivityCompleted { output: value }` within the same
+    ///   transaction
+    /// * the task row is set to `COMPLETED`
+    /// * the workflow is woken
+    /// * the transaction commits — user writes and the event are visible together
+    ///
+    /// If `f` returns `Err(e)` the transaction is rolled back: user writes are
+    /// discarded and the activity's error propagates through the normal retry
+    /// and `ActivityFailed` path.
+    ///
+    /// # Constraints
+    ///
+    /// * **Not supported for local activities.** Local activities run inline on
+    ///   the workflow worker and do not have a dedicated DB connection.  Calling
+    ///   `run_transactional` on a local activity context returns `Err`.
+    /// * **DB must be the same cluster.** The connection comes from harvest's
+    ///   own worker pool.  Cross-cluster atomicity is not possible — use the
+    ///   traditional idempotency-key pattern for that case.
+    /// * **Keep bodies short.** The Postgres row lock held during `f` blocks
+    ///   concurrent event appends for the same workflow execution.  Long-running
+    ///   bodies (> a few seconds) will delay other activities and should use
+    ///   regular activities with idempotency keys instead.
+    /// * **Heartbeating is unaffected** — `ctx.heartbeat()` still works
+    ///   normally outside the `run_transactional` closure.
+    ///
+    /// # Errors
+    ///
+    /// Returns `Err(String)` when:
+    /// * this context has no transactional pool attached (e.g. test contexts
+    ///   or local activities),
+    /// * a DB connection cannot be acquired from the pool,
+    /// * `f` returns `Err(e)` (the user error is propagated as-is), or
+    /// * the harvest finalization (event append / task complete / workflow wake)
+    ///   fails.
+    ///
+    /// # Example
+    ///
+    /// ```rust,ignore
+    /// use autumn_harvest::prelude::*;
+    ///
+    /// #[activity(start_to_close = "30s")]
+    /// async fn create_order(ctx: &ActivityContext, order: Order) -> Result<OrderId, String> {
+    ///     ctx.run_transactional(|conn| Box::pin(async move {
+    ///         diesel::insert_into(orders::table)
+    ///             .values(&NewOrder::from(&order))
+    ///             .execute(conn)
+    ///             .await
+    ///             .map_err(|e| e.to_string())?;
+    ///         Ok(order.id)
+    ///     })).await
+    /// }
+    /// ```
+    #[cfg(feature = "db")]
+    pub async fn run_transactional<T, F>(&self, f: F) -> Result<T, String>
+    where
+        F: for<'conn> FnOnce(
+                &'conn mut diesel_async::AsyncPgConnection,
+            ) -> futures::future::BoxFuture<'conn, Result<T, String>>
+            + Send,
+        T: serde::Serialize + Send,
+    {
+        use diesel_async::AsyncConnection as _;
+        use scoped_futures::ScopedFutureExt as _;
+
+        let Some(txn) = &self.transactional_state else {
+            return Err(
+                "ctx.run_transactional() is not supported for this activity context: \
+                 transactional activities require a regular (non-local) activity whose \
+                 worker pool shares the harvest Postgres cluster; \
+                 test contexts and local activities do not have a transactional pool attached"
+                    .to_string(),
+            );
+        };
+
+        let exec_id = txn.exec_id;
+        let activity_id = txn.activity_id;
+        let task_id = txn.task_id;
+
+        let mut conn = txn.pool.get().await.map_err(|e| {
+            format!("transactional activity failed to acquire DB connection: {e}")
+        })?;
+
+        conn.transaction::<T, HarvestError, _>(|conn| {
+            async move {
+                // Run user domain writes.
+                let user_result = f(conn)
+                    .await
+                    .map_err(HarvestError::Config)?;
+
+                // Serialize the result for the event log.
+                let output = serde_json::to_value(&user_result)
+                    .map_err(HarvestError::Serialization)?;
+
+                // Idempotency guard: verify the task is still RUNNING before
+                // we commit.  If it's already COMPLETED (e.g. this is a
+                // crash-recovery attempt where the first transaction succeeded)
+                // we roll back the user writes so the caller sees a clean
+                // slate, matching the "exactly-once" contract.
+                match crate::queue::task_state_for_update(conn, task_id).await? {
+                    Some(ref s) if s == "RUNNING" => {}
+                    Some(other) => {
+                        return Err(HarvestError::Config(format!(
+                            "transactional activity task {task_id} is in state '{other}', \
+                             not RUNNING; rolling back user writes (the ActivityCompleted \
+                             event was already committed by a prior attempt)"
+                        )));
+                    }
+                    None => {
+                        return Err(HarvestError::Config(format!(
+                            "transactional activity task {task_id} no longer exists; \
+                             rolling back user writes"
+                        )));
+                    }
+                }
+
+                // Lock the execution row and load history so we can compute the
+                // next sequential event_id before appending.
+                let history = crate::store::lock_and_load_history(conn, exec_id).await?;
+
+                // Append ActivityCompleted within the same transaction.
+                let completion_event = crate::event::WorkflowEvent::ActivityCompleted {
+                    activity_id,
+                    output: output.clone(),
+                };
+                crate::store::append_events(
+                    conn,
+                    exec_id,
+                    &[completion_event],
+                    history.next_event_id,
+                )
+                .await?;
+
+                // Mark the task COMPLETED.
+                crate::queue::complete_task(conn, task_id, output).await?;
+
+                // Wake the workflow so it can pick up the ActivityCompleted
+                // result on its next execution cycle.
+                crate::queue::wake_workflow_task(conn, exec_id).await?;
+
+                Ok(user_result)
+            }
+            .scope_boxed()
+        })
+        .await
+        .map_err(|e| e.to_string())
     }
 
     /// Constructor for testing -- no heartbeat channel, default cancel token.

--- a/autumn-harvest/src/queue.rs
+++ b/autumn-harvest/src/queue.rs
@@ -583,6 +583,27 @@ pub async fn concurrency_key_stats(
 /// observed after the activity has successfully finished.
 ///
 /// # Errors
+/// Lock the task queue row `FOR UPDATE` and return its current `state`.
+///
+/// Used by [`crate::context::ActivityContext::run_transactional`] to verify
+/// the task is still `RUNNING` before committing the transactional activity
+/// result.  Returns `None` when the row no longer exists.
+pub(crate) async fn task_state_for_update(
+    conn: &mut AsyncPgConnection,
+    task_id: Uuid,
+) -> HarvestResult<Option<String>> {
+    use crate::schema::harvest_task_queue::dsl;
+
+    dsl::harvest_task_queue
+        .find(task_id)
+        .for_update()
+        .select(dsl::state)
+        .first::<String>(conn)
+        .await
+        .optional()
+        .map_err(crate::error::database_error)
+}
+
 ///
 /// Returns [`crate::error::HarvestError::Database`] on update failure.
 pub async fn complete_task(

--- a/autumn-harvest/src/store.rs
+++ b/autumn-harvest/src/store.rs
@@ -318,6 +318,45 @@ pub async fn admit_update_event(
 
 /// Load the full event history for a workflow execution, ordered by `event_id`.
 ///
+/// Lock the workflow execution row `FOR UPDATE` and then load its full event
+/// history.
+///
+/// Acquiring the row lock first ensures that concurrent event appends
+/// (e.g. from a second worker racing on the same task) serialise correctly:
+/// the transaction that holds the lock owns the right to append the next
+/// event batch.
+///
+/// This is an internal helper called by the transactional activity commit
+/// path in [`crate::context::ActivityContext::run_transactional`] and by
+/// several private functions in `worker.rs`.
+///
+/// # Errors
+///
+/// Returns [`crate::error::HarvestError::NotFound`] when the execution row
+/// does not exist, and [`crate::error::HarvestError::Database`] on any other
+/// query failure.
+pub(crate) async fn lock_and_load_history(
+    conn: &mut AsyncPgConnection,
+    exec_id: ExecutionId,
+) -> HarvestResult<EventHistory> {
+    use crate::error::HarvestError;
+    use crate::schema::harvest_workflow_executions::dsl;
+
+    // Acquire a row-level lock so concurrent writers serialize around this
+    // transaction.  We only need the id to confirm the row exists.
+    dsl::harvest_workflow_executions
+        .find(exec_id.as_uuid())
+        .for_update()
+        .select(dsl::id)
+        .first::<uuid::Uuid>(conn)
+        .await
+        .optional()
+        .map_err(crate::error::database_error)?
+        .ok_or_else(|| HarvestError::NotFound(format!("workflow execution {exec_id}")))?;
+
+    load_history(conn, exec_id).await
+}
+
 /// Deserializes each row's `event_data` JSON back into [`WorkflowEvent`].
 /// The returned [`EventHistory::next_event_id`] is set to one past the last
 /// loaded event (or 0 if the history is empty), ready for use with

--- a/autumn-harvest/src/store.rs
+++ b/autumn-harvest/src/store.rs
@@ -358,6 +358,7 @@ pub(crate) async fn lock_and_load_history(
 }
 
 /// Deserializes each row's `event_data` JSON back into [`WorkflowEvent`].
+///
 /// The returned [`EventHistory::next_event_id`] is set to one past the last
 /// loaded event (or 0 if the history is empty), ready for use with
 /// [`append_events()`].

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -25,6 +25,8 @@ use crate::builder::WorkerConfig;
 use crate::context::{
     ActivityContext, SharedState, WorkflowCommand, WorkflowHistoryPolicy, empty_shared_state,
 };
+#[cfg(feature = "db")]
+use crate::context::TransactionalState;
 use crate::dlq::{self, DeadLetterReason, NewDeadLetterEntry};
 use crate::error::{HarvestError, HarvestResult};
 use crate::event::WorkflowEvent;
@@ -3215,6 +3217,13 @@ async fn process_activity_task(
     .with_trace_context(trace_carrier.clone())
     .with_idempotency_key(IdempotencyKey::from_activity_exec_id(activity_id))
     .with_attempt(task_attempt(task));
+    #[cfg(feature = "db")]
+    let ctx = ctx.with_transactional_state(TransactionalState {
+        pool: pool.clone(),
+        exec_id,
+        activity_id,
+        task_id: task.id,
+    });
 
     let telemetry = registry.telemetry().clone();
     // ADR-0001 §3: restore the producer's trace context so the activity span

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -3242,12 +3242,20 @@ async fn process_activity_task(
     .with_trace_context(trace_carrier.clone())
     .with_idempotency_key(IdempotencyKey::from_activity_exec_id(activity_id))
     .with_attempt(task_attempt(task));
+    // Compute cap before the handler so run_transactional can enforce it
+    // inside the transaction (before ActivityCompleted is committed).
+    let effective_result_cap = activity
+        .max_result_bytes
+        .map_or(registry.max_activity_result_bytes, |per_activity| {
+            per_activity.max(registry.max_activity_result_bytes)
+        });
     #[cfg(feature = "db")]
     let ctx = ctx.with_transactional_state(TransactionalState {
         pool: pool.clone(),
         exec_id,
         activity_id,
         task_id: task.id,
+        max_result_bytes: effective_result_cap,
     });
 
     let telemetry = registry.telemetry().clone();
@@ -3281,14 +3289,6 @@ async fn process_activity_task(
         span,
     )
     .await;
-
-    let effective_result_cap = registry
-        .activities
-        .get(activity_name)
-        .and_then(|a| a.max_result_bytes)
-        .map_or(registry.max_activity_result_bytes, |per_activity| {
-            per_activity.max(registry.max_activity_result_bytes)
-        });
 
     // Pre-normalize oversized results to non-retryable failures BEFORE emitting
     // metrics so that an Ok result above the cap is counted as Failed, not Completed.

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -2837,6 +2837,20 @@ async fn finalize_activity_failure(
                 return Ok(());
             };
             if state != "RUNNING" {
+                // If the task reached COMPLETED before the handler returned
+                // (e.g. via run_transactional) and the handler then returned
+                // Err, the error is discarded — the workflow already observed
+                // ActivityCompleted.  Emit a warning so the misuse is visible.
+                if state == "COMPLETED" {
+                    tracing::warn!(
+                        task_id = %task.id,
+                        activity_name = %activity_name,
+                        "activity handler returned Err but task is already COMPLETED \
+                         (run_transactional committed it); the error is discarded and \
+                         the workflow observes ActivityCompleted — run_transactional \
+                         must be the final expression in the activity handler"
+                    );
+                }
                 return Ok(());
             }
             store::append_events(conn, exec_id, &[failed_event], history.next_event_id).await?;

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -22,11 +22,11 @@ use tokio::sync::Semaphore;
 use tokio_util::sync::CancellationToken;
 
 use crate::builder::WorkerConfig;
+#[cfg(feature = "db")]
+use crate::context::TransactionalState;
 use crate::context::{
     ActivityContext, SharedState, WorkflowCommand, WorkflowHistoryPolicy, empty_shared_state,
 };
-#[cfg(feature = "db")]
-use crate::context::TransactionalState;
 use crate::dlq::{self, DeadLetterReason, NewDeadLetterEntry};
 use crate::error::{HarvestError, HarvestResult};
 use crate::event::WorkflowEvent;
@@ -3172,31 +3172,42 @@ async fn execute_activity_future_with_cancellation(
 #[allow(clippy::too_many_lines)]
 async fn process_activity_task(
     pool: &DbPool,
-    conn: &mut AsyncPgConnection,
     registry: &HandlerRegistry,
     task: &TaskQueueItem,
     worker_id: &str,
     cancellation_grace_period: Duration,
 ) -> HarvestResult<()> {
     let Some(exec_uuid) = task.workflow_exec_id else {
-        return fail_task_only(conn, task.id, "activity task missing workflow_exec_id").await;
+        let mut conn = pool.get().await.map_err(crate::error::database_error)?;
+        return fail_task_only(&mut conn, task.id, "activity task missing workflow_exec_id").await;
     };
     let Some(activity_name) = task.activity_name.as_deref() else {
-        return fail_task_only(conn, task.id, "activity task missing activity_name").await;
+        let mut conn = pool.get().await.map_err(crate::error::database_error)?;
+        return fail_task_only(&mut conn, task.id, "activity task missing activity_name").await;
     };
     let exec_id = execution_id_from_uuid(exec_uuid);
 
     let Some(activity) = registry.activities.get(activity_name) else {
         let error = format!("no activity handler registered for '{activity_name}'");
-        fail_task_and_execution(conn, task, worker_id, &error).await?;
+        let mut conn = pool.get().await.map_err(crate::error::database_error)?;
+        fail_task_and_execution(&mut conn, task, worker_id, &error).await?;
         return Err(HarvestError::Config(error));
     };
 
-    let started_result =
-        append_activity_started_if_pending(conn, task, exec_id, activity_name, worker_id).await;
-    let Some(activity_id) = fail_execution_on_error(conn, task, worker_id, started_result).await?
-    else {
-        return Ok(());
+    // Setup phase: acquire a connection, append ActivityStarted, then drop it
+    // so the pool slot is free before the handler runs.  This prevents a
+    // deadlock when `run_transactional` needs a second slot from the same pool
+    // while max_size connections are already claimed by concurrent activity tasks.
+    let activity_id = {
+        let mut conn = pool.get().await.map_err(crate::error::database_error)?;
+        let started_result =
+            append_activity_started_if_pending(&mut conn, task, exec_id, activity_name, worker_id)
+                .await;
+        match fail_execution_on_error(&mut conn, task, worker_id, started_result).await? {
+            Some(id) => id,
+            None => return Ok(()),
+        }
+        // conn is dropped here, returning the slot to the pool
     };
 
     let cancel = CancellationToken::new();
@@ -3322,13 +3333,16 @@ async fn process_activity_task(
     cancel.cancel();
     drop(activity_future);
 
+    // Finalization phase: re-acquire a connection now that the handler is done.
+    let mut conn = pool.get().await.map_err(crate::error::database_error)?;
     let retry_policy_result = configured_retry_policy(task);
-    let retry_policy = fail_execution_on_error(conn, task, worker_id, retry_policy_result).await?;
+    let retry_policy =
+        fail_execution_on_error(&mut conn, task, worker_id, retry_policy_result).await?;
 
     // activity_result is already cap-normalized (oversized Ok → non-retryable Err);
     // pass 0 so handle_activity_result skips the redundant cap check.
     handle_activity_result(
-        conn,
+        &mut conn,
         task,
         exec_id,
         activity_id,
@@ -5035,9 +5049,13 @@ async fn process_task(
             .await
         }
         ClaimedTaskKind::Activity => {
+            // Drop the connection before the handler runs: run_transactional
+            // acquires a second pool slot inside the handler, and holding this
+            // one during execution would cause a deadlock when max_size
+            // connections are all claimed by concurrent activity tasks.
+            drop(conn);
             process_activity_task(
                 pool,
-                &mut conn,
                 registry.as_ref(),
                 &task,
                 worker_id,

--- a/autumn-harvest/tests/transactional_activity_tests.rs
+++ b/autumn-harvest/tests/transactional_activity_tests.rs
@@ -18,21 +18,23 @@ use autumn_harvest::models::WorkflowExecution;
 use autumn_harvest::prelude::*;
 use autumn_harvest::schema::harvest_workflow_executions;
 use autumn_harvest::types::ExecutionId;
-use autumn_harvest::worker::{DbPool, HandlerRegistry, Worker, WorkerRuntimeConfig};
 use autumn_harvest::types::Priority;
-use autumn_harvest::{StartWorkflowParams, WorkflowIdReusePolicy, start_or_load_workflow_execution};
+use autumn_harvest::worker::{DbPool, HandlerRegistry, Worker, WorkerRuntimeConfig};
+use autumn_harvest::{
+    StartWorkflowParams, WorkflowIdReusePolicy, start_or_load_workflow_execution,
+};
 
 /// Holds either a live testcontainers handle (keeps the container running) or
 /// nothing when a pre-existing database is used via `TEST_DATABASE_URL`.
 #[allow(dead_code)]
 enum DbHandle {
-    Container(testcontainers::ContainerAsync<Postgres>),
+    Container(Box<testcontainers::ContainerAsync<Postgres>>),
     External,
 }
 
 /// Serializes integration tests that share a `user_records` table when run
-/// against a single Postgres instance (i.e. when TEST_DATABASE_URL is set).
-static DB_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+/// against a single Postgres instance (i.e. when `TEST_DATABASE_URL` is set).
+static DB_TEST_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
 
 // ---------------------------------------------------------------------------
 // Migration SQL (same set as integration_e2e.rs)
@@ -105,9 +107,7 @@ async fn setup_db() -> (String, DbHandle) {
         let mut conn = AsyncPgConnection::establish(&url)
             .await
             .expect("connect to TEST_DATABASE_URL");
-        conn.batch_execute(INIT_SQL)
-            .await
-            .unwrap_or(());  // ignore "already exists" errors on repeat runs
+        conn.batch_execute(INIT_SQL).await.unwrap_or(()); // ignore "already exists" errors on repeat runs
         return (url, DbHandle::External);
     }
 
@@ -120,10 +120,10 @@ async fn setup_db() -> (String, DbHandle) {
     let host = container.get_host().await.expect("get host");
     let port = container.get_host_port_ipv4(5432).await.expect("get port");
     let db_url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
-    (db_url, DbHandle::Container(container))
+    (db_url, DbHandle::Container(Box::new(container)))
 }
 
-async fn make_pool(db_url: &str) -> DbPool {
+fn make_pool(db_url: &str) -> DbPool {
     let manager = diesel_async::pooled_connection::AsyncDieselConnectionManager::<
         diesel_async::AsyncPgConnection,
     >::new(db_url);
@@ -134,9 +134,7 @@ async fn make_pool(db_url: &str) -> DbPool {
 }
 
 async fn load_execution(db_url: &str, exec_id: ExecutionId) -> WorkflowExecution {
-    let mut conn = AsyncPgConnection::establish(db_url)
-        .await
-        .expect("connect");
+    let mut conn = AsyncPgConnection::establish(db_url).await.expect("connect");
     harvest_workflow_executions::table
         .find(exec_id.as_uuid())
         .select(WorkflowExecution::as_select())
@@ -156,7 +154,7 @@ async fn wait_for_state(db_url: &str, exec_id: ExecutionId, target: &str) {
         }
     })
     .await
-    .unwrap_or_else(|_| panic!("workflow did not reach '{target}' within timeout"))
+    .unwrap_or_else(|_| panic!("workflow did not reach '{target}' within timeout"));
 }
 
 fn make_worker(_db_url: &str, registry: Arc<HandlerRegistry>) -> Arc<Worker> {
@@ -195,9 +193,7 @@ struct CountRow {
 }
 
 async fn count_user_records(db_url: &str) -> i64 {
-    let mut conn = AsyncPgConnection::establish(db_url)
-        .await
-        .expect("connect");
+    let mut conn = AsyncPgConnection::establish(db_url).await.expect("connect");
     let rows = diesel::sql_query("SELECT COUNT(*)::bigint AS n FROM user_records")
         .load::<CountRow>(&mut conn)
         .await
@@ -206,9 +202,7 @@ async fn count_user_records(db_url: &str) -> i64 {
 }
 
 async fn count_activity_completed_events(db_url: &str, exec_id: ExecutionId) -> i64 {
-    let mut conn = AsyncPgConnection::establish(db_url)
-        .await
-        .expect("connect");
+    let mut conn = AsyncPgConnection::establish(db_url).await.expect("connect");
     let rows = diesel::sql_query(
         "SELECT COUNT(*)::bigint AS n FROM harvest_events \
          WHERE workflow_exec_id = $1 AND event_data->>'type' = 'ActivityCompleted'",
@@ -243,15 +237,14 @@ async fn insert_record_txn(ctx: &ActivityContext, value: String) -> Result<(), S
 
 /// Inserts a row but returns `Err` — the transaction must roll back.
 #[activity(start_to_close = "30s")]
-async fn insert_then_fail_txn(ctx: &ActivityContext, _value: String) -> Result<(), String> {
+async fn insert_then_fail_txn(ctx: &ActivityContext, value: String) -> Result<(), String> {
+    let _ = value;
     ctx.run_transactional(|conn| {
         Box::pin(async move {
-            diesel::sql_query(
-                "INSERT INTO user_records (value) VALUES ('should_be_rolled_back')",
-            )
-            .execute(conn)
-            .await
-            .map_err(|e| e.to_string())?;
+            diesel::sql_query("INSERT INTO user_records (value) VALUES ('should_be_rolled_back')")
+                .execute(conn)
+                .await
+                .map_err(|e| e.to_string())?;
             // Deliberately fail after the insert
             Err("intentional failure".to_string())
         })
@@ -260,14 +253,16 @@ async fn insert_then_fail_txn(ctx: &ActivityContext, _value: String) -> Result<(
 }
 
 #[workflow]
-async fn happy_txn_workflow(ctx: &WorkflowContext, _input: ()) -> Result<(), String> {
+async fn happy_txn_workflow(ctx: &WorkflowContext, input: ()) -> Result<(), String> {
+    let () = input;
     ctx.execute_activity(&insert_record_txn_info(), "hello".to_string())
         .await
         .map_err(|e| e.to_string())
 }
 
 #[workflow]
-async fn failing_txn_workflow(ctx: &WorkflowContext, _input: ()) -> Result<(), String> {
+async fn failing_txn_workflow(ctx: &WorkflowContext, input: ()) -> Result<(), String> {
+    let () = input;
     ctx.execute_activity(&insert_then_fail_txn_info(), "fail".to_string())
         .await
         .map_err(|e| e.to_string())
@@ -281,7 +276,7 @@ async fn failing_txn_workflow(ctx: &WorkflowContext, _input: ()) -> Result<(), S
 /// event after a successful transactional activity.
 #[tokio::test]
 async fn transactional_activity_happy_path_atomic_commit() {
-    let _guard = DB_TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let _guard = DB_TEST_LOCK.lock().await;
     let (db_url, _container) = setup_db().await;
     let mut setup_conn = AsyncPgConnection::establish(&db_url)
         .await
@@ -291,7 +286,7 @@ async fn transactional_activity_happy_path_atomic_commit() {
         .await
         .expect("create user_records");
 
-    let pool = make_pool(&db_url).await;
+    let pool = make_pool(&db_url);
     let registry = Arc::new(HandlerRegistry::new(
         vec![happy_txn_workflow_info()],
         vec![insert_record_txn_info()],
@@ -354,7 +349,7 @@ async fn transactional_activity_happy_path_atomic_commit() {
 /// The workflow fails (no retry policy configured on the activity).
 #[tokio::test]
 async fn transactional_activity_err_rolls_back_user_writes() {
-    let _guard = DB_TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let _guard = DB_TEST_LOCK.lock().await;
     let (db_url, _container) = setup_db().await;
     let mut setup_conn = AsyncPgConnection::establish(&db_url)
         .await
@@ -364,7 +359,7 @@ async fn transactional_activity_err_rolls_back_user_writes() {
         .await
         .expect("create user_records");
 
-    let pool = make_pool(&db_url).await;
+    let pool = make_pool(&db_url);
     let registry = Arc::new(HandlerRegistry::new(
         vec![failing_txn_workflow_info()],
         vec![insert_then_fail_txn_info()],

--- a/autumn-harvest/tests/transactional_activity_tests.rs
+++ b/autumn-harvest/tests/transactional_activity_tests.rs
@@ -1,0 +1,437 @@
+#![cfg(feature = "db")]
+//! Integration tests for transactional activities (issue #352).
+//!
+//! These tests prove that `ctx.run_transactional` atomically commits user
+//! domain writes and the `ActivityCompleted` event in one Postgres
+//! transaction; on error the writes are rolled back and the activity fails.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use diesel::prelude::*;
+use diesel::sql_types::{BigInt, Text};
+use diesel_async::{AsyncConnection, AsyncPgConnection, RunQueryDsl, SimpleAsyncConnection};
+use testcontainers_modules::postgres::Postgres;
+use testcontainers_modules::testcontainers::runners::AsyncRunner;
+
+use autumn_harvest::models::WorkflowExecution;
+use autumn_harvest::prelude::*;
+use autumn_harvest::schema::harvest_workflow_executions;
+use autumn_harvest::types::ExecutionId;
+use autumn_harvest::worker::{DbPool, HandlerRegistry, Worker, WorkerRuntimeConfig};
+use autumn_harvest::types::Priority;
+use autumn_harvest::{StartWorkflowParams, WorkflowIdReusePolicy, start_or_load_workflow_execution};
+
+/// Holds either a live testcontainers handle (keeps the container running) or
+/// nothing when a pre-existing database is used via `TEST_DATABASE_URL`.
+#[allow(dead_code)]
+enum DbHandle {
+    Container(testcontainers::ContainerAsync<Postgres>),
+    External,
+}
+
+/// Serializes integration tests that share a `user_records` table when run
+/// against a single Postgres instance (i.e. when TEST_DATABASE_URL is set).
+static DB_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+// ---------------------------------------------------------------------------
+// Migration SQL (same set as integration_e2e.rs)
+// ---------------------------------------------------------------------------
+
+const INIT_SQL: &str = concat!(
+    include_str!("../migrations/20260409000000_harvest_initial/up.sql"),
+    "\n",
+    include_str!("../migrations/20260424000001_harvest_trace_context/up.sql"),
+    "\n",
+    include_str!("../migrations/20260505000000_harvest_heartbeat_details/up.sql"),
+    "\n",
+    include_str!("../migrations/20260427000000_harvest_continue_as_new/up.sql"),
+    "\n",
+    include_str!("../migrations/20260429000000_harvest_concurrency_key/up.sql"),
+    "\n",
+    include_str!("../migrations/20260430000000_harvest_workflow_schedules/up.sql"),
+    "\n",
+    include_str!("../migrations/20260430000001_harvest_external_tasks/up.sql"),
+    "\n",
+    include_str!("../migrations/20260508000000_harvest_external_task_updated_at/up.sql"),
+    "\n",
+    include_str!("../migrations/20260506000000_harvest_audit_log/up.sql"),
+    "\n",
+    include_str!("../migrations/20260501000000_harvest_workers/up.sql"),
+    "\n",
+    include_str!("../migrations/20260508010000_harvest_workers_drain_deadline/up.sql"),
+    "\n",
+    include_str!("../migrations/20260509000000_harvest_build_routing/up.sql"),
+    "\n",
+    include_str!("../migrations/20260513000000_harvest_schedule_pause_metadata/up.sql"),
+    "\n",
+    include_str!("../migrations/20260514020000_harvest_task_activity_id/up.sql"),
+    "\n",
+    include_str!("../migrations/20260518000000_harvest_signal_idempotency/up.sql"),
+    "\n",
+    include_str!("../migrations/20260517000000_harvest_schedule_jitter/up.sql"),
+    "\n",
+    include_str!("../migrations/20260517000001_harvest_schedule_overlap_policy/up.sql"),
+    "\n",
+    include_str!("../migrations/20260518000001_harvest_workflow_execution_timeout/up.sql"),
+    "\n",
+    include_str!("../migrations/20260519000000_harvest_calendar_awareness/up.sql"),
+    "\n",
+    include_str!("../migrations/20260522000000_harvest_schedule_decisions/up.sql"),
+    "\n",
+    include_str!("../migrations/20260522000001_harvest_rate_limiting/up.sql"),
+    "\n",
+    include_str!("../migrations/20260526000001_harvest_parent_close_policy/up.sql"),
+);
+
+const CREATE_USER_RECORDS: &str = "
+    DROP TABLE IF EXISTS user_records;
+    CREATE TABLE user_records (
+        id BIGSERIAL PRIMARY KEY,
+        value TEXT NOT NULL
+    );
+";
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+/// Set up a test database. If `TEST_DATABASE_URL` is set in the environment,
+/// use that Postgres instance and apply migrations directly (tests are
+/// responsible for isolation via unique IDs and a fresh `user_records` table).
+/// Otherwise spin up a throwaway testcontainers Postgres container.
+async fn setup_db() -> (String, DbHandle) {
+    if let Ok(url) = std::env::var("TEST_DATABASE_URL") {
+        let mut conn = AsyncPgConnection::establish(&url)
+            .await
+            .expect("connect to TEST_DATABASE_URL");
+        conn.batch_execute(INIT_SQL)
+            .await
+            .unwrap_or(());  // ignore "already exists" errors on repeat runs
+        return (url, DbHandle::External);
+    }
+
+    let container = Postgres::default()
+        .with_init_sql(INIT_SQL.to_string().into_bytes())
+        .start()
+        .await
+        .expect("failed to start Postgres container");
+
+    let host = container.get_host().await.expect("get host");
+    let port = container.get_host_port_ipv4(5432).await.expect("get port");
+    let db_url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+    (db_url, DbHandle::Container(container))
+}
+
+async fn make_pool(db_url: &str) -> DbPool {
+    let manager = diesel_async::pooled_connection::AsyncDieselConnectionManager::<
+        diesel_async::AsyncPgConnection,
+    >::new(db_url);
+    deadpool::managed::Pool::builder(manager)
+        .max_size(10)
+        .build()
+        .expect("pool build failed")
+}
+
+async fn load_execution(db_url: &str, exec_id: ExecutionId) -> WorkflowExecution {
+    let mut conn = AsyncPgConnection::establish(db_url)
+        .await
+        .expect("connect");
+    harvest_workflow_executions::table
+        .find(exec_id.as_uuid())
+        .select(WorkflowExecution::as_select())
+        .first(&mut conn)
+        .await
+        .expect("load execution")
+}
+
+async fn wait_for_state(db_url: &str, exec_id: ExecutionId, target: &str) {
+    tokio::time::timeout(Duration::from_secs(15), async {
+        loop {
+            let execution = load_execution(db_url, exec_id).await;
+            if execution.state == target {
+                return;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("workflow did not reach '{target}' within timeout"))
+}
+
+fn make_worker(_db_url: &str, registry: Arc<HandlerRegistry>) -> Arc<Worker> {
+    Arc::new(
+        Worker::new(
+            WorkerRuntimeConfig {
+                worker_id: uuid::Uuid::new_v4().to_string(),
+                queues: vec!["default".to_string()],
+                notification_database_url: None,
+                max_concurrent_workflows: 4,
+                max_concurrent_activities: 4,
+                poll_interval: Duration::from_millis(25),
+                shutdown_timeout: Duration::from_secs(2),
+                cancellation_grace_period: Duration::from_secs(1),
+                sticky_timeout: Duration::ZERO,
+                max_local_activity_start_to_close: Duration::from_secs(60),
+                shard_assignments: vec![autumn_harvest::types::ShardId::new(0)],
+                worker_heartbeat_interval: Duration::from_secs(30),
+                build_id: String::new(),
+                deployment_name: None,
+                workflow_cache_size: 100,
+                priority_aging_secs: None,
+                unknown_target_grace_window: Duration::from_secs(5),
+                sharded_pool: None,
+            },
+            registry,
+        )
+        .expect("worker should build"),
+    )
+}
+
+#[derive(QueryableByName)]
+struct CountRow {
+    #[diesel(sql_type = BigInt)]
+    n: i64,
+}
+
+async fn count_user_records(db_url: &str) -> i64 {
+    let mut conn = AsyncPgConnection::establish(db_url)
+        .await
+        .expect("connect");
+    let rows = diesel::sql_query("SELECT COUNT(*)::bigint AS n FROM user_records")
+        .load::<CountRow>(&mut conn)
+        .await
+        .expect("count user_records");
+    rows[0].n
+}
+
+async fn count_activity_completed_events(db_url: &str, exec_id: ExecutionId) -> i64 {
+    let mut conn = AsyncPgConnection::establish(db_url)
+        .await
+        .expect("connect");
+    let rows = diesel::sql_query(
+        "SELECT COUNT(*)::bigint AS n FROM harvest_events \
+         WHERE workflow_exec_id = $1 AND event_data->>'type' = 'ActivityCompleted'",
+    )
+    .bind::<diesel::sql_types::Uuid, _>(exec_id.as_uuid())
+    .load::<CountRow>(&mut conn)
+    .await
+    .expect("count ActivityCompleted events");
+    rows[0].n
+}
+
+// ---------------------------------------------------------------------------
+// Activity and workflow definitions
+// ---------------------------------------------------------------------------
+
+/// Inserts a row inside `run_transactional` — commits atomically with
+/// `ActivityCompleted`.
+#[activity(start_to_close = "30s")]
+async fn insert_record_txn(ctx: &ActivityContext, value: String) -> Result<(), String> {
+    ctx.run_transactional(|conn| {
+        Box::pin(async move {
+            diesel::sql_query("INSERT INTO user_records (value) VALUES ($1)")
+                .bind::<Text, _>(value.as_str())
+                .execute(conn)
+                .await
+                .map_err(|e| e.to_string())?;
+            Ok(())
+        })
+    })
+    .await
+}
+
+/// Inserts a row but returns `Err` — the transaction must roll back.
+#[activity(start_to_close = "30s")]
+async fn insert_then_fail_txn(ctx: &ActivityContext, _value: String) -> Result<(), String> {
+    ctx.run_transactional(|conn| {
+        Box::pin(async move {
+            diesel::sql_query(
+                "INSERT INTO user_records (value) VALUES ('should_be_rolled_back')",
+            )
+            .execute(conn)
+            .await
+            .map_err(|e| e.to_string())?;
+            // Deliberately fail after the insert
+            Err("intentional failure".to_string())
+        })
+    })
+    .await
+}
+
+#[workflow]
+async fn happy_txn_workflow(ctx: &WorkflowContext, _input: ()) -> Result<(), String> {
+    ctx.execute_activity(&insert_record_txn_info(), "hello".to_string())
+        .await
+        .map_err(|e| e.to_string())
+}
+
+#[workflow]
+async fn failing_txn_workflow(ctx: &WorkflowContext, _input: ()) -> Result<(), String> {
+    ctx.execute_activity(&insert_then_fail_txn_info(), "fail".to_string())
+        .await
+        .map_err(|e| e.to_string())
+}
+
+// ---------------------------------------------------------------------------
+// Integration tests
+// ---------------------------------------------------------------------------
+
+/// Happy path: exactly one `user_records` row and one `ActivityCompleted`
+/// event after a successful transactional activity.
+#[tokio::test]
+async fn transactional_activity_happy_path_atomic_commit() {
+    let _guard = DB_TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let (db_url, _container) = setup_db().await;
+    let mut setup_conn = AsyncPgConnection::establish(&db_url)
+        .await
+        .expect("connect");
+    setup_conn
+        .batch_execute(CREATE_USER_RECORDS)
+        .await
+        .expect("create user_records");
+
+    let pool = make_pool(&db_url).await;
+    let registry = Arc::new(HandlerRegistry::new(
+        vec![happy_txn_workflow_info()],
+        vec![insert_record_txn_info()],
+    ));
+    let worker = make_worker(&db_url, registry);
+    let worker_pool = pool.clone();
+    let worker_handle = tokio::spawn({
+        let w = worker.clone();
+        async move { w.run(&worker_pool).await }
+    });
+
+    let exec_id = {
+        let mut conn = pool.get().await.unwrap();
+        start_or_load_workflow_execution(
+            &mut conn,
+            StartWorkflowParams {
+                workflow_name: "happy_txn_workflow",
+                workflow_id: &format!("txn-happy-{}", uuid::Uuid::new_v4()),
+                exec_id: ExecutionId::new(),
+                input: serde_json::json!(null),
+                parent_id: None,
+                queue_name: "default",
+                execution_timeout: None,
+                memo: None,
+                search_attrs: None,
+                reuse_policy: WorkflowIdReusePolicy::AllowDuplicate,
+                trace_context: None,
+                max_execution_timeout_ceiling: None,
+                concurrency_key: None,
+                concurrency_limit: None,
+                priority: Priority::default(),
+                max_workflow_input_bytes: 0,
+                start_at: None,
+                delay: None,
+                max_workflow_start_delay: None,
+            },
+        )
+        .await
+        .expect("start workflow")
+        .exec_id
+    };
+
+    wait_for_state(&db_url, exec_id, "COMPLETED").await;
+    worker.shutdown();
+    let _ = worker_handle.await;
+
+    assert_eq!(
+        count_user_records(&db_url).await,
+        1,
+        "exactly one user row — user write committed atomically with ActivityCompleted"
+    );
+    assert_eq!(
+        count_activity_completed_events(&db_url, exec_id).await,
+        1,
+        "exactly one ActivityCompleted event in harvest_events"
+    );
+}
+
+/// Error path: when the closure returns `Err`, user writes are rolled back.
+/// The workflow fails (no retry policy configured on the activity).
+#[tokio::test]
+async fn transactional_activity_err_rolls_back_user_writes() {
+    let _guard = DB_TEST_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let (db_url, _container) = setup_db().await;
+    let mut setup_conn = AsyncPgConnection::establish(&db_url)
+        .await
+        .expect("connect");
+    setup_conn
+        .batch_execute(CREATE_USER_RECORDS)
+        .await
+        .expect("create user_records");
+
+    let pool = make_pool(&db_url).await;
+    let registry = Arc::new(HandlerRegistry::new(
+        vec![failing_txn_workflow_info()],
+        vec![insert_then_fail_txn_info()],
+    ));
+    let worker = make_worker(&db_url, registry);
+    let worker_pool = pool.clone();
+    let worker_handle = tokio::spawn({
+        let w = worker.clone();
+        async move { w.run(&worker_pool).await }
+    });
+
+    let exec_id = {
+        let mut conn = pool.get().await.unwrap();
+        start_or_load_workflow_execution(
+            &mut conn,
+            StartWorkflowParams {
+                workflow_name: "failing_txn_workflow",
+                workflow_id: &format!("txn-fail-{}", uuid::Uuid::new_v4()),
+                exec_id: ExecutionId::new(),
+                input: serde_json::json!(null),
+                parent_id: None,
+                queue_name: "default",
+                execution_timeout: None,
+                memo: None,
+                search_attrs: None,
+                reuse_policy: WorkflowIdReusePolicy::AllowDuplicate,
+                trace_context: None,
+                max_execution_timeout_ceiling: None,
+                concurrency_key: None,
+                concurrency_limit: None,
+                priority: Priority::default(),
+                max_workflow_input_bytes: 0,
+                start_at: None,
+                delay: None,
+                max_workflow_start_delay: None,
+            },
+        )
+        .await
+        .expect("start workflow")
+        .exec_id
+    };
+
+    // The workflow will fail because the activity returns Err with no retry
+    wait_for_state(&db_url, exec_id, "FAILED").await;
+    worker.shutdown();
+    let _ = worker_handle.await;
+
+    assert_eq!(
+        count_user_records(&db_url).await,
+        0,
+        "zero user rows — transactional rollback discarded the insert"
+    );
+}
+
+/// `run_transactional` on a test context (no DB pool attached) returns a
+/// descriptive error rather than panicking.
+#[cfg(feature = "testing")]
+#[tokio::test]
+async fn run_transactional_without_pool_returns_descriptive_error() {
+    let ctx = ActivityContext::new_test();
+    let result: Result<(), String> = ctx
+        .run_transactional(|_conn| Box::pin(async { Ok(()) }))
+        .await;
+    assert!(result.is_err(), "expected Err when no transactional pool");
+    let msg = result.unwrap_err();
+    assert!(
+        msg.contains("transactional") || msg.contains("not supported"),
+        "error message should describe the restriction; got: {msg}"
+    );
+}

--- a/docs/transactional-activities.md
+++ b/docs/transactional-activities.md
@@ -1,0 +1,121 @@
+# Transactional Activities
+
+## The dual-write problem
+
+An activity that writes to a user table and then returns `Ok(output)` relies on
+two separate commits:
+
+1. The user table write inside the activity body.
+2. The `ActivityCompleted` event appended by the worker after the activity
+   returns.
+
+If the worker process crashes or the network drops between these two steps, the
+worker retries the task. A retry re-executes the activity body — the user table
+write happens a second time while `ActivityCompleted` was never recorded, so the
+workflow correctly resumes. This is the standard at-least-once model for
+activities backed by an idempotency key.
+
+**When at-least-once isn't enough** — for example, a payment charge, a coupon
+redemption, or an inventory reservation — you need the domain write and the
+`ActivityCompleted` event to land atomically in one Postgres transaction.
+`ctx.run_transactional` provides exactly that.
+
+## Using `run_transactional`
+
+```rust
+#[activity(start_to_close = "30s")]
+async fn charge_payment(ctx: &ActivityContext, amount_cents: i64) -> Result<(), String> {
+    ctx.run_transactional(|conn| {
+        Box::pin(async move {
+            diesel::sql_query(
+                "INSERT INTO payments (amount_cents, status) VALUES ($1, 'CHARGED')"
+            )
+            .bind::<diesel::sql_types::BigInt, _>(amount_cents)
+            .execute(conn)
+            .await
+            .map_err(|e| e.to_string())?;
+
+            Ok(())
+        })
+    })
+    .await
+}
+```
+
+The closure receives an `&mut AsyncPgConnection` that is already inside a
+Postgres transaction.  When the closure returns `Ok(value)`:
+
+1. The user writes made via `conn` are committed.
+2. The `ActivityCompleted` event is appended to `harvest_events`.
+3. The task queue row is marked `COMPLETED`.
+4. The workflow execution is woken.
+
+All four writes happen inside one transaction. Either all land or none land.
+
+When the closure returns `Err(msg)`:
+
+- The transaction is rolled back — user writes are discarded.
+- The activity reports failure through the normal retry / failure path.
+
+### Idempotency guard
+
+`run_transactional` takes a `FOR UPDATE` lock on both the task queue row and the
+workflow execution row before committing.  If the task was already completed
+(e.g. a duplicate delivery from the queue), the guard detects `state ≠ RUNNING`
+and returns an error, preventing a double-commit.
+
+### Replaying a transactional activity
+
+From the workflow's perspective a transactional activity looks identical to a
+regular activity: the replay engine sees an `ActivityCompleted` event in history
+and returns the recorded output without re-executing the closure. There is no
+additional `WorkflowEvent` variant.
+
+## When to use `run_transactional` vs an idempotency key
+
+| Scenario | Recommendation |
+|---|---|
+| Payment charge, inventory debit, coupon redemption | `run_transactional` |
+| Email send, webhook delivery | Idempotency key (`ctx.idempotency_key()`) |
+| External API call with its own idempotency | Idempotency key |
+| Pure computation, cache read | Neither — just return the result |
+
+`run_transactional` requires that the user's domain database is the **same
+Postgres cluster** as the harvest metadata store. If your domain data lives in a
+separate database you cannot achieve single-transaction atomicity; use an
+idempotency key and accept at-least-once semantics instead.
+
+## Restrictions
+
+- **Not available in local activities.** Local activities run on the workflow
+  worker and have no DB connection attached. Calling `run_transactional` on a
+  local-activity context returns a descriptive `Err` rather than panicking.
+- **Not available in test contexts.** `ActivityContext::new_test()` has no pool.
+  The same descriptive error is returned, making it safe to call in unit tests.
+- **Heartbeating.** The closure runs inside a transaction. Long-running work
+  inside `run_transactional` cannot heartbeat because heartbeats write to a
+  separate pool. Keep transactional closures short (< 5 s).
+- **Retry policy.** If the closure returns `Err`, the activity follows its
+  normal retry policy. Each retry attempt opens a new transaction.
+
+## Testing
+
+Use `ActivityContext::new_test()` (requires the `testing` feature) to verify
+that `run_transactional` returns the expected descriptive error in test contexts:
+
+```rust
+#[cfg(feature = "testing")]
+#[tokio::test]
+async fn run_transactional_on_test_ctx_returns_error() {
+    let ctx = ActivityContext::new_test();
+    let result: Result<(), String> = ctx
+        .run_transactional(|_conn| Box::pin(async { Ok(()) }))
+        .await;
+    assert!(result.is_err());
+}
+```
+
+For integration tests use `testcontainers` (or set `TEST_DATABASE_URL` to point
+at a local Postgres) and verify that after a successful transactional activity
+the user table row and `ActivityCompleted` event are both present, and that after
+a failing activity zero user rows were committed.

--- a/docs/transactional-activities.md
+++ b/docs/transactional-activities.md
@@ -87,6 +87,25 @@ idempotency key and accept at-least-once semantics instead.
 
 ## Restrictions
 
+- **Must be the final expression.** Once `run_transactional` returns `Ok`,
+  harvest has already committed `ActivityCompleted` and marked the task
+  `COMPLETED`. Any fallible work done by the activity *after* this call cannot
+  roll back the committed event — if it fails, the workflow still observes
+  success. Always return the result of `run_transactional` directly:
+
+  ```rust
+  // ✅ Correct — run_transactional is the final expression
+  ctx.run_transactional(|conn| Box::pin(async move { ... })).await
+
+  // ❌ Wrong — failure in do_more_work() is silently discarded by the workflow
+  ctx.run_transactional(|conn| Box::pin(async move { ... })).await?;
+  do_more_work().await?;
+  Ok(())
+  ```
+
+  If the activity function fails after `run_transactional`, a `WARN`-level log
+  entry is emitted so the misuse is observable in production.
+
 - **Not available in local activities.** Local activities run on the workflow
   worker and have no DB connection attached. Calling `run_transactional` on a
   local-activity context returns a descriptive `Err` rather than panicking.


### PR DESCRIPTION
## Summary

Implements transactional activities via `ActivityContext::run_transactional()`, allowing user domain writes and the `ActivityCompleted` event to be committed atomically in a single Postgres transaction. This eliminates the dual-write problem for activities that modify shared state, ensuring exactly-once semantics without requiring idempotency keys.

## Key Changes

- **New `TransactionalState` struct** in `context.rs`: Holds the connection pool, execution ID, activity ID, and task ID needed to bind user writes to the harvest transaction.

- **`ActivityContext::run_transactional()` method**: Primary API that accepts a closure receiving `&mut AsyncPgConnection`. The closure runs inside a transaction that:
  - Executes user domain writes
  - Appends `ActivityCompleted` event
  - Marks the task `COMPLETED`
  - Wakes the workflow
  - All within one atomic transaction

- **Idempotency guard**: Uses `FOR UPDATE` locks on both task queue and workflow execution rows to detect duplicate deliveries and prevent double-commits.

- **New helper functions**:
  - `store::lock_and_load_history()`: Acquires row lock and loads event history for safe concurrent appends
  - `queue::task_state_for_update()`: Locks task row and returns current state for idempotency verification

- **Worker integration**: `with_transactional_state()` method attaches transactional state to activity contexts after `ActivityStarted` event is committed, making the `activity_id` stable.

- **Comprehensive integration tests** (`transactional_activity_tests.rs`):
  - Happy path: verifies atomic commit of user row and `ActivityCompleted` event
  - Error path: verifies rollback of user writes when closure returns `Err`
  - Test context safety: verifies descriptive error when called on test contexts

- **Documentation** (`docs/transactional-activities.md`): Explains the dual-write problem, usage patterns, when to use vs idempotency keys, and restrictions.

## Implementation Details

- Transactional state is `None` for test contexts, local activities, and any context not constructed by the worker's regular activity dispatch path. Calling `run_transactional()` on these contexts returns a descriptive error rather than panicking.

- The closure receives a connection already inside a transaction managed by `AsyncConnection::transaction()`. User writes and harvest finalization (event append, task complete, workflow wake) all happen within this transaction.

- Heartbeating remains unaffected—`ctx.heartbeat()` still works normally outside the `run_transactional` closure.

- Retry policy is unchanged: if the closure returns `Err`, the activity follows its normal retry path with each attempt opening a new transaction.

- Feature-gated behind `db` feature (same as other database functionality).

https://claude.ai/code/session_01TRn3ZS5QxXBwsnQbPMqN6Z