### PR TITLE
⚡ Bolt: [performance improvement] Avoid intermediate heap allocation in worker history extension

### DIFF
--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -5050,7 +5050,8 @@ async fn process_workflow_task(
                             .await;
                     }
                 };
-                history_events.extend(new_events.clone());
+                // Use `.iter().cloned()` to prevent an unnecessary intermediate heap allocation of the entire Vec
+                history_events.extend(new_events.iter().cloned());
                 let current_history_event_count =
                     u64::try_from(history_events.len()).unwrap_or(u64::MAX);
                 if let Some(cap) = registry.history_policy().event_hard_cap()


### PR DESCRIPTION
💡 What: Replaced `.extend(new_events.clone())` with `.extend(new_events.iter().cloned())` in `worker.rs`.
🎯 Why: The original code unnecessarily allocated an entire `Vec` on the heap when cloning `new_events` before iterating over it for the extension.
📊 Impact: Prevents an intermediate heap allocation when persisting external signal inline outcomes, saving memory and CPU cycles during history application.
🔬 Measurement: Run `cargo test -p autumn-harvest` and `cargo clippy` to verify behavior remains identical.

---
*PR created automatically by Jules for task [16364853145222784980](https://jules.google.com/task/16364853145222784980) started by @madmax983*