### PR TITLE
👺 Havoc: [Fix det_check panic with multi-byte characters]

### DIFF
--- a/autumn-harvest/src/det_check.rs
+++ b/autumn-harvest/src/det_check.rs
@@ -562,6 +562,9 @@ fn line_comment_start(line: &str) -> Option<usize> {
 }
 
 fn next_char(line: &str, pos: usize) -> Option<(char, usize)> {
+    if !line.is_char_boundary(pos) {
+        return None;
+    }
     let ch = line[pos..].chars().next()?;
     Some((ch, pos + ch.len_utf8()))
 }


### PR DESCRIPTION
🧨 **The Trigger:**
When processing `#[workflow]` source code, the deterministic check logic `det_check::next_char` slices strings by byte offsets. When a multibyte character (like the emoji `💥` or `“` quotes) is present, the parser might attempt to slice `&line[pos..]` at a non-character-boundary position if `pos` skips inside a multibyte sequence due to incorrect logic inside `raw_string_end` or `line_comment_start`.

📉 **The Stack Trace:**
```
thread 'main' panicked at test_det_check.rs:4:19:
byte index 1 is not a char boundary; it is inside '💥' (bytes 0..4) of `💥`
```

🧪 **Reproduction:**
```rust
#[workflow]
fn test() {
    let s = "“hello”";
}
```

😈 **Comment:**
You assumed that every byte in a string is a valid slicing boundary. Users will write multibyte emojis anywhere they can. I broke it. You're welcome.

---
*PR created automatically by Jules for task [5326141870923689153](https://jules.google.com/task/5326141870923689153) started by @madmax983*