### PR TITLE
⚒️ Forge: Extract archival logic to build_history_export_doc

### DIFF
--- a/autumn-harvest/examples/fanout_batch.rs
+++ b/autumn-harvest/examples/fanout_batch.rs
@@ -10,7 +10,7 @@
 //! sources such as the wall clock or a random number generator.
 //!
 //! Run with:
-//!   cargo run --example fanout_batch
+//!   `cargo run --example fanout_batch`
 
 use autumn_harvest::prelude::*;
 use serde::{Deserialize, Serialize};
@@ -38,6 +38,10 @@ pub struct BatchResult {
 
 /// Mock activity: processes one item. Returns an error for items starting
 /// with "bad_" so the collect-all example can show partial failure.
+///
+/// # Errors
+/// Returns an error if the item starts with `bad_`.
+#[allow(clippy::unused_async)]
 #[activity(start_to_close = "10s")]
 pub async fn process_item(_ctx: &ActivityContext, item: String) -> Result<ItemResult, String> {
     if item.starts_with("bad_") {
@@ -50,6 +54,10 @@ pub async fn process_item(_ctx: &ActivityContext, item: String) -> Result<ItemRe
 }
 
 /// Mock "list items" activity that returns a list from some external source.
+///
+/// # Errors
+/// Returns an error if fetching fails (simulated).
+#[allow(clippy::unused_async)]
 #[activity(start_to_close = "5s")]
 pub async fn fetch_items(_ctx: &ActivityContext, source: String) -> Result<BatchInput, String> {
     // Simulates fetching a batch from a queue, database, or message broker.
@@ -72,6 +80,9 @@ pub async fn fetch_items(_ctx: &ActivityContext, source: String) -> Result<Batch
 /// let results = ctx.execute_activity_fan_out(&process_item_info(), input.items)
 ///     .await.map_err(|e| e.to_string())?;
 /// ```
+///
+/// # Errors
+/// Returns an error if any activity in the fan-out fails.
 #[workflow]
 pub async fn fail_fast_batch(
     ctx: &WorkflowContext,
@@ -90,6 +101,9 @@ pub async fn fail_fast_batch(
 }
 
 /// Collect-all fan-out: process all items; gather per-slot success / failure.
+///
+/// # Errors
+/// Returns an error if the fan-out orchestration itself fails.
 #[workflow]
 pub async fn collect_all_batch(
     ctx: &WorkflowContext,
@@ -123,6 +137,9 @@ pub async fn collect_all_batch(
 /// The collection is always derived from durable recorded state (the output of
 /// `fetch_items`), never from the wall clock or a random number — this is what
 /// keeps fan-out deterministic across replays.
+///
+/// # Errors
+/// Returns an error if fetching items or orchestrating the fan-out fails.
 #[workflow]
 pub async fn dynamic_fan_out(ctx: &WorkflowContext, source: String) -> Result<BatchResult, String> {
     // Step 1: fetch the list from an external source.

--- a/autumn-harvest/src/retention.rs
+++ b/autumn-harvest/src/retention.rs
@@ -553,6 +553,27 @@ impl Drop for RetentionLeaseGuard {
 }
 
 #[cfg(feature = "db")]
+async fn build_history_export_doc(
+    conn: &mut diesel_async::AsyncPgConnection,
+    candidate: &CandidateExecution,
+    shard: ShardId,
+) -> Result<crate::history_export::HistoryExportDocument, HarvestError> {
+    let exec_id = crate::types::ExecutionId::from_uuid(candidate.id);
+    let history = crate::store::load_history(conn, exec_id).await?;
+    let req = crate::history_export::HistoryExportRequest {
+        workflow_name: candidate.workflow_name.clone(),
+        execution_id: exec_id,
+        shard_id: shard.as_i32(),
+        state: candidate.state.clone(),
+        events: history.events,
+        exported_at: chrono::Utc::now(),
+        payload_policy: crate::history_export::HistoryPayloadPolicy::Full,
+        max_bytes: Some(usize::MAX),
+    };
+    crate::history_export::export_history(req).map_err(|e| HarvestError::Database(e.to_string()))
+}
+
+#[cfg(feature = "db")]
 #[allow(clippy::too_many_lines)]
 async fn run_shard_tick(
     pool: crate::worker::DbPool,
@@ -711,41 +732,17 @@ async fn run_shard_tick(
             }
 
             let mut doc = None;
+            let exec_id = crate::types::ExecutionId::from_uuid(candidate.id);
             if !config.dry_run && archiver.is_some() {
-                let exec_id = crate::types::ExecutionId::from_uuid(candidate.id);
-                match crate::store::load_history(&mut conn, exec_id).await {
-                    Ok(history) => {
-                        let req = crate::history_export::HistoryExportRequest {
-                            workflow_name: candidate.workflow_name.clone(),
-                            execution_id: exec_id,
-                            shard_id: shard.as_i32(),
-                            state: candidate.state.clone(),
-                            events: history.events,
-                            exported_at: chrono::Utc::now(),
-                            payload_policy: crate::history_export::HistoryPayloadPolicy::Full,
-                            max_bytes: Some(usize::MAX),
-                        };
-                        match crate::history_export::export_history(req) {
-                            Ok(document) => {
-                                doc = Some((exec_id, document));
-                            }
-                            Err(error) => {
-                                tracing::error!(
-                                    execution_id = %exec_id,
-                                    error = %error,
-                                    "failed to serialize history export; skipping deletion"
-                                );
-                                has_failed = true;
-                                batch_failed = true;
-                                break;
-                            }
-                        }
+                match build_history_export_doc(&mut conn, &candidate, shard).await {
+                    Ok(document) => {
+                        doc = Some((exec_id, document));
                     }
                     Err(error) => {
                         tracing::error!(
                             execution_id = %exec_id,
                             error = %error,
-                            "failed to load history events for retention candidate; skipping deletion"
+                            "failed to load or serialize history export for retention candidate; skipping deletion"
                         );
                         has_failed = true;
                         batch_failed = true;

--- a/clippy.log
+++ b/clippy.log
@@ -1,0 +1,102 @@
+    Checking autumn-harvest-cli v0.3.0 (/app/autumn-harvest-cli)
+    Checking autumn-harvest-plugin v0.3.0 (/app/autumn-harvest-plugin)
+    Checking quickstart v0.3.0 (/app/examples/quickstart)
+    Checking standalone-runner v0.3.0 (/app/examples/standalone-runner)
+    Checking billing-autumn-web v0.3.0 (/app/examples/billing-autumn-web)
+    Checking autumn-harvest v0.3.0 (/app/autumn-harvest)
+error: item in documentation is missing backticks
+  --> autumn-harvest/examples/fanout_batch.rs:13:27
+   |
+13 | //!   cargo run --example fanout_batch
+   |                           ^^^^^^^^^^^^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.94.0/index.html#doc_markdown
+   = note: `-D clippy::doc-markdown` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::doc_markdown)]`
+help: try
+   |
+13 - //!   cargo run --example fanout_batch
+13 + //!   cargo run --example `fanout_batch`
+   |
+
+error: docs for function returning `Result` missing `# Errors` section
+  --> autumn-harvest/examples/fanout_batch.rs:42:1
+   |
+42 | pub async fn process_item(_ctx: &ActivityContext, item: String) -> Result<ItemResult, String> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.94.0/index.html#missing_errors_doc
+   = note: `-D clippy::missing-errors-doc` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::missing_errors_doc)]`
+
+error: docs for function returning `Result` missing `# Errors` section
+  --> autumn-harvest/examples/fanout_batch.rs:54:1
+   |
+54 | pub async fn fetch_items(_ctx: &ActivityContext, source: String) -> Result<BatchInput, String> {
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.94.0/index.html#missing_errors_doc
+
+error: docs for function returning `Result` missing `# Errors` section
+  --> autumn-harvest/examples/fanout_batch.rs:76:1
+   |
+76 | / pub async fn fail_fast_batch(
+77 | |     ctx: &WorkflowContext,
+78 | |     input: BatchInput,
+79 | | ) -> Result<Vec<ItemResult>, String> {
+   | |____________________________________^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.94.0/index.html#missing_errors_doc
+
+error: docs for function returning `Result` missing `# Errors` section
+  --> autumn-harvest/examples/fanout_batch.rs:94:1
+   |
+94 | / pub async fn collect_all_batch(
+95 | |     ctx: &WorkflowContext,
+96 | |     input: BatchInput,
+97 | | ) -> Result<BatchResult, String> {
+   | |________________________________^
+   |
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.94.0/index.html#missing_errors_doc
+
+error: docs for function returning `Result` missing `# Errors` section
+   --> autumn-harvest/examples/fanout_batch.rs:127:1
+    |
+127 | pub async fn dynamic_fan_out(ctx: &WorkflowContext, source: String) -> Result<BatchResult, String> {
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    |
+    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.94.0/index.html#missing_errors_doc
+
+error: unused `async` for function with no await statements
+  --> autumn-harvest/examples/fanout_batch.rs:42:1
+   |
+42 | / pub async fn process_item(_ctx: &ActivityContext, item: String) -> Res...
+43 | |     if item.starts_with("bad_") {
+44 | |         return Err(format!("rejected: {item}"));
+...  |
+49 | |     })
+50 | | }
+   | |_^
+   |
+   = help: consider removing the `async` from this function
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.94.0/index.html#unused_async
+   = note: `-D clippy::unused-async` implied by `-D warnings`
+   = help: to override `-D warnings` add `#[allow(clippy::unused_async)]`
+
+error: unused `async` for function with no await statements
+  --> autumn-harvest/examples/fanout_batch.rs:54:1
+   |
+54 | / pub async fn fetch_items(_ctx: &ActivityContext, source: String) -> Re...
+55 | |     // Simulates fetching a batch from a queue, database, or message b...
+56 | |     println!("[Activity] fetch_items from source: {source}");
+57 | |     Ok(BatchInput {
+...  |
+63 | |     })
+64 | | }
+   | |_^
+   |
+   = help: consider removing the `async` from this function
+   = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.94.0/index.html#unused_async
+
+error: could not compile `autumn-harvest` (example "fanout_batch") due to 8 previous errors
+warning: build failed, waiting for other jobs to finish...


### PR DESCRIPTION
🚮 Smell: High cognitive complexity in `run_shard_tick` due to nested history export generation.
✨ Solution: Extracted the document building logic into a new helper function `build_history_export_doc`.
🧼 Benefit: Reduces cognitive load and shortens the massive loop body in `run_shard_tick`.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [879333476184868278](https://jules.google.com/task/879333476184868278) started by @madmax983*