### PR TITLE
🌟 Nova: Status Visualization for DAG

### DIFF
--- a/autumn-harvest/src/dag_export.rs
+++ b/autumn-harvest/src/dag_export.rs
@@ -4,6 +4,7 @@
 //! and tool-compatible diagram formats such as Mermaid.js and Graphviz DOT.
 //! This is useful for debugging, documentation, and visualizing dependencies.
 use crate::dag::DagDefinition;
+use crate::policy::TaskStatus;
 use std::fmt::Write;
 
 /// Exports the DAG definition to a Mermaid.js flowchart.
@@ -42,6 +43,51 @@ pub fn export_mermaid(dag: &DagDefinition) -> Result<String, std::fmt::Error> {
     for (i, task) in tasks.iter().enumerate() {
         for &upstream in &task.upstreams {
             writeln!(out, "    t{upstream} --> t{i}")?;
+        }
+    }
+
+    Ok(out)
+}
+
+/// Exports the DAG definition to a Mermaid.js flowchart with status colors.
+///
+/// Nodes will be styled with CSS classes corresponding to their `TaskStatus`.
+///
+/// # Errors
+/// Returns `std::fmt::Error` if string formatting fails.
+pub fn export_mermaid_with_status(
+    dag: &DagDefinition,
+    statuses: &[TaskStatus],
+) -> Result<String, std::fmt::Error> {
+    let mut out = String::new();
+    writeln!(out, "graph TD")?;
+
+    let tasks = dag.tasks();
+
+    for (i, task) in tasks.iter().enumerate() {
+        writeln!(out, "    t{i}[\"{}\"]", task.activity_name)?;
+    }
+
+    for (i, task) in tasks.iter().enumerate() {
+        for &upstream in &task.upstreams {
+            writeln!(out, "    t{upstream} --> t{i}")?;
+        }
+    }
+
+    // Add class definitions
+    writeln!(out, "    classDef status_Succeeded fill:#d4edda,stroke:#28a745,color:#155724;")?;
+    writeln!(out, "    classDef status_Failed fill:#f8d7da,stroke:#dc3545,color:#721c24;")?;
+    writeln!(out, "    classDef status_Skipped fill:#e2e3e5,stroke:#6c757d,color:#383d41;")?;
+
+    // Assign classes to nodes
+    for (i, status) in statuses.iter().enumerate() {
+        if i < tasks.len() {
+            let status_str = match status {
+                TaskStatus::Succeeded => "Succeeded",
+                TaskStatus::Failed => "Failed",
+                TaskStatus::Skipped => "Skipped",
+            };
+            writeln!(out, "    class t{i} status_{status_str};")?;
         }
     }
 
@@ -153,5 +199,30 @@ digraph DAG {
 }
 ";
         assert_eq!(dot, expected_dot);
+    }
+
+    #[test]
+    fn test_export_mermaid_with_status() {
+        let mut builder = DagBuilder::new();
+        let a = builder.activity(dummy_activity);
+        let b = builder.activity(dummy_activity2).upstream(&a);
+        let _c = builder.activity(dummy_activity3).upstream(&b);
+        let dag = builder.build().unwrap();
+
+        let statuses = vec![
+            crate::policy::TaskStatus::Succeeded,
+            crate::policy::TaskStatus::Failed,
+            crate::policy::TaskStatus::Skipped,
+        ];
+
+        let mermaid = export_mermaid_with_status(&dag, &statuses).unwrap();
+
+        assert!(mermaid.contains("classDef status_Succeeded fill:#d4edda,stroke:#28a745,color:#155724;"));
+        assert!(mermaid.contains("classDef status_Failed fill:#f8d7da,stroke:#dc3545,color:#721c24;"));
+        assert!(mermaid.contains("classDef status_Skipped fill:#e2e3e5,stroke:#6c757d,color:#383d41;"));
+
+        assert!(mermaid.contains("class t0 status_Succeeded;"));
+        assert!(mermaid.contains("class t1 status_Failed;"));
+        assert!(mermaid.contains("class t2 status_Skipped;"));
     }
 }


### PR DESCRIPTION
💡 **The Spark:** "I noticed we can export a DAG to Mermaid and simulate it, but we lack a way to visualize the exact execution path and failures visually."
🚀 **The Feature:** "Implemented `export_mermaid_with_status`, taking a `DagDefinition` and a slice of `TaskStatus` to output a CSS-styled Mermaid chart."
🔮 **The Potential:** "Could be hooked into the UI or CLI to dynamically show workflow progress or trace failed nodes visually."
⚠️ **Risk:** "Low. Purely additive helper function in `dag_export.rs`, fully covered by a new test."

---
*PR created automatically by Jules for task [7336271014766471035](https://jules.google.com/task/7336271014766471035) started by @madmax983*