### PR TITLE
⚡ Bolt: Use char_indices for zero-cost string truncation

### DIFF
--- a/autumn-harvest-plugin/src/ui.rs
+++ b/autumn-harvest-plugin/src/ui.rs
@@ -2304,7 +2304,12 @@ fn render_worker_table(rows: &[WorkerRow], shard_id: ShardId) -> Markup {
                             } @else {
                                 a href={ "build-routing?build_id=" (url_encode(&row.worker.build_id)) }
                                   title="View in Build Routing" {
-                                    code { (row.worker.build_id.chars().take(16).collect::<String>()) }
+                                    @let short_build = if let Some((idx, _)) = row.worker.build_id.char_indices().nth(16) {
+                                        &row.worker.build_id[..idx]
+                                    } else {
+                                        &row.worker.build_id
+                                    };
+                                    code { (short_build) }
                                 }
                             }
                         }
@@ -3418,7 +3423,11 @@ fn badge_class(state: &str) -> &'static str {
 }
 
 fn short_id(id: &str) -> String {
-    id.chars().take(8).collect::<String>() + "…"
+    if let Some((idx, _)) = id.char_indices().nth(8) {
+        format!("{}…", &id[..idx])
+    } else {
+        format!("{id}…")
+    }
 }
 
 fn url_encode(input: &str) -> String {

--- a/autumn-harvest/src/store.rs
+++ b/autumn-harvest/src/store.rs
@@ -665,7 +665,11 @@ fn summarize_error(error: Option<String>) -> Option<String> {
         return None;
     }
 
-    Some(first_line.chars().take(MAX_ERROR_SUMMARY_CHARS).collect())
+    if let Some((idx, _)) = first_line.char_indices().nth(MAX_ERROR_SUMMARY_CHARS) {
+        Some(first_line[..idx].to_string())
+    } else {
+        Some(first_line)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
💡 What: Replaced `.chars().take(n).collect::<String>()` with `.char_indices().nth(n)` and direct string slicing.
🎯 Why: Truncating strings by collecting `.chars()` into a new `String` allocates memory on the heap. Slicing the existing string avoids these unnecessary allocations.
📊 Impact: Removes unnecessary heap allocations on UI rendering hot paths and error summarizing.
🔬 Measurement: Run `cargo test` and observe identical truncation behavior without the intermediate allocation.

---
*PR created automatically by Jules for task [136321307897989593](https://jules.google.com/task/136321307897989593) started by @madmax983*