### PR TITLE
🔒 Warden: [Prevent DoS via unbounded Axum payload buffering]

### DIFF
--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -13,7 +13,6 @@ use autumn_web::session::Session;
 use axum::Extension;
 use axum::Json;
 use axum::Router;
-use axum::body::Bytes;
 use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::middleware::{self, Next};
@@ -4912,7 +4911,7 @@ async fn batch_start_workflows(
     Extension(api_state): Extension<HarvestApiState>,
     maybe_session: Option<Extension<Session>>,
     headers: axum::http::HeaderMap,
-    body_bytes: Bytes,
+    body: axum::body::Body,
 ) -> axum::response::Response {
     use axum::response::IntoResponse as _;
 
@@ -4925,18 +4924,19 @@ async fn batch_start_workflows(
 
     // ── Enforce byte-size cap ────────────────────────────────────────────────
     let max_bytes = api_state.batch_start_max_bytes();
-    let body_len = u64::try_from(body_bytes.len()).unwrap_or(u64::MAX);
-    if body_len > max_bytes {
+    #[allow(clippy::cast_possible_truncation)]
+    let limit = usize::try_from(max_bytes).unwrap_or(usize::MAX);
+    let Ok(body_bytes) = axum::body::to_bytes(body, limit).await else {
         return (
             StatusCode::PAYLOAD_TOO_LARGE,
             Json(serde_json::json!({
                 "error": format!(
-                    "request body ({body_len} bytes) exceeds max_total_bytes ({max_bytes} bytes)"
+                    "request body exceeds max_total_bytes ({max_bytes} bytes)"
                 )
             })),
         )
             .into_response();
-    }
+    };
 
     // ── Parse request ────────────────────────────────────────────────────────
     let request: BatchStartRequest = match serde_json::from_slice(&body_bytes) {
@@ -6637,15 +6637,24 @@ struct QueryWorkflowResponse {
 async fn query_workflow_post(
     Extension(api_state): Extension<HarvestApiState>,
     Path((id, query_name)): Path<(String, String)>,
-    body: Bytes,
+    body: axum::body::Body,
 ) -> Result<Json<QueryWorkflowResponse>, AutumnError> {
+    // Cap the payload size to prevent buffering unbounded memory before doing any work
+    let limit = 2 * 1024 * 1024; // 2MB default generic limit
+    let Ok(body_bytes) = axum::body::to_bytes(body, limit).await else {
+        return Err(AutumnError::bad_request_msg(
+            "invalid body or payload too large".to_string(),
+        ));
+    };
+
     let exec_id = parse_execution_id(&id)?;
     let ctx = hydrate_ctx_for_query(&api_state, exec_id).await?;
     let start = Instant::now(); // measure handler invocation latency, not hydration cost
-    let args: Value = if body.is_empty() {
+
+    let args: Value = if body_bytes.is_empty() {
         Value::Null
     } else {
-        serde_json::from_slice::<QueryWorkflowRequest>(&body)
+        serde_json::from_slice::<QueryWorkflowRequest>(&body_bytes)
             .map(|r| r.args)
             .map_err(|e| AutumnError::bad_request_msg(format!("invalid JSON body: {e}")))?
     };
@@ -10049,14 +10058,20 @@ fn url_encode_for_redirect(input: &str) -> String {
     out
 }
 
+#[allow(clippy::too_many_lines)]
 async fn bulk_replay_dead_letters_handler(
     Extension(api_state): Extension<HarvestApiState>,
     headers: axum::http::HeaderMap,
-    body: axum::body::Bytes,
+    body: axum::body::Body,
 ) -> axum::response::Response {
     use axum::response::IntoResponse as _;
 
-    let request = match parse_bulk_dlq_request(&headers, &body) {
+    let limit = 2 * 1024 * 1024; // 2MB
+    let Ok(body_bytes) = axum::body::to_bytes(body, limit).await else {
+        return AutumnError::bad_request_msg("payload too large").into_response();
+    };
+
+    let request = match parse_bulk_dlq_request(&headers, &body_bytes) {
         Ok(request) => request,
         Err(error) => return error.into_response(),
     };
@@ -10157,14 +10172,20 @@ async fn bulk_replay_dead_letters_handler(
     }
 }
 
+#[allow(clippy::too_many_lines)]
 async fn bulk_discard_dead_letters_handler(
     Extension(api_state): Extension<HarvestApiState>,
     headers: axum::http::HeaderMap,
-    body: axum::body::Bytes,
+    body: axum::body::Body,
 ) -> axum::response::Response {
     use axum::response::IntoResponse as _;
 
-    let request = match parse_bulk_dlq_request(&headers, &body) {
+    let limit = 2 * 1024 * 1024; // 2MB
+    let Ok(body_bytes) = axum::body::to_bytes(body, limit).await else {
+        return AutumnError::bad_request_msg("payload too large").into_response();
+    };
+
+    let request = match parse_bulk_dlq_request(&headers, &body_bytes) {
         Ok(request) => request,
         Err(error) => return error.into_response(),
     };

--- a/autumn-harvest-plugin/tests/security.rs
+++ b/autumn-harvest-plugin/tests/security.rs
@@ -762,3 +762,116 @@ async fn eris_require_auth_blocks_trigger_schedule() {
         .unwrap();
     assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
 }
+
+// ── Payload limit DoS tests ────────────────────────────────────────────────
+
+#[tokio::test]
+async fn warden_batch_start_workflows_enforces_payload_limit() {
+    let api_state = HarvestApiState::new();
+    let limit = api_state.batch_start_max_bytes();
+    let app = app_with_api_state(api_state);
+
+    let large_body = vec![b'a'; usize::try_from(limit).unwrap_or(usize::MAX - 20) + 10];
+    let mut request = Request::builder()
+        .method(Method::POST)
+        .uri("/workflows/batch_start")
+        .header("Content-Type", "application/json")
+        .body(Body::from(large_body))
+        .unwrap();
+    let mut data = HashMap::new();
+    data.insert("user_id".to_string(), "operator-1".to_string());
+    request.extensions_mut().insert(Session::new_for_test(
+        "harvest-test-session".to_string(),
+        data,
+    ));
+
+    let res = app.oneshot(request).await.unwrap();
+    assert_eq!(res.status(), StatusCode::PAYLOAD_TOO_LARGE);
+}
+
+#[tokio::test]
+async fn warden_query_workflow_post_enforces_payload_limit() {
+    let app = unauthenticated_app();
+
+    let large_body = vec![b'a'; 2 * 1024 * 1024 + 10]; // Over 2MB
+    let mut request = Request::builder()
+        .method(Method::POST)
+        .uri("/workflows/00000000-0000-0000-0000-000000000001/query/my_query")
+        .header("Content-Type", "application/json")
+        .body(Body::from(large_body))
+        .unwrap();
+    let mut data = HashMap::new();
+    data.insert("user_id".to_string(), "operator-1".to_string());
+    request.extensions_mut().insert(Session::new_for_test(
+        "harvest-test-session".to_string(),
+        data,
+    ));
+
+    let res = app.oneshot(request).await.unwrap();
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+
+    let bytes = autumn_web::reexports::axum::body::to_bytes(res.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let body_str = String::from_utf8_lossy(&bytes);
+
+    assert!(body_str.contains("payload too large"));
+}
+
+#[tokio::test]
+async fn warden_bulk_replay_dead_letters_enforces_payload_limit() {
+    let app = authenticated_app();
+
+    let large_body = vec![b'a'; 2 * 1024 * 1024 + 10]; // Over 2MB
+    let mut request = Request::builder()
+        .method(Method::POST)
+        .uri("/dead-letters/replay")
+        .header("Content-Type", "application/json")
+        .body(Body::from(large_body))
+        .unwrap();
+    let mut data = HashMap::new();
+    data.insert("user_id".to_string(), "operator-1".to_string());
+    request.extensions_mut().insert(Session::new_for_test(
+        "harvest-test-session".to_string(),
+        data,
+    ));
+
+    let res = app.oneshot(request).await.unwrap();
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+
+    let bytes = autumn_web::reexports::axum::body::to_bytes(res.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let body_str = String::from_utf8_lossy(&bytes);
+
+    assert!(body_str.contains("payload too large"));
+}
+
+#[tokio::test]
+async fn warden_bulk_discard_dead_letters_enforces_payload_limit() {
+    let app = authenticated_app();
+
+    let large_body = vec![b'a'; 2 * 1024 * 1024 + 10]; // Over 2MB
+    let mut request = Request::builder()
+        .method(Method::POST)
+        .uri("/dead-letters/discard")
+        .header("Content-Type", "application/json")
+        .body(Body::from(large_body))
+        .unwrap();
+    let mut data = HashMap::new();
+    data.insert("user_id".to_string(), "operator-1".to_string());
+    request.extensions_mut().insert(Session::new_for_test(
+        "harvest-test-session".to_string(),
+        data,
+    ));
+
+    let res = app.oneshot(request).await.unwrap();
+    assert_eq!(res.status(), StatusCode::BAD_REQUEST);
+
+    let bytes = autumn_web::reexports::axum::body::to_bytes(res.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let body_str = String::from_utf8_lossy(&bytes);
+
+    assert!(body_str.contains("payload too large"));
+}


### PR DESCRIPTION
🦠 Threat: `axum::body::Bytes` buffers the entire request payload into memory unconditionally. An attacker can submit massive payloads to endpoints using `Bytes` (like `/workflows/batch_start`, `/workflows/{id}/query/{query_name}`, and bulk dead-letter operations), leading to OOM (Out Of Memory) DoS vulnerabilities.
🛡️ Defense: Replaced `axum::body::Bytes` with `axum::body::Body` and used `axum::body::to_bytes(body, limit)` to cap memory extraction. The batch endpoint relies on its configured `api_state.batch_start_max_bytes()`, while the others are capped generically at 2MB.
💥 Severity: High - memory exhaustion crashes the instance.
🧪 Verification: Added specific DoS tests in `autumn-harvest-plugin/tests/security.rs`.

---
*PR created automatically by Jules for task [16146367498275668866](https://jules.google.com/task/16146367498275668866) started by @madmax983*