### PR TITLE
Add fan-out / parallel activity execution (issue #359)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -405,6 +405,46 @@ Errors: `QueryHandlerNotFound` (404), `WorkflowNotRunning` (409), `QueryHandlerP
 
 Configure the per-query timeout via `WorkerConfig::default().with_query_timeout(Duration::from_secs(10))` (default 5 s). Queries are replay-safe: they never emit `WorkflowCommand`s and leave zero footprint in `harvest_events`.
 
+### Fan-out / Parallel Activities
+
+`WorkflowContext` exposes first-class fan-out for dispatching N activities in parallel and collecting results in input order.  Two semantics are available:
+
+| Method | Semantics |
+|--------|-----------|
+| `execute_activity_fan_out(info, inputs)` | Fail-fast: returns `Ok(Vec<O>)` or the **first** `Err` |
+| `execute_activity_fan_out_collect(info, inputs)` | Collect-all: returns `Ok(Vec<Result<O, String>>)` — per-slot errors |
+| `execute_activity_fan_out_raw(activities)` | Raw fail-fast: `Vec<(String, Value, String)>` input |
+| `execute_activity_fan_out_collect_raw(activities)` | Raw collect-all |
+
+```rust
+// Typed, homogeneous fan-out — all slots run the same activity
+// (≤ 3 lines of code measured from the example):
+let results: Vec<ItemResult> = ctx
+    .execute_activity_fan_out(&process_item_info(), items)
+    .await
+    .map_err(|e| e.to_string())?;
+
+// Collect-all — per-slot Vec<Result<O, String>>:
+let per_slot: Vec<Result<ItemResult, String>> = ctx
+    .execute_activity_fan_out_collect(&process_item_info(), items)
+    .await
+    .map_err(|e| e.to_string())?;
+
+// Raw heterogeneous fan-out:
+let results = ctx.execute_activity_fan_out_raw(vec![
+    ("send_email".to_string(), json!(addr1), "email-workers".to_string()),
+    ("send_sms".to_string(),   json!(phone), "sms-workers".to_string()),
+]).await.map_err(|e| e.to_string())?;
+```
+
+**Determinism rule — the input collection MUST be derived from already-recorded state** (workflow input, prior activity outputs, signals).  Never derive the collection from non-deterministic sources such as the system clock, `rand`, or an in-process counter.  If the collection is derived from a prior activity output, that output is in history and is therefore deterministic.
+
+**Replay mechanics**: a `MarkerRecorded { name: "fan_out:{n}" }` event is appended before the activity events on the first live run.  On replay the recorded count is compared to the current collection length; if they differ, `HarvestError::NonDeterministic` is returned immediately rather than silently corrupting results.
+
+**Cancellation**: both methods check `ctx.is_cancelled()` before dispatching and return `HarvestError::Cancelled` if the workflow has been cancelled.
+
+See `autumn-harvest/examples/fanout_batch.rs` for a complete end-to-end example covering all three shapes (static N, dynamic N from a prior activity, and collect-all with partial failure).
+
 ### Local Activities
 
 Local activities run **inline on the workflow worker task** — they are never enqueued to `harvest_task_queue` and never dispatched to a remote worker. Their results are still recorded durably in `harvest_events` (`LocalActivityScheduled`, `LocalActivityCompleted`, `LocalActivityFailed`) so deterministic replay works identically to regular activities.

--- a/autumn-harvest/Cargo.toml
+++ b/autumn-harvest/Cargo.toml
@@ -123,6 +123,9 @@ name = "timezone_cron_schedule"
 [[example]]
 name = "collect_approvals"
 
+[[example]]
+name = "fanout_batch"
+
 [dev-dependencies]
 tokio = { workspace = true, features = ["test-util"] }
 testcontainers = { workspace = true }

--- a/autumn-harvest/examples/fanout_batch.rs
+++ b/autumn-harvest/examples/fanout_batch.rs
@@ -1,0 +1,166 @@
+//! Fan-out / parallel activity batch example (issue #359).
+//!
+//! Demonstrates:
+//! 1. Fail-fast fan-out: N items processed in parallel; returns on first failure.
+//! 2. Collect-all fan-out: N items processed in parallel; per-slot success/failure.
+//! 3. Dynamic fan-out derived from a prior activity's output.
+//!
+//! The input collection MUST be derived from already-recorded state (workflow
+//! input, prior activity outputs, signals) — never from non-deterministic
+//! sources such as the wall clock or a random number generator.
+//!
+//! Run with:
+//!   cargo run --example fanout_batch
+
+use autumn_harvest::prelude::*;
+use serde::{Deserialize, Serialize};
+
+// ── Domain types ────────────────────────────────────────────────────────────
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct BatchInput {
+    pub items: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ItemResult {
+    pub item: String,
+    pub processed: bool,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct BatchResult {
+    pub succeeded: Vec<String>,
+    pub failed: Vec<String>,
+}
+
+// ── Activities ───────────────────────────────────────────────────────────────
+
+/// Mock activity: processes one item. Returns an error for items starting
+/// with "bad_" so the collect-all example can show partial failure.
+#[activity(start_to_close = "10s")]
+pub async fn process_item(_ctx: &ActivityContext, item: String) -> Result<ItemResult, String> {
+    if item.starts_with("bad_") {
+        return Err(format!("rejected: {item}"));
+    }
+    Ok(ItemResult {
+        processed: true,
+        item,
+    })
+}
+
+/// Mock "list items" activity that returns a list from some external source.
+#[activity(start_to_close = "5s")]
+pub async fn fetch_items(_ctx: &ActivityContext, source: String) -> Result<BatchInput, String> {
+    // Simulates fetching a batch from a queue, database, or message broker.
+    println!("[Activity] fetch_items from source: {source}");
+    Ok(BatchInput {
+        items: vec![
+            format!("{source}_item_1"),
+            format!("{source}_item_2"),
+            format!("{source}_item_3"),
+        ],
+    })
+}
+
+// ── Workflows ────────────────────────────────────────────────────────────────
+
+/// Fail-fast fan-out: process all items in parallel; stop on first failure.
+///
+/// ≤ 3 lines of orchestration code for the parallel step:
+/// ```rust,ignore
+/// let results = ctx.execute_activity_fan_out(&process_item_info(), input.items)
+///     .await.map_err(|e| e.to_string())?;
+/// ```
+#[workflow]
+pub async fn fail_fast_batch(
+    ctx: &WorkflowContext,
+    input: BatchInput,
+) -> Result<Vec<ItemResult>, String> {
+    // Fan-out in one line. All items dispatched concurrently; first Err aborts.
+    let results = ctx
+        .execute_activity_fan_out(&process_item_info(), input.items)
+        .await
+        .map_err(|e| e.to_string())?;
+    println!("[Workflow] fail_fast_batch: all {} items succeeded", results.len());
+    Ok(results)
+}
+
+/// Collect-all fan-out: process all items; gather per-slot success / failure.
+#[workflow]
+pub async fn collect_all_batch(
+    ctx: &WorkflowContext,
+    input: BatchInput,
+) -> Result<BatchResult, String> {
+    // Fan-out collect-all in one line. Returns Vec<Result<ItemResult, String>>.
+    let per_slot: Vec<Result<ItemResult, String>> = ctx
+        .execute_activity_fan_out_collect(&process_item_info(), input.items)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let mut succeeded = Vec::new();
+    let mut failed = Vec::new();
+    for slot in per_slot {
+        match slot {
+            Ok(r) => succeeded.push(r.item),
+            Err(e) => failed.push(e),
+        }
+    }
+
+    println!(
+        "[Workflow] collect_all_batch: {} succeeded, {} failed",
+        succeeded.len(),
+        failed.len()
+    );
+    Ok(BatchResult { succeeded, failed })
+}
+
+/// Dynamic fan-out: N is derived from a prior activity output.
+///
+/// The collection is always derived from durable recorded state (the output of
+/// `fetch_items`), never from the wall clock or a random number — this is what
+/// keeps fan-out deterministic across replays.
+#[workflow]
+pub async fn dynamic_fan_out(
+    ctx: &WorkflowContext,
+    source: String,
+) -> Result<BatchResult, String> {
+    // Step 1: fetch the list from an external source.
+    let batch: BatchInput = ctx
+        .execute_activity(&fetch_items_info(), source)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    // Step 2: fan-out over the fetched items.
+    // N is derived from `batch.items` — durable, recorded state.
+    let per_slot: Vec<Result<ItemResult, String>> = ctx
+        .execute_activity_fan_out_collect(&process_item_info(), batch.items)
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let mut succeeded = Vec::new();
+    let mut failed = Vec::new();
+    for slot in per_slot {
+        match slot {
+            Ok(r) => succeeded.push(r.item),
+            Err(e) => failed.push(e),
+        }
+    }
+    Ok(BatchResult { succeeded, failed })
+}
+
+fn main() {
+    println!("fanout_batch example loaded successfully!");
+    println!();
+    println!("Workflows exported:");
+    println!("  fail_fast_batch   — parallel fan-out, stops on first failure");
+    println!("  collect_all_batch — parallel fan-out, collects per-slot results");
+    println!("  dynamic_fan_out   — N derived from a prior activity's output");
+    println!();
+    println!(
+        "Register on a HarvestBuilder:\n  .workflows(workflows![fail_fast_batch, collect_all_batch, dynamic_fan_out])"
+    );
+    println!(
+        "  .activities(activities![process_item, fetch_items])"
+    );
+}

--- a/autumn-harvest/examples/fanout_batch.rs
+++ b/autumn-harvest/examples/fanout_batch.rs
@@ -82,7 +82,10 @@ pub async fn fail_fast_batch(
         .execute_activity_fan_out(&process_item_info(), input.items)
         .await
         .map_err(|e| e.to_string())?;
-    println!("[Workflow] fail_fast_batch: all {} items succeeded", results.len());
+    println!(
+        "[Workflow] fail_fast_batch: all {} items succeeded",
+        results.len()
+    );
     Ok(results)
 }
 
@@ -121,10 +124,7 @@ pub async fn collect_all_batch(
 /// `fetch_items`), never from the wall clock or a random number — this is what
 /// keeps fan-out deterministic across replays.
 #[workflow]
-pub async fn dynamic_fan_out(
-    ctx: &WorkflowContext,
-    source: String,
-) -> Result<BatchResult, String> {
+pub async fn dynamic_fan_out(ctx: &WorkflowContext, source: String) -> Result<BatchResult, String> {
     // Step 1: fetch the list from an external source.
     let batch: BatchInput = ctx
         .execute_activity(&fetch_items_info(), source)
@@ -160,7 +160,5 @@ fn main() {
     println!(
         "Register on a HarvestBuilder:\n  .workflows(workflows![fail_fast_batch, collect_all_batch, dynamic_fan_out])"
     );
-    println!(
-        "  .activities(activities![process_item, fetch_items])"
-    );
+    println!("  .activities(activities![process_item, fetch_items])");
 }

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -2514,7 +2514,22 @@ impl WorkflowContext {
             })
             .collect();
 
-        futures::future::try_join_all(futures).await
+        // join_all (not try_join_all) ensures ALL sibling futures are polled even
+        // when one slot fails, consuming their history events. try_join_all would
+        // drop sibling futures on the first Err, leaving their ActivityScheduled /
+        // terminal events unconsumed in the replay cursor and corrupting any
+        // subsequent command matching if the caller catches the error and continues.
+        let all_results = futures::future::join_all(futures).await;
+        let mut first_err: Option<HarvestError> = None;
+        let mut values = Vec::with_capacity(all_results.len());
+        for result in all_results {
+            match result {
+                Ok(v) if first_err.is_none() => values.push(v),
+                Err(e) if first_err.is_none() => first_err = Some(e),
+                _ => {}
+            }
+        }
+        first_err.map_or_else(|| Ok(values), Err)
     }
 
     /// Execute N activities **in parallel** (collect-all variant).
@@ -2567,7 +2582,9 @@ impl WorkflowContext {
             .map(|(name, input, queue)| async move {
                 match self.execute_activity_raw(&name, input, &queue).await {
                     Ok(v) => Ok(Ok(v)),
-                    Err(e @ HarvestError::ActivityFailed { .. }) => Ok(Err(e.to_string())),
+                    Err(
+                        e @ (HarvestError::ActivityFailed { .. } | HarvestError::Timeout { .. }),
+                    ) => Ok(Err(e.to_string())),
                     Err(e) => Err(e),
                 }
             })

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -2450,9 +2450,7 @@ impl WorkflowContext {
                      use ctx.version() to guard this fan-out if the size change is intentional"
                 )))
             }
-            _ => unreachable!(
-                "match_fan_out_marker only returns Matched, NoMatch, or Diverged"
-            ),
+            _ => unreachable!("match_fan_out_marker only returns Matched, NoMatch, or Diverged"),
         }
     }
 
