### PR TITLE
⚡ Bolt: [performance improvement] Optimize summarize_error in store.rs

### DIFF
--- a/autumn-harvest/src/store.rs
+++ b/autumn-harvest/src/store.rs
@@ -665,7 +665,11 @@ fn summarize_error(error: Option<String>) -> Option<String> {
         return None;
     }
 
-    Some(first_line.chars().take(MAX_ERROR_SUMMARY_CHARS).collect())
+    let end_idx = first_line
+        .char_indices()
+        .nth(MAX_ERROR_SUMMARY_CHARS)
+        .map_or(first_line.len(), |(idx, _)| idx);
+    Some(first_line[..end_idx].to_string())
 }
 
 #[cfg(test)]


### PR DESCRIPTION
💡 What: Replaced the memory-allocating string truncation logic `Some(first_line.chars().take(MAX_ERROR_SUMMARY_CHARS).collect())` with direct byte-boundary string slicing `first_line[..end_idx].to_string()` utilizing `char_indices`.
🎯 Why: Iterating over chars and collecting into a new string causes unnecessary heap allocations. This function runs when recording an `ActivityFailed` or `WorkflowFailed` event into history.
📊 Impact: Removes an intermediate heap allocation when truncating error summaries.
🔬 Measurement: Run unit tests using `cargo test -p autumn-harvest` and look for compile/clippy regressions.

---
*PR created automatically by Jules for task [13894403960093177904](https://jules.google.com/task/13894403960093177904) started by @madmax983*