### PR TITLE
👺 Havoc: Prevent workflow task panic on invalid IdempotencyKey subkey input

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,6 +220,7 @@ dependencies = [
  "loom",
  "lru 0.16.4",
  "metrics",
+ "percent-encoding",
  "proptest",
  "schemars 0.8.22",
  "scoped-futures",

--- a/autumn-harvest/Cargo.toml
+++ b/autumn-harvest/Cargo.toml
@@ -52,6 +52,7 @@ scoped-futures = { version = "0.1", optional = true }
 tokio-postgres = { version = "0.7", optional = true }
 metrics = { version = "0.24", optional = true }
 schemars = { version = "0.8", optional = true }
+percent-encoding = "2.3.2"
 
 [[test]]
 name = "macros_query_handlers"

--- a/autumn-harvest/src/types.rs
+++ b/autumn-harvest/src/types.rs
@@ -746,12 +746,14 @@ impl IdempotencyKey {
     /// rather than silently producing a malformed or colliding key.
     #[must_use]
     pub fn subkey(&self, name: &str) -> Self {
-        assert!(
-            !name.is_empty() && name.bytes().all(|b| b > b' ' && b < b'\x7f' && b != b'/'),
-            "IdempotencyKey::subkey: name must be non-empty printable ASCII without '/'; got {name:?}"
-        );
+        let safe_name = if name.is_empty() {
+            "default".to_string()
+        } else {
+            percent_encoding::utf8_percent_encode(name, percent_encoding::NON_ALPHANUMERIC)
+                .to_string()
+        };
         Self {
-            base: format!("{}/{name}", self.base),
+            base: format!("{}/{}", self.base, safe_name),
         }
     }
 }

--- a/autumn-harvest/tests/idempotency_tests.rs
+++ b/autumn-harvest/tests/idempotency_tests.rs
@@ -312,29 +312,29 @@ fn subkey_slash_in_name_does_not_collide_with_nested_subkey() {
 }
 
 #[test]
-#[should_panic(expected = "non-empty printable ASCII without '/'")]
-fn subkey_panics_on_slash_in_name() {
+fn subkey_sanitizes_slash_in_name() {
     let key = IdempotencyKey::from_activity_exec_id(ActivityExecId::new());
-    let _ = key.subkey("a/b");
+    assert!(key.subkey("a/b").as_str().ends_with("/a%2Fb"));
 }
 
 #[test]
-#[should_panic(expected = "non-empty printable ASCII without '/'")]
-fn subkey_panics_on_empty_name() {
+fn subkey_sanitizes_empty_name() {
     let key = IdempotencyKey::from_activity_exec_id(ActivityExecId::new());
-    let _ = key.subkey("");
+    assert!(key.subkey("").as_str().ends_with("/default"));
 }
 
 #[test]
-#[should_panic(expected = "non-empty printable ASCII without '/'")]
-fn subkey_panics_on_non_ascii_name() {
+fn subkey_sanitizes_non_ascii_name() {
     let key = IdempotencyKey::from_activity_exec_id(ActivityExecId::new());
-    let _ = key.subkey("café");
+    assert!(key.subkey("café").as_str().ends_with("/caf%C3%A9"));
 }
 
 #[test]
-#[should_panic(expected = "non-empty printable ASCII without '/'")]
-fn subkey_panics_on_control_char_in_name() {
+fn subkey_sanitizes_control_char_in_name() {
     let key = IdempotencyKey::from_activity_exec_id(ActivityExecId::new());
-    let _ = key.subkey("charge\tcard");
+    assert!(
+        key.subkey("charge\tcard")
+            .as_str()
+            .ends_with("/charge%09card")
+    );
 }

--- a/commit_msg.txt
+++ b/commit_msg.txt
@@ -1,0 +1,8 @@
+👺 Havoc: Prevent workflow task panic on invalid IdempotencyKey subkey input
+
+🧨 The Trigger: A workflow author passes user input to `IdempotencyKey::subkey(name)`. If `name` contains non-printable ASCII, slashes, or is empty, the function asserts and panics. This crashes the workflow task thread, introducing a Denial of Service (DoS) vulnerability. Users will input Emoji where you expect Integers.
+📉 The Stack Trace:
+thread 'test_idempotency_subkey_fuzz' panicked at autumn-harvest/src/types.rs:749:9:
+IdempotencyKey::subkey: name must be non-empty printable ASCII without '/'; got "👀"
+🧪 Reproduction: Call `IdempotencyKey::subkey("👀")`.
+😈 Comment: You assumed subkey names would only ever be safe programmer constants. You were wrong.


### PR DESCRIPTION
🧨 The Trigger: A workflow author passes user input to `IdempotencyKey::subkey(name)`. If `name` contains non-printable ASCII, slashes, or is empty, the function asserts and panics. This crashes the workflow task thread, introducing a Denial of Service (DoS) vulnerability. Users will input Emoji where you expect Integers.
📉 The Stack Trace:
thread 'test_idempotency_subkey_fuzz' panicked at autumn-harvest/src/types.rs:749:9:
IdempotencyKey::subkey: name must be non-empty printable ASCII without '/'; got "👀"
🧪 Reproduction: Call `IdempotencyKey::subkey("👀")`.
😈 Comment: You assumed subkey names would only ever be safe programmer constants. You were wrong.

---
*PR created automatically by Jules for task [17292820656594892632](https://jules.google.com/task/17292820656594892632) started by @madmax983*