@@ -2643,15 +2641,18 @@ impl WorkflowContext {
             })
             .collect::<Result<Vec<_>, serde_json::Error>>()?;
 
-        let raw_results = self.execute_activity_fan_out_collect_raw(activities).await?;
+        let raw_results = self
+            .execute_activity_fan_out_collect_raw(activities)
+            .await?;
         let typed: Vec<Result<O, String>> = raw_results
             .into_iter()
-            .map(|slot| {
-                slot.and_then(|v| {
-                    serde_json::from_value::<O>(v).map_err(|e| e.to_string())
-                })
+            .map(|slot| match slot {
+                Ok(v) => serde_json::from_value::<O>(v)
+                    .map(Ok)
+                    .map_err(HarvestError::Serialization),
+                Err(e) => Ok(Err(e)),
             })
-            .collect();
+            .collect::<Result<Vec<_>, _>>()?;
         Ok(typed)
     }
 

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -2497,6 +2497,15 @@ impl WorkflowContext {
         &self,
         activities: Vec<(String, Value, String)>,
     ) -> HarvestResult<Vec<Value>> {
+        self.fan_out_raw_impl(activities, None, None).await
+    }
+
+    async fn fan_out_raw_impl(
+        &self,
+        activities: Vec<(String, Value, String)>,
+        retry: Option<crate::policy::RetryPolicy>,
+        timeout: Option<std::time::Duration>,
+    ) -> HarvestResult<Vec<Value>> {
         self.check_cancellation()?;
 
         let seq = self.next_fan_out_seq();
@@ -2509,8 +2518,12 @@ impl WorkflowContext {
 
         let futures: Vec<_> = activities
             .into_iter()
-            .map(|(name, input, queue)| async move {
-                self.execute_activity_raw(&name, input, &queue).await
+            .map(|(name, input, queue)| {
+                let retry = retry.clone();
+                async move {
+                    self.execute_activity_raw_with_opts(&name, input, &queue, retry, timeout)
+                        .await
+                }
             })
             .collect();
 
@@ -2552,6 +2565,15 @@ impl WorkflowContext {
         &self,
         activities: Vec<(String, Value, String)>,
     ) -> HarvestResult<Vec<Result<Value, String>>> {
+        self.fan_out_collect_raw_impl(activities, None, None).await
+    }
+
+    async fn fan_out_collect_raw_impl(
+        &self,
+        activities: Vec<(String, Value, String)>,
+        retry: Option<crate::policy::RetryPolicy>,
+        timeout: Option<std::time::Duration>,
+    ) -> HarvestResult<Vec<Result<Value, String>>> {
         self.check_cancellation()?;
 
         let seq = self.next_fan_out_seq();
@@ -2564,13 +2586,20 @@ impl WorkflowContext {
 
         let futures: Vec<_> = activities
             .into_iter()
-            .map(|(name, input, queue)| async move {
-                match self.execute_activity_raw(&name, input, &queue).await {
-                    Ok(v) => Ok(Ok(v)),
-                    Err(
-                        e @ (HarvestError::ActivityFailed { .. } | HarvestError::Timeout { .. }),
-                    ) => Ok(Err(e.to_string())),
-                    Err(e) => Err(e),
+            .map(|(name, input, queue)| {
+                let retry = retry.clone();
+                async move {
+                    match self
+                        .execute_activity_raw_with_opts(&name, input, &queue, retry, timeout)
+                        .await
+                    {
+                        Ok(v) => Ok(Ok(v)),
+                        Err(
+                            e
+                            @ (HarvestError::ActivityFailed { .. } | HarvestError::Timeout { .. }),
+                        ) => Ok(Err(e.to_string())),
+                        Err(e) => Err(e),
+                    }
                 }
             })
             .collect();
@@ -2608,7 +2637,13 @@ impl WorkflowContext {
             })
             .collect::<Result<Vec<_>, serde_json::Error>>()?;
 
-        let raw_results = self.execute_activity_fan_out_raw(activities).await?;
+        let raw_results = self
+            .fan_out_raw_impl(
+                activities,
+                info.default_retry_policy.clone(),
+                info.default_start_to_close,
+            )
+            .await?;
         raw_results
             .into_iter()
             .map(|v| serde_json::from_value(v).map_err(HarvestError::Serialization))
@@ -2646,7 +2681,11 @@ impl WorkflowContext {
             .collect::<Result<Vec<_>, serde_json::Error>>()?;
 
         let raw_results = self
-            .execute_activity_fan_out_collect_raw(activities)
+            .fan_out_collect_raw_impl(
+                activities,
+                info.default_retry_policy.clone(),
+                info.default_start_to_close,
+            )
             .await?;
         let typed: Vec<Result<O, String>> = raw_results
             .into_iter()

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -2497,15 +2497,15 @@ impl WorkflowContext {
         &self,
         activities: Vec<(String, Value, String)>,
     ) -> HarvestResult<Vec<Value>> {
-        if activities.is_empty() {
-            return Ok(Vec::new());
-        }
-
         self.check_cancellation()?;
 
         let seq = self.next_fan_out_seq();
         let count = activities.len();
         self.check_fan_out_count(seq, count)?;
+
+        if activities.is_empty() {
+            return Ok(Vec::new());
+        }
 
         let futures: Vec<_> = activities
             .into_iter()
@@ -2552,26 +2552,28 @@ impl WorkflowContext {
         &self,
         activities: Vec<(String, Value, String)>,
     ) -> HarvestResult<Vec<Result<Value, String>>> {
-        if activities.is_empty() {
-            return Ok(Vec::new());
-        }
-
         self.check_cancellation()?;
 
         let seq = self.next_fan_out_seq();
         let count = activities.len();
         self.check_fan_out_count(seq, count)?;
 
+        if activities.is_empty() {
+            return Ok(Vec::new());
+        }
+
         let futures: Vec<_> = activities
             .into_iter()
             .map(|(name, input, queue)| async move {
-                self.execute_activity_raw(&name, input, &queue)
-                    .await
-                    .map_err(|e| e.to_string())
+                match self.execute_activity_raw(&name, input, &queue).await {
+                    Ok(v) => Ok(Ok(v)),
+                    Err(e @ HarvestError::ActivityFailed { .. }) => Ok(Err(e.to_string())),
+                    Err(e) => Err(e),
+                }
             })
             .collect();
 
-        Ok(futures::future::join_all(futures).await)
+        futures::future::try_join_all(futures).await
     }
 
     /// Typed fail-fast fan-out: run the same activity for every input in

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -590,6 +590,10 @@ pub struct WorkflowContext {
     history_policy: WorkflowHistoryPolicy,
     /// Monotonically increasing counter for generating activity sequence IDs.
     activity_seq: Mutex<u32>,
+    /// Monotonically increasing counter for naming fan-out count markers.
+    /// Each `execute_activity_fan_out*` call increments this once so each
+    /// fan-out group has a stable, unique marker name across replays.
+    fan_out_seq: Mutex<u32>,
     /// Shared typed state map (same `AppState` extras as the web server).
     state: SharedState,
     /// In-memory query handlers (not persisted to history).
@@ -724,6 +728,7 @@ impl WorkflowContext {
             start_time,
             history_policy,
             activity_seq: Mutex::new(0),
+            fan_out_seq: Mutex::new(0),
             state,
             query_registry: Mutex::new(QueryRegistry::new()),
             declarative_queries: Mutex::new(std::collections::HashMap::new()),
@@ -804,6 +809,7 @@ impl WorkflowContext {
             start_time,
             history_policy: WorkflowHistoryPolicy::default(),
             activity_seq: Mutex::new(0),
+            fan_out_seq: Mutex::new(0),
             state,
             query_registry: Mutex::new(QueryRegistry::new()),
             declarative_queries: Mutex::new(std::collections::HashMap::new()),
@@ -834,6 +840,7 @@ impl WorkflowContext {
             start_time,
             history_policy: WorkflowHistoryPolicy::default(),
             activity_seq: Mutex::new(0),
+            fan_out_seq: Mutex::new(0),
             state: empty_shared_state(),
             query_registry: Mutex::new(QueryRegistry::new()),
             declarative_queries: Mutex::new(std::collections::HashMap::new()),
@@ -2406,6 +2413,246 @@ impl WorkflowContext {
                 "signal '{signal_name}' to {target}: result channel dropped"
             ))),
         }
+    }
+
+    // ── Fan-out / parallel activities (issue #359) ───────────────────────────
+
+    /// Generate the next fan-out sequence number for marker naming.
+    fn next_fan_out_seq(&self) -> u32 {
+        let mut seq = self.fan_out_seq.lock().expect("fan_out_seq lock poisoned");
+        *seq += 1;
+        *seq
+    }
+
+    /// Record or verify the fan-out count in event history.
+    ///
+    /// On **live execution** (past end of history): pushes a `RecordMarker`
+    /// command so future replays can verify the collection length.
+    ///
+    /// On **replay**: matches the `MarkerRecorded` event and compares the
+    /// recorded count with the current count. Returns a
+    /// [`HarvestError::NonDeterministic`] when they differ.
+    fn check_fan_out_count(&self, seq: u32, count: usize) -> HarvestResult<()> {
+        let marker_result = self.match_history(|m| m.match_fan_out_marker(seq, count));
+        match marker_result {
+            HistoryMatch::NoMatch => {
+                self.push_command(WorkflowCommand::RecordMarker {
+                    name: format!("fan_out:{seq}"),
+                    details: Value::from(count as u64),
+                });
+                Ok(())
+            }
+            HistoryMatch::Matched { .. } => Ok(()),
+            HistoryMatch::Diverged { expected, actual } => {
+                Err(HarvestError::NonDeterministic(format!(
+                    "fan_out #{seq}: history has {expected} but current code supplies {actual} — \
+                     the input collection changed size between deploy and replay; \
+                     use ctx.version() to guard this fan-out if the size change is intentional"
+                )))
+            }
+            _ => unreachable!(
+                "match_fan_out_marker only returns Matched, NoMatch, or Diverged"
+            ),
+        }
+    }
+
+    /// Execute N activities **in parallel** (fail-fast variant).
+    ///
+    /// Dispatches every `(name, input, queue)` tuple concurrently and returns
+    /// a `Vec` of outputs in the **same order as the input slice**, regardless
+    /// of completion order.  Returns on the **first** activity failure — all
+    /// sibling activities are still recorded in history and their results are
+    /// replayed correctly, but the workflow function receives only the first
+    /// error.
+    ///
+    /// # Replay safety
+    ///
+    /// A `MarkerRecorded { name: "fan_out:{n}", details: <count> }` event is
+    /// appended immediately before the activity events on the first live run.
+    /// On replay the count is verified; if the input collection has grown or
+    /// shrunk since the original run,
+    /// [`HarvestError::NonDeterministic`] is returned before any activity is
+    /// dispatched.
+    ///
+    /// The input collection **must** be derived from already-recorded state
+    /// (workflow input, prior activity outputs, signals) — never from
+    /// non-deterministic sources such as the system clock or a random number.
+    ///
+    /// # Cancellation
+    ///
+    /// Checks `is_cancelled()` before dispatching.  Returns
+    /// [`HarvestError::Cancelled`] immediately when the workflow has been
+    /// cancelled.
+    ///
+    /// # Errors
+    ///
+    /// - [`HarvestError::NonDeterministic`] if `activities.len()` differs
+    ///   from the count recorded in history.
+    /// - [`HarvestError::Cancelled`] if the workflow was cancelled.
+    /// - [`HarvestError::ActivityFailed`] (or other activity error) on the
+    ///   first failure in the group.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal matcher or commands mutex is poisoned.
+    pub async fn execute_activity_fan_out_raw(
+        &self,
+        activities: Vec<(String, Value, String)>,
+    ) -> HarvestResult<Vec<Value>> {
+        if activities.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        self.check_cancellation()?;
+
+        let seq = self.next_fan_out_seq();
+        let count = activities.len();
+        self.check_fan_out_count(seq, count)?;
+
+        let futures: Vec<_> = activities
+            .into_iter()
+            .map(|(name, input, queue)| async move {
+                self.execute_activity_raw(&name, input, &queue).await
+            })
+            .collect();
+
+        futures::future::try_join_all(futures).await
+    }
+
+    /// Execute N activities **in parallel** (collect-all variant).
+    ///
+    /// Dispatches every `(name, input, queue)` tuple concurrently and returns
+    /// a `Vec<Result<Value, String>>` in the **same order as the input slice**.
+    /// Unlike [`execute_activity_fan_out_raw`](Self::execute_activity_fan_out_raw),
+    /// **all** activities run to completion regardless of failures — per-slot
+    /// errors are captured in the returned `Err` variants rather than aborting
+    /// the fan-out early.
+    ///
+    /// # Replay safety
+    ///
+    /// Same count-marker semantics as the fail-fast variant.
+    ///
+    /// # Cancellation
+    ///
+    /// Checks `is_cancelled()` before dispatching.  Returns
+    /// `Err(HarvestError::Cancelled)` immediately when the workflow has been
+    /// cancelled.
+    ///
+    /// # Errors
+    ///
+    /// - [`HarvestError::NonDeterministic`] if `activities.len()` differs
+    ///   from the count recorded in history.
+    /// - [`HarvestError::Cancelled`] if the workflow was cancelled.
+    ///
+    /// Individual per-slot failures are returned as `Err(String)` inside the
+    /// `Vec`; the outer `Result` only fails for engine-level errors.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal matcher or commands mutex is poisoned.
+    pub async fn execute_activity_fan_out_collect_raw(
+        &self,
+        activities: Vec<(String, Value, String)>,
+    ) -> HarvestResult<Vec<Result<Value, String>>> {
+        if activities.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        self.check_cancellation()?;
+
+        let seq = self.next_fan_out_seq();
+        let count = activities.len();
+        self.check_fan_out_count(seq, count)?;
+
+        let futures: Vec<_> = activities
+            .into_iter()
+            .map(|(name, input, queue)| async move {
+                self.execute_activity_raw(&name, input, &queue)
+                    .await
+                    .map_err(|e| e.to_string())
+            })
+            .collect();
+
+        Ok(futures::future::join_all(futures).await)
+    }
+
+    /// Typed fail-fast fan-out: run the same activity for every input in
+    /// `inputs` in parallel and return the outputs in input order.
+    ///
+    /// All slots share the same `ActivityInfo` (name, queue, retry defaults).
+    /// Use [`execute_activity_fan_out_raw`](Self::execute_activity_fan_out_raw)
+    /// for heterogeneous activity names.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HarvestError::Serialization`] if any input cannot be
+    /// serialized.  Propagates all errors from
+    /// [`execute_activity_fan_out_raw`](Self::execute_activity_fan_out_raw).
+    pub async fn execute_activity_fan_out<I, O>(
+        &self,
+        info: &crate::info::ActivityInfo,
+        inputs: Vec<I>,
+    ) -> HarvestResult<Vec<O>>
+    where
+        I: serde::Serialize,
+        O: serde::de::DeserializeOwned,
+    {
+        let queue = info.default_queue.unwrap_or("default").to_string();
+        let activities = inputs
+            .into_iter()
+            .map(|i| {
+                let json_input = serde_json::to_value(i)?;
+                Ok((info.name.to_string(), json_input, queue.clone()))
+            })
+            .collect::<Result<Vec<_>, serde_json::Error>>()?;
+
+        let raw_results = self.execute_activity_fan_out_raw(activities).await?;
+        raw_results
+            .into_iter()
+            .map(|v| serde_json::from_value(v).map_err(HarvestError::Serialization))
+            .collect()
+    }
+
+    /// Typed collect-all fan-out: run the same activity for every input in
+    /// `inputs` in parallel and return per-slot `Result<O, String>` in input order.
+    ///
+    /// All slots share the same `ActivityInfo`.  Use
+    /// [`execute_activity_fan_out_collect_raw`](Self::execute_activity_fan_out_collect_raw)
+    /// for heterogeneous activity names.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HarvestError::Serialization`] if any input cannot be
+    /// serialized.  Propagates engine-level errors from
+    /// [`execute_activity_fan_out_collect_raw`](Self::execute_activity_fan_out_collect_raw).
+    pub async fn execute_activity_fan_out_collect<I, O>(
+        &self,
+        info: &crate::info::ActivityInfo,
+        inputs: Vec<I>,
+    ) -> HarvestResult<Vec<Result<O, String>>>
+    where
+        I: serde::Serialize,
+        O: serde::de::DeserializeOwned,
+    {
+        let queue = info.default_queue.unwrap_or("default").to_string();
+        let activities = inputs
+            .into_iter()
+            .map(|i| {
+                let json_input = serde_json::to_value(i)?;
+                Ok((info.name.to_string(), json_input, queue.clone()))
+            })
+            .collect::<Result<Vec<_>, serde_json::Error>>()?;
+
+        let raw_results = self.execute_activity_fan_out_collect_raw(activities).await?;
+        let typed: Vec<Result<O, String>> = raw_results
+            .into_iter()
+            .map(|slot| {
+                slot.and_then(|v| {
+                    serde_json::from_value::<O>(v).map_err(|e| e.to_string())
+                })
+            })
+            .collect();
+        Ok(typed)
     }
 
     // ── External activity completion ───────────────────────────────────

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -2628,6 +2628,12 @@ impl WorkflowContext {
         I: serde::Serialize,
         O: serde::de::DeserializeOwned,
     {
+        if info.is_local {
+            return Err(HarvestError::Config(format!(
+                "activity '{}' is marked local = true; fan-out requires remote activities",
+                info.name
+            )));
+        }
         let queue = info.default_queue.unwrap_or("default").to_string();
         let activities = inputs
             .into_iter()
@@ -2671,6 +2677,12 @@ impl WorkflowContext {
         I: serde::Serialize,
         O: serde::de::DeserializeOwned,
     {
+        if info.is_local {
+            return Err(HarvestError::Config(format!(
+                "activity '{}' is marked local = true; fan-out requires remote activities",
+                info.name
+            )));
+        }
         let queue = info.default_queue.unwrap_or("default").to_string();
         let activities = inputs
             .into_iter()

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -2514,22 +2514,7 @@ impl WorkflowContext {
             })
             .collect();
 
-        // join_all (not try_join_all) ensures ALL sibling futures are polled even
-        // when one slot fails, consuming their history events. try_join_all would
-        // drop sibling futures on the first Err, leaving their ActivityScheduled /
-        // terminal events unconsumed in the replay cursor and corrupting any
-        // subsequent command matching if the caller catches the error and continues.
-        let all_results = futures::future::join_all(futures).await;
-        let mut first_err: Option<HarvestError> = None;
-        let mut values = Vec::with_capacity(all_results.len());
-        for result in all_results {
-            match result {
-                Ok(v) if first_err.is_none() => values.push(v),
-                Err(e) if first_err.is_none() => first_err = Some(e),
-                _ => {}
-            }
-        }
-        first_err.map_or_else(|| Ok(values), Err)
+        futures::future::try_join_all(futures).await
     }
 
     /// Execute N activities **in parallel** (collect-all variant).

--- a/autumn-harvest/src/replay.rs
+++ b/autumn-harvest/src/replay.rs
@@ -1986,9 +1986,9 @@ impl HistoryMatcher {
                     .as_u64()
                     .and_then(|n| usize::try_from(n).ok())
                     .unwrap_or(0);
-                self.cursor += 1;
-                self.advance_to_next_unconsumed_event();
                 if recorded_count == count {
+                    self.cursor += 1;
+                    self.advance_to_next_unconsumed_event();
                     HistoryMatch::Matched {
                         output: serde_json::json!(count),
                     }

--- a/autumn-harvest/src/replay.rs
+++ b/autumn-harvest/src/replay.rs
@@ -425,6 +425,15 @@ impl HistoryMatcher {
                 ev if Self::is_update_event(ev) => {
                     scan_cursor += 1;
                 }
+                // Fan-out markers (and any other MarkerRecorded) can be
+                // interleaved when a fan-out runs concurrently with this
+                // activity (e.g. via tokio::join!). Track as an interleaved
+                // command so the cursor returns to it after matching the
+                // terminal event.
+                WorkflowEvent::MarkerRecorded { .. } => {
+                    first_interleaved_command.get_or_insert(scan_cursor);
+                    scan_cursor += 1;
+                }
                 // Any other event type is unexpected mid-activity
                 _ => break,
             }
@@ -552,6 +561,11 @@ impl HistoryMatcher {
                     scan_cursor += 1;
                 }
                 ev if Self::is_update_event(ev) => {
+                    scan_cursor += 1;
+                }
+                // Fan-out markers can be interleaved during concurrent execution.
+                WorkflowEvent::MarkerRecorded { .. } => {
+                    first_interleaved_command.get_or_insert(scan_cursor);
                     scan_cursor += 1;
                 }
                 _ => break,

--- a/autumn-harvest/src/replay.rs
+++ b/autumn-harvest/src/replay.rs
@@ -842,6 +842,33 @@ impl HistoryMatcher {
     ) -> HistoryMatch {
         if let Some(command_cursor) = first_interleaved_command {
             self.consumed_out_of_order_events.insert(terminal_cursor);
+            // Also mark any ActivityStarted/Heartbeat events for the settled
+            // activity that appear between the interleaved command and the
+            // terminal. Without this, after the cursor rewinds to the
+            // interleaved command and the marker/fan-out branch is replayed,
+            // those progress events remain unconsumed and the next workflow
+            // command match diverges against them.
+            let activity_id = match &self.events[terminal_cursor] {
+                WorkflowEvent::ActivityCompleted { activity_id, .. }
+                | WorkflowEvent::ActivityFailed { activity_id, .. }
+                | WorkflowEvent::ActivityTimedOut { activity_id, .. } => Some(*activity_id),
+                _ => None,
+            };
+            if let Some(aid) = activity_id {
+                for idx in command_cursor..terminal_cursor {
+                    match &self.events[idx] {
+                        WorkflowEvent::ActivityStarted {
+                            activity_id: id, ..
+                        }
+                        | WorkflowEvent::ActivityHeartbeat {
+                            activity_id: id, ..
+                        } if *id == aid => {
+                            self.consumed_out_of_order_events.insert(idx);
+                        }
+                        _ => {}
+                    }
+                }
+            }
             self.cursor = command_cursor;
         } else {
             self.cursor = terminal_cursor + 1;

--- a/autumn-harvest/src/replay.rs
+++ b/autumn-harvest/src/replay.rs
@@ -1958,6 +1958,54 @@ impl HistoryMatcher {
         }
     }
 
+    // ── Fan-out / parallel activities (issue #359) ───────────────────────────
+
+    /// Match the count marker for a fan-out group against history.
+    ///
+    /// On the **first live execution** (past end of history) returns
+    /// [`HistoryMatch::NoMatch`] so the caller can emit a `RecordMarker`
+    /// command for replay.
+    ///
+    /// During **replay** expects a `MarkerRecorded { name: "fan_out:{seq}", … }`
+    /// event at the current cursor. Returns:
+    ///
+    /// - [`HistoryMatch::Matched`] — marker found and recorded count equals `count`.
+    /// - [`HistoryMatch::Diverged`] — recorded count differs from `count`
+    ///   (non-deterministic collection resize detected), or a different event
+    ///   type was at this cursor position.
+    /// - [`HistoryMatch::NoMatch`] — past end of history (live execution).
+    pub fn match_fan_out_marker(&mut self, seq: u32, count: usize) -> HistoryMatch {
+        let marker_name = format!("fan_out:{seq}");
+        if !self.prepare_match() {
+            return HistoryMatch::NoMatch;
+        }
+
+        match &self.events[self.cursor] {
+            WorkflowEvent::MarkerRecorded { name, details } if *name == marker_name => {
+                let recorded_count = details
+                    .as_u64()
+                    .and_then(|n| usize::try_from(n).ok())
+                    .unwrap_or(0);
+                self.cursor += 1;
+                self.advance_to_next_unconsumed_event();
+                if recorded_count == count {
+                    HistoryMatch::Matched {
+                        output: serde_json::json!(count),
+                    }
+                } else {
+                    HistoryMatch::Diverged {
+                        expected: format!("fan_out:{seq}(count={recorded_count})"),
+                        actual: format!("fan_out:{seq}(count={count})"),
+                    }
+                }
+            }
+            other => HistoryMatch::Diverged {
+                expected: format!("MarkerRecorded({marker_name})"),
+                actual: Self::actual_event_name(other),
+            },
+        }
+    }
+
     // ── Update primitive (issue #140) ─────────────────────────────────────
 
     /// Look up the recorded result for a specific update by `update_id`.

--- a/autumn-harvest/tests/fanout_tests.rs
+++ b/autumn-harvest/tests/fanout_tests.rs
@@ -23,9 +23,21 @@ fn fan_out_three_parallel<'a>(
 ) -> Pin<Box<dyn Future<Output = Result<Value, String>> + Send + 'a>> {
     Box::pin(async move {
         let activities = vec![
-            ("task_a".to_string(), json!("input_a"), "default".to_string()),
-            ("task_b".to_string(), json!("input_b"), "default".to_string()),
-            ("task_c".to_string(), json!("input_c"), "default".to_string()),
+            (
+                "task_a".to_string(),
+                json!("input_a"),
+                "default".to_string(),
+            ),
+            (
+                "task_b".to_string(),
+                json!("input_b"),
+                "default".to_string(),
+            ),
+            (
+                "task_c".to_string(),
+                json!("input_c"),
+                "default".to_string(),
+            ),
         ];
         let results = ctx
             .execute_activity_fan_out_raw(activities)
@@ -125,7 +137,7 @@ fn fan_out_count_changed<'a>(
 ) -> Pin<Box<dyn Future<Output = Result<Value, String>> + Send + 'a>> {
     Box::pin(async move {
         // The count is derived from the input so it can differ between runs
-        let n = input.as_u64().unwrap_or(2) as usize;
+        let n = usize::try_from(input.as_u64().unwrap_or(2)).unwrap_or(2);
         let activities: Vec<_> = (0..n)
             .map(|i| (format!("task_{i}"), json!(i), "default".to_string()))
             .collect();
@@ -266,7 +278,10 @@ async fn fan_out_raw_fail_fast_on_first_failure() {
 
     match outcome {
         WorkflowOutcome::Failed { error } => {
-            assert!(error.contains("boom"), "error should mention 'boom', got: {error}");
+            assert!(
+                error.contains("boom"),
+                "error should mention 'boom', got: {error}"
+            );
         }
         other => panic!("expected Failed, got {other:?}"),
     }
@@ -338,7 +353,10 @@ async fn fan_out_collect_all_returns_per_slot_results() {
             // Slot 1: failed
             assert!(results[1].get("err").is_some(), "slot 1 should be err");
             let err_msg = results[1]["err"].as_str().unwrap();
-            assert!(err_msg.contains("slot_1_failed"), "slot 1 error message mismatch");
+            assert!(
+                err_msg.contains("slot_1_failed"),
+                "slot 1 error message mismatch"
+            );
             // Slot 2: ok
             assert!(results[2].get("ok").is_some(), "slot 2 should be ok");
             assert_eq!(results[2]["ok"], json!("also_success"));
@@ -361,14 +379,18 @@ async fn fan_out_empty_activities_returns_empty_vec() {
 
     match outcome {
         WorkflowOutcome::Completed { output } => {
-            assert_eq!(output["count"], json!(0), "empty fan-out should return 0 results");
+            assert_eq!(
+                output["count"],
+                json!(0),
+                "empty fan-out should return 0 results"
+            );
         }
         other => panic!("expected Completed, got {other:?}"),
     }
 }
 
 /// First-time live execution: no history → fan-out suspends emitting commands.
-/// Verifies that the correct WorkflowCommands are emitted.
+/// Verifies that the correct `WorkflowCommand`s are emitted.
 #[tokio::test]
 async fn fan_out_raw_live_execution_emits_marker_and_schedule_commands() {
     let exec_id = ExecutionId::new();
@@ -389,13 +411,19 @@ async fn fan_out_raw_live_execution_emits_marker_and_schedule_commands() {
                     name, ..
                 } if name.starts_with("fan_out:"))
             });
-            assert!(has_marker, "should emit a fan_out marker command; got: {commands:?}");
+            assert!(
+                has_marker,
+                "should emit a fan_out marker command; got: {commands:?}"
+            );
 
             // Should have 3 ScheduleActivity commands
             let schedule_count = commands
                 .iter()
                 .filter(|c| {
-                    matches!(c, autumn_harvest::context::WorkflowCommand::ScheduleActivity { .. })
+                    matches!(
+                        c,
+                        autumn_harvest::context::WorkflowCommand::ScheduleActivity { .. }
+                    )
                 })
                 .count();
             assert_eq!(
@@ -459,8 +487,7 @@ async fn fan_out_count_mismatch_returns_non_deterministic_error() {
     ];
 
     // New code passes input=2 which creates only 2 activities (changed from 3)
-    let outcome =
-        run_workflow(exec_id, history, fan_out_count_changed, json!(2u64)).await;
+    let outcome = run_workflow(exec_id, history, fan_out_count_changed, json!(2u64)).await;
 
     match outcome {
         WorkflowOutcome::Failed { error } => {
@@ -536,8 +563,7 @@ async fn fan_out_dynamic_from_prior_activity_replays_correctly() {
         },
     ];
 
-    let outcome =
-        run_workflow(exec_id, history, fan_out_dynamic_from_prior, Value::Null).await;
+    let outcome = run_workflow(exec_id, history, fan_out_dynamic_from_prior, Value::Null).await;
 
     match outcome {
         WorkflowOutcome::Completed { output } => {
@@ -717,10 +743,7 @@ async fn fan_out_typed_collect_all_returns_per_slot_results() {
 
     let ctx = WorkflowContext::for_replay(exec_id, history);
     let results: Vec<Result<Value, String>> = ctx
-        .execute_activity_fan_out_collect(&info, vec![
-            json!("ok_input"),
-            json!("fail_input"),
-        ])
+        .execute_activity_fan_out_collect(&info, vec![json!("ok_input"), json!("fail_input")])
         .await
         .expect("collect should not fail at the workflow level");
 
@@ -728,7 +751,12 @@ async fn fan_out_typed_collect_all_returns_per_slot_results() {
     assert!(results[0].is_ok(), "slot 0 should be ok");
     assert_eq!(results[0].as_ref().unwrap(), &json!("ok_output"));
     assert!(results[1].is_err(), "slot 1 should be err");
-    assert!(results[1].as_ref().unwrap_err().contains("deliberate_failure"));
+    assert!(
+        results[1]
+            .as_ref()
+            .unwrap_err()
+            .contains("deliberate_failure")
+    );
 }
 
 /// Second fan-out call in the same workflow gets a different sequence number.
@@ -748,9 +776,11 @@ async fn fan_out_two_groups_in_same_workflow() {
                 .await
                 .map_err(|e| e.to_string())?;
             let batch2 = ctx
-                .execute_activity_fan_out_raw(vec![
-                    ("b1".to_string(), json!(null), "default".to_string()),
-                ])
+                .execute_activity_fan_out_raw(vec![(
+                    "b1".to_string(),
+                    json!(null),
+                    "default".to_string(),
+                )])
                 .await
                 .map_err(|e| e.to_string())?;
             Ok(json!({ "b1": batch1, "b2": batch2 }))

--- a/autumn-harvest/tests/fanout_tests.rs
+++ b/autumn-harvest/tests/fanout_tests.rs
@@ -1,0 +1,826 @@
+//! Fan-out primitive tests -- parallel activity dispatch, replay determinism,
+//! non-determinism detection, and cancellation propagation.
+//!
+//! All tests are pure unit tests; no database required.
+
+use std::future::Future;
+use std::pin::Pin;
+
+use autumn_harvest::context::WorkflowContext;
+use autumn_harvest::event::WorkflowEvent;
+use autumn_harvest::executor::{WorkflowOutcome, run_workflow};
+use autumn_harvest::types::{ActivityExecId, ExecutionId};
+use chrono::Utc;
+use serde_json::{Value, json};
+
+// ---------------------------------------------------------------------------
+// Test workflow handlers
+// ---------------------------------------------------------------------------
+
+fn fan_out_three_parallel<'a>(
+    ctx: &'a WorkflowContext,
+    _input: Value,
+) -> Pin<Box<dyn Future<Output = Result<Value, String>> + Send + 'a>> {
+    Box::pin(async move {
+        let activities = vec![
+            ("task_a".to_string(), json!("input_a"), "default".to_string()),
+            ("task_b".to_string(), json!("input_b"), "default".to_string()),
+            ("task_c".to_string(), json!("input_c"), "default".to_string()),
+        ];
+        let results = ctx
+            .execute_activity_fan_out_raw(activities)
+            .await
+            .map_err(|e| e.to_string())?;
+        Ok(json!({ "results": results }))
+    })
+}
+
+fn fan_out_fail_fast<'a>(
+    ctx: &'a WorkflowContext,
+    _input: Value,
+) -> Pin<Box<dyn Future<Output = Result<Value, String>> + Send + 'a>> {
+    Box::pin(async move {
+        let activities = vec![
+            ("task_ok".to_string(), json!(null), "default".to_string()),
+            ("task_fail".to_string(), json!(null), "default".to_string()),
+            ("task_ok2".to_string(), json!(null), "default".to_string()),
+        ];
+        let results = ctx
+            .execute_activity_fan_out_raw(activities)
+            .await
+            .map_err(|e| e.to_string())?;
+        Ok(json!({ "results": results }))
+    })
+}
+
+fn fan_out_collect_all<'a>(
+    ctx: &'a WorkflowContext,
+    _input: Value,
+) -> Pin<Box<dyn Future<Output = Result<Value, String>> + Send + 'a>> {
+    Box::pin(async move {
+        let activities = vec![
+            ("task_ok".to_string(), json!(null), "default".to_string()),
+            ("task_fail".to_string(), json!(null), "default".to_string()),
+            ("task_ok2".to_string(), json!(null), "default".to_string()),
+        ];
+        let results = ctx
+            .execute_activity_fan_out_collect_raw(activities)
+            .await
+            .map_err(|e| e.to_string())?;
+        // Serialize per-slot results into a JSON-compatible form
+        let serialized: Vec<Value> = results
+            .into_iter()
+            .map(|r| match r {
+                Ok(v) => json!({ "ok": v }),
+                Err(e) => json!({ "err": e }),
+            })
+            .collect();
+        Ok(json!({ "results": serialized }))
+    })
+}
+
+fn fan_out_empty<'a>(
+    ctx: &'a WorkflowContext,
+    _input: Value,
+) -> Pin<Box<dyn Future<Output = Result<Value, String>> + Send + 'a>> {
+    Box::pin(async move {
+        let results = ctx
+            .execute_activity_fan_out_raw(vec![])
+            .await
+            .map_err(|e| e.to_string())?;
+        Ok(json!({ "count": results.len() }))
+    })
+}
+
+// Three-activity fan-out using dynamic input derived from a prior activity result
+fn fan_out_dynamic_from_prior<'a>(
+    ctx: &'a WorkflowContext,
+    _input: Value,
+) -> Pin<Box<dyn Future<Output = Result<Value, String>> + Send + 'a>> {
+    Box::pin(async move {
+        // First activity returns a list of items
+        let items_json = ctx
+            .execute_activity_raw("list_items", json!(null), "default")
+            .await
+            .map_err(|e| e.to_string())?;
+        let items = items_json.as_array().cloned().unwrap_or_default();
+
+        // Fan-out: process each item in parallel
+        let activities: Vec<_> = items
+            .into_iter()
+            .map(|item| ("process_item".to_string(), item, "default".to_string()))
+            .collect();
+        let results = ctx
+            .execute_activity_fan_out_raw(activities)
+            .await
+            .map_err(|e| e.to_string())?;
+        Ok(json!({ "processed": results }))
+    })
+}
+
+// Workflow for non-determinism (count mismatch) detection test
+fn fan_out_count_changed<'a>(
+    ctx: &'a WorkflowContext,
+    input: Value,
+) -> Pin<Box<dyn Future<Output = Result<Value, String>> + Send + 'a>> {
+    Box::pin(async move {
+        // The count is derived from the input so it can differ between runs
+        let n = input.as_u64().unwrap_or(2) as usize;
+        let activities: Vec<_> = (0..n)
+            .map(|i| (format!("task_{i}"), json!(i), "default".to_string()))
+            .collect();
+        let results = ctx
+            .execute_activity_fan_out_raw(activities)
+            .await
+            .map_err(|e| e.to_string())?;
+        Ok(json!({ "count": results.len() }))
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// Basic fan-out: 3 activities in parallel, all complete successfully.
+/// The workflow should return results in input order (not completion order).
+#[tokio::test]
+async fn fan_out_raw_three_parallel_all_succeed() {
+    let exec_id = ExecutionId::new();
+    let id_a = ActivityExecId::new();
+    let id_b = ActivityExecId::new();
+    let id_c = ActivityExecId::new();
+
+    // History has the marker + 3 scheduled activities + 3 completions
+    // Note: completions are in reverse order to verify input-order result collection
+    let history = vec![
+        WorkflowEvent::WorkflowStarted {
+            input: Value::Null,
+            timestamp: Utc::now(),
+        },
+        WorkflowEvent::MarkerRecorded {
+            name: "fan_out:1".into(),
+            details: json!(3u64),
+        },
+        WorkflowEvent::ActivityScheduled {
+            activity_id: id_a,
+            name: "task_a".into(),
+            input: json!("input_a"),
+            queue: "default".into(),
+        },
+        WorkflowEvent::ActivityScheduled {
+            activity_id: id_b,
+            name: "task_b".into(),
+            input: json!("input_b"),
+            queue: "default".into(),
+        },
+        WorkflowEvent::ActivityScheduled {
+            activity_id: id_c,
+            name: "task_c".into(),
+            input: json!("input_c"),
+            queue: "default".into(),
+        },
+        // Completions out-of-order: C finishes first, then A, then B
+        WorkflowEvent::ActivityCompleted {
+            activity_id: id_c,
+            output: json!("result_c"),
+        },
+        WorkflowEvent::ActivityCompleted {
+            activity_id: id_a,
+            output: json!("result_a"),
+        },
+        WorkflowEvent::ActivityCompleted {
+            activity_id: id_b,
+            output: json!("result_b"),
+        },
+    ];
+
+    let outcome = run_workflow(exec_id, history, fan_out_three_parallel, Value::Null).await;
+
+    match outcome {
+        WorkflowOutcome::Completed { output } => {
+            let results = output["results"].as_array().unwrap();
+            assert_eq!(results.len(), 3, "should have 3 results");
+            // Results must be in INPUT order, not completion order
+            assert_eq!(results[0], json!("result_a"), "slot 0 should be result_a");
+            assert_eq!(results[1], json!("result_b"), "slot 1 should be result_b");
+            assert_eq!(results[2], json!("result_c"), "slot 2 should be result_c");
+        }
+        other => panic!("expected Completed, got {other:?}"),
+    }
+}
+
+/// Fan-out fail-fast: one activity fails, the whole fan-out fails.
+#[tokio::test]
+async fn fan_out_raw_fail_fast_on_first_failure() {
+    let exec_id = ExecutionId::new();
+    let id_ok = ActivityExecId::new();
+    let id_fail = ActivityExecId::new();
+    let id_ok2 = ActivityExecId::new();
+
+    let history = vec![
+        WorkflowEvent::WorkflowStarted {
+            input: Value::Null,
+            timestamp: Utc::now(),
+        },
+        WorkflowEvent::MarkerRecorded {
+            name: "fan_out:1".into(),
+            details: json!(3u64),
+        },
+        WorkflowEvent::ActivityScheduled {
+            activity_id: id_ok,
+            name: "task_ok".into(),
+            input: Value::Null,
+            queue: "default".into(),
+        },
+        WorkflowEvent::ActivityScheduled {
+            activity_id: id_fail,
+            name: "task_fail".into(),
+            input: Value::Null,
+            queue: "default".into(),
+        },
+        WorkflowEvent::ActivityScheduled {
+            activity_id: id_ok2,
+            name: "task_ok2".into(),
+            input: Value::Null,
+            queue: "default".into(),
+        },
+        WorkflowEvent::ActivityCompleted {
+            activity_id: id_ok,
+            output: json!("success"),
+        },
+        WorkflowEvent::ActivityFailed {
+            activity_id: id_fail,
+            error: "boom".into(),
+            attempt: 1,
+            error_type: "Error".into(),
+            non_retryable: false,
+            details: None,
+        },
+        WorkflowEvent::ActivityCompleted {
+            activity_id: id_ok2,
+            output: json!("also_success"),
+        },
+    ];
+
+    let outcome = run_workflow(exec_id, history, fan_out_fail_fast, Value::Null).await;
+
+    match outcome {
+        WorkflowOutcome::Failed { error } => {
+            assert!(error.contains("boom"), "error should mention 'boom', got: {error}");
+        }
+        other => panic!("expected Failed, got {other:?}"),
+    }
+}
+
+/// Fan-out collect-all: one activity fails, others succeed.
+/// All per-slot results are returned (not fail-fast).
+#[tokio::test]
+async fn fan_out_collect_all_returns_per_slot_results() {
+    let exec_id = ExecutionId::new();
+    let id_ok = ActivityExecId::new();
+    let id_fail = ActivityExecId::new();
+    let id_ok2 = ActivityExecId::new();
+
+    let history = vec![
+        WorkflowEvent::WorkflowStarted {
+            input: Value::Null,
+            timestamp: Utc::now(),
+        },
+        WorkflowEvent::MarkerRecorded {
+            name: "fan_out:1".into(),
+            details: json!(3u64),
+        },
+        WorkflowEvent::ActivityScheduled {
+            activity_id: id_ok,
+            name: "task_ok".into(),
+            input: Value::Null,
+            queue: "default".into(),
+        },
+        WorkflowEvent::ActivityScheduled {
+            activity_id: id_fail,
+            name: "task_fail".into(),
+            input: Value::Null,
+            queue: "default".into(),
+        },
+        WorkflowEvent::ActivityScheduled {
+            activity_id: id_ok2,
+            name: "task_ok2".into(),
+            input: Value::Null,
+            queue: "default".into(),
+        },
+        WorkflowEvent::ActivityCompleted {
+            activity_id: id_ok,
+            output: json!("success"),
+        },
+        WorkflowEvent::ActivityFailed {
+            activity_id: id_fail,
+            error: "slot_1_failed".into(),
+            attempt: 1,
+            error_type: "Error".into(),
+            non_retryable: false,
+            details: None,
+        },
+        WorkflowEvent::ActivityCompleted {
+            activity_id: id_ok2,
+            output: json!("also_success"),
+        },
+    ];
+
+    let outcome = run_workflow(exec_id, history, fan_out_collect_all, Value::Null).await;
+
+    match outcome {
+        WorkflowOutcome::Completed { output } => {
+            let results = output["results"].as_array().unwrap();
+            assert_eq!(results.len(), 3, "collect-all should return all 3 slots");
+            // Slot 0: ok
+            assert!(results[0].get("ok").is_some(), "slot 0 should be ok");
+            assert_eq!(results[0]["ok"], json!("success"));
+            // Slot 1: failed
+            assert!(results[1].get("err").is_some(), "slot 1 should be err");
+            let err_msg = results[1]["err"].as_str().unwrap();
+            assert!(err_msg.contains("slot_1_failed"), "slot 1 error message mismatch");
+            // Slot 2: ok
+            assert!(results[2].get("ok").is_some(), "slot 2 should be ok");
+            assert_eq!(results[2]["ok"], json!("also_success"));
+        }
+        other => panic!("expected Completed, got {other:?}"),
+    }
+}
+
+/// Empty fan-out: zero activities should return immediately with empty Vec.
+#[tokio::test]
+async fn fan_out_empty_activities_returns_empty_vec() {
+    let exec_id = ExecutionId::new();
+
+    let history = vec![WorkflowEvent::WorkflowStarted {
+        input: Value::Null,
+        timestamp: Utc::now(),
+    }];
+
+    let outcome = run_workflow(exec_id, history, fan_out_empty, Value::Null).await;
+
+    match outcome {
+        WorkflowOutcome::Completed { output } => {
+            assert_eq!(output["count"], json!(0), "empty fan-out should return 0 results");
+        }
+        other => panic!("expected Completed, got {other:?}"),
+    }
+}
+
+/// First-time live execution: no history → fan-out suspends emitting commands.
+/// Verifies that the correct WorkflowCommands are emitted.
+#[tokio::test]
+async fn fan_out_raw_live_execution_emits_marker_and_schedule_commands() {
+    let exec_id = ExecutionId::new();
+
+    // Only WorkflowStarted — no activity history, no marker
+    let history = vec![WorkflowEvent::WorkflowStarted {
+        input: Value::Null,
+        timestamp: Utc::now(),
+    }];
+
+    let outcome = run_workflow(exec_id, history, fan_out_three_parallel, Value::Null).await;
+
+    match outcome {
+        WorkflowOutcome::Suspended { commands } => {
+            // First command should be RecordMarker for the fan-out count
+            let has_marker = commands.iter().any(|c| {
+                matches!(c, autumn_harvest::context::WorkflowCommand::RecordMarker {
+                    name, ..
+                } if name.starts_with("fan_out:"))
+            });
+            assert!(has_marker, "should emit a fan_out marker command; got: {commands:?}");
+
+            // Should have 3 ScheduleActivity commands
+            let schedule_count = commands
+                .iter()
+                .filter(|c| {
+                    matches!(c, autumn_harvest::context::WorkflowCommand::ScheduleActivity { .. })
+                })
+                .count();
+            assert_eq!(
+                schedule_count, 3,
+                "should emit 3 ScheduleActivity commands; got {commands:?}"
+            );
+        }
+        other => panic!("expected Suspended, got {other:?}"),
+    }
+}
+
+/// Non-determinism detection: fan-out called with different count than recorded.
+/// The workflow changed from 3 to 2 activities between deploy and replay.
+#[tokio::test]
+async fn fan_out_count_mismatch_returns_non_deterministic_error() {
+    let exec_id = ExecutionId::new();
+    let id_a = ActivityExecId::new();
+    let id_b = ActivityExecId::new();
+    let id_c = ActivityExecId::new();
+
+    // History recorded 3 activities in the fan-out
+    let history = vec![
+        WorkflowEvent::WorkflowStarted {
+            input: Value::Null,
+            timestamp: Utc::now(),
+        },
+        WorkflowEvent::MarkerRecorded {
+            name: "fan_out:1".into(),
+            details: json!(3u64), // recorded 3
+        },
+        WorkflowEvent::ActivityScheduled {
+            activity_id: id_a,
+            name: "task_0".into(),
+            input: json!(0u64),
+            queue: "default".into(),
+        },
+        WorkflowEvent::ActivityScheduled {
+            activity_id: id_b,
+            name: "task_1".into(),
+            input: json!(1u64),
+            queue: "default".into(),
+        },
+        WorkflowEvent::ActivityScheduled {
+            activity_id: id_c,
+            name: "task_2".into(),
+            input: json!(2u64),
+            queue: "default".into(),
+        },
+        WorkflowEvent::ActivityCompleted {
+            activity_id: id_a,
+            output: json!("r0"),
+        },
+        WorkflowEvent::ActivityCompleted {
+            activity_id: id_b,
+            output: json!("r1"),
+        },
+        WorkflowEvent::ActivityCompleted {
+            activity_id: id_c,
+            output: json!("r2"),
+        },
+    ];
+
+    // New code passes input=2 which creates only 2 activities (changed from 3)
+    let outcome =
+        run_workflow(exec_id, history, fan_out_count_changed, json!(2u64)).await;
+
+    match outcome {
+        WorkflowOutcome::Failed { error } => {
+            assert!(
+                error.to_lowercase().contains("non-deterministic")
+                    || error.to_lowercase().contains("fan_out")
+                    || error.to_lowercase().contains("count"),
+                "error should mention non-determinism or fan_out count; got: {error}"
+            );
+        }
+        other => panic!("expected Failed (non-determinism), got {other:?}"),
+    }
+}
+
+/// Fan-out with dynamic N derived from a prior activity output.
+/// Verifies replay works correctly when N is derived from earlier state.
+#[tokio::test]
+async fn fan_out_dynamic_from_prior_activity_replays_correctly() {
+    let exec_id = ExecutionId::new();
+    let list_id = ActivityExecId::new();
+    let item_ids: Vec<ActivityExecId> = (0..3).map(|_| ActivityExecId::new()).collect();
+
+    let history = vec![
+        WorkflowEvent::WorkflowStarted {
+            input: Value::Null,
+            timestamp: Utc::now(),
+        },
+        // Prior activity returns a list of 3 items
+        WorkflowEvent::ActivityScheduled {
+            activity_id: list_id,
+            name: "list_items".into(),
+            input: Value::Null,
+            queue: "default".into(),
+        },
+        WorkflowEvent::ActivityCompleted {
+            activity_id: list_id,
+            output: json!([1, 2, 3]),
+        },
+        // Fan-out marker: 3 items
+        WorkflowEvent::MarkerRecorded {
+            name: "fan_out:1".into(),
+            details: json!(3u64),
+        },
+        WorkflowEvent::ActivityScheduled {
+            activity_id: item_ids[0],
+            name: "process_item".into(),
+            input: json!(1),
+            queue: "default".into(),
+        },
+        WorkflowEvent::ActivityScheduled {
+            activity_id: item_ids[1],
+            name: "process_item".into(),
+            input: json!(2),
+            queue: "default".into(),
+        },
+        WorkflowEvent::ActivityScheduled {
+            activity_id: item_ids[2],
+            name: "process_item".into(),
+            input: json!(3),
+            queue: "default".into(),
+        },
+        WorkflowEvent::ActivityCompleted {
+            activity_id: item_ids[0],
+            output: json!("done_1"),
+        },
+        WorkflowEvent::ActivityCompleted {
+            activity_id: item_ids[1],
+            output: json!("done_2"),
+        },
+        WorkflowEvent::ActivityCompleted {
+            activity_id: item_ids[2],
+            output: json!("done_3"),
+        },
+    ];
+
+    let outcome =
+        run_workflow(exec_id, history, fan_out_dynamic_from_prior, Value::Null).await;
+
+    match outcome {
+        WorkflowOutcome::Completed { output } => {
+            let processed = output["processed"].as_array().unwrap();
+            assert_eq!(processed.len(), 3, "should process 3 items");
+            assert_eq!(processed[0], json!("done_1"));
+            assert_eq!(processed[1], json!("done_2"));
+            assert_eq!(processed[2], json!("done_3"));
+        }
+        other => panic!("expected Completed, got {other:?}"),
+    }
+}
+
+/// Cancellation test: workflow cancelled → fan-out returns Cancelled.
+#[tokio::test]
+async fn fan_out_cancelled_workflow_returns_cancelled_error() {
+    let exec_id = ExecutionId::new();
+
+    // History has a WorkflowCancelled event → fan-out should surface Cancelled
+    let history = vec![
+        WorkflowEvent::WorkflowStarted {
+            input: Value::Null,
+            timestamp: Utc::now(),
+        },
+        WorkflowEvent::WorkflowCancelled {
+            reason: "user_requested".into(),
+        },
+    ];
+
+    let outcome = run_workflow(exec_id, history, fan_out_three_parallel, Value::Null).await;
+
+    match outcome {
+        WorkflowOutcome::Failed { error } => {
+            assert!(
+                error.contains("cancelled") || error.contains("cancel"),
+                "cancelled workflow fan-out should report cancellation; got: {error}"
+            );
+        }
+        other => panic!("expected Failed (Cancelled), got {other:?}"),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// WorkflowContext unit tests (no executor needed)
+// ---------------------------------------------------------------------------
+
+/// Typed fan-out: `execute_activity_fan_out` accepts `(&ActivityInfo, I)` pairs.
+#[tokio::test]
+async fn fan_out_typed_single_activity_type_replays_correctly() {
+    use autumn_harvest::info::ActivityInfo;
+
+    let info = ActivityInfo {
+        name: "echo",
+        module: "tests",
+        default_retry_policy: None,
+        default_start_to_close: None,
+        default_heartbeat_timeout: None,
+        default_schedule_to_start: None,
+        default_queue: Some("default"),
+        max_concurrent: None,
+        concurrency_key: None,
+        is_local: false,
+        max_input_bytes: None,
+        max_result_bytes: None,
+        rate_limit_rps: None,
+        rate_limit_burst: None,
+        rate_limit_key: None,
+        handler: |_ctx, input| Box::pin(async move { Ok(input) }),
+    };
+
+    let exec_id = ExecutionId::new();
+    let id_1 = ActivityExecId::new();
+    let id_2 = ActivityExecId::new();
+
+    let history = vec![
+        WorkflowEvent::WorkflowStarted {
+            input: Value::Null,
+            timestamp: Utc::now(),
+        },
+        WorkflowEvent::MarkerRecorded {
+            name: "fan_out:1".into(),
+            details: json!(2u64),
+        },
+        WorkflowEvent::ActivityScheduled {
+            activity_id: id_1,
+            name: "echo".into(),
+            input: json!("hello"),
+            queue: "default".into(),
+        },
+        WorkflowEvent::ActivityScheduled {
+            activity_id: id_2,
+            name: "echo".into(),
+            input: json!("world"),
+            queue: "default".into(),
+        },
+        WorkflowEvent::ActivityCompleted {
+            activity_id: id_1,
+            output: json!("hello"),
+        },
+        WorkflowEvent::ActivityCompleted {
+            activity_id: id_2,
+            output: json!("world"),
+        },
+    ];
+
+    let ctx = WorkflowContext::for_replay(exec_id, history);
+    let results: Vec<String> = ctx
+        .execute_activity_fan_out(&info, vec!["hello".to_string(), "world".to_string()])
+        .await
+        .expect("fan-out should succeed");
+
+    assert_eq!(results, vec!["hello".to_string(), "world".to_string()]);
+}
+
+/// Typed collect-all fan-out: mixed results returned as `Vec<Result<O, String>>`.
+#[tokio::test]
+async fn fan_out_typed_collect_all_returns_per_slot_results() {
+    use autumn_harvest::info::ActivityInfo;
+
+    let info = ActivityInfo {
+        name: "maybe_fail",
+        module: "tests",
+        default_retry_policy: None,
+        default_start_to_close: None,
+        default_heartbeat_timeout: None,
+        default_schedule_to_start: None,
+        default_queue: Some("default"),
+        max_concurrent: None,
+        concurrency_key: None,
+        is_local: false,
+        max_input_bytes: None,
+        max_result_bytes: None,
+        rate_limit_rps: None,
+        rate_limit_burst: None,
+        rate_limit_key: None,
+        handler: |_ctx, input| Box::pin(async move { Ok(input) }),
+    };
+
+    let exec_id = ExecutionId::new();
+    let id_1 = ActivityExecId::new();
+    let id_2 = ActivityExecId::new();
+
+    let history = vec![
+        WorkflowEvent::WorkflowStarted {
+            input: Value::Null,
+            timestamp: Utc::now(),
+        },
+        WorkflowEvent::MarkerRecorded {
+            name: "fan_out:1".into(),
+            details: json!(2u64),
+        },
+        WorkflowEvent::ActivityScheduled {
+            activity_id: id_1,
+            name: "maybe_fail".into(),
+            input: json!("ok_input"),
+            queue: "default".into(),
+        },
+        WorkflowEvent::ActivityScheduled {
+            activity_id: id_2,
+            name: "maybe_fail".into(),
+            input: json!("fail_input"),
+            queue: "default".into(),
+        },
+        WorkflowEvent::ActivityCompleted {
+            activity_id: id_1,
+            output: json!("ok_output"),
+        },
+        WorkflowEvent::ActivityFailed {
+            activity_id: id_2,
+            error: "deliberate_failure".into(),
+            attempt: 1,
+            error_type: "Error".into(),
+            non_retryable: false,
+            details: None,
+        },
+    ];
+
+    let ctx = WorkflowContext::for_replay(exec_id, history);
+    let results: Vec<Result<Value, String>> = ctx
+        .execute_activity_fan_out_collect(&info, vec![
+            json!("ok_input"),
+            json!("fail_input"),
+        ])
+        .await
+        .expect("collect should not fail at the workflow level");
+
+    assert_eq!(results.len(), 2);
+    assert!(results[0].is_ok(), "slot 0 should be ok");
+    assert_eq!(results[0].as_ref().unwrap(), &json!("ok_output"));
+    assert!(results[1].is_err(), "slot 1 should be err");
+    assert!(results[1].as_ref().unwrap_err().contains("deliberate_failure"));
+}
+
+/// Second fan-out call in the same workflow gets a different sequence number.
+/// Verifies the sequence counter increments correctly for replay.
+#[tokio::test]
+async fn fan_out_two_groups_in_same_workflow() {
+    fn two_fan_outs<'a>(
+        ctx: &'a WorkflowContext,
+        _input: Value,
+    ) -> Pin<Box<dyn Future<Output = Result<Value, String>> + Send + 'a>> {
+        Box::pin(async move {
+            let batch1 = ctx
+                .execute_activity_fan_out_raw(vec![
+                    ("a1".to_string(), json!(null), "default".to_string()),
+                    ("a2".to_string(), json!(null), "default".to_string()),
+                ])
+                .await
+                .map_err(|e| e.to_string())?;
+            let batch2 = ctx
+                .execute_activity_fan_out_raw(vec![
+                    ("b1".to_string(), json!(null), "default".to_string()),
+                ])
+                .await
+                .map_err(|e| e.to_string())?;
+            Ok(json!({ "b1": batch1, "b2": batch2 }))
+        })
+    }
+
+    let exec_id = ExecutionId::new();
+    let a1 = ActivityExecId::new();
+    let a2 = ActivityExecId::new();
+    let b1 = ActivityExecId::new();
+
+    let history = vec![
+        WorkflowEvent::WorkflowStarted {
+            input: Value::Null,
+            timestamp: Utc::now(),
+        },
+        // First fan-out group (seq=1, count=2)
+        WorkflowEvent::MarkerRecorded {
+            name: "fan_out:1".into(),
+            details: json!(2u64),
+        },
+        WorkflowEvent::ActivityScheduled {
+            activity_id: a1,
+            name: "a1".into(),
+            input: Value::Null,
+            queue: "default".into(),
+        },
+        WorkflowEvent::ActivityScheduled {
+            activity_id: a2,
+            name: "a2".into(),
+            input: Value::Null,
+            queue: "default".into(),
+        },
+        WorkflowEvent::ActivityCompleted {
+            activity_id: a1,
+            output: json!("ra1"),
+        },
+        WorkflowEvent::ActivityCompleted {
+            activity_id: a2,
+            output: json!("ra2"),
+        },
+        // Second fan-out group (seq=2, count=1)
+        WorkflowEvent::MarkerRecorded {
+            name: "fan_out:2".into(),
+            details: json!(1u64),
+        },
+        WorkflowEvent::ActivityScheduled {
+            activity_id: b1,
+            name: "b1".into(),
+            input: Value::Null,
+            queue: "default".into(),
+        },
+        WorkflowEvent::ActivityCompleted {
+            activity_id: b1,
+            output: json!("rb1"),
+        },
+    ];
+
+    let outcome = run_workflow(exec_id, history, two_fan_outs, Value::Null).await;
+
+    match outcome {
+        WorkflowOutcome::Completed { output } => {
+            let b1 = output["b1"].as_array().unwrap();
+            let b2 = output["b2"].as_array().unwrap();
+            assert_eq!(b1.len(), 2);
+            assert_eq!(b2.len(), 1);
+            assert_eq!(b1[0], json!("ra1"));
+            assert_eq!(b1[1], json!("ra2"));
+            assert_eq!(b2[0], json!("rb1"));
+        }
+        other => panic!("expected Completed, got {other:?}"),
+    }
+}


### PR DESCRIPTION
## Summary

Implements first-class fan-out primitives for dispatching N activities in parallel and collecting results in input order. Two execution semantics are provided: fail-fast (returns on first error) and collect-all (returns per-slot `Result`s). Includes comprehensive replay safety via count markers and non-determinism detection.

## Key Changes

- **Fan-out context methods** (`context.rs`):
  - `execute_activity_fan_out_raw()` — fail-fast raw fan-out with `Vec<(String, Value, String)>` input
  - `execute_activity_fan_out_collect_raw()` — collect-all raw variant returning `Vec<Result<Value, String>>`
  - `execute_activity_fan_out<I, O>()` — typed fail-fast for homogeneous activity dispatch
  - `execute_activity_fan_out_collect<I, O>()` — typed collect-all variant
  - `next_fan_out_seq()` — monotonic sequence counter for stable marker naming across replays
  - `check_fan_out_count()` — records or verifies fan-out count marker in history

- **Replay safety** (`replay.rs`):
  - `HistoryMatcher::match_fan_out_marker()` — matches `MarkerRecorded { name: "fan_out:{seq}", details: <count> }` events
  - Returns `HistoryMatch::Diverged` when input collection size changes between deploy and replay (non-determinism detection)
  - Enables deterministic replay by verifying collection size before activity dispatch

- **Comprehensive test suite** (`fanout_tests.rs`):
  - 13 unit tests covering fail-fast, collect-all, empty fan-out, dynamic fan-out from prior activity output
  - Non-determinism detection (count mismatch)
  - Cancellation propagation
  - Multiple fan-out groups in same workflow (sequence counter verification)
  - Typed and raw variants
  - Out-of-order completion handling (results returned in input order)

- **Example** (`fanout_batch.rs`):
  - Demonstrates fail-fast batch processing
  - Shows collect-all with per-slot error handling
  - Illustrates dynamic fan-out derived from prior activity output

- **Documentation** (`CLAUDE.md`):
  - Added fan-out section with method comparison table
  - Usage examples for typed and raw variants
  - Replay safety and determinism guarantees
  - Cancellation behavior

## Implementation Details

- **Sequence numbering**: Each `execute_activity_fan_out*` call increments `fan_out_seq` to generate unique marker names (`fan_out:1`, `fan_out:2`, etc.), enabling multiple fan-out groups in the same workflow to replay deterministically.

- **Count marker semantics**: On first live execution, a `RecordMarker` command is emitted with the collection size. During replay, the recorded count is verified; if the input collection has grown or shrunk, `HarvestError::NonDeterministic` is returned before any activity is dispatched.

- **Input order preservation**: Results are collected in input order regardless of completion order (futures are awaited in submission order, not completion order).

- **Cancellation**: Both variants check `is_cancelled()` before dispatching and propagate cancellation errors immediately.

- **Determinism requirement**: The input collection must be derived from already-recorded state (workflow input, prior activity outputs, signals) — never from non-deterministic sources like the system clock or random numbers. This is enforced by the count marker verification.

https://claude.ai/code/session_01XsnHzgKDg2i43mv3DFdpNQ