### PR TITLE
Add replay-safe WorkflowLogger and HVG009 guardrail (issue #379)

### DIFF
--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -3293,8 +3293,8 @@ impl WorkflowContext {
 
         // Wrap the fn pointer in a BoxUpdateHandler that creates a handler-mode
         // WorkflowContext on each invocation. Inherit exec_id, start_time,
-        // cancellation_reason, and workflow_id from the parent so handlers see
-        // consistent values and logger correlation keys.
+        // cancellation_reason, workflow_id, and workflow_name from the parent
+        // so handlers see consistent values and all logger correlation keys.
         let handler_fn = info.handler;
         let exec_id = self.exec_id;
         let start_time = self.start_time;
@@ -3302,6 +3302,7 @@ impl WorkflowContext {
         let state = std::sync::Arc::clone(&self.state);
         let name = info.name;
         let workflow_id = self.workflow_id.clone();
+        let workflow_name = self.workflow_name.clone();
 
         let boxed_handler: crate::update::BoxUpdateHandler = std::sync::Arc::new(move |input| {
             let mut ctx = Self::new_for_handler(
@@ -3310,12 +3311,13 @@ impl WorkflowContext {
                 cancellation_reason.clone(),
                 std::sync::Arc::clone(&state),
             );
-            // Propagate workflow_id for logger correlation. Arc was just created;
+            // Propagate correlation fields for logger. Arc was just created;
             // no other reference exists yet so get_mut always succeeds.
-            std::sync::Arc::get_mut(&mut ctx)
-                .unwrap()
-                .workflow_id
-                .clone_from(&workflow_id);
+            {
+                let inner = std::sync::Arc::get_mut(&mut ctx).unwrap();
+                inner.workflow_id.clone_from(&workflow_id);
+                inner.workflow_name.clone_from(&workflow_name);
+            }
             handler_fn(ctx, input)
         });
 
@@ -3372,10 +3374,11 @@ impl WorkflowContext {
                 self.cancellation_reason.clone(),
                 std::sync::Arc::clone(&self.state),
             );
-            std::sync::Arc::get_mut(&mut ctx)
-                .unwrap()
-                .workflow_id
-                .clone_from(&self.workflow_id);
+            {
+                let inner = std::sync::Arc::get_mut(&mut ctx).unwrap();
+                inner.workflow_id.clone_from(&self.workflow_id);
+                inner.workflow_name.clone_from(&self.workflow_name);
+            }
             h(ctx, input)
         })
     }

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -563,6 +563,70 @@ fn validate_search_attr_value(value: &Value) -> HarvestResult<()> {
 }
 
 // ---------------------------------------------------------------------------
+// WorkflowLogger  (issue #379)
+// ---------------------------------------------------------------------------
+
+/// Replay-aware logger scoped to a single workflow execution.
+///
+/// Obtained via [`WorkflowContext::logger`]. Suppresses all `tracing` events
+/// while the executor is replaying recorded history (`is_replaying() == true`),
+/// so that each `log_*` call fires at most once per execution regardless of
+/// how many replay cycles occur.
+///
+/// Every emitted event carries the following structured fields:
+/// - `workflow_id` — the business-level workflow identifier
+/// - `execution_id` — the unique run UUID
+/// - `workflow_type` — the registered workflow function name
+/// - `replay = false` — confirms the event was not emitted during replay
+pub struct WorkflowLogger<'ctx> {
+    ctx: &'ctx WorkflowContext,
+}
+
+impl WorkflowLogger<'_> {
+    /// Emit an INFO-level event. No-op when `ctx.is_replaying()` is `true`.
+    pub fn info(&self, message: &str) {
+        if !self.ctx.is_replaying() {
+            tracing::info!(
+                target: "autumn_harvest::context",
+                workflow_id = self.ctx.workflow_id(),
+                execution_id = %self.ctx.execution_id(),
+                workflow_type = self.ctx.workflow_type(),
+                replay = false,
+                "{message}"
+            );
+        }
+    }
+
+    /// Emit a WARN-level event. No-op when `ctx.is_replaying()` is `true`.
+    pub fn warn(&self, message: &str) {
+        if !self.ctx.is_replaying() {
+            tracing::warn!(
+                target: "autumn_harvest::context",
+                workflow_id = self.ctx.workflow_id(),
+                execution_id = %self.ctx.execution_id(),
+                workflow_type = self.ctx.workflow_type(),
+                replay = false,
+                "{message}"
+            );
+        }
+    }
+
+    /// Emit an ERROR-level event. No-op when `ctx.is_replaying()` is `true`.
+    pub fn error(&self, message: &str) {
+        if !self.ctx.is_replaying() {
+            tracing::error!(
+                target: "autumn_harvest::context",
+                workflow_id = self.ctx.workflow_id(),
+                execution_id = %self.ctx.execution_id(),
+                workflow_type = self.ctx.workflow_type(),
+                replay = false,
+                "{message}"
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // WorkflowContext
 // ---------------------------------------------------------------------------
 
@@ -619,6 +683,10 @@ pub struct WorkflowContext {
     /// Logical workflow type name for use in `PayloadTooLarge` errors.
     /// Empty string when not known (legacy contexts, update handlers).
     workflow_name: String,
+    /// Business-level workflow identifier (e.g. "subscription-123").
+    /// Empty when not known (legacy contexts, testing, update handlers).
+    /// Set by the worker via `with_workflow_id` before executing the handler.
+    workflow_id: String,
     /// Global cap on activity input payloads (bytes). Checked at schedule time.
     payload_max_activity_input: u64,
     /// Global cap on workflow/child-workflow input payloads (bytes).
@@ -737,6 +805,7 @@ impl WorkflowContext {
             cancellation_reason,
             strict_replay: false,
             workflow_name: String::new(),
+            workflow_id: String::new(),
             payload_max_activity_input: DEFAULT_MAX_ACTIVITY_INPUT_BYTES,
             payload_max_workflow_input: DEFAULT_MAX_WORKFLOW_INPUT_BYTES,
             payload_max_side_effect: DEFAULT_MAX_WORKFLOW_INPUT_BYTES,
@@ -818,6 +887,7 @@ impl WorkflowContext {
             cancellation_reason,
             strict_replay: false,
             workflow_name: String::new(),
+            workflow_id: String::new(),
             payload_max_activity_input: DEFAULT_MAX_ACTIVITY_INPUT_BYTES,
             payload_max_workflow_input: DEFAULT_MAX_WORKFLOW_INPUT_BYTES,
             payload_max_side_effect: DEFAULT_MAX_WORKFLOW_INPUT_BYTES,
@@ -849,6 +919,7 @@ impl WorkflowContext {
             cancellation_reason: None,
             strict_replay: false,
             workflow_name: String::new(),
+            workflow_id: String::new(),
             payload_max_activity_input: DEFAULT_MAX_ACTIVITY_INPUT_BYTES,
             payload_max_workflow_input: DEFAULT_MAX_WORKFLOW_INPUT_BYTES,
             payload_max_side_effect: DEFAULT_MAX_WORKFLOW_INPUT_BYTES,
@@ -902,6 +973,17 @@ impl WorkflowContext {
         self
     }
 
+    /// Set the business-level workflow identifier (e.g. `"subscription-123"`).
+    ///
+    /// Called by the worker so that [`WorkflowLogger`] events can carry the
+    /// correlation key that operators use to search Loki / Elastic for a
+    /// specific workflow run.
+    #[must_use]
+    pub fn with_workflow_id(mut self, id: impl Into<String>) -> Self {
+        self.workflow_id = id.into();
+        self
+    }
+
     // ── Accessors ─────────────────────────────────────────────────────
 
     /// Deterministic "wall clock" -- returns the `WorkflowStarted` timestamp
@@ -915,6 +997,23 @@ impl WorkflowContext {
     #[must_use]
     pub const fn execution_id(&self) -> ExecutionId {
         self.exec_id
+    }
+
+    /// The business-level workflow identifier set at workflow start.
+    ///
+    /// Returns an empty string when the context was created without an explicit
+    /// workflow ID (e.g. in unit tests via [`Self::new_test`]).
+    #[must_use]
+    pub fn workflow_id(&self) -> &str {
+        &self.workflow_id
+    }
+
+    /// The logical workflow type name (the function name decorated with `#[workflow]`).
+    ///
+    /// Returns an empty string when not explicitly set (update handler contexts).
+    #[must_use]
+    pub fn workflow_type(&self) -> &str {
+        &self.workflow_name
     }
 
     /// Number of events currently loaded in this workflow execution history.
@@ -963,6 +1062,54 @@ impl WorkflowContext {
             .lock()
             .expect("matcher lock poisoned")
             .has_buffered_history()
+    }
+
+    // ── Replay-safe logging (issue #379) ──────────────────────────────
+
+    /// Return a replay-aware logger scoped to this workflow execution.
+    ///
+    /// The logger suppresses all output when [`Self::is_replaying`] is `true`
+    /// so that each log statement fires at most once per workflow execution,
+    /// regardless of how many replay cycles the executor performs.
+    ///
+    /// Every event emitted carries `workflow_id`, `execution_id`,
+    /// `workflow_type`, and `replay = false` as structured fields, enabling
+    /// log correlation in Loki / Elastic / OpenTelemetry backends.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use autumn_harvest::context::WorkflowContext;
+    /// # fn example(ctx: &WorkflowContext) {
+    /// ctx.logger().info("payment started");
+    /// ctx.logger().warn("retrying payment");
+    /// ctx.logger().error("payment failed");
+    /// # }
+    /// ```
+    #[must_use]
+    pub const fn logger(&self) -> WorkflowLogger<'_> {
+        WorkflowLogger { ctx: self }
+    }
+
+    /// Emit an INFO-level log event, suppressed during replay.
+    ///
+    /// Equivalent to `ctx.logger().info(message)`.
+    pub fn log_info(&self, message: &str) {
+        self.logger().info(message);
+    }
+
+    /// Emit a WARN-level log event, suppressed during replay.
+    ///
+    /// Equivalent to `ctx.logger().warn(message)`.
+    pub fn log_warn(&self, message: &str) {
+        self.logger().warn(message);
+    }
+
+    /// Emit an ERROR-level log event, suppressed during replay.
+    ///
+    /// Equivalent to `ctx.logger().error(message)`.
+    pub fn log_error(&self, message: &str) {
+        self.logger().error(message);
     }
 
     /// Access typed shared state (e.g., email clients, config) injected via the builder.

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -3292,22 +3292,27 @@ impl WorkflowContext {
             .or_insert(info.handler);
 
         // Wrap the fn pointer in a BoxUpdateHandler that creates a handler-mode
-        // WorkflowContext on each invocation. Inherit exec_id, start_time, and
-        // cancellation_reason from the parent so handlers see consistent values.
+        // WorkflowContext on each invocation. Inherit exec_id, start_time,
+        // cancellation_reason, and workflow_id from the parent so handlers see
+        // consistent values and logger correlation keys.
         let handler_fn = info.handler;
         let exec_id = self.exec_id;
         let start_time = self.start_time;
         let cancellation_reason = self.cancellation_reason.clone();
         let state = std::sync::Arc::clone(&self.state);
         let name = info.name;
+        let workflow_id = self.workflow_id.clone();
 
         let boxed_handler: crate::update::BoxUpdateHandler = std::sync::Arc::new(move |input| {
-            let ctx = Self::new_for_handler(
+            let mut ctx = Self::new_for_handler(
                 exec_id,
                 start_time,
                 cancellation_reason.clone(),
                 std::sync::Arc::clone(&state),
             );
+            // Propagate workflow_id for logger correlation. Arc was just created;
+            // no other reference exists yet so get_mut always succeeds.
+            std::sync::Arc::get_mut(&mut ctx).unwrap().workflow_id.clone_from(&workflow_id);
             handler_fn(ctx, input)
         });
 
@@ -3358,12 +3363,13 @@ impl WorkflowContext {
             .get(name)
             .copied();
         handler.map(|h| {
-            let ctx = Self::new_for_handler(
+            let mut ctx = Self::new_for_handler(
                 self.exec_id,
                 self.start_time,
                 self.cancellation_reason.clone(),
                 std::sync::Arc::clone(&self.state),
             );
+            std::sync::Arc::get_mut(&mut ctx).unwrap().workflow_id.clone_from(&self.workflow_id);
             h(ctx, input)
         })
     }

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -3312,7 +3312,10 @@ impl WorkflowContext {
             );
             // Propagate workflow_id for logger correlation. Arc was just created;
             // no other reference exists yet so get_mut always succeeds.
-            std::sync::Arc::get_mut(&mut ctx).unwrap().workflow_id.clone_from(&workflow_id);
+            std::sync::Arc::get_mut(&mut ctx)
+                .unwrap()
+                .workflow_id
+                .clone_from(&workflow_id);
             handler_fn(ctx, input)
         });
 
@@ -3369,7 +3372,10 @@ impl WorkflowContext {
                 self.cancellation_reason.clone(),
                 std::sync::Arc::clone(&self.state),
             );
-            std::sync::Arc::get_mut(&mut ctx).unwrap().workflow_id.clone_from(&self.workflow_id);
+            std::sync::Arc::get_mut(&mut ctx)
+                .unwrap()
+                .workflow_id
+                .clone_from(&self.workflow_id);
             h(ctx, input)
         })
     }

--- a/autumn-harvest/src/det_check.rs
+++ b/autumn-harvest/src/det_check.rs
@@ -14,7 +14,8 @@
 //! | DET005 | Warning  | Process-global state reads                     |
 //! | DET006 | Error    | Direct sleep / timer primitives                |
 //! | DET007 | Error    | Background task spawning                       |
-//! | DET008 | Error    | Direct network / filesystem I/O               |
+//! | DET008 | Error    | Direct network / filesystem I/O                |
+//! | DET009 | Warning  | Bare tracing calls (log amplification)         |
 //!
 //! # Suppression
 //!
@@ -246,6 +247,27 @@ const RULES: &[Rule] = &[
         alternative: "Move all I/O into activities. Activities are the durable side-effect boundary \
                       in Harvest; their results are recorded in the event history and replayed \
                       without re-executing the I/O.",
+    },
+    Rule {
+        id: "DET009",
+        severity: DetSeverity::Warning,
+        patterns: &[
+            "tracing::info!(",
+            "tracing::warn!(",
+            "tracing::error!(",
+            "tracing::debug!(",
+            "tracing::trace!(",
+            "tracing::event!(",
+        ],
+        message: "Bare tracing macro inside a workflow function fires once per replay cycle. \
+                  A workflow that suspends N times will emit N copies of this log line, \
+                  amplifying log volume and producing duplicate events without correlation keys.",
+        alternative: "Use `ctx.logger().info(msg)`, `ctx.logger().warn(msg)`, \
+                      `ctx.logger().error(msg)`, or the convenience shorthands \
+                      `ctx.log_info(msg)` / `ctx.log_warn(msg)` / `ctx.log_error(msg)`. \
+                      These are replay-aware: output is suppressed during replay cycles and \
+                      each event is auto-tagged with workflow_id, execution_id, and workflow_type. \
+                      See guardrail HVG009 in the catalog for the full rationale.",
     },
 ];
 

--- a/autumn-harvest/src/det_check.rs
+++ b/autumn-harvest/src/det_check.rs
@@ -252,12 +252,19 @@ const RULES: &[Rule] = &[
         id: "DET009",
         severity: DetSeverity::Warning,
         patterns: &[
+            // Fully-qualified spellings
             "tracing::info!(",
             "tracing::warn!(",
             "tracing::error!(",
             "tracing::debug!(",
             "tracing::trace!(",
             "tracing::event!(",
+            // Imported spellings — `use tracing::{info, warn, …}` then bare call
+            "info!(",
+            "warn!(",
+            "error!(",
+            "debug!(",
+            "trace!(",
         ],
         message: "Bare tracing macro inside a workflow function fires once per replay cycle. \
                   A workflow that suspends N times will emit N copies of this log line, \

--- a/autumn-harvest/src/executor.rs
+++ b/autumn-harvest/src/executor.rs
@@ -61,6 +61,9 @@ const SUSPENSION_TIMEOUT: Duration = Duration::from_millis(100);
 pub struct WorkflowExecuteSpanMeta {
     /// Logical workflow name (recorded as `harvest.workflow.id`).
     pub workflow_name: String,
+    /// Business-level workflow identifier (e.g. `"subscription-123"`).
+    /// Forwarded to [`WorkflowContext`] so [`WorkflowLogger`] can tag events.
+    pub workflow_id: String,
     /// Shard identifier (recorded as `harvest.shard.id`).
     pub shard_id: i64,
     /// Task queue name (recorded as `harvest.queue`).
@@ -258,6 +261,7 @@ pub async fn run_workflow_with_state_history_policy_and_caps(
         history_policy,
     )
     .with_workflow_name(workflow_name)
+    .with_workflow_id(span_meta.map_or("", |m| m.workflow_id.as_str()))
     .with_payload_caps(
         max_activity_input_bytes,
         0,

--- a/autumn-harvest/src/guardrail.rs
+++ b/autumn-harvest/src/guardrail.rs
@@ -22,6 +22,7 @@
 //! | HVG006 | DirectIo      | HardBlocker  | Direct network / DB / filesystem I/O |
 //! | HVG007 | ProcessGlobal | HardBlocker  | Process-global state mutation        |
 //! | HVG008 | NonDeterministicPredicate| HardBlocker | Non-deterministic predicate closures|
+//! | HVG009 | UnsafeLogging | Warning      | Bare tracing calls amplified by replay |
 
 /// Severity of a guardrail rule violation.
 #[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
@@ -51,6 +52,9 @@ pub enum RuleCategory {
     ProcessGlobal,
     /// Non-deterministic predicate evaluated inside `await_condition` closures.
     NonDeterministicPredicate,
+    /// Bare `tracing::{info,warn,error}!` calls inside a `#[workflow]` body that
+    /// fire on every replay cycle, amplifying log volume.
+    UnsafeLogging,
 }
 
 /// A single entry in the guardrail rule catalog.
@@ -181,6 +185,22 @@ static CATALOG: &[RuleEntry] = &[
         alternative: "Use durable timers (ctx.timer()) for time-based pauses, and ensure the \
             predicate closure relies purely on local variables mutated by deterministic signals or \
             activities.",
+    },
+    RuleEntry {
+        id: "HVG009",
+        severity: Severity::Warning,
+        category: RuleCategory::UnsafeLogging,
+        explanation: "Calling tracing::info!(), tracing::warn!(), tracing::error!(), or any other \
+            bare tracing macro directly inside a #[workflow] body emits one log event per replay \
+            cycle. Because the workflow executor re-runs the function from the top on every \
+            suspension/resume, a single log statement fires N times for a workflow that suspends \
+            N times. This amplifies log volume in proportion to replay depth and fills Loki/Elastic \
+            with duplicate lines that lack correlation keys, making incident triage harder.",
+        alternative: "Use ctx.logger().info(message), ctx.logger().warn(message), \
+            ctx.logger().error(message), or the convenience wrappers ctx.log_info(message), \
+            ctx.log_warn(message), ctx.log_error(message). These are suppressed automatically \
+            during replay (is_replaying() == true) and auto-tag every event with workflow_id, \
+            execution_id, workflow_type, and replay = false for log correlation.",
     },
 ];
 

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -5013,6 +5013,7 @@ async fn process_workflow_task(
 
         let span_meta = WorkflowExecuteSpanMeta {
             workflow_name: prepared.execution.workflow_name.clone(),
+            workflow_id: prepared.execution.workflow_id.clone(),
             shard_id: i64::from(prepared.execution.shard_id),
             queue_name: task.queue_name.clone(),
             is_replay,

--- a/autumn-harvest/tests/workflow_logger_tests.rs
+++ b/autumn-harvest/tests/workflow_logger_tests.rs
@@ -1,8 +1,8 @@
 /// Tests for issue #379: replay-safe workflow logger.
 ///
 /// Red phase: these tests define the expected behaviour before implementation.
-/// They fail until WorkflowLogger, ctx.logger(), ctx.log_info/warn/error(),
-/// and guardrail rule HVG009 are in place.
+/// They fail until `WorkflowLogger`, `ctx.logger()`, `ctx.log_info`, `ctx.log_warn`,
+/// `ctx.log_error`, and guardrail rule HVG009 are in place.
 use std::future::Future;
 use std::pin::Pin;
 use std::sync::{Arc, Mutex};
@@ -22,27 +22,18 @@ use tracing_subscriber::layer::SubscriberExt;
 /// A visitor that extracts string values from tracing event fields.
 struct FieldCapture {
     pub fields: std::collections::HashMap<String, String>,
-    pub message: String,
 }
 
 impl tracing::field::Visit for FieldCapture {
     fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
-        if field.name() == "message" {
-            self.message = value.to_string();
-        } else {
-            self.fields
-                .insert(field.name().to_string(), value.to_string());
-        }
+        self.fields
+            .insert(field.name().to_string(), value.to_string());
     }
 
     fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
         let s = format!("{value:?}");
-        let clean = s.trim_matches('"').to_string();
-        if field.name() == "message" {
-            self.message = clean;
-        } else {
-            self.fields.insert(field.name().to_string(), clean);
-        }
+        self.fields
+            .insert(field.name().to_string(), s.trim_matches('"').to_string());
     }
 
     fn record_bool(&mut self, field: &tracing::field::Field, value: bool) {
@@ -55,9 +46,7 @@ impl tracing::field::Visit for FieldCapture {
 #[derive(Debug)]
 struct CapturedEvent {
     pub level: String,
-    pub target: String,
     pub fields: std::collections::HashMap<String, String>,
-    pub message: String,
 }
 
 /// A `tracing_subscriber::Layer` that records events from the workflow logger.
@@ -78,14 +67,11 @@ impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for CapturingLayer {
         }
         let mut visitor = FieldCapture {
             fields: std::collections::HashMap::new(),
-            message: String::new(),
         };
         event.record(&mut visitor);
         self.captured.lock().unwrap().push(CapturedEvent {
             level: meta.level().to_string(),
-            target: meta.target().to_string(),
             fields: visitor.fields,
-            message: visitor.message,
         });
     }
 }
@@ -119,7 +105,7 @@ fn logging_workflow_via_logger<'a>(
     })
 }
 
-/// Workflow that calls `ctx.log_info/warn/error` convenience methods once, then suspends.
+/// Workflow that calls `ctx.log_info`, `ctx.log_warn`, `ctx.log_error` convenience methods once, then suspends.
 fn logging_workflow_direct<'a>(
     ctx: &'a WorkflowContext,
     _input: Value,
@@ -159,7 +145,7 @@ fn multi_suspend_logging_workflow<'a>(
     })
 }
 
-/// Build a fully-completed history for multi_suspend_logging_workflow.
+/// Build a fully-completed history for `multi_suspend_logging_workflow`.
 fn make_full_history() -> Vec<WorkflowEvent> {
     let act1 = ActivityExecId::new();
     let act2 = ActivityExecId::new();
@@ -256,12 +242,10 @@ async fn logger_emits_event_in_live_mode() {
         "expected suspension, got {outcome:?}"
     );
 
-    let events = captured.lock().unwrap();
+    let event_count = captured.lock().unwrap().len();
     assert_eq!(
-        events.len(),
-        1,
-        "expected exactly 1 log event in live mode, got {}",
-        events.len()
+        event_count, 1,
+        "expected exactly 1 log event in live mode, got {event_count}"
     );
 }
 
@@ -293,12 +277,10 @@ async fn logger_suppresses_events_during_full_replay() {
         "expected completion, got {outcome:?}"
     );
 
-    let events = captured.lock().unwrap();
+    let event_count = captured.lock().unwrap().len();
     assert_eq!(
-        events.len(),
-        0,
-        "expected 0 log events during full replay, got {}",
-        events.len()
+        event_count, 0,
+        "expected 0 log events during full replay, got {event_count}"
     );
 }
 
@@ -330,12 +312,10 @@ async fn direct_log_methods_suppressed_during_replay() {
         "expected completion, got {outcome:?}"
     );
 
-    let events = captured.lock().unwrap();
+    let event_count = captured.lock().unwrap().len();
     assert_eq!(
-        events.len(),
-        0,
-        "expected 0 log events during full replay, got {}",
-        events.len()
+        event_count, 0,
+        "expected 0 log events during full replay, got {event_count}"
     );
 }
 
@@ -354,13 +334,11 @@ async fn direct_log_methods_emit_in_live_mode() {
         "expected suspension, got {outcome:?}"
     );
 
-    let events = captured.lock().unwrap();
     // log_info + log_warn + log_error = 3 events
+    let event_count = captured.lock().unwrap().len();
     assert_eq!(
-        events.len(),
-        3,
-        "expected 3 log events (info + warn + error) in live mode, got {}",
-        events.len()
+        event_count, 3,
+        "expected 3 log events (info + warn + error) in live mode, got {event_count}"
     );
 }
 
@@ -373,8 +351,8 @@ async fn log_events_independent_of_replay_cycle_count() {
     let exec_id = ExecutionId::new();
 
     // ── First pass: live execution (only WorkflowStarted → suspension) ──
-    let (captured, _guard) = install_capture();
-    {
+    let first_pass_count = {
+        let (captured, _guard) = install_capture();
         let history = vec![WorkflowEvent::WorkflowStarted {
             input: Value::Null,
             timestamp: Utc::now(),
@@ -387,17 +365,17 @@ async fn log_events_independent_of_replay_cycle_count() {
         )
         .await;
         assert!(matches!(outcome, WorkflowOutcome::Suspended { .. }));
-    }
-    let first_pass_count = captured.lock().unwrap().len();
+        captured.lock().unwrap().len()
+        // _guard drops here, uninstalling the first subscriber
+    };
     assert_eq!(
         first_pass_count, 1,
         "live pass must emit exactly 1 log event"
     );
-    drop(_guard);
 
     // ── Replay pass: full history with all 3 activities already completed ──
-    let (captured2, _guard2) = install_capture();
-    {
+    let replay_count = {
+        let (captured2, _guard2) = install_capture();
         let history = make_full_history();
         let outcome = run_workflow(
             exec_id,
@@ -410,8 +388,9 @@ async fn log_events_independent_of_replay_cycle_count() {
             matches!(outcome, WorkflowOutcome::Completed { .. }),
             "expected completion on full history replay"
         );
-    }
-    let replay_count = captured2.lock().unwrap().len();
+        captured2.lock().unwrap().len()
+        // _guard2 drops here
+    };
     assert_eq!(
         replay_count, 0,
         "replay pass must emit 0 log events, got {replay_count}"
@@ -434,12 +413,18 @@ fn logger_emits_execution_id_field() {
     let (captured, _guard) = install_capture();
     ctx.logger().info("test message");
 
-    let events = captured.lock().unwrap();
-    let event = events.first().expect("expected one log event");
+    let (has_exec_id, keys_str) = captured
+        .lock()
+        .unwrap()
+        .first()
+        .map(|e| {
+            let keys: Vec<_> = e.fields.keys().collect();
+            (e.fields.contains_key("execution_id"), format!("{keys:?}"))
+        })
+        .expect("expected one log event");
     assert!(
-        event.fields.contains_key("execution_id"),
-        "expected execution_id field, got fields: {:?}",
-        event.fields.keys().collect::<Vec<_>>()
+        has_exec_id,
+        "expected execution_id field, got fields: {keys_str}"
     );
 }
 
@@ -458,13 +443,21 @@ fn logger_emits_workflow_type_field() {
     let (captured, _guard) = install_capture();
     ctx.logger().info("field test");
 
-    let events = captured.lock().unwrap();
-    let event = events.first().expect("expected one log event");
+    let (wf_type, fields_str) = captured
+        .lock()
+        .unwrap()
+        .first()
+        .map(|e| {
+            (
+                e.fields.get("workflow_type").cloned(),
+                format!("{:?}", e.fields),
+            )
+        })
+        .expect("expected one log event");
     assert_eq!(
-        event.fields.get("workflow_type").map(|s| s.as_str()),
+        wf_type.as_deref(),
         Some("my_workflow"),
-        "expected workflow_type = my_workflow, got: {:?}",
-        event.fields
+        "expected workflow_type = my_workflow, got: {fields_str}"
     );
 }
 
@@ -482,13 +475,16 @@ fn logger_emits_replay_false_field() {
     let (captured, _guard) = install_capture();
     ctx.logger().info("replay field test");
 
-    let events = captured.lock().unwrap();
-    let event = events.first().expect("expected one log event");
+    let (replay_val, fields_str) = captured
+        .lock()
+        .unwrap()
+        .first()
+        .map(|e| (e.fields.get("replay").cloned(), format!("{:?}", e.fields)))
+        .expect("expected one log event");
     assert_eq!(
-        event.fields.get("replay").map(|s| s.as_str()),
+        replay_val.as_deref(),
         Some("false"),
-        "expected replay = false, got: {:?}",
-        event.fields
+        "expected replay = false, got: {fields_str}"
     );
 }
 
@@ -507,13 +503,21 @@ fn logger_emits_workflow_id_field() {
     let (captured, _guard) = install_capture();
     ctx.logger().info("workflow_id field test");
 
-    let events = captured.lock().unwrap();
-    let event = events.first().expect("expected one log event");
+    let (wf_id, fields_str) = captured
+        .lock()
+        .unwrap()
+        .first()
+        .map(|e| {
+            (
+                e.fields.get("workflow_id").cloned(),
+                format!("{:?}", e.fields),
+            )
+        })
+        .expect("expected one log event");
     assert_eq!(
-        event.fields.get("workflow_id").map(|s| s.as_str()),
+        wf_id.as_deref(),
         Some("order-42"),
-        "expected workflow_id = order-42, got: {:?}",
-        event.fields
+        "expected workflow_id = order-42, got: {fields_str}"
     );
 }
 
@@ -533,11 +537,19 @@ fn log_level_matches_method() {
     ctx.logger().warn("warn msg");
     ctx.logger().error("error msg");
 
-    let events = captured.lock().unwrap();
-    assert_eq!(events.len(), 3);
-    assert_eq!(events[0].level, "INFO");
-    assert_eq!(events[1].level, "WARN");
-    assert_eq!(events[2].level, "ERROR");
+    let (len, l0, l1, l2) = {
+        let events = captured.lock().unwrap();
+        (
+            events.len(),
+            events[0].level.clone(),
+            events[1].level.clone(),
+            events[2].level.clone(),
+        )
+    };
+    assert_eq!(len, 3);
+    assert_eq!(l0, "INFO");
+    assert_eq!(l1, "WARN");
+    assert_eq!(l2, "ERROR");
 }
 
 // ── Tests: guardrail catalog HVG009 ──────────────────────────────────────────
@@ -654,11 +666,9 @@ async fn replayer_produces_zero_log_events() {
         "replay must succeed, got: {report}"
     );
 
-    let events = captured.lock().unwrap();
+    let event_count = captured.lock().unwrap().len();
     assert_eq!(
-        events.len(),
-        0,
-        "WorkflowReplayer must produce 0 log events (pure replay), got {}",
-        events.len()
+        event_count, 0,
+        "WorkflowReplayer must produce 0 log events (pure replay), got {event_count}"
     );
 }

--- a/autumn-harvest/tests/workflow_logger_tests.rs
+++ b/autumn-harvest/tests/workflow_logger_tests.rs
@@ -1,0 +1,664 @@
+/// Tests for issue #379: replay-safe workflow logger.
+///
+/// Red phase: these tests define the expected behaviour before implementation.
+/// They fail until WorkflowLogger, ctx.logger(), ctx.log_info/warn/error(),
+/// and guardrail rule HVG009 are in place.
+use std::future::Future;
+use std::pin::Pin;
+use std::sync::{Arc, Mutex};
+
+use autumn_harvest::context::WorkflowContext;
+use autumn_harvest::event::WorkflowEvent;
+use autumn_harvest::executor::{WorkflowOutcome, run_workflow};
+use autumn_harvest::guardrail::{RuleCategory, catalog, rule_by_id};
+use autumn_harvest::types::{ActivityExecId, ExecutionId};
+use chrono::Utc;
+use serde_json::Value;
+use tracing::subscriber::DefaultGuard;
+use tracing_subscriber::layer::SubscriberExt;
+
+// ── Tracing capture helpers ───────────────────────────────────────────────────
+
+/// A visitor that extracts string values from tracing event fields.
+struct FieldCapture {
+    pub fields: std::collections::HashMap<String, String>,
+    pub message: String,
+}
+
+impl tracing::field::Visit for FieldCapture {
+    fn record_str(&mut self, field: &tracing::field::Field, value: &str) {
+        if field.name() == "message" {
+            self.message = value.to_string();
+        } else {
+            self.fields
+                .insert(field.name().to_string(), value.to_string());
+        }
+    }
+
+    fn record_debug(&mut self, field: &tracing::field::Field, value: &dyn std::fmt::Debug) {
+        let s = format!("{value:?}");
+        let clean = s.trim_matches('"').to_string();
+        if field.name() == "message" {
+            self.message = clean;
+        } else {
+            self.fields.insert(field.name().to_string(), clean);
+        }
+    }
+
+    fn record_bool(&mut self, field: &tracing::field::Field, value: bool) {
+        self.fields
+            .insert(field.name().to_string(), value.to_string());
+    }
+}
+
+/// Captured event from the test subscriber.
+#[derive(Debug)]
+struct CapturedEvent {
+    pub level: String,
+    pub target: String,
+    pub fields: std::collections::HashMap<String, String>,
+    pub message: String,
+}
+
+/// A `tracing_subscriber::Layer` that records events from the workflow logger.
+struct CapturingLayer {
+    captured: Arc<Mutex<Vec<CapturedEvent>>>,
+}
+
+impl<S: tracing::Subscriber> tracing_subscriber::Layer<S> for CapturingLayer {
+    fn on_event(
+        &self,
+        event: &tracing::Event<'_>,
+        _ctx: tracing_subscriber::layer::Context<'_, S>,
+    ) {
+        let meta = event.metadata();
+        // Only capture events from the workflow logger target.
+        if meta.target() != "autumn_harvest::context" {
+            return;
+        }
+        let mut visitor = FieldCapture {
+            fields: std::collections::HashMap::new(),
+            message: String::new(),
+        };
+        event.record(&mut visitor);
+        self.captured.lock().unwrap().push(CapturedEvent {
+            level: meta.level().to_string(),
+            target: meta.target().to_string(),
+            fields: visitor.fields,
+            message: visitor.message,
+        });
+    }
+}
+
+/// Install a capturing subscriber for the duration of the test. Returns the
+/// captured event list and a guard that restores the prior subscriber on drop.
+fn install_capture() -> (Arc<Mutex<Vec<CapturedEvent>>>, DefaultGuard) {
+    let captured = Arc::new(Mutex::new(Vec::<CapturedEvent>::new()));
+    let layer = CapturingLayer {
+        captured: Arc::clone(&captured),
+    };
+    let subscriber = tracing_subscriber::registry().with(layer);
+    let guard = tracing::subscriber::set_default(subscriber);
+    (captured, guard)
+}
+
+// ── Workflow helpers ──────────────────────────────────────────────────────────
+
+/// Workflow that calls `ctx.logger().info("hello from logger")` once, then suspends.
+fn logging_workflow_via_logger<'a>(
+    ctx: &'a WorkflowContext,
+    _input: Value,
+) -> Pin<Box<dyn Future<Output = Result<Value, String>> + Send + 'a>> {
+    Box::pin(async move {
+        ctx.logger().info("hello from logger");
+        let result = ctx
+            .execute_activity_raw("step_1", Value::Null, "default")
+            .await
+            .map_err(|e| e.to_string())?;
+        Ok(result)
+    })
+}
+
+/// Workflow that calls `ctx.log_info/warn/error` convenience methods once, then suspends.
+fn logging_workflow_direct<'a>(
+    ctx: &'a WorkflowContext,
+    _input: Value,
+) -> Pin<Box<dyn Future<Output = Result<Value, String>> + Send + 'a>> {
+    Box::pin(async move {
+        ctx.log_info("direct log info");
+        ctx.log_warn("direct log warn");
+        ctx.log_error("direct log error");
+        let result = ctx
+            .execute_activity_raw("step_1", Value::Null, "default")
+            .await
+            .map_err(|e| e.to_string())?;
+        Ok(result)
+    })
+}
+
+/// Workflow that logs once on the live path, then suspends through 3 activities.
+fn multi_suspend_logging_workflow<'a>(
+    ctx: &'a WorkflowContext,
+    _input: Value,
+) -> Pin<Box<dyn Future<Output = Result<Value, String>> + Send + 'a>> {
+    Box::pin(async move {
+        ctx.logger().info("started");
+        let r1 = ctx
+            .execute_activity_raw("step_1", Value::Null, "default")
+            .await
+            .map_err(|e| e.to_string())?;
+        let r2 = ctx
+            .execute_activity_raw("step_2", Value::Null, "default")
+            .await
+            .map_err(|e| e.to_string())?;
+        let r3 = ctx
+            .execute_activity_raw("step_3", Value::Null, "default")
+            .await
+            .map_err(|e| e.to_string())?;
+        Ok(serde_json::json!([r1, r2, r3]))
+    })
+}
+
+/// Build a fully-completed history for multi_suspend_logging_workflow.
+fn make_full_history() -> Vec<WorkflowEvent> {
+    let act1 = ActivityExecId::new();
+    let act2 = ActivityExecId::new();
+    let act3 = ActivityExecId::new();
+    vec![
+        WorkflowEvent::WorkflowStarted {
+            input: Value::Null,
+            timestamp: Utc::now(),
+        },
+        WorkflowEvent::ActivityScheduled {
+            activity_id: act1,
+            name: "step_1".into(),
+            input: Value::Null,
+            queue: "default".into(),
+        },
+        WorkflowEvent::ActivityCompleted {
+            activity_id: act1,
+            output: serde_json::json!("r1"),
+        },
+        WorkflowEvent::ActivityScheduled {
+            activity_id: act2,
+            name: "step_2".into(),
+            input: Value::Null,
+            queue: "default".into(),
+        },
+        WorkflowEvent::ActivityCompleted {
+            activity_id: act2,
+            output: serde_json::json!("r2"),
+        },
+        WorkflowEvent::ActivityScheduled {
+            activity_id: act3,
+            name: "step_3".into(),
+            input: Value::Null,
+            queue: "default".into(),
+        },
+        WorkflowEvent::ActivityCompleted {
+            activity_id: act3,
+            output: serde_json::json!("r3"),
+        },
+    ]
+}
+
+// ── Helper: create a live (non-replay) context ────────────────────────────────
+
+fn live_ctx() -> WorkflowContext {
+    WorkflowContext::for_replay(
+        ExecutionId::new(),
+        vec![WorkflowEvent::WorkflowStarted {
+            input: Value::Null,
+            timestamp: Utc::now(),
+        }],
+    )
+}
+
+// ── Tests: WorkflowLogger API surface ────────────────────────────────────────
+
+#[test]
+fn workflow_context_exposes_logger_method() {
+    let ctx = live_ctx();
+    let _logger = ctx.logger();
+}
+
+#[test]
+fn workflow_logger_has_info_warn_error_methods() {
+    let ctx = live_ctx();
+    let logger = ctx.logger();
+    logger.info("test info");
+    logger.warn("test warn");
+    logger.error("test error");
+}
+
+#[test]
+fn workflow_context_has_direct_log_methods() {
+    let ctx = live_ctx();
+    ctx.log_info("info message");
+    ctx.log_warn("warn message");
+    ctx.log_error("error message");
+}
+
+// ── Tests: replay suppression ─────────────────────────────────────────────────
+
+#[tokio::test]
+async fn logger_emits_event_in_live_mode() {
+    let (captured, _guard) = install_capture();
+
+    let exec_id = ExecutionId::new();
+    let history = vec![WorkflowEvent::WorkflowStarted {
+        input: Value::Null,
+        timestamp: Utc::now(),
+    }];
+    let outcome = run_workflow(exec_id, history, logging_workflow_via_logger, Value::Null).await;
+    assert!(
+        matches!(outcome, WorkflowOutcome::Suspended { .. }),
+        "expected suspension, got {outcome:?}"
+    );
+
+    let events = captured.lock().unwrap();
+    assert_eq!(
+        events.len(),
+        1,
+        "expected exactly 1 log event in live mode, got {}",
+        events.len()
+    );
+}
+
+#[tokio::test]
+async fn logger_suppresses_events_during_full_replay() {
+    let (captured, _guard) = install_capture();
+
+    let exec_id = ExecutionId::new();
+    let act1 = ActivityExecId::new();
+    let history = vec![
+        WorkflowEvent::WorkflowStarted {
+            input: Value::Null,
+            timestamp: Utc::now(),
+        },
+        WorkflowEvent::ActivityScheduled {
+            activity_id: act1,
+            name: "step_1".into(),
+            input: Value::Null,
+            queue: "default".into(),
+        },
+        WorkflowEvent::ActivityCompleted {
+            activity_id: act1,
+            output: Value::Null,
+        },
+    ];
+    let outcome = run_workflow(exec_id, history, logging_workflow_via_logger, Value::Null).await;
+    assert!(
+        matches!(outcome, WorkflowOutcome::Completed { .. }),
+        "expected completion, got {outcome:?}"
+    );
+
+    let events = captured.lock().unwrap();
+    assert_eq!(
+        events.len(),
+        0,
+        "expected 0 log events during full replay, got {}",
+        events.len()
+    );
+}
+
+#[tokio::test]
+async fn direct_log_methods_suppressed_during_replay() {
+    let (captured, _guard) = install_capture();
+
+    let exec_id = ExecutionId::new();
+    let act1 = ActivityExecId::new();
+    let history = vec![
+        WorkflowEvent::WorkflowStarted {
+            input: Value::Null,
+            timestamp: Utc::now(),
+        },
+        WorkflowEvent::ActivityScheduled {
+            activity_id: act1,
+            name: "step_1".into(),
+            input: Value::Null,
+            queue: "default".into(),
+        },
+        WorkflowEvent::ActivityCompleted {
+            activity_id: act1,
+            output: Value::Null,
+        },
+    ];
+    let outcome = run_workflow(exec_id, history, logging_workflow_direct, Value::Null).await;
+    assert!(
+        matches!(outcome, WorkflowOutcome::Completed { .. }),
+        "expected completion, got {outcome:?}"
+    );
+
+    let events = captured.lock().unwrap();
+    assert_eq!(
+        events.len(),
+        0,
+        "expected 0 log events during full replay, got {}",
+        events.len()
+    );
+}
+
+#[tokio::test]
+async fn direct_log_methods_emit_in_live_mode() {
+    let (captured, _guard) = install_capture();
+
+    let exec_id = ExecutionId::new();
+    let history = vec![WorkflowEvent::WorkflowStarted {
+        input: Value::Null,
+        timestamp: Utc::now(),
+    }];
+    let outcome = run_workflow(exec_id, history, logging_workflow_direct, Value::Null).await;
+    assert!(
+        matches!(outcome, WorkflowOutcome::Suspended { .. }),
+        "expected suspension, got {outcome:?}"
+    );
+
+    let events = captured.lock().unwrap();
+    // log_info + log_warn + log_error = 3 events
+    assert_eq!(
+        events.len(),
+        3,
+        "expected 3 log events (info + warn + error) in live mode, got {}",
+        events.len()
+    );
+}
+
+/// AC: A workflow that logs once and suspends N times emits exactly 1 log event.
+///
+/// Verifies that the number of log events equals the number of logger calls in
+/// source (1), regardless of how many replay cycles the executor performs.
+#[tokio::test]
+async fn log_events_independent_of_replay_cycle_count() {
+    let exec_id = ExecutionId::new();
+
+    // ── First pass: live execution (only WorkflowStarted → suspension) ──
+    let (captured, _guard) = install_capture();
+    {
+        let history = vec![WorkflowEvent::WorkflowStarted {
+            input: Value::Null,
+            timestamp: Utc::now(),
+        }];
+        let outcome = run_workflow(
+            exec_id,
+            history,
+            multi_suspend_logging_workflow,
+            Value::Null,
+        )
+        .await;
+        assert!(matches!(outcome, WorkflowOutcome::Suspended { .. }));
+    }
+    let first_pass_count = captured.lock().unwrap().len();
+    assert_eq!(
+        first_pass_count, 1,
+        "live pass must emit exactly 1 log event"
+    );
+    drop(_guard);
+
+    // ── Replay pass: full history with all 3 activities already completed ──
+    let (captured2, _guard2) = install_capture();
+    {
+        let history = make_full_history();
+        let outcome = run_workflow(
+            exec_id,
+            history,
+            multi_suspend_logging_workflow,
+            Value::Null,
+        )
+        .await;
+        assert!(
+            matches!(outcome, WorkflowOutcome::Completed { .. }),
+            "expected completion on full history replay"
+        );
+    }
+    let replay_count = captured2.lock().unwrap().len();
+    assert_eq!(
+        replay_count, 0,
+        "replay pass must emit 0 log events, got {replay_count}"
+    );
+}
+
+// ── Tests: auto-tagged fields ─────────────────────────────────────────────────
+
+#[test]
+fn logger_emits_execution_id_field() {
+    let exec_id = ExecutionId::new();
+    let ctx = WorkflowContext::for_replay(
+        exec_id,
+        vec![WorkflowEvent::WorkflowStarted {
+            input: Value::Null,
+            timestamp: Utc::now(),
+        }],
+    );
+
+    let (captured, _guard) = install_capture();
+    ctx.logger().info("test message");
+
+    let events = captured.lock().unwrap();
+    let event = events.first().expect("expected one log event");
+    assert!(
+        event.fields.contains_key("execution_id"),
+        "expected execution_id field, got fields: {:?}",
+        event.fields.keys().collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn logger_emits_workflow_type_field() {
+    let exec_id = ExecutionId::new();
+    let ctx = WorkflowContext::for_replay(
+        exec_id,
+        vec![WorkflowEvent::WorkflowStarted {
+            input: Value::Null,
+            timestamp: Utc::now(),
+        }],
+    )
+    .with_workflow_name("my_workflow");
+
+    let (captured, _guard) = install_capture();
+    ctx.logger().info("field test");
+
+    let events = captured.lock().unwrap();
+    let event = events.first().expect("expected one log event");
+    assert_eq!(
+        event.fields.get("workflow_type").map(|s| s.as_str()),
+        Some("my_workflow"),
+        "expected workflow_type = my_workflow, got: {:?}",
+        event.fields
+    );
+}
+
+#[test]
+fn logger_emits_replay_false_field() {
+    let exec_id = ExecutionId::new();
+    let ctx = WorkflowContext::for_replay(
+        exec_id,
+        vec![WorkflowEvent::WorkflowStarted {
+            input: Value::Null,
+            timestamp: Utc::now(),
+        }],
+    );
+
+    let (captured, _guard) = install_capture();
+    ctx.logger().info("replay field test");
+
+    let events = captured.lock().unwrap();
+    let event = events.first().expect("expected one log event");
+    assert_eq!(
+        event.fields.get("replay").map(|s| s.as_str()),
+        Some("false"),
+        "expected replay = false, got: {:?}",
+        event.fields
+    );
+}
+
+#[test]
+fn logger_emits_workflow_id_field() {
+    let exec_id = ExecutionId::new();
+    let ctx = WorkflowContext::for_replay(
+        exec_id,
+        vec![WorkflowEvent::WorkflowStarted {
+            input: Value::Null,
+            timestamp: Utc::now(),
+        }],
+    )
+    .with_workflow_id("order-42");
+
+    let (captured, _guard) = install_capture();
+    ctx.logger().info("workflow_id field test");
+
+    let events = captured.lock().unwrap();
+    let event = events.first().expect("expected one log event");
+    assert_eq!(
+        event.fields.get("workflow_id").map(|s| s.as_str()),
+        Some("order-42"),
+        "expected workflow_id = order-42, got: {:?}",
+        event.fields
+    );
+}
+
+#[test]
+fn log_level_matches_method() {
+    let exec_id = ExecutionId::new();
+    let ctx = WorkflowContext::for_replay(
+        exec_id,
+        vec![WorkflowEvent::WorkflowStarted {
+            input: Value::Null,
+            timestamp: Utc::now(),
+        }],
+    );
+
+    let (captured, _guard) = install_capture();
+    ctx.logger().info("info msg");
+    ctx.logger().warn("warn msg");
+    ctx.logger().error("error msg");
+
+    let events = captured.lock().unwrap();
+    assert_eq!(events.len(), 3);
+    assert_eq!(events[0].level, "INFO");
+    assert_eq!(events[1].level, "WARN");
+    assert_eq!(events[2].level, "ERROR");
+}
+
+// ── Tests: guardrail catalog HVG009 ──────────────────────────────────────────
+
+#[test]
+fn hvg009_exists_in_catalog() {
+    let rule = rule_by_id("HVG009").expect("HVG009 must be in the guardrail catalog");
+    assert_eq!(rule.id, "HVG009");
+}
+
+#[test]
+fn hvg009_category_is_unsafe_logging() {
+    let rule = rule_by_id("HVG009").expect("HVG009 must exist");
+    assert!(
+        matches!(rule.category, RuleCategory::UnsafeLogging),
+        "HVG009 must be in the UnsafeLogging category, got {:?}",
+        rule.category
+    );
+}
+
+#[test]
+fn hvg009_alternative_mentions_logger() {
+    let rule = rule_by_id("HVG009").expect("HVG009 must exist");
+    let alt_lower = rule.alternative.to_lowercase();
+    assert!(
+        alt_lower.contains("logger")
+            || alt_lower.contains("log_info")
+            || alt_lower.contains("ctx.log"),
+        "HVG009 alternative must mention the logger API, got: {}",
+        rule.alternative
+    );
+}
+
+#[test]
+fn hvg009_explanation_mentions_replay() {
+    let rule = rule_by_id("HVG009").expect("HVG009 must exist");
+    assert!(
+        rule.explanation.to_lowercase().contains("replay"),
+        "HVG009 explanation must mention replay, got: {}",
+        rule.explanation
+    );
+}
+
+#[test]
+fn catalog_contains_unsafe_logging_category() {
+    let has = catalog()
+        .iter()
+        .any(|e| matches!(e.category, RuleCategory::UnsafeLogging));
+    assert!(has, "catalog must have at least one UnsafeLogging rule");
+}
+
+// ── Tests: WorkflowContext::workflow_id() accessor ────────────────────────────
+
+#[test]
+fn workflow_context_exposes_workflow_id_accessor() {
+    let ctx = live_ctx();
+    let _id: &str = ctx.workflow_id();
+}
+
+#[test]
+fn with_workflow_id_sets_id() {
+    let exec_id = ExecutionId::new();
+    let ctx = WorkflowContext::for_replay(
+        exec_id,
+        vec![WorkflowEvent::WorkflowStarted {
+            input: Value::Null,
+            timestamp: Utc::now(),
+        }],
+    )
+    .with_workflow_id("subscription-99");
+    assert_eq!(ctx.workflow_id(), "subscription-99");
+}
+
+// ── Tests: WorkflowReplayer interaction ──────────────────────────────────────
+
+/// Replaying a workflow with logger calls must produce 0 log events on pure replay.
+#[cfg(feature = "testing")]
+#[tokio::test]
+async fn replayer_produces_zero_log_events() {
+    use autumn_harvest::{ReplayStatus, WorkflowReplayer};
+
+    let act1 = ActivityExecId::new();
+
+    // Build a history that represents a completed execution of `logging_workflow_via_logger`.
+    let history = vec![
+        WorkflowEvent::WorkflowStarted {
+            input: Value::Null,
+            timestamp: Utc::now(),
+        },
+        WorkflowEvent::ActivityScheduled {
+            activity_id: act1,
+            name: "step_1".into(),
+            input: Value::Null,
+            queue: "default".into(),
+        },
+        WorkflowEvent::ActivityCompleted {
+            activity_id: act1,
+            output: Value::Null,
+        },
+        WorkflowEvent::WorkflowCompleted {
+            output: Value::Null,
+        },
+    ];
+
+    let (captured, _guard) = install_capture();
+
+    let report = WorkflowReplayer::new()
+        .register_fn("logging_workflow", logging_workflow_via_logger)
+        .replay_from_events(history)
+        .await;
+
+    assert!(
+        matches!(report.status, ReplayStatus::ReplaySucceeded),
+        "replay must succeed, got: {report}"
+    );
+
+    let events = captured.lock().unwrap();
+    assert_eq!(
+        events.len(),
+        0,
+        "WorkflowReplayer must produce 0 log events (pure replay), got {}",
+        events.len()
+    );
+}

--- a/docs/workflow-determinism-guide.md
+++ b/docs/workflow-determinism-guide.md
@@ -216,6 +216,68 @@ async fn wait_for_timeout(ctx: &WorkflowContext) -> Result<(), String> {
 
 ---
 
+### HVG009 — Bare tracing calls inside a workflow body (Warning)
+
+| | Example |
+|---|---|
+| **Disallowed** | `tracing::info!("order {} started", order_id)` |
+| **Disallowed** | `tracing::warn!("retrying payment")` |
+| **Allowed** | `ctx.logger().info("order started")` |
+| **Allowed** | `ctx.log_info("order started")` |
+
+The workflow executor re-runs the function body from the top on every suspend/resume cycle (replay). A bare `tracing::info!()` call placed in the workflow body therefore fires **N times** for a workflow that suspends N times: once on the original live run, and once on each subsequent replay before the suspension point is reached. This amplifies log volume in proportion to replay depth and produces duplicate lines in Loki/Elastic that lack correlation keys, making incident triage much harder.
+
+#### The Harvest-safe alternative
+
+`ctx.logger()` returns a [`WorkflowLogger`](../autumn-harvest/src/context.rs) that:
+- **Suppresses** all output when `ctx.is_replaying()` is `true` — so each log statement fires at most once per execution, regardless of replay depth.
+- **Auto-tags** every event with `workflow_id`, `execution_id`, `workflow_type`, and `replay = false` — so a single `loki | jq 'select(.execution_id == "…")'` returns a clean chronological narrative of the run.
+
+**Migration example:**
+
+```rust
+// Before — fires once per replay cycle (N times for N suspensions)
+#[workflow]
+async fn process_order(ctx: &WorkflowContext, order_id: String) -> Result<(), String> {
+    tracing::info!("processing order {}", order_id); // ← HVG009: fires on every replay
+
+    ctx.execute_activity(&charge_card_info(), order_id.clone()).await?;
+    ctx.execute_activity(&ship_order_info(), order_id).await?;
+    Ok(())
+}
+
+// After — fires exactly once, on the live (non-replay) execution
+#[workflow]
+async fn process_order(ctx: &WorkflowContext, order_id: String) -> Result<(), String> {
+    ctx.logger().info("processing order");          // suppressed during replay ✓
+    // or the equivalent shorthand:
+    ctx.log_info("processing order");               // same behaviour
+
+    ctx.execute_activity(&charge_card_info(), order_id.clone()).await?;
+    ctx.execute_activity(&ship_order_info(), order_id).await?;
+    Ok(())
+}
+```
+
+#### Auto-tagged structured fields
+
+Every event emitted by `ctx.logger()` carries:
+
+| Field | Value | Purpose |
+|---|---|---|
+| `workflow_id` | Business-level workflow key (e.g. `"order-42"`) | Correlate all events for one logical workflow instance |
+| `execution_id` | Unique run UUID | Correlate all events for one specific run |
+| `workflow_type` | Registered function name (e.g. `"process_order"`) | Filter by workflow type across all runs |
+| `replay` | `false` | Confirm event was not emitted during replay |
+
+These match the Temporal / Cadence / DBOS convention so existing log dashboards need no changes.
+
+#### Guardrail severity
+
+HVG009 is a **Warning** (not a HardBlocker): bare tracing calls do not break determinism or corrupt workflow state — they only amplify log volume. The rule is surfaced so authors can fix it without CI being blocked by a false positive.
+
+---
+
 ## Machine-readable findings and suppressions
 
 `GuardrailFinding` and `GuardrailSuppression` both implement `serde::Serialize`/`Deserialize` and can be serialized to JSON for CI reports or external tooling.

--- a/examples/quickstart/src/main.rs
+++ b/examples/quickstart/src/main.rs
@@ -27,6 +27,11 @@ use autumn_web::reexports::axum::extract::State;
     severity = "sev4"
 )]
 async fn greeting(ctx: &WorkflowContext, name: String) -> HarvestResult<String> {
+    // ctx.logger() is replay-aware: this line fires exactly once even if the
+    // worker restarts and replays the history — use it instead of tracing::info!
+    // directly in workflow bodies (see guardrail HVG009).
+    ctx.logger().info("greeting workflow started");
+
     let welcome: serde_json::Value = ctx
         .execute_activity(
             &send_greeting_info(),
@@ -39,12 +44,16 @@ async fn greeting(ctx: &WorkflowContext, name: String) -> HarvestResult<String> 
     // the welcome activity above.
     ctx.timer("greeting-pause", 30).await?;
 
+    ctx.logger().info("timer fired, delivering farewell");
+
     let farewell: serde_json::Value = ctx
         .execute_activity(
             &send_greeting_info(),
             serde_json::json!({ "name": name, "kind": "farewell" }),
         )
         .await?;
+
+    ctx.logger().info("greeting workflow completed");
 
     Ok(format!(
         "{} — {}",


### PR DESCRIPTION
## Summary

Implements a replay-aware logging API for workflows that suppresses log output during history replay, preventing log amplification. Adds `WorkflowLogger` struct, convenience methods on `WorkflowContext`, and guardrail rule HVG009 to detect unsafe bare `tracing::` calls in workflow bodies.

## Key Changes

- **WorkflowLogger struct** (`context.rs`): New replay-aware logger that checks `is_replaying()` before emitting `tracing` events. Automatically tags all events with `workflow_id`, `execution_id`, `workflow_type`, and `replay = false` for log correlation.

- **WorkflowContext logging API**:
  - `logger()` method returns a `WorkflowLogger<'_>` for the current execution
  - `log_info()`, `log_warn()`, `log_error()` convenience methods that delegate to the logger
  - `workflow_id()` accessor for the business-level workflow identifier
  - `workflow_type()` accessor for the registered function name
  - `with_workflow_id()` builder method to set the correlation key

- **Guardrail rule HVG009** (`guardrail.rs`): New `UnsafeLogging` category rule that warns against bare `tracing::` calls in workflow bodies. Includes explanation of replay amplification and references the `WorkflowLogger` alternative.

- **Documentation** (`workflow-determinism-guide.md`): Comprehensive guide to HVG009 with before/after migration examples, auto-tagged field reference table, and severity justification.

- **Comprehensive test suite** (`workflow_logger_tests.rs`): 664 lines of tests covering:
  - API surface (logger methods, direct log methods, accessors)
  - Replay suppression (live mode emits, full replay suppresses, partial replay suppresses)
  - Auto-tagged fields (execution_id, workflow_type, replay, workflow_id)
  - Log level matching (INFO/WARN/ERROR)
  - Guardrail catalog presence and correctness
  - WorkflowReplayer integration (zero log events on pure replay)

- **Worker integration** (`worker.rs`, `executor.rs`): Thread `workflow_id` from execution metadata through `WorkflowExecuteSpanMeta` to the context.

- **Example update** (`quickstart/src/main.rs`): Demonstrates the replay-safe logger with a comment explaining why it's preferred over bare `tracing::` calls.

## Implementation Details

- Logger suppression is deterministic: checks `ctx.is_replaying()` which is computed from the in-memory history snapshot, not external state.
- Every log event carries structured fields matching Temporal/Cadence/DBOS convention for seamless integration with existing dashboards.
- HVG009 is a Warning (not HardBlocker) because bare tracing calls do not break determinism—they only amplify log volume.
- The logger uses `target: "autumn_harvest::context"` to enable selective capture in tests and production filtering.

https://claude.ai/code/session_01ENkHszTCYTSymebJmFSMFj