### PR TITLE
⚒️ Forge: Refactor Command Bookkeeping Check

### DIFF
--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -366,6 +366,20 @@ pub enum WorkflowCommand {
     },
 }
 
+impl WorkflowCommand {
+    /// Returns `true` if this command is a bookkeeping command.
+    #[must_use]
+    pub const fn is_bookkeeping(&self) -> bool {
+        matches!(
+            self,
+            Self::RecordMarker { .. }
+                | Self::RecordUpdateResult { .. }
+                | Self::UpsertSearchAttributes { .. }
+                | Self::SpawnDetachedChildWorkflow { .. }
+        )
+    }
+}
+
 // Manual Debug because oneshot::Sender is not Debug.
 impl std::fmt::Debug for WorkflowCommand {
     #[allow(clippy::too_many_lines)]

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -486,31 +486,19 @@ fn should_requeue_signal_wait(commands: &[WorkflowCommand]) -> bool {
     });
 
     let only_wait_or_bookkeeping = commands.iter().all(|cmd| {
-        matches!(
-            cmd,
-            WorkflowCommand::WaitForSignal { .. }
-                | WorkflowCommand::SignalExternalWorkflow { .. }
-                | WorkflowCommand::RecordMarker { .. }
-                | WorkflowCommand::RecordUpdateResult { .. }
-                | WorkflowCommand::UpsertSearchAttributes { .. }
-                | WorkflowCommand::SpawnDetachedChildWorkflow { .. }
-        )
+        cmd.is_bookkeeping()
+            || matches!(
+                cmd,
+                WorkflowCommand::WaitForSignal { .. }
+                    | WorkflowCommand::SignalExternalWorkflow { .. }
+            )
     });
 
     has_wait && only_wait_or_bookkeeping
 }
 
 fn only_bookkeeping_commands(commands: &[WorkflowCommand]) -> bool {
-    !commands.is_empty()
-        && commands.iter().all(|cmd| {
-            matches!(
-                cmd,
-                WorkflowCommand::RecordMarker { .. }
-                    | WorkflowCommand::RecordUpdateResult { .. }
-                    | WorkflowCommand::UpsertSearchAttributes { .. }
-                    | WorkflowCommand::SpawnDetachedChildWorkflow { .. }
-            )
-        })
+    !commands.is_empty() && commands.iter().all(WorkflowCommand::is_bookkeeping)
 }
 
 #[derive(Debug, Clone)]
@@ -709,11 +697,10 @@ fn extract_all_scheduled_activities(
     let mut scheduled = Vec::new();
 
     for cmd in commands {
+        if cmd.is_bookkeeping() {
+            continue;
+        }
         match cmd {
-            WorkflowCommand::RecordMarker { .. }
-            | WorkflowCommand::RecordUpdateResult { .. }
-            | WorkflowCommand::UpsertSearchAttributes { .. }
-            | WorkflowCommand::SpawnDetachedChildWorkflow { .. } => {}
             WorkflowCommand::ScheduleActivity {
                 activity_id,
                 name,
@@ -747,11 +734,10 @@ fn extract_all_activity_waits(commands: &[WorkflowCommand]) -> Option<Vec<Activi
     let mut activity_ids = Vec::new();
 
     for cmd in commands {
+        if cmd.is_bookkeeping() {
+            continue;
+        }
         match cmd {
-            WorkflowCommand::RecordMarker { .. }
-            | WorkflowCommand::RecordUpdateResult { .. }
-            | WorkflowCommand::UpsertSearchAttributes { .. }
-            | WorkflowCommand::SpawnDetachedChildWorkflow { .. } => {}
             WorkflowCommand::WaitForActivity { activity_id, .. } => activity_ids.push(*activity_id),
             _ => return None,
         }
@@ -793,16 +779,13 @@ fn extract_started_timer_for_suspension(
 
     // Now verify that all other commands in the batch are either bookkeeping OR signal waits.
     let is_valid = commands.iter().all(|cmd| {
-        matches!(
-            cmd,
-            WorkflowCommand::StartTimer { .. }
-                | WorkflowCommand::WaitForSignal { .. }
-                | WorkflowCommand::SignalExternalWorkflow { .. }
-                | WorkflowCommand::RecordMarker { .. }
-                | WorkflowCommand::RecordUpdateResult { .. }
-                | WorkflowCommand::UpsertSearchAttributes { .. }
-                | WorkflowCommand::SpawnDetachedChildWorkflow { .. }
-        )
+        cmd.is_bookkeeping()
+            || matches!(
+                cmd,
+                WorkflowCommand::StartTimer { .. }
+                    | WorkflowCommand::WaitForSignal { .. }
+                    | WorkflowCommand::SignalExternalWorkflow { .. }
+            )
     });
 
     if is_valid { Some(first_timer) } else { None }
@@ -815,18 +798,8 @@ fn extract_started_timer_for_suspension(
 fn extract_all_started_child_workflows(
     commands: &[WorkflowCommand],
 ) -> Option<Vec<StartedChildWorkflowCommand>> {
-    let non_markers: Vec<&WorkflowCommand> = commands
-        .iter()
-        .filter(|c| {
-            !matches!(
-                c,
-                WorkflowCommand::RecordMarker { .. }
-                    | WorkflowCommand::RecordUpdateResult { .. }
-                    | WorkflowCommand::UpsertSearchAttributes { .. }
-                    | WorkflowCommand::SpawnDetachedChildWorkflow { .. }
-            )
-        })
-        .collect();
+    let non_markers: Vec<&WorkflowCommand> =
+        commands.iter().filter(|c| !c.is_bookkeeping()).collect();
 
     if non_markers.is_empty() {
         return None;


### PR DESCRIPTION
🚮 Smell: Manual `matches!` blocks checking for four specific "bookkeeping" workflow commands are duplicated across multiple functions.
✨ Solution: Added `WorkflowCommand::is_bookkeeping()` helper method and used it to replace the duplicated boolean logic.
🧼 Benefit: Reduces code repetition, improves readability, and makes it trivial to add new bookkeeping commands in the future.
🛡️ Verification: Tests passed. No logic changed.

---
*PR created automatically by Jules for task [6549847039359560259](https://jules.google.com/task/6549847039359560259) started by @madmax983*