### PR TITLE
🔒 Warden: [Fix DoS in bulk DLQ handlers]

### DIFF
--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -10737,14 +10737,27 @@ fn url_encode_for_redirect(input: &str) -> String {
     out
 }
 
+#[allow(clippy::too_many_lines)]
 async fn bulk_replay_dead_letters_handler(
     Extension(api_state): Extension<HarvestApiState>,
     headers: axum::http::HeaderMap,
-    body: axum::body::Bytes,
+    body: axum::body::Body,
 ) -> axum::response::Response {
     use axum::response::IntoResponse as _;
 
-    let request = match parse_bulk_dlq_request(&headers, &body) {
+    #[allow(clippy::cast_possible_truncation)]
+    let body_bytes = match axum::body::to_bytes(body, 2 * 1024 * 1024).await {
+        Ok(b) => b,
+        Err(e) => {
+            return (
+                axum::http::StatusCode::PAYLOAD_TOO_LARGE,
+                axum::Json(serde_json::json!({"error": format!("payload too large: {e}")})),
+            )
+                .into_response();
+        }
+    };
+
+    let request = match parse_bulk_dlq_request(&headers, &body_bytes) {
         Ok(request) => request,
         Err(error) => return error.into_response(),
     };
@@ -10845,14 +10858,27 @@ async fn bulk_replay_dead_letters_handler(
     }
 }
 
+#[allow(clippy::too_many_lines)]
 async fn bulk_discard_dead_letters_handler(
     Extension(api_state): Extension<HarvestApiState>,
     headers: axum::http::HeaderMap,
-    body: axum::body::Bytes,
+    body: axum::body::Body,
 ) -> axum::response::Response {
     use axum::response::IntoResponse as _;
 
-    let request = match parse_bulk_dlq_request(&headers, &body) {
+    #[allow(clippy::cast_possible_truncation)]
+    let body_bytes = match axum::body::to_bytes(body, 2 * 1024 * 1024).await {
+        Ok(b) => b,
+        Err(e) => {
+            return (
+                axum::http::StatusCode::PAYLOAD_TOO_LARGE,
+                axum::Json(serde_json::json!({"error": format!("payload too large: {e}")})),
+            )
+                .into_response();
+        }
+    };
+
+    let request = match parse_bulk_dlq_request(&headers, &body_bytes) {
         Ok(request) => request,
         Err(error) => return error.into_response(),
     };

--- a/autumn-harvest-plugin/tests/security.rs
+++ b/autumn-harvest-plugin/tests/security.rs
@@ -146,6 +146,62 @@ async fn eris_unauthenticated_start_workflow_terminate_if_running_is_blocked() {
 }
 
 #[tokio::test]
+async fn warden_bulk_replay_dlq_rejects_oversized_payload() {
+    let app = authenticated_app();
+    let large_body = "x".repeat(3 * 1024 * 1024);
+    let mut request = Request::builder()
+        .method("POST")
+        .uri("/dead-letters/replay")
+        .header(
+            autumn_web::reexports::axum::http::header::CONTENT_TYPE,
+            "application/json",
+        )
+        .body(Body::from(large_body))
+        .unwrap();
+
+    let mut data = std::collections::HashMap::new();
+    data.insert("user_id".to_string(), "operator-1".to_string());
+
+    request
+        .extensions_mut()
+        .insert(autumn_web::session::Session::new_for_test(
+            "harvest-test-session".to_string(),
+            data,
+        ));
+
+    let res = app.oneshot(request).await.unwrap();
+    assert_eq!(res.status(), StatusCode::PAYLOAD_TOO_LARGE);
+}
+
+#[tokio::test]
+async fn warden_bulk_discard_dlq_rejects_oversized_payload() {
+    let app = authenticated_app();
+    let large_body = "x".repeat(3 * 1024 * 1024);
+    let mut request = Request::builder()
+        .method("POST")
+        .uri("/dead-letters/discard")
+        .header(
+            autumn_web::reexports::axum::http::header::CONTENT_TYPE,
+            "application/json",
+        )
+        .body(Body::from(large_body))
+        .unwrap();
+
+    let mut data = std::collections::HashMap::new();
+    data.insert("user_id".to_string(), "operator-1".to_string());
+
+    request
+        .extensions_mut()
+        .insert(autumn_web::session::Session::new_for_test(
+            "harvest-test-session".to_string(),
+            data,
+        ));
+
+    let res = app.oneshot(request).await.unwrap();
+    assert_eq!(res.status(), StatusCode::PAYLOAD_TOO_LARGE);
+}
+
+#[tokio::test]
 async fn eris_start_workflow_terminate_if_running_honors_configured_session_key() {
     let api_state = HarvestApiState::new();
     api_state.set_admin_auth_session_key("operator_id");


### PR DESCRIPTION
🔒 Warden: [Fix DoS in bulk DLQ handlers]

🦠 Threat: Unbounded payload extraction in bulk DLQ handlers could lead to memory exhaustion (DoS).
🛡️ Defense: Switched from `axum::body::Bytes` extractor to `axum::body::to_bytes` with a 2MB limit.
💥 Severity: High - could panic server via OOM.
🧪 Verification: Added test cases demonstrating rejection of payloads > 2MB.

---
*PR created automatically by Jules for task [1261480446491432021](https://jules.google.com/task/1261480446491432021) started by @madmax983*