### PR TITLE
🔒 Warden: [security fix] mitigate memory exhaustion vulnerability

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -134,9 +134,9 @@ dependencies = [
 
 [[package]]
 name = "astral-tokio-tar"
-version = "0.6.1"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ce73b17c62717c4b6a9af10b43e87c578b0cac27e00666d48304d3b7d2c0693"
+checksum = "cb50a7aae84a03bf55b067832bc376f4961b790c97e64d3eacee97d389b90277"
 dependencies = [
  "filetime",
  "futures-core",
@@ -2703,9 +2703,9 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.24.5"
+version = "0.24.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff56c2e7dce6bd462e3b8919986a617027481b1dcc703175b58cf9dd98a2f071"
+checksum = "89550ee9f79e88fef3119de263694973a8adb26c21d75322164fb8c493039fe2"
 dependencies = [
  "portable-atomic",
  "rapidhash",
@@ -4630,7 +4630,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.2",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -13,8 +13,10 @@ use autumn_web::session::Session;
 use axum::Extension;
 use axum::Json;
 use axum::Router;
-use axum::body::Bytes;
+use axum::body::Body;
 use axum::extract::{Path, Query, State};
+
+const MAX_API_PAYLOAD_BYTES: usize = 2 * 1024 * 1024; // 2 MiB
 use axum::http::StatusCode;
 use axum::middleware::{self, Next};
 use axum::response::IntoResponse;
@@ -4684,9 +4686,19 @@ async fn batch_start_workflows(
     Extension(api_state): Extension<HarvestApiState>,
     maybe_session: Option<Extension<Session>>,
     headers: axum::http::HeaderMap,
-    body_bytes: Bytes,
+    body: Body,
 ) -> axum::response::Response {
     use axum::response::IntoResponse as _;
+
+    let max_bytes = api_state.batch_start_max_bytes();
+    #[allow(clippy::cast_possible_truncation)]
+    let body_bytes = match axum::body::to_bytes(body, max_bytes as usize).await {
+        Ok(b) => b,
+        Err(e) => {
+            return AutumnError::bad_request_msg(format!("failed to read body: {e}"))
+                .into_response();
+        }
+    };
 
     if !has_harvest_admin_access(&api_state, maybe_session.map(|Extension(s)| s)).await {
         return AutumnError::unauthorized_msg("authentication required").into_response();
@@ -4696,7 +4708,6 @@ async fn batch_start_workflows(
     let route = "POST /workflows/batch_start";
 
     // ── Enforce byte-size cap ────────────────────────────────────────────────
-    let max_bytes = api_state.batch_start_max_bytes();
     let body_len = u64::try_from(body_bytes.len()).unwrap_or(u64::MAX);
     if body_len > max_bytes {
         return (
@@ -6343,15 +6354,19 @@ struct QueryWorkflowResponse {
 async fn query_workflow_post(
     Extension(api_state): Extension<HarvestApiState>,
     Path((id, query_name)): Path<(String, String)>,
-    body: Bytes,
+    body: Body,
 ) -> Result<Json<QueryWorkflowResponse>, AutumnError> {
+    let body_bytes = axum::body::to_bytes(body, MAX_API_PAYLOAD_BYTES)
+        .await
+        .map_err(|e| AutumnError::bad_request_msg(format!("failed to read body: {e}")))?;
+
     let exec_id = parse_execution_id(&id)?;
     let ctx = hydrate_ctx_for_query(&api_state, exec_id).await?;
     let start = Instant::now(); // measure handler invocation latency, not hydration cost
-    let args: Value = if body.is_empty() {
+    let args: Value = if body_bytes.is_empty() {
         Value::Null
     } else {
-        serde_json::from_slice::<QueryWorkflowRequest>(&body)
+        serde_json::from_slice::<QueryWorkflowRequest>(&body_bytes)
             .map(|r| r.args)
             .map_err(|e| AutumnError::bad_request_msg(format!("invalid JSON body: {e}")))?
     };
@@ -9434,14 +9449,23 @@ fn url_encode_for_redirect(input: &str) -> String {
     out
 }
 
+#[allow(clippy::too_many_lines)]
 async fn bulk_replay_dead_letters_handler(
     Extension(api_state): Extension<HarvestApiState>,
     headers: axum::http::HeaderMap,
-    body: axum::body::Bytes,
+    body: Body,
 ) -> axum::response::Response {
     use axum::response::IntoResponse as _;
 
-    let request = match parse_bulk_dlq_request(&headers, &body) {
+    let body_bytes = match axum::body::to_bytes(body, MAX_API_PAYLOAD_BYTES).await {
+        Ok(b) => b,
+        Err(e) => {
+            return AutumnError::bad_request_msg(format!("failed to read body: {e}"))
+                .into_response();
+        }
+    };
+
+    let request = match parse_bulk_dlq_request(&headers, &body_bytes) {
         Ok(request) => request,
         Err(error) => return error.into_response(),
     };
@@ -9542,14 +9566,23 @@ async fn bulk_replay_dead_letters_handler(
     }
 }
 
+#[allow(clippy::too_many_lines)]
 async fn bulk_discard_dead_letters_handler(
     Extension(api_state): Extension<HarvestApiState>,
     headers: axum::http::HeaderMap,
-    body: axum::body::Bytes,
+    body: Body,
 ) -> axum::response::Response {
     use axum::response::IntoResponse as _;
 
-    let request = match parse_bulk_dlq_request(&headers, &body) {
+    let body_bytes = match axum::body::to_bytes(body, MAX_API_PAYLOAD_BYTES).await {
+        Ok(b) => b,
+        Err(e) => {
+            return AutumnError::bad_request_msg(format!("failed to read body: {e}"))
+                .into_response();
+        }
+    };
+
+    let request = match parse_bulk_dlq_request(&headers, &body_bytes) {
         Ok(request) => request,
         Err(error) => return error.into_response(),
     };


### PR DESCRIPTION
🦠 Threat: Unbounded `axum::body::Bytes` extractors were used in multiple management API endpoints (`batch_start_workflows`, `query_workflow_post`, `bulk_replay_dead_letters_handler`, `bulk_discard_dead_letters_handler`). This buffered entire request payloads into memory before handler execution, exposing the application to Memory Exhaustion (Denial of Service) attacks from maliciously large payloads. Additionally, `cargo audit` reported a known vulnerability in `astral-tokio-tar` (RUSTSEC-2026-0145).
 
🛡️ Defense: Replaced the unbounded `Bytes` extractors with `axum::body::Body` and manually extracted the byte stream using `axum::body::to_bytes` with a strictly enforced size limit. We utilized the dynamically configured `api_state.batch_start_max_bytes()` for batch endpoints and introduced a safe default `MAX_API_PAYLOAD_BYTES` of 2 MiB for the other endpoints. We also bumped `astral-tokio-tar` to `0.6.2` to patch the vulnerability.
 
💥 Severity: Critical. A malicious user could crash the system via Out Of Memory (OOM) by sending a multi-gigabyte JSON payload to the unauthenticated query endpoints or dead letter queue endpoints.
 
🧪 Verification: Unit tests and integration tests passed via `cargo test`, and `cargo clippy` passed. Handled the truncation correctly.

---
*PR created automatically by Jules for task [16087595614593695001](https://jules.google.com/task/16087595614593695001) started by @madmax983*