### PR TITLE
🛡️ Sentry: [test coverage improvement] Replace unwrap with robust table-driven tests

### DIFF
--- a/autumn-harvest/src/batch.rs
+++ b/autumn-harvest/src/batch.rs
@@ -818,11 +818,21 @@ mod tests {
     }
 
     #[test]
-    fn batch_action_serializes_pascal_case() {
-        let value = serde_json::to_value(BatchAction::Cancel).unwrap();
-        assert_eq!(value, json!("Cancel"));
-        let deserialized: BatchAction = serde_json::from_value(json!("Signal")).unwrap();
-        assert_eq!(deserialized, BatchAction::Signal);
+    fn batch_action_serializes_pascal_case() -> Result<(), serde_json::Error> {
+        let test_cases = vec![
+            (BatchAction::Cancel, json!("Cancel")),
+            (BatchAction::Terminate, json!("Terminate")),
+            (BatchAction::Signal, json!("Signal")),
+        ];
+
+        for (action, expected_json) in test_cases {
+            let value = serde_json::to_value(&action)?;
+            assert_eq!(value, expected_json);
+            let deserialized: BatchAction = serde_json::from_value(expected_json)?;
+            assert_eq!(deserialized, action);
+        }
+
+        Ok(())
     }
 
     #[test]
@@ -858,13 +868,14 @@ mod tests {
     }
 
     #[test]
-    fn batch_target_error_round_trips_json() {
+    fn batch_target_error_round_trips_json() -> Result<(), serde_json::Error> {
         let err = BatchTargetError {
             execution_id: "00000000-0000-4000-8000-000000000001".to_string(),
             reason: "workflow execution already terminal (COMPLETED)".to_string(),
         };
-        let value = serde_json::to_value(&err).unwrap();
-        let back: BatchTargetError = serde_json::from_value(value).unwrap();
+        let value = serde_json::to_value(&err)?;
+        let back: BatchTargetError = serde_json::from_value(value)?;
         assert_eq!(back, err);
+        Ok(())
     }
 }

--- a/autumn-harvest/src/error.rs
+++ b/autumn-harvest/src/error.rs
@@ -487,16 +487,6 @@ mod tests {
     }
 
     #[test]
-    fn harvest_error_display_includes_task_name() {
-        let e = HarvestError::Timeout {
-            timeout_type: TimeoutType::StartToClose,
-            task_name: "send_email".into(),
-        };
-        assert!(e.to_string().contains("send_email"));
-        assert!(e.to_string().contains("StartToClose"));
-    }
-
-    #[test]
     #[allow(clippy::unnecessary_literal_unwrap)]
     fn harvest_result_ok() -> HarvestResult<()> {
         let r: HarvestResult<i32> = Ok(42);
@@ -515,34 +505,55 @@ mod tests {
     }
 
     #[test]
-    fn timeout_type_display_is_correct() {
-        assert_eq!(TimeoutType::StartToClose.to_string(), "StartToClose");
-        assert_eq!(TimeoutType::ScheduleToStart.to_string(), "ScheduleToStart");
-        assert_eq!(TimeoutType::ScheduleToClose.to_string(), "ScheduleToClose");
-        assert_eq!(TimeoutType::Heartbeat.to_string(), "Heartbeat");
-        assert_eq!(
-            TimeoutType::WorkflowExecution.to_string(),
-            "WorkflowExecution"
-        );
+    fn harvest_error_timeout_display_includes_type_and_name() {
+        let test_cases = vec![
+            (TimeoutType::StartToClose, "StartToClose", "send_email"),
+            (
+                TimeoutType::ScheduleToStart,
+                "ScheduleToStart",
+                "charge_card",
+            ),
+            (
+                TimeoutType::ScheduleToClose,
+                "ScheduleToClose",
+                "process_image",
+            ),
+            (TimeoutType::Heartbeat, "Heartbeat", "long_poll"),
+            (
+                TimeoutType::WorkflowExecution,
+                "WorkflowExecution",
+                "billing_reconciliation",
+            ),
+        ];
+
+        for (timeout_type, expected_str, task_name) in test_cases {
+            let e = HarvestError::Timeout {
+                timeout_type: timeout_type.clone(),
+                task_name: task_name.into(),
+            };
+            let msg = e.to_string();
+            assert!(msg.contains(task_name));
+            assert!(msg.contains(expected_str));
+            assert_eq!(timeout_type.to_string(), expected_str);
+        }
     }
 
     #[test]
-    fn timeout_type_workflow_execution_round_trips_serde() {
-        let t = TimeoutType::WorkflowExecution;
-        let json = serde_json::to_string(&t).unwrap();
-        let back: TimeoutType = serde_json::from_str(&json).unwrap();
-        assert_eq!(back, TimeoutType::WorkflowExecution);
-    }
+    fn timeout_type_round_trips_serde() -> Result<(), serde_json::Error> {
+        let test_cases = vec![
+            TimeoutType::StartToClose,
+            TimeoutType::ScheduleToStart,
+            TimeoutType::ScheduleToClose,
+            TimeoutType::Heartbeat,
+            TimeoutType::WorkflowExecution,
+        ];
 
-    #[test]
-    fn harvest_error_timeout_workflow_execution_display() {
-        let e = HarvestError::Timeout {
-            timeout_type: TimeoutType::WorkflowExecution,
-            task_name: "billing_reconciliation".into(),
-        };
-        let msg = e.to_string();
-        assert!(msg.contains("billing_reconciliation"));
-        assert!(msg.contains("WorkflowExecution"));
+        for t in test_cases {
+            let json = serde_json::to_string(&t)?;
+            let back: TimeoutType = serde_json::from_str(&json)?;
+            assert_eq!(back, t);
+        }
+        Ok(())
     }
 
     #[test]


### PR DESCRIPTION
🛡️ Sentry: [test coverage improvement] Replace unwrap with robust table-driven tests

🎯 Target:
- `autumn-harvest/src/batch.rs` (Tests: `batch_action_serializes_pascal_case`, `batch_target_error_round_trips_json`)
- `autumn-harvest/src/error.rs` (Tests: `harvest_error_timeout_display_includes_type_and_name`, `timeout_type_round_trips_serde`)

💣 Risk:
- Eliminates potential test panics caused by `.unwrap()` calls on deserialization parsing logic.
- Avoids fragile, fragmented tests that don't cover all enum variants.

🧪 Strategy:
- Replaced multiple individual `.unwrap()` deserialization tests with complete table-driven loops iterating over all enum variants (`BatchAction`, `TimeoutType`).
- Changed test function signatures to return `Result<(), serde_json::Error>`, safely propagating parse errors using the `?` operator instead of panicking.
- Consolidated disparate formatting tests into a unified table-driven format asserting on the `.to_string()` implementation.

🔬 Verification:
- `cargo test -p autumn-harvest batch`
- `cargo test -p autumn-harvest error`

---
*PR created automatically by Jules for task [9464137932049447266](https://jules.google.com/task/9464137932049447266) started by @madmax983*