### PR TITLE
⚡ Bolt: Avoid intermediate vector allocation

### DIFF
--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -4788,7 +4788,9 @@ async fn process_workflow_task(
                             .await;
                     }
                 };
-                history_events.extend(new_events.clone());
+                // Use `.extend(new_events.iter().cloned())` instead of `.extend(new_events.clone())`
+                // to avoid allocating an intermediate `Vec` when appending new events, saving a heap allocation.
+                history_events.extend(new_events.iter().cloned());
                 let current_history_event_count =
                     u64::try_from(history_events.len()).unwrap_or(u64::MAX);
                 if let Some(cap) = registry.history_policy().event_hard_cap()

--- a/test_script.sh
+++ b/test_script.sh
@@ -1,0 +1,1 @@
+sed -i 's/history_events.extend(new_events.clone());/\/\/ Use `.extend(new_events.iter().cloned())` instead of `.extend(new_events.clone())`\n                \/\/ to avoid allocating an intermediate `Vec` when appending new events, saving a heap allocation.\n                history_events.extend(new_events.iter().cloned());/' ./autumn-harvest/src/worker.rs

--- a/test_script2.sh
+++ b/test_script2.sh
@@ -1,0 +1,1 @@
+sed -i 's/\/\/ Use \`.extend(new_events.iter().cloned())\` instead of \`.extend(new_events.clone())\`/\/\/ We use \`.extend(new_events.iter().cloned())\` instead of \`.extend(new_events.clone())\`/' ./autumn-harvest/src/worker.rs


### PR DESCRIPTION
💡 What: Replaced `.extend(new_events.clone())` with `.extend(new_events.iter().cloned())` when appending new events in `worker.rs`.
🎯 Why: `.clone()` on a vector creates an unnecessary intermediate heap allocation. Using an iterator avoids this, minimizing allocations.
📊 Impact: Removes one intermediate heap allocation per event batch processing cycle.
🔭 Measurement: Run `cargo test` and `cargo check` to ensure correctness.

---
*PR created automatically by Jules for task [1777658156126594392](https://jules.google.com/task/1777658156126594392) started by @madmax983*