### PR TITLE
Implement queue & task eligibility explainer for stuck-task triage

### DIFF
--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -15582,7 +15582,7 @@ async fn evaluate_eligibility_for_shard(
         }
     }
 
-    let mut concurrency_saturated_keys = HashSet::new();
+    let mut running_map = HashMap::new();
     if !keys_to_check.is_empty() {
         #[derive(diesel::QueryableByName)]
         struct ConcurrencyRow {
@@ -15607,21 +15607,8 @@ async fn evaluate_eligibility_for_shard(
         .await
         .map_err(database_error)?;
 
-        let mut running_map = HashMap::new();
         for r in rows {
             running_map.insert((r.key, r.task_type), r.running_count);
-        }
-
-        for t in tasks.iter().filter(|t| t.state == "PENDING") {
-            if let (Some(key), Some(cap)) = (&t.concurrency_key, t.concurrency_cap) {
-                let running = running_map
-                    .get(&(key.clone(), t.task_type.clone()))
-                    .copied()
-                    .unwrap_or(0);
-                if running >= i64::from(cap) {
-                    concurrency_saturated_keys.insert((key.clone(), t.task_type.clone()));
-                }
-            }
         }
     }
 
@@ -15783,10 +15770,14 @@ async fn evaluate_eligibility_for_shard(
                     }
                 }
 
-                if t.concurrency_key.as_ref().is_some_and(|key| {
-                    concurrency_saturated_keys.contains(&(key.clone(), t.task_type.clone()))
-                }) {
-                    reasons.push("concurrency_saturated".to_string());
+                if let (Some(key), Some(cap)) = (&t.concurrency_key, t.concurrency_cap) {
+                    let running = running_map
+                        .get(&(key.clone(), t.task_type.clone()))
+                        .copied()
+                        .unwrap_or(0);
+                    if running >= i64::from(cap) {
+                        reasons.push("concurrency_saturated".to_string());
+                    }
                 }
 
                 if let Some(ref rlk) = t.rate_limit_key {
@@ -15929,7 +15920,50 @@ async fn get_queue_eligibility(
         )));
     }
 
-    for res in shards.values() {
+    let shards_with_pending: Vec<_> = shards
+        .values()
+        .filter(|res| res.pending_count > 0)
+        .collect();
+
+    let target_shards = if shards_with_pending.is_empty() {
+        shards.values().collect::<Vec<_>>()
+    } else {
+        shards_with_pending
+    };
+
+    let mut worst_rank = 0;
+    let mut worst_diag = "healthy".to_string();
+    for shard_res in &target_shards {
+        let diag = &shard_res.summary.diagnosis;
+        let rank = match diag.as_str() {
+            "no_online_workers" => 4,
+            "no_eligible_workers" => 3,
+            "all_draining" => 2,
+            "all_capacity_full" => 1,
+            _ => 0,
+        };
+        if rank > worst_rank {
+            worst_rank = rank;
+            worst_diag.clone_from(diag);
+        }
+    }
+    let diagnosis = worst_diag;
+
+    let responsible_shards: Vec<_> = target_shards
+        .into_iter()
+        .filter(|res| {
+            let rank = match res.summary.diagnosis.as_str() {
+                "no_online_workers" => 4,
+                "no_eligible_workers" => 3,
+                "all_draining" => 2,
+                "all_capacity_full" => 1,
+                _ => 0,
+            };
+            rank == worst_rank
+        })
+        .collect();
+
+    for res in responsible_shards {
         let has_pending_tasks = res.pending_count > 0;
 
         for w in &res.eligible_workers {
@@ -15966,35 +16000,6 @@ async fn get_queue_eligibility(
 
     eligible_workers.sort_by(|a, b| a.worker_id.cmp(&b.worker_id));
     ineligible_workers.sort_by(|a, b| a.worker_id.cmp(&b.worker_id));
-
-    let shards_with_pending: Vec<_> = shards
-        .values()
-        .filter(|res| res.pending_count > 0)
-        .collect();
-
-    let target_shards = if shards_with_pending.is_empty() {
-        shards.values().collect::<Vec<_>>()
-    } else {
-        shards_with_pending
-    };
-
-    let mut worst_rank = 0;
-    let mut worst_diag = "healthy".to_string();
-    for shard_res in target_shards {
-        let diag = &shard_res.summary.diagnosis;
-        let rank = match diag.as_str() {
-            "no_online_workers" => 4,
-            "no_eligible_workers" => 3,
-            "all_draining" => 2,
-            "all_capacity_full" => 1,
-            _ => 0,
-        };
-        if rank > worst_rank {
-            worst_rank = rank;
-            worst_diag.clone_from(diag);
-        }
-    }
-    let diagnosis = worst_diag;
 
     let mut req_builds: Vec<String> = global_required_build_ids.into_iter().collect();
     req_builds.sort();

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -15795,7 +15795,7 @@ async fn evaluate_eligibility_for_shard(
                         .as_ref()
                         .is_some_and(|act_name| cb_activities.contains(act_name));
                     if !has_cb && saturated_rate_limits.contains(rlk) {
-                        reasons.push("concurrency_saturated".to_string());
+                        reasons.push("rate_limit_saturated".to_string());
                     }
                 }
 
@@ -15832,10 +15832,11 @@ async fn evaluate_eligibility_for_shard(
     let diagnosis = if num_online == 0 {
         "no_online_workers".to_string()
     } else {
-        let all_draining = eligible_workers.iter().all(|w| w.status == "Draining")
+        let all_draining = eligible_workers.is_empty()
+            && !ineligible_workers.is_empty()
             && ineligible_workers
                 .iter()
-                .all(|w| w.reason_codes.contains(&"worker_draining".to_string()));
+                .all(|w| w.reason_codes == vec!["worker_draining".to_string()]);
         if all_draining {
             "all_draining".to_string()
         } else {
@@ -15966,51 +15967,34 @@ async fn get_queue_eligibility(
     eligible_workers.sort_by(|a, b| a.worker_id.cmp(&b.worker_id));
     ineligible_workers.sort_by(|a, b| a.worker_id.cmp(&b.worker_id));
 
-    let num_online = eligible_workers.len() + ineligible_workers.len();
-    let diagnosis = if num_online == 0 {
-        "no_online_workers".to_string()
-    } else {
-        let all_draining = eligible_workers.iter().all(|w| w.status == "Draining")
-            && ineligible_workers
-                .iter()
-                .all(|w| w.reason_codes.contains(&"worker_draining".to_string()));
-        if all_draining {
-            "all_draining".to_string()
-        } else {
-            let eligible_non_draining: Vec<_> = eligible_workers
-                .iter()
-                .filter(|w| w.status != "Draining")
-                .collect();
+    let shards_with_pending: Vec<_> = shards
+        .values()
+        .filter(|res| res.pending_count > 0)
+        .collect();
 
-            if eligible_workers.is_empty() {
-                "no_eligible_workers".to_string()
-            } else if !eligible_non_draining.is_empty() {
-                let mut all_full = true;
-                for w_info in &eligible_non_draining {
-                    let mut found_cap = false;
-                    for shard_res in shards.values() {
-                        if shard_res.eligible_workers.iter().any(|w| {
-                            w.worker_id == w_info.worker_id && w.in_flight_count < w.max_concurrency
-                        }) {
-                            found_cap = true;
-                            break;
-                        }
-                    }
-                    if found_cap {
-                        all_full = false;
-                        break;
-                    }
-                }
-                if all_full {
-                    "all_capacity_full".to_string()
-                } else {
-                    "healthy".to_string()
-                }
-            } else {
-                "healthy".to_string()
-            }
-        }
+    let target_shards = if shards_with_pending.is_empty() {
+        shards.values().collect::<Vec<_>>()
+    } else {
+        shards_with_pending
     };
+
+    let mut worst_rank = 0;
+    let mut worst_diag = "healthy".to_string();
+    for shard_res in target_shards {
+        let diag = &shard_res.summary.diagnosis;
+        let rank = match diag.as_str() {
+            "no_online_workers" => 4,
+            "no_eligible_workers" => 3,
+            "all_draining" => 2,
+            "all_capacity_full" => 1,
+            _ => 0,
+        };
+        if rank > worst_rank {
+            worst_rank = rank;
+            worst_diag.clone_from(diag);
+        }
+    }
+    let diagnosis = worst_diag;
 
     let mut req_builds: Vec<String> = global_required_build_ids.into_iter().collect();
     req_builds.sort();
@@ -16051,6 +16035,8 @@ async fn get_task_eligibility(
         else {
             continue;
         };
+
+        drop(conn);
 
         let Ok(res) =
             evaluate_eligibility_for_shard(&api_state, shard_id, &t.queue_name, Some(task_id))

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -15402,6 +15402,8 @@ pub struct EligibleWorkerInfo {
     pub deployment_name: Option<String>,
     pub shard_assignments: Vec<i32>,
     pub status: String,
+    pub in_flight_count: i32,
+    pub max_concurrency: i32,
 }
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
@@ -15429,6 +15431,11 @@ pub struct TaskEligibilityResponse {
     pub summary: EligibilitySummary,
 }
 
+#[allow(
+    clippy::collapsible_if,
+    clippy::cast_precision_loss,
+    clippy::too_many_lines
+)]
 async fn evaluate_eligibility_for_shard(
     api_state: &HarvestApiState,
     shard_id: ShardId,
@@ -15454,11 +15461,17 @@ async fn evaluate_eligibility_for_shard(
         tasks = harvest_task_queue::table
             .filter(harvest_task_queue::queue_name.eq(queue_name))
             .filter(harvest_task_queue::state.eq("PENDING"))
+            .filter(harvest_task_queue::scheduled_at.le(chrono::Utc::now()))
+            .filter(
+                harvest_task_queue::schedule_to_close_at
+                    .is_null()
+                    .or(harvest_task_queue::schedule_to_close_at.gt(chrono::Utc::now())),
+            )
             .order((
                 harvest_task_queue::priority.desc(),
                 harvest_task_queue::scheduled_at.asc(),
             ))
-            .limit(100)
+            .limit(1000)
             .select(autumn_harvest::models::TaskQueueItem::as_select())
             .load::<autumn_harvest::models::TaskQueueItem>(&mut conn)
             .await
@@ -15466,15 +15479,22 @@ async fn evaluate_eligibility_for_shard(
     }
 
     let pending_count = if target_task_id.is_some() {
-        if tasks.iter().any(|t| t.state == "PENDING") {
-            1
-        } else {
-            0
-        }
+        i64::from(tasks.iter().any(|t| {
+            t.state == "PENDING"
+                && t.scheduled_at <= chrono::Utc::now()
+                && (t.schedule_to_close_at.is_none()
+                    || t.schedule_to_close_at.unwrap() > chrono::Utc::now())
+        }))
     } else {
         let count: i64 = harvest_task_queue::table
             .filter(harvest_task_queue::queue_name.eq(queue_name))
             .filter(harvest_task_queue::state.eq("PENDING"))
+            .filter(harvest_task_queue::scheduled_at.le(chrono::Utc::now()))
+            .filter(
+                harvest_task_queue::schedule_to_close_at
+                    .is_null()
+                    .or(harvest_task_queue::schedule_to_close_at.gt(chrono::Utc::now())),
+            )
             .count()
             .get_result(&mut conn)
             .await
@@ -15484,8 +15504,19 @@ async fn evaluate_eligibility_for_shard(
 
     let oldest_pending_age_secs = if target_task_id.is_some() {
         tasks
-            .get(0)
-            .and_then(|t| if t.state == "PENDING" { Some(t) } else { None })
+            .as_slice()
+            .first()
+            .and_then(|t| {
+                if t.state == "PENDING"
+                    && t.scheduled_at <= chrono::Utc::now()
+                    && (t.schedule_to_close_at.is_none()
+                        || t.schedule_to_close_at.unwrap() > chrono::Utc::now())
+                {
+                    Some(t)
+                } else {
+                    None
+                }
+            })
             .map(|t| {
                 let age = chrono::Utc::now().signed_duration_since(t.scheduled_at);
                 age.num_seconds()
@@ -15494,6 +15525,12 @@ async fn evaluate_eligibility_for_shard(
         let oldest_scheduled: Option<chrono::DateTime<chrono::Utc>> = harvest_task_queue::table
             .filter(harvest_task_queue::queue_name.eq(queue_name))
             .filter(harvest_task_queue::state.eq("PENDING"))
+            .filter(harvest_task_queue::scheduled_at.le(chrono::Utc::now()))
+            .filter(
+                harvest_task_queue::schedule_to_close_at
+                    .is_null()
+                    .or(harvest_task_queue::schedule_to_close_at.gt(chrono::Utc::now())),
+            )
             .select(harvest_task_queue::scheduled_at)
             .order(harvest_task_queue::scheduled_at.asc())
             .first::<chrono::DateTime<chrono::Utc>>(&mut conn)
@@ -15507,12 +15544,10 @@ async fn evaluate_eligibility_for_shard(
     };
 
     let mut required_build_ids = Vec::new();
-    for t in &tasks {
-        if t.state == "PENDING" {
-            if let Some(ref bid) = t.required_build_id {
-                if !required_build_ids.contains(bid) {
-                    required_build_ids.push(bid.clone());
-                }
+    for t in tasks.iter().filter(|t| t.state == "PENDING") {
+        if let Some(ref bid) = t.required_build_id {
+            if !required_build_ids.contains(bid) {
+                required_build_ids.push(bid.clone());
             }
         }
     }
@@ -15539,12 +15574,10 @@ async fn evaluate_eligibility_for_shard(
         .map_err(map_error)?;
 
     let mut keys_to_check = Vec::new();
-    for t in &tasks {
-        if t.state == "PENDING" {
-            if let Some(ref k) = t.concurrency_key {
-                if !keys_to_check.contains(k) {
-                    keys_to_check.push(k.clone());
-                }
+    for t in tasks.iter().filter(|t| t.state == "PENDING") {
+        if let Some(ref k) = t.concurrency_key {
+            if !keys_to_check.contains(k) {
+                keys_to_check.push(k.clone());
             }
         }
     }
@@ -15579,17 +15612,77 @@ async fn evaluate_eligibility_for_shard(
             running_map.insert((r.key, r.task_type), r.running_count);
         }
 
-        for t in &tasks {
-            if t.state == "PENDING" {
-                if let (Some(key), Some(cap)) = (&t.concurrency_key, t.concurrency_cap) {
-                    let running = running_map
-                        .get(&(key.clone(), t.task_type.clone()))
-                        .cloned()
-                        .unwrap_or(0);
-                    if running >= i64::from(cap) {
-                        concurrency_saturated_keys.insert((key.clone(), t.task_type.clone()));
-                    }
+        for t in tasks.iter().filter(|t| t.state == "PENDING") {
+            if let (Some(key), Some(cap)) = (&t.concurrency_key, t.concurrency_cap) {
+                let running = running_map
+                    .get(&(key.clone(), t.task_type.clone()))
+                    .copied()
+                    .unwrap_or(0);
+                if running >= i64::from(cap) {
+                    concurrency_saturated_keys.insert((key.clone(), t.task_type.clone()));
                 }
+            }
+        }
+    }
+
+    let cb_activities = api_state
+        .runtime()
+        .ok()
+        .map(|r| {
+            r.registry()
+                .circuit_breakers()
+                .tracked_activity_names()
+                .to_vec()
+        })
+        .unwrap_or_default();
+
+    let mut rate_limit_keys = Vec::new();
+    for t in tasks.iter().filter(|t| t.state == "PENDING") {
+        if let Some(ref rlk) = t.rate_limit_key {
+            let has_cb = t
+                .activity_name
+                .as_ref()
+                .is_some_and(|act_name| cb_activities.contains(act_name));
+            if !has_cb && !rate_limit_keys.contains(rlk) {
+                rate_limit_keys.push(rlk.clone());
+            }
+        }
+    }
+
+    let mut saturated_rate_limits = HashSet::new();
+    if !rate_limit_keys.is_empty() {
+        #[derive(diesel::QueryableByName)]
+        struct RateLimitRow {
+            #[diesel(sql_type = diesel::sql_types::Text)]
+            key: String,
+            #[diesel(sql_type = diesel::sql_types::Double)]
+            tokens: f64,
+            #[diesel(sql_type = diesel::sql_types::Double)]
+            burst: f64,
+            #[diesel(sql_type = diesel::sql_types::Double)]
+            refill_rate: f64,
+            #[diesel(sql_type = diesel::sql_types::Timestamptz)]
+            last_refilled_at: chrono::DateTime<chrono::Utc>,
+        }
+
+        let rows: Vec<RateLimitRow> = diesel::sql_query(
+            "SELECT key, tokens, burst, refill_rate, last_refilled_at \
+             FROM harvest_rate_limit_buckets \
+             WHERE key = ANY($1)",
+        )
+        .bind::<diesel::sql_types::Array<diesel::sql_types::Text>, _>(&rate_limit_keys)
+        .load(&mut conn)
+        .await
+        .map_err(database_error)?;
+
+        for r in rows {
+            let elapsed = chrono::Utc::now()
+                .signed_duration_since(r.last_refilled_at)
+                .num_milliseconds() as f64
+                / 1000.0;
+            let current_tokens = (r.tokens + elapsed * r.refill_rate).min(r.burst);
+            if current_tokens < 1.0 {
+                saturated_rate_limits.insert(r.key);
             }
         }
     }
@@ -15597,7 +15690,15 @@ async fn evaluate_eligibility_for_shard(
     let mut eligible_workers = Vec::new();
     let mut ineligible_workers = Vec::new();
 
-    let pending_tasks: Vec<_> = tasks.iter().filter(|t| t.state == "PENDING").collect();
+    let pending_tasks: Vec<_> = tasks
+        .iter()
+        .filter(|t| {
+            t.state == "PENDING"
+                && t.scheduled_at <= chrono::Utc::now()
+                && (t.schedule_to_close_at.is_none()
+                    || t.schedule_to_close_at.unwrap() > chrono::Utc::now())
+        })
+        .collect();
 
     for w in &online_workers {
         let w_id = w.worker.worker_id.clone();
@@ -15609,7 +15710,7 @@ async fn evaluate_eligibility_for_shard(
             .as_array()
             .map(|arr| {
                 arr.iter()
-                    .filter_map(|v| v.as_i64().map(|n| n as i32))
+                    .filter_map(|v| v.as_i64().and_then(|n| i32::try_from(n).ok()))
                     .collect()
             })
             .unwrap_or_default();
@@ -15621,6 +15722,8 @@ async fn evaluate_eligibility_for_shard(
             deployment_name,
             shard_assignments: shard_assignments.clone(),
             status: status.clone(),
+            in_flight_count: w.worker.in_flight_count,
+            max_concurrency: w.worker.max_concurrency,
         };
 
         let mut worker_reasons = Vec::new();
@@ -15631,7 +15734,7 @@ async fn evaluate_eligibility_for_shard(
             .as_array()
             .map(|arr| {
                 arr.iter()
-                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .filter_map(|v| v.as_str().map(ToString::to_string))
                     .collect()
             })
             .unwrap_or_default();
@@ -15672,18 +15775,26 @@ async fn evaluate_eligibility_for_shard(
                     reasons.push("build_incompatible".to_string());
                 }
 
-                if let Some(ref sticky_worker) = t.sticky_worker_id {
-                    if let Some(ref sticky_until) = t.sticky_until {
-                        if *sticky_until > chrono::Utc::now()
-                            && w.worker.worker_id != *sticky_worker
-                        {
-                            reasons.push("sticky_owned_by_other_worker".to_string());
-                        }
+                if let (Some(sticky_worker), Some(sticky_until)) =
+                    (&t.sticky_worker_id, &t.sticky_until)
+                {
+                    if *sticky_until > chrono::Utc::now() && w.worker.worker_id != *sticky_worker {
+                        reasons.push("sticky_owned_by_other_worker".to_string());
                     }
                 }
 
-                if let Some(ref key) = t.concurrency_key {
-                    if concurrency_saturated_keys.contains(&(key.clone(), t.task_type.clone())) {
+                if t.concurrency_key.as_ref().is_some_and(|key| {
+                    concurrency_saturated_keys.contains(&(key.clone(), t.task_type.clone()))
+                }) {
+                    reasons.push("concurrency_saturated".to_string());
+                }
+
+                if let Some(ref rlk) = t.rate_limit_key {
+                    let has_cb = t
+                        .activity_name
+                        .as_ref()
+                        .is_some_and(|act_name| cb_activities.contains(act_name));
+                    if !has_cb && saturated_rate_limits.contains(rlk) {
                         reasons.push("concurrency_saturated".to_string());
                     }
                 }
@@ -15691,9 +15802,8 @@ async fn evaluate_eligibility_for_shard(
                 if reasons.is_empty() {
                     eligible_for_any = true;
                     break;
-                } else {
-                    task_failures.push(reasons);
                 }
+                task_failures.push(reasons);
             }
 
             if eligible_for_any {
@@ -15739,14 +15849,9 @@ async fn evaluate_eligibility_for_shard(
             } else if !eligible_non_draining.is_empty() {
                 let mut all_full = true;
                 for w_info in &eligible_non_draining {
-                    if let Some(w) = online_workers
-                        .iter()
-                        .find(|w| w.worker.worker_id == w_info.worker_id)
-                    {
-                        if w.worker.in_flight_count < w.worker.max_concurrency {
-                            all_full = false;
-                            break;
-                        }
+                    if w_info.in_flight_count < w_info.max_concurrency {
+                        all_full = false;
+                        break;
                     }
                 }
                 if all_full {
@@ -15772,6 +15877,7 @@ async fn evaluate_eligibility_for_shard(
     })
 }
 
+#[allow(clippy::too_many_lines)]
 async fn get_queue_eligibility(
     Extension(api_state): Extension<HarvestApiState>,
     Path(queue_name): Path<String>,
@@ -15794,26 +15900,13 @@ async fn get_queue_eligibility(
             Ok(res) => {
                 global_pending_count += res.pending_count;
                 if let Some(age) = res.oldest_pending_age_secs {
-                    global_oldest_pending_age_secs = Some(match global_oldest_pending_age_secs {
-                        Some(current) => std::cmp::max(current, age),
-                        None => age,
-                    });
+                    global_oldest_pending_age_secs = Some(
+                        global_oldest_pending_age_secs
+                            .map_or(age, |current| std::cmp::max(current, age)),
+                    );
                 }
                 for bid in &res.required_build_ids {
                     global_required_build_ids.insert(bid.clone());
-                }
-
-                for w in &res.eligible_workers {
-                    shard_eligible.insert(w.worker_id.clone(), w.clone());
-                    online_worker_ids.insert(w.worker_id.clone());
-                }
-
-                for w in &res.ineligible_workers {
-                    shard_ineligible
-                        .entry(w.worker_id.clone())
-                        .or_insert_with(std::collections::HashSet::new)
-                        .extend(w.reason_codes.iter().cloned());
-                    online_worker_ids.insert(w.worker_id.clone());
                 }
 
                 shards.insert(shard_id.as_i32().to_string(), res);
@@ -15824,6 +15917,33 @@ async fn get_queue_eligibility(
                     error: e.to_string(),
                 });
             }
+        }
+    }
+
+    if shards.is_empty() && !shard_errors.is_empty() {
+        let first_err = shard_errors.remove(0);
+        return Err(AutumnError::service_unavailable_msg(format!(
+            "failed to inspect any shard. First error on shard {}: {}",
+            first_err.shard_id, first_err.error
+        )));
+    }
+
+    for res in shards.values() {
+        let has_pending_tasks = res.pending_count > 0;
+
+        for w in &res.eligible_workers {
+            if has_pending_tasks || global_pending_count == 0 {
+                shard_eligible.insert(w.worker_id.clone(), w.clone());
+            }
+            online_worker_ids.insert(w.worker_id.clone());
+        }
+
+        for w in &res.ineligible_workers {
+            shard_ineligible
+                .entry(w.worker_id.clone())
+                .or_insert_with(std::collections::HashSet::new)
+                .extend(w.reason_codes.iter().cloned());
+            online_worker_ids.insert(w.worker_id.clone());
         }
     }
 
@@ -15868,31 +15988,12 @@ async fn get_queue_eligibility(
                 let mut all_full = true;
                 for w_info in &eligible_non_draining {
                     let mut found_cap = false;
-                    for (_shard_id, shard_pool) in pool.iter_shards() {
-                        if let Ok(mut conn) = acquire_conn(shard_pool).await {
-                            let stale_threshold = api_state.worker_stale_threshold();
-                            if let Ok(w) = list_workers(
-                                &mut conn,
-                                &WorkerFilters {
-                                    limit: 100,
-                                    build_id: Some(w_info.build_id.clone()),
-                                    ..Default::default()
-                                },
-                                stale_threshold,
-                            )
-                            .await
-                            {
-                                if let Some(worker_row) =
-                                    w.iter().find(|w| w.worker.worker_id == w_info.worker_id)
-                                {
-                                    if worker_row.worker.in_flight_count
-                                        < worker_row.worker.max_concurrency
-                                    {
-                                        found_cap = true;
-                                        break;
-                                    }
-                                }
-                            }
+                    for shard_res in shards.values() {
+                        if shard_res.eligible_workers.iter().any(|w| {
+                            w.worker_id == w_info.worker_id && w.in_flight_count < w.max_concurrency
+                        }) {
+                            found_cap = true;
+                            break;
                         }
                     }
                     if found_cap {
@@ -15938,38 +16039,43 @@ async fn get_task_eligibility(
     let pool = api_state.storage_pool().map_err(map_error)?;
 
     for (shard_id, shard_pool) in pool.iter_shards() {
-        let mut conn = acquire_conn(shard_pool).await?;
-        let task = harvest_task_queue::table
+        let Ok(mut conn) = acquire_conn(shard_pool).await else {
+            continue;
+        };
+        let Ok(Some(t)) = harvest_task_queue::table
             .find(task_id)
             .select(autumn_harvest::models::TaskQueueItem::as_select())
             .first::<autumn_harvest::models::TaskQueueItem>(&mut conn)
             .await
             .optional()
-            .map_err(database_error)?;
+        else {
+            continue;
+        };
 
-        if let Some(t) = task {
-            let res =
-                evaluate_eligibility_for_shard(&api_state, shard_id, &t.queue_name, Some(task_id))
-                    .await?;
+        let Ok(res) =
+            evaluate_eligibility_for_shard(&api_state, shard_id, &t.queue_name, Some(task_id))
+                .await
+        else {
+            continue;
+        };
 
-            let mut eligible_workers = res.eligible_workers;
-            let mut ineligible_workers = res.ineligible_workers;
-            eligible_workers.sort_by(|a, b| a.worker_id.cmp(&b.worker_id));
-            ineligible_workers.sort_by(|a, b| a.worker_id.cmp(&b.worker_id));
+        let mut eligible_workers = res.eligible_workers;
+        let mut ineligible_workers = res.ineligible_workers;
+        eligible_workers.sort_by(|a, b| a.worker_id.cmp(&b.worker_id));
+        ineligible_workers.sort_by(|a, b| a.worker_id.cmp(&b.worker_id));
 
-            return Ok(Json(TaskEligibilityResponse {
-                task_id,
-                queue_name: t.queue_name,
-                pending_count: res.pending_count,
-                oldest_pending_age_secs: res.oldest_pending_age_secs,
-                required_build_id: t.required_build_id,
-                assigned_shard: shard_id.as_i32(),
-                concurrency_key: t.concurrency_key,
-                eligible_workers,
-                ineligible_workers,
-                summary: res.summary,
-            }));
-        }
+        return Ok(Json(TaskEligibilityResponse {
+            task_id,
+            queue_name: t.queue_name,
+            pending_count: res.pending_count,
+            oldest_pending_age_secs: res.oldest_pending_age_secs,
+            required_build_id: t.required_build_id,
+            assigned_shard: shard_id.as_i32(),
+            concurrency_key: t.concurrency_key,
+            eligible_workers,
+            ineligible_workers,
+            summary: res.summary,
+        }));
     }
 
     Err(AutumnError::not_found_msg(format!(

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -2141,7 +2141,16 @@ pub fn harvest_api_router(api_state: HarvestApiState) -> Router<AppState> {
         )
         .route(
             "/admin/gates/{id}",
-            delete(lift_gate_handler).route_layer(require_admin),
+            delete(lift_gate_handler).route_layer(require_admin.clone()),
+        )
+        // Stuck-task triage eligibility explainer (issue #380)
+        .route(
+            "/admin/queues/{queue_name}/eligibility",
+            get(get_queue_eligibility).route_layer(require_admin.clone()),
+        )
+        .route(
+            "/admin/tasks/{id}/eligibility",
+            get(get_task_eligibility).route_layer(require_admin),
         )
         .layer(Extension(api_state))
 }
@@ -2287,6 +2296,9 @@ pub const fn management_api_routes() -> &'static [(&'static str, &'static str)] 
         ("GET", "/admin/gates"),
         ("POST", "/admin/gates"),
         ("DELETE", "/admin/gates/{id}"),
+        // ── stuck-task triage eligibility (issue #380) ────────────────────────
+        ("GET", "/admin/queues/{queue_name}/eligibility"),
+        ("GET", "/admin/tasks/{id}/eligibility"),
     ]
 }
 
@@ -3054,6 +3066,37 @@ pub const fn management_api_response_fields()
             ]),
         ),
         ("DELETE", "/admin/gates/{id}", Some(&["lifted"])),
+        (
+            "GET",
+            "/admin/queues/{queue_name}/eligibility",
+            Some(&[
+                "queue_name",
+                "pending_count",
+                "oldest_pending_age_secs",
+                "required_build_ids",
+                "eligible_workers",
+                "ineligible_workers",
+                "summary",
+                "shards",
+                "shard_errors",
+            ]),
+        ),
+        (
+            "GET",
+            "/admin/tasks/{id}/eligibility",
+            Some(&[
+                "task_id",
+                "queue_name",
+                "pending_count",
+                "oldest_pending_age_secs",
+                "required_build_id",
+                "assigned_shard",
+                "concurrency_key",
+                "eligible_workers",
+                "ineligible_workers",
+                "summary",
+            ]),
+        ),
     ]
 }
 
@@ -15317,6 +15360,621 @@ async fn retire_build_handler(
         )
             .into_response()
     }
+}
+
+// ── Stuck-task triage eligibility explainer structures (issue #380) ──────────
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct QueueEligibilityResponse {
+    pub queue_name: String,
+    pub pending_count: i64,
+    pub oldest_pending_age_secs: Option<i64>,
+    pub required_build_ids: Vec<String>,
+    pub eligible_workers: Vec<EligibleWorkerInfo>,
+    pub ineligible_workers: Vec<IneligibleWorkerInfo>,
+    pub summary: EligibilitySummary,
+    #[serde(default, skip_serializing_if = "std::collections::BTreeMap::is_empty")]
+    pub shards: std::collections::BTreeMap<String, ShardEligibilityResponse>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub shard_errors: Vec<EligibilityShardError>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct ShardEligibilityResponse {
+    pub pending_count: i64,
+    pub oldest_pending_age_secs: Option<i64>,
+    pub required_build_ids: Vec<String>,
+    pub eligible_workers: Vec<EligibleWorkerInfo>,
+    pub ineligible_workers: Vec<IneligibleWorkerInfo>,
+    pub summary: EligibilitySummary,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct EligibilityShardError {
+    pub shard_id: i32,
+    pub error: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct EligibleWorkerInfo {
+    pub worker_id: String,
+    pub build_id: String,
+    pub deployment_name: Option<String>,
+    pub shard_assignments: Vec<i32>,
+    pub status: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct IneligibleWorkerInfo {
+    pub worker_id: String,
+    pub reason_codes: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct EligibilitySummary {
+    pub diagnosis: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct TaskEligibilityResponse {
+    pub task_id: uuid::Uuid,
+    pub queue_name: String,
+    pub pending_count: i64,
+    pub oldest_pending_age_secs: Option<i64>,
+    pub required_build_id: Option<String>,
+    pub assigned_shard: i32,
+    pub concurrency_key: Option<String>,
+    pub eligible_workers: Vec<EligibleWorkerInfo>,
+    pub ineligible_workers: Vec<IneligibleWorkerInfo>,
+    pub summary: EligibilitySummary,
+}
+
+async fn evaluate_eligibility_for_shard(
+    api_state: &HarvestApiState,
+    shard_id: ShardId,
+    queue_name: &str,
+    target_task_id: Option<uuid::Uuid>,
+) -> Result<ShardEligibilityResponse, AutumnError> {
+    use std::collections::{HashMap, HashSet};
+    let mut conn = db_conn_for_shard(api_state, shard_id).await?;
+
+    let mut tasks = Vec::new();
+    if let Some(task_id) = target_task_id {
+        let task = harvest_task_queue::table
+            .find(task_id)
+            .select(autumn_harvest::models::TaskQueueItem::as_select())
+            .first::<autumn_harvest::models::TaskQueueItem>(&mut conn)
+            .await
+            .optional()
+            .map_err(database_error)?;
+        if let Some(t) = task {
+            tasks.push(t);
+        }
+    } else {
+        tasks = harvest_task_queue::table
+            .filter(harvest_task_queue::queue_name.eq(queue_name))
+            .filter(harvest_task_queue::state.eq("PENDING"))
+            .order((
+                harvest_task_queue::priority.desc(),
+                harvest_task_queue::scheduled_at.asc(),
+            ))
+            .limit(100)
+            .select(autumn_harvest::models::TaskQueueItem::as_select())
+            .load::<autumn_harvest::models::TaskQueueItem>(&mut conn)
+            .await
+            .map_err(database_error)?;
+    }
+
+    let pending_count = if target_task_id.is_some() {
+        if tasks.iter().any(|t| t.state == "PENDING") {
+            1
+        } else {
+            0
+        }
+    } else {
+        let count: i64 = harvest_task_queue::table
+            .filter(harvest_task_queue::queue_name.eq(queue_name))
+            .filter(harvest_task_queue::state.eq("PENDING"))
+            .count()
+            .get_result(&mut conn)
+            .await
+            .map_err(database_error)?;
+        count
+    };
+
+    let oldest_pending_age_secs = if target_task_id.is_some() {
+        tasks
+            .get(0)
+            .and_then(|t| if t.state == "PENDING" { Some(t) } else { None })
+            .map(|t| {
+                let age = chrono::Utc::now().signed_duration_since(t.scheduled_at);
+                age.num_seconds()
+            })
+    } else {
+        let oldest_scheduled: Option<chrono::DateTime<chrono::Utc>> = harvest_task_queue::table
+            .filter(harvest_task_queue::queue_name.eq(queue_name))
+            .filter(harvest_task_queue::state.eq("PENDING"))
+            .select(harvest_task_queue::scheduled_at)
+            .order(harvest_task_queue::scheduled_at.asc())
+            .first::<chrono::DateTime<chrono::Utc>>(&mut conn)
+            .await
+            .optional()
+            .map_err(database_error)?;
+        oldest_scheduled.map(|ts| {
+            let age = chrono::Utc::now().signed_duration_since(ts);
+            age.num_seconds()
+        })
+    };
+
+    let mut required_build_ids = Vec::new();
+    for t in &tasks {
+        if t.state == "PENDING" {
+            if let Some(ref bid) = t.required_build_id {
+                if !required_build_ids.contains(bid) {
+                    required_build_ids.push(bid.clone());
+                }
+            }
+        }
+    }
+
+    let stale_threshold = api_state.worker_stale_threshold();
+    let workers = list_workers(
+        &mut conn,
+        &WorkerFilters {
+            limit: i64::MAX,
+            ..Default::default()
+        },
+        stale_threshold,
+    )
+    .await
+    .map_err(map_error)?;
+
+    let online_workers: Vec<_> = workers
+        .into_iter()
+        .filter(|w| w.health == autumn_harvest::workers::WorkerHealth::Healthy)
+        .collect();
+
+    let compat_set = autumn_harvest::build_routing::load_compat_set(&mut conn)
+        .await
+        .map_err(map_error)?;
+
+    let mut keys_to_check = Vec::new();
+    for t in &tasks {
+        if t.state == "PENDING" {
+            if let Some(ref k) = t.concurrency_key {
+                if !keys_to_check.contains(k) {
+                    keys_to_check.push(k.clone());
+                }
+            }
+        }
+    }
+
+    let mut concurrency_saturated_keys = HashSet::new();
+    if !keys_to_check.is_empty() {
+        #[derive(diesel::QueryableByName)]
+        struct ConcurrencyRow {
+            #[diesel(sql_type = diesel::sql_types::Text)]
+            key: String,
+            #[diesel(sql_type = diesel::sql_types::Text)]
+            task_type: String,
+            #[diesel(sql_type = diesel::sql_types::BigInt)]
+            running_count: i64,
+        }
+
+        let rows: Vec<ConcurrencyRow> = diesel::sql_query(
+            "SELECT concurrency_key AS key, task_type, COUNT(*) AS running_count \
+             FROM harvest_task_queue \
+             WHERE state = 'RUNNING' \
+               AND concurrency_key = ANY($1) \
+               AND worker_id IS NOT NULL \
+             GROUP BY concurrency_key, task_type",
+        )
+        .bind::<diesel::sql_types::Array<diesel::sql_types::Text>, _>(&keys_to_check)
+        .load(&mut conn)
+        .await
+        .map_err(database_error)?;
+
+        let mut running_map = HashMap::new();
+        for r in rows {
+            running_map.insert((r.key, r.task_type), r.running_count);
+        }
+
+        for t in &tasks {
+            if t.state == "PENDING" {
+                if let (Some(key), Some(cap)) = (&t.concurrency_key, t.concurrency_cap) {
+                    let running = running_map
+                        .get(&(key.clone(), t.task_type.clone()))
+                        .cloned()
+                        .unwrap_or(0);
+                    if running >= i64::from(cap) {
+                        concurrency_saturated_keys.insert((key.clone(), t.task_type.clone()));
+                    }
+                }
+            }
+        }
+    }
+
+    let mut eligible_workers = Vec::new();
+    let mut ineligible_workers = Vec::new();
+
+    let pending_tasks: Vec<_> = tasks.iter().filter(|t| t.state == "PENDING").collect();
+
+    for w in &online_workers {
+        let w_id = w.worker.worker_id.clone();
+        let build_id = w.worker.build_id.clone();
+        let deployment_name = w.worker.deployment_name.clone();
+        let shard_assignments: Vec<i32> = w
+            .worker
+            .shard_assignments
+            .as_array()
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_i64().map(|n| n as i32))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let status = w.worker.status.clone();
+
+        let w_info = EligibleWorkerInfo {
+            worker_id: w_id.clone(),
+            build_id,
+            deployment_name,
+            shard_assignments: shard_assignments.clone(),
+            status: status.clone(),
+        };
+
+        let mut worker_reasons = Vec::new();
+
+        let subscribed_queues: Vec<String> = w
+            .worker
+            .queues
+            .as_array()
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                    .collect()
+            })
+            .unwrap_or_default();
+        if !subscribed_queues.contains(&queue_name.to_string()) {
+            worker_reasons.push("wrong_queue_subscription".to_string());
+        }
+
+        if !shard_assignments.contains(&(shard_id.as_i32())) {
+            worker_reasons.push("wrong_shard_assignment".to_string());
+        }
+
+        if status == "Draining" {
+            worker_reasons.push("worker_draining".to_string());
+        }
+
+        if status == "Stopped" {
+            worker_reasons.push("worker_stopped".to_string());
+        }
+
+        if !worker_reasons.is_empty() {
+            ineligible_workers.push(IneligibleWorkerInfo {
+                worker_id: w_id,
+                reason_codes: worker_reasons,
+            });
+            continue;
+        }
+
+        if pending_tasks.is_empty() {
+            eligible_workers.push(w_info);
+        } else {
+            let mut eligible_for_any = false;
+            let mut task_failures = Vec::new();
+
+            for t in &pending_tasks {
+                let mut reasons = Vec::new();
+
+                if !compat_set.is_eligible(&w.worker.build_id, t.required_build_id.as_deref()) {
+                    reasons.push("build_incompatible".to_string());
+                }
+
+                if let Some(ref sticky_worker) = t.sticky_worker_id {
+                    if let Some(ref sticky_until) = t.sticky_until {
+                        if *sticky_until > chrono::Utc::now()
+                            && w.worker.worker_id != *sticky_worker
+                        {
+                            reasons.push("sticky_owned_by_other_worker".to_string());
+                        }
+                    }
+                }
+
+                if let Some(ref key) = t.concurrency_key {
+                    if concurrency_saturated_keys.contains(&(key.clone(), t.task_type.clone())) {
+                        reasons.push("concurrency_saturated".to_string());
+                    }
+                }
+
+                if reasons.is_empty() {
+                    eligible_for_any = true;
+                    break;
+                } else {
+                    task_failures.push(reasons);
+                }
+            }
+
+            if eligible_for_any {
+                eligible_workers.push(w_info);
+            } else {
+                let mut merged_reasons = HashSet::new();
+                for tf in task_failures {
+                    for r in tf {
+                        merged_reasons.insert(r);
+                    }
+                }
+                let mut reason_codes: Vec<String> = merged_reasons.into_iter().collect();
+                reason_codes.sort();
+                if reason_codes.is_empty() {
+                    reason_codes.push("unknown".to_string());
+                }
+                ineligible_workers.push(IneligibleWorkerInfo {
+                    worker_id: w_id,
+                    reason_codes,
+                });
+            }
+        }
+    }
+
+    let num_online = eligible_workers.len() + ineligible_workers.len();
+    let diagnosis = if num_online == 0 {
+        "no_online_workers".to_string()
+    } else {
+        let all_draining = eligible_workers.iter().all(|w| w.status == "Draining")
+            && ineligible_workers
+                .iter()
+                .all(|w| w.reason_codes.contains(&"worker_draining".to_string()));
+        if all_draining {
+            "all_draining".to_string()
+        } else {
+            let eligible_non_draining: Vec<_> = eligible_workers
+                .iter()
+                .filter(|w| w.status != "Draining")
+                .collect();
+
+            if eligible_workers.is_empty() {
+                "no_eligible_workers".to_string()
+            } else if !eligible_non_draining.is_empty() {
+                let mut all_full = true;
+                for w_info in &eligible_non_draining {
+                    if let Some(w) = online_workers
+                        .iter()
+                        .find(|w| w.worker.worker_id == w_info.worker_id)
+                    {
+                        if w.worker.in_flight_count < w.worker.max_concurrency {
+                            all_full = false;
+                            break;
+                        }
+                    }
+                }
+                if all_full {
+                    "all_capacity_full".to_string()
+                } else {
+                    "healthy".to_string()
+                }
+            } else {
+                "healthy".to_string()
+            }
+        }
+    };
+
+    let summary = EligibilitySummary { diagnosis };
+
+    Ok(ShardEligibilityResponse {
+        pending_count,
+        oldest_pending_age_secs,
+        required_build_ids,
+        eligible_workers,
+        ineligible_workers,
+        summary,
+    })
+}
+
+async fn get_queue_eligibility(
+    Extension(api_state): Extension<HarvestApiState>,
+    Path(queue_name): Path<String>,
+) -> Result<Json<QueueEligibilityResponse>, AutumnError> {
+    let pool = api_state.storage_pool().map_err(map_error)?;
+
+    let mut shards = std::collections::BTreeMap::new();
+    let mut shard_errors = Vec::new();
+
+    let mut global_pending_count = 0;
+    let mut global_oldest_pending_age_secs = None;
+    let mut global_required_build_ids = std::collections::HashSet::new();
+
+    let mut shard_eligible = std::collections::HashMap::new();
+    let mut shard_ineligible = std::collections::HashMap::new();
+    let mut online_worker_ids = std::collections::HashSet::new();
+
+    for (shard_id, _shard_pool) in pool.iter_shards() {
+        match evaluate_eligibility_for_shard(&api_state, shard_id, &queue_name, None).await {
+            Ok(res) => {
+                global_pending_count += res.pending_count;
+                if let Some(age) = res.oldest_pending_age_secs {
+                    global_oldest_pending_age_secs = Some(match global_oldest_pending_age_secs {
+                        Some(current) => std::cmp::max(current, age),
+                        None => age,
+                    });
+                }
+                for bid in &res.required_build_ids {
+                    global_required_build_ids.insert(bid.clone());
+                }
+
+                for w in &res.eligible_workers {
+                    shard_eligible.insert(w.worker_id.clone(), w.clone());
+                    online_worker_ids.insert(w.worker_id.clone());
+                }
+
+                for w in &res.ineligible_workers {
+                    shard_ineligible
+                        .entry(w.worker_id.clone())
+                        .or_insert_with(std::collections::HashSet::new)
+                        .extend(w.reason_codes.iter().cloned());
+                    online_worker_ids.insert(w.worker_id.clone());
+                }
+
+                shards.insert(shard_id.as_i32().to_string(), res);
+            }
+            Err(e) => {
+                shard_errors.push(EligibilityShardError {
+                    shard_id: shard_id.as_i32(),
+                    error: e.to_string(),
+                });
+            }
+        }
+    }
+
+    let mut eligible_workers = Vec::new();
+    let mut ineligible_workers = Vec::new();
+
+    for w_id in online_worker_ids {
+        if let Some(w_info) = shard_eligible.get(&w_id) {
+            eligible_workers.push(w_info.clone());
+        } else if let Some(reasons_set) = shard_ineligible.get(&w_id) {
+            let mut reason_codes: Vec<String> = reasons_set.iter().cloned().collect();
+            reason_codes.sort();
+            ineligible_workers.push(IneligibleWorkerInfo {
+                worker_id: w_id,
+                reason_codes,
+            });
+        }
+    }
+
+    eligible_workers.sort_by(|a, b| a.worker_id.cmp(&b.worker_id));
+    ineligible_workers.sort_by(|a, b| a.worker_id.cmp(&b.worker_id));
+
+    let num_online = eligible_workers.len() + ineligible_workers.len();
+    let diagnosis = if num_online == 0 {
+        "no_online_workers".to_string()
+    } else {
+        let all_draining = eligible_workers.iter().all(|w| w.status == "Draining")
+            && ineligible_workers
+                .iter()
+                .all(|w| w.reason_codes.contains(&"worker_draining".to_string()));
+        if all_draining {
+            "all_draining".to_string()
+        } else {
+            let eligible_non_draining: Vec<_> = eligible_workers
+                .iter()
+                .filter(|w| w.status != "Draining")
+                .collect();
+
+            if eligible_workers.is_empty() {
+                "no_eligible_workers".to_string()
+            } else if !eligible_non_draining.is_empty() {
+                let mut all_full = true;
+                for w_info in &eligible_non_draining {
+                    let mut found_cap = false;
+                    for (_shard_id, shard_pool) in pool.iter_shards() {
+                        if let Ok(mut conn) = acquire_conn(shard_pool).await {
+                            let stale_threshold = api_state.worker_stale_threshold();
+                            if let Ok(w) = list_workers(
+                                &mut conn,
+                                &WorkerFilters {
+                                    limit: 100,
+                                    build_id: Some(w_info.build_id.clone()),
+                                    ..Default::default()
+                                },
+                                stale_threshold,
+                            )
+                            .await
+                            {
+                                if let Some(worker_row) =
+                                    w.iter().find(|w| w.worker.worker_id == w_info.worker_id)
+                                {
+                                    if worker_row.worker.in_flight_count
+                                        < worker_row.worker.max_concurrency
+                                    {
+                                        found_cap = true;
+                                        break;
+                                    }
+                                }
+                            }
+                        }
+                    }
+                    if found_cap {
+                        all_full = false;
+                        break;
+                    }
+                }
+                if all_full {
+                    "all_capacity_full".to_string()
+                } else {
+                    "healthy".to_string()
+                }
+            } else {
+                "healthy".to_string()
+            }
+        }
+    };
+
+    let mut req_builds: Vec<String> = global_required_build_ids.into_iter().collect();
+    req_builds.sort();
+
+    Ok(Json(QueueEligibilityResponse {
+        queue_name,
+        pending_count: global_pending_count,
+        oldest_pending_age_secs: global_oldest_pending_age_secs,
+        required_build_ids: req_builds,
+        eligible_workers,
+        ineligible_workers,
+        summary: EligibilitySummary { diagnosis },
+        shards,
+        shard_errors,
+    }))
+}
+
+async fn get_task_eligibility(
+    Extension(api_state): Extension<HarvestApiState>,
+    Path(task_id_str): Path<String>,
+) -> Result<Json<TaskEligibilityResponse>, AutumnError> {
+    let task_id = task_id_str
+        .parse::<uuid::Uuid>()
+        .map_err(|_| AutumnError::bad_request_msg(format!("invalid task id '{task_id_str}'")))?;
+
+    let pool = api_state.storage_pool().map_err(map_error)?;
+
+    for (shard_id, shard_pool) in pool.iter_shards() {
+        let mut conn = acquire_conn(shard_pool).await?;
+        let task = harvest_task_queue::table
+            .find(task_id)
+            .select(autumn_harvest::models::TaskQueueItem::as_select())
+            .first::<autumn_harvest::models::TaskQueueItem>(&mut conn)
+            .await
+            .optional()
+            .map_err(database_error)?;
+
+        if let Some(t) = task {
+            let res =
+                evaluate_eligibility_for_shard(&api_state, shard_id, &t.queue_name, Some(task_id))
+                    .await?;
+
+            let mut eligible_workers = res.eligible_workers;
+            let mut ineligible_workers = res.ineligible_workers;
+            eligible_workers.sort_by(|a, b| a.worker_id.cmp(&b.worker_id));
+            ineligible_workers.sort_by(|a, b| a.worker_id.cmp(&b.worker_id));
+
+            return Ok(Json(TaskEligibilityResponse {
+                task_id,
+                queue_name: t.queue_name,
+                pending_count: res.pending_count,
+                oldest_pending_age_secs: res.oldest_pending_age_secs,
+                required_build_id: t.required_build_id,
+                assigned_shard: shard_id.as_i32(),
+                concurrency_key: t.concurrency_key,
+                eligible_workers,
+                ineligible_workers,
+                summary: res.summary,
+            }));
+        }
+    }
+
+    Err(AutumnError::not_found_msg(format!(
+        "task {task_id} not found"
+    )))
 }
 
 #[cfg(test)]

--- a/autumn-harvest-plugin/tests/eligibility_tests.rs
+++ b/autumn-harvest-plugin/tests/eligibility_tests.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::too_many_lines)]
+
 use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::Duration;
@@ -17,7 +19,6 @@ use autumn_web::AppState;
 use autumn_web::reexports::axum;
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
-use diesel_async::AsyncConnection;
 use diesel_async::AsyncPgConnection;
 use diesel_async::RunQueryDsl;
 use diesel_async::pooled_connection::AsyncDieselConnectionManager;
@@ -189,37 +190,25 @@ async fn seed_task_detailed(
     let mut conn = pool.get().await.expect("task seeding connection");
     let id = uuid::Uuid::new_v4();
 
-    let required_build_clause = required_build_id
-        .map(|v| format!("'{}'", v))
-        .unwrap_or_else(|| "NULL".to_string());
-    let sticky_worker_clause = sticky_worker_id
-        .map(|v| format!("'{}'", v))
-        .unwrap_or_else(|| "NULL".to_string());
+    let required_build_clause =
+        required_build_id.map_or_else(|| "NULL".to_string(), |v| format!("'{v}'"));
+    let sticky_worker_clause =
+        sticky_worker_id.map_or_else(|| "NULL".to_string(), |v| format!("'{v}'"));
     let sticky_until_clause = sticky_until_interval
-        .map(|v| format!("NOW() + INTERVAL '{}'", v))
-        .unwrap_or_else(|| "NULL".to_string());
-    let concurrency_key_clause = concurrency_key
-        .map(|v| format!("'{}'", v))
-        .unwrap_or_else(|| "NULL".to_string());
-    let concurrency_cap_clause = concurrency_cap
-        .map(|v| v.to_string())
-        .unwrap_or_else(|| "NULL".to_string());
+        .map_or_else(|| "NULL".to_string(), |v| format!("NOW() + INTERVAL '{v}'"));
+    let concurrency_key_clause =
+        concurrency_key.map_or_else(|| "NULL".to_string(), |v| format!("'{v}'"));
+    let concurrency_cap_clause =
+        concurrency_cap.map_or_else(|| "NULL".to_string(), |v| v.to_string());
 
     diesel::sql_query(format!(
         "INSERT INTO harvest_task_queue (
             id, queue_name, task_type, input, state, priority, max_attempts, scheduled_at,
             required_build_id, sticky_worker_id, sticky_until, concurrency_key, concurrency_cap
          ) VALUES (
-            '{}', '{}', 'workflow', '{{}}'::jsonb, 'PENDING', 0, 1, NOW() - INTERVAL '5 seconds',
-            {}, {}, {}, {}, {}
-         )",
-        id,
-        queue_name,
-        required_build_clause,
-        sticky_worker_clause,
-        sticky_until_clause,
-        concurrency_key_clause,
-        concurrency_cap_clause
+            '{id}', '{queue_name}', 'workflow', '{{}}'::jsonb, 'PENDING', 0, 1, NOW() - INTERVAL '5 seconds',
+            {required_build_clause}, {sticky_worker_clause}, {sticky_until_clause}, {concurrency_key_clause}, {concurrency_cap_clause}
+         )"
     ))
     .execute(&mut conn)
     .await
@@ -240,7 +229,7 @@ async fn get_json_with_auth(
     uri: impl Into<String>,
     has_admin: bool,
 ) -> (StatusCode, Value) {
-    let mut req = Request::builder()
+    let req = Request::builder()
         .method("GET")
         .uri(uri.into())
         .body(Body::empty())
@@ -395,13 +384,14 @@ async fn test_queue_and_task_eligibility_scenarios() {
     assert!(body["oldest_pending_age_secs"].as_i64().is_some());
 
     // Distinct build IDs across pending rows: "v2" and null (null should be absent or represented, required_build_ids is a list of strings)
-    let req_builds: Vec<String> = body["required_build_ids"]
-        .as_array()
-        .unwrap()
-        .iter()
-        .map(|v| v.as_str().unwrap().to_string())
-        .collect();
-    assert!(req_builds.contains(&"v2".to_string()));
+    // Distinct build IDs across pending rows: "v2" and null (null should be absent or represented, required_build_ids is a list of strings)
+    assert!(
+        body["required_build_ids"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|v| v.as_str().unwrap() == "v2")
+    );
 
     // Eligible workers check: worker-eligible passes all gates for at least one task (specifically Task A and C, wait, Task C has concurrency key saturated, but Task A doesn't).
     let eligible_list = body["eligible_workers"].as_array().unwrap();
@@ -410,68 +400,83 @@ async fn test_queue_and_task_eligibility_scenarios() {
         .map(|w| w["worker_id"].as_str().unwrap())
         .collect();
     assert!(eligible_ids.contains(&"worker-eligible"));
+    let w_el = eligible_list
+        .iter()
+        .find(|w| w["worker_id"] == "worker-eligible")
+        .unwrap();
+    assert_eq!(w_el["in_flight_count"], 0);
+    assert_eq!(w_el["max_concurrency"], 10);
+
+    assert!(eligible_ids.contains(&"worker-full-capacity"));
+    let w_full = eligible_list
+        .iter()
+        .find(|w| w["worker_id"] == "worker-full-capacity")
+        .unwrap();
+    assert_eq!(w_full["in_flight_count"], 2);
+    assert_eq!(w_full["max_concurrency"], 2);
+
     // worker-stale is offline, should not be in either list
     assert!(!eligible_ids.contains(&"worker-stale"));
 
     // Ineligible workers check
     let ineligible_list = body["ineligible_workers"].as_array().unwrap();
-    let ineligible_ids: Vec<&str> = ineligible_list
-        .iter()
-        .map(|w| w["worker_id"].as_str().unwrap())
-        .collect();
-    assert!(!ineligible_ids.contains(&"worker-stale"));
+    assert!(
+        !ineligible_list
+            .iter()
+            .any(|w| w["worker_id"].as_str().unwrap() == "worker-stale")
+    );
 
     // Check wrong_queue_subscription
     let w_wrong_q = ineligible_list
         .iter()
         .find(|w| w["worker_id"] == "worker-wrong-queue")
         .unwrap();
-    let reasons: Vec<&str> = w_wrong_q["reason_codes"]
-        .as_array()
-        .unwrap()
-        .iter()
-        .map(|v| v.as_str().unwrap())
-        .collect();
-    assert!(reasons.contains(&"wrong_queue_subscription"));
+    assert!(
+        w_wrong_q["reason_codes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|v| v.as_str().unwrap() == "wrong_queue_subscription")
+    );
 
     // Check wrong_shard_assignment
     let w_wrong_s = ineligible_list
         .iter()
         .find(|w| w["worker_id"] == "worker-wrong-shard")
         .unwrap();
-    let reasons: Vec<&str> = w_wrong_s["reason_codes"]
-        .as_array()
-        .unwrap()
-        .iter()
-        .map(|v| v.as_str().unwrap())
-        .collect();
-    assert!(reasons.contains(&"wrong_shard_assignment"));
+    assert!(
+        w_wrong_s["reason_codes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|v| v.as_str().unwrap() == "wrong_shard_assignment")
+    );
 
     // Check worker_draining
     let w_drain = ineligible_list
         .iter()
         .find(|w| w["worker_id"] == "worker-draining")
         .unwrap();
-    let reasons: Vec<&str> = w_drain["reason_codes"]
-        .as_array()
-        .unwrap()
-        .iter()
-        .map(|v| v.as_str().unwrap())
-        .collect();
-    assert!(reasons.contains(&"worker_draining"));
+    assert!(
+        w_drain["reason_codes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|v| v.as_str().unwrap() == "worker_draining")
+    );
 
     // Check worker_stopped
     let w_stop = ineligible_list
         .iter()
         .find(|w| w["worker_id"] == "worker-stopped")
         .unwrap();
-    let reasons: Vec<&str> = w_stop["reason_codes"]
-        .as_array()
-        .unwrap()
-        .iter()
-        .map(|v| v.as_str().unwrap())
-        .collect();
-    assert!(reasons.contains(&"worker_stopped"));
+    assert!(
+        w_stop["reason_codes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|v| v.as_str().unwrap() == "worker_stopped")
+    );
 
     // Check diagnosis is "healthy" since we have worker-eligible which is active, eligible, and has capacity
     assert_eq!(body["summary"]["diagnosis"], "healthy");
@@ -505,7 +510,7 @@ async fn test_task_eligibility_endpoints() {
     let app = harvest_api_router(state).with_state(AppState::for_test().with_profile("test"));
 
     let (status, body) =
-        get_json_with_auth(&app, format!("/admin/tasks/{}/eligibility", task_id), true).await;
+        get_json_with_auth(&app, format!("/admin/tasks/{task_id}/eligibility"), true).await;
     assert_eq!(status, StatusCode::OK);
     assert_eq!(body["task_id"], task_id.to_string());
     assert_eq!(body["queue_name"], "test-queue");
@@ -517,14 +522,258 @@ async fn test_task_eligibility_endpoints() {
         .iter()
         .find(|w| w["worker_id"] == "worker-incompatible")
         .unwrap();
-    let reasons: Vec<&str> = w_incompat["reason_codes"]
-        .as_array()
-        .unwrap()
-        .iter()
-        .map(|v| v.as_str().unwrap())
-        .collect();
-    assert!(reasons.contains(&"build_incompatible"));
+    assert!(
+        w_incompat["reason_codes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|v| v.as_str().unwrap() == "build_incompatible")
+    );
 
     // Since only worker-incompatible is online and it is incompatible, the diagnosis should be "no_eligible_workers"
     assert_eq!(body["summary"]["diagnosis"], "no_eligible_workers");
+}
+
+async fn seed_rate_limit_bucket(
+    pool: &DbPool,
+    key: &str,
+    refill_rate: f64,
+    burst: f64,
+    tokens: f64,
+) {
+    let mut conn = pool
+        .get()
+        .await
+        .expect("rate limit bucket seeding connection");
+    diesel::sql_query(
+        "INSERT INTO harvest_rate_limit_buckets (key, refill_rate, burst, tokens, last_refilled_at, created_at, updated_at)
+         VALUES ($1, $2, $3, $4, NOW(), NOW(), NOW())"
+    )
+    .bind::<diesel::sql_types::Text, _>(key)
+    .bind::<diesel::sql_types::Double, _>(refill_rate)
+    .bind::<diesel::sql_types::Double, _>(burst)
+    .bind::<diesel::sql_types::Double, _>(tokens)
+    .execute(&mut conn)
+    .await
+    .expect("failed to insert rate limit bucket");
+}
+
+async fn seed_task_with_rate_limit_and_date(
+    pool: &DbPool,
+    queue_name: &str,
+    rate_limit_key: Option<&str>,
+    activity_name: Option<&str>,
+    scheduled_at_clause: &str,
+    schedule_to_close_at_clause: &str,
+) -> uuid::Uuid {
+    let mut conn = pool.get().await.expect("task seeding connection");
+    let id = uuid::Uuid::new_v4();
+
+    let rate_limit_key_clause =
+        rate_limit_key.map_or_else(|| "NULL".to_string(), |v| format!("'{v}'"));
+    let activity_name_clause =
+        activity_name.map_or_else(|| "NULL".to_string(), |v| format!("'{v}'"));
+
+    diesel::sql_query(format!(
+        "INSERT INTO harvest_task_queue (
+            id, queue_name, task_type, input, state, priority, max_attempts, scheduled_at,
+            rate_limit_key, activity_name, schedule_to_close_at
+         ) VALUES (
+            '{id}', '{queue_name}', 'workflow', '{{}}'::jsonb, 'PENDING', 0, 1, {scheduled_at_clause},
+            {rate_limit_key_clause}, {activity_name_clause}, {schedule_to_close_at_clause}
+         )"
+    ))
+    .execute(&mut conn)
+    .await
+    .expect("failed to insert test task");
+
+    id
+}
+
+fn build_two_shard_pool(shard0_pool: DbPool, shard1_pool: DbPool) -> HarvestDbPool {
+    let mut pools = BTreeMap::new();
+    pools.insert(ShardId::new(0), shard0_pool);
+    pools.insert(ShardId::new(1), shard1_pool);
+    HarvestDbPool::sharded(ShardedDbPool::from_map(pools, ShardId::new(0)))
+}
+
+fn two_shard_router() -> ShardRouter {
+    ShardRouter::new(
+        vec![ShardId::new(0), ShardId::new(1)],
+        vec![ShardId::new(0), ShardId::new(1)],
+        ShardId::new(0),
+    )
+}
+
+#[tokio::test]
+async fn test_eligibility_optimizations_and_resilience() {
+    let (database_url, _container) = setup_database_url_with_migrations().await;
+    let pool = build_test_pool(&database_url);
+
+    // 1. Seed rate limit bucket with 0 tokens (saturated)
+    seed_rate_limit_bucket(&pool, "my-rate-limit-key", 0.0, 1.0, 0.0).await;
+
+    // Seed task with saturated rate limit key
+    let _task_rl = seed_task_with_rate_limit_and_date(
+        &pool,
+        "test-queue-rl",
+        Some("my-rate-limit-key"),
+        Some("my-activity"),
+        "NOW() - INTERVAL '5 seconds'",
+        "NULL",
+    )
+    .await;
+
+    // 2. Seed non-claimable task A: scheduled in the future (scheduled_at > NOW())
+    seed_task_with_rate_limit_and_date(
+        &pool,
+        "test-queue-rl",
+        None,
+        None,
+        "NOW() + INTERVAL '10 minutes'",
+        "NULL",
+    )
+    .await;
+
+    // Seed non-claimable task B: expired (schedule_to_close_at < NOW())
+    seed_task_with_rate_limit_and_date(
+        &pool,
+        "test-queue-rl",
+        None,
+        None,
+        "NOW() - INTERVAL '10 minutes'",
+        "NOW() - INTERVAL '5 seconds'",
+    )
+    .await;
+
+    // Register active worker for rate limit queue
+    register_active_worker_with_build(
+        &pool,
+        "worker-rate-limited",
+        &["test-queue-rl"],
+        &[0],
+        "v1",
+        10,
+        0,
+    )
+    .await;
+
+    let state = api_state(
+        HarvestDbPool::from(pool.clone()),
+        runtime_for(&["test-queue-rl"], ShardRouter::single()),
+    );
+    state.set_admin_auth_boundary(true);
+    let app = harvest_api_router(state).with_state(AppState::for_test().with_profile("test"));
+
+    // Query queue eligibility
+    let (status, body) =
+        get_json_with_auth(&app, "/admin/queues/test-queue-rl/eligibility", true).await;
+    assert_eq!(status, StatusCode::OK);
+    // pending_count should be exactly 1 (only the rate-limited one is claimable; scheduled in future and expired are excluded)
+    assert_eq!(body["pending_count"], 1);
+
+    // worker-rate-limited should be marked ineligible with reason "concurrency_saturated"
+    let ineligible_list = body["ineligible_workers"].as_array().unwrap();
+    let w_rl = ineligible_list
+        .iter()
+        .find(|w| w["worker_id"] == "worker-rate-limited")
+        .unwrap();
+    assert!(
+        w_rl["reason_codes"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .any(|v| v.as_str().unwrap() == "concurrency_saturated")
+    );
+
+    // 3. Test capacity limit: register a worker that has max capacity reached
+    // Seed a new clean queue task
+    let task_cap = seed_task_detailed(&pool, "test-queue-cap", None, None, None, None, None).await;
+    register_active_worker_with_build(
+        &pool,
+        "worker-at-capacity",
+        &["test-queue-cap"],
+        &[0],
+        "v1",
+        5,
+        5, // in_flight_count = max_concurrency
+    )
+    .await;
+
+    let state_cap = api_state(
+        HarvestDbPool::from(pool.clone()),
+        runtime_for(&["test-queue-cap"], ShardRouter::single()),
+    );
+    state_cap.set_admin_auth_boundary(true);
+    let app_cap =
+        harvest_api_router(state_cap).with_state(AppState::for_test().with_profile("test"));
+
+    let (status_cap, body_cap) =
+        get_json_with_auth(&app_cap, "/admin/queues/test-queue-cap/eligibility", true).await;
+    assert_eq!(status_cap, StatusCode::OK);
+    // worker-at-capacity should be in eligible_workers, but because it's full, diagnosis should be "all_capacity_full"
+    let eligible_cap = body_cap["eligible_workers"].as_array().unwrap();
+    assert!(
+        eligible_cap
+            .iter()
+            .any(|w| w["worker_id"] == "worker-at-capacity")
+    );
+    assert_eq!(body_cap["summary"]["diagnosis"], "all_capacity_full");
+
+    // 4. Test multi-shard resilience (graceful skip of unhealthy shard)
+    // Setup two shards: Shard 0 (healthy) and Shard 1 (broken/unhealthy)
+    let shard0_pool = pool.clone();
+    // Simulate broken connection by using a non-existent port
+    let shard1_pool = build_test_pool("postgres://postgres:postgres@localhost:54321/nonexistent");
+
+    let sharded_pool = build_two_shard_pool(shard0_pool, shard1_pool);
+    let state_sharded = api_state(
+        sharded_pool,
+        runtime_for(&["test-queue-cap"], two_shard_router()),
+    );
+    state_sharded.set_admin_auth_boundary(true);
+    let app_sharded =
+        harvest_api_router(state_sharded).with_state(AppState::for_test().with_profile("test"));
+
+    // GET /admin/tasks/{id}/eligibility for task_cap on shard 0 should succeed, skipping/ignoring the unhealthy shard 1
+    let (status_task, body_task) = get_json_with_auth(
+        &app_sharded,
+        format!("/admin/tasks/{task_cap}/eligibility"),
+        true,
+    )
+    .await;
+    assert_eq!(status_task, StatusCode::OK);
+    assert_eq!(body_task["task_id"], task_cap.to_string());
+    assert_eq!(body_task["assigned_shard"], 0);
+
+    // GET /admin/queues/test-queue-cap/eligibility should also succeed because at least one shard (shard 0) is healthy
+    let (status_queue, body_queue) = get_json_with_auth(
+        &app_sharded,
+        "/admin/queues/test-queue-cap/eligibility",
+        true,
+    )
+    .await;
+    assert_eq!(status_queue, StatusCode::OK);
+    assert_eq!(body_queue["queue_name"], "test-queue-cap");
+
+    // Now test service unavailable: if we only query a broken queue, or if all shards fail
+    let all_broken_pool = build_two_shard_pool(
+        build_test_pool("postgres://postgres:postgres@localhost:54321/nonexistent"),
+        build_test_pool("postgres://postgres:postgres@localhost:54321/nonexistent"),
+    );
+    let state_all_broken = api_state(
+        all_broken_pool,
+        runtime_for(&["test-queue-cap"], two_shard_router()),
+    );
+    state_all_broken.set_admin_auth_boundary(true);
+    let app_all_broken =
+        harvest_api_router(state_all_broken).with_state(AppState::for_test().with_profile("test"));
+
+    let req = Request::builder()
+        .method("GET")
+        .uri("/admin/queues/test-queue-cap/eligibility")
+        .body(Body::empty())
+        .unwrap();
+    let res = app_all_broken.oneshot(req).await.unwrap();
+    assert_eq!(res.status(), StatusCode::SERVICE_UNAVAILABLE);
 }

--- a/autumn-harvest-plugin/tests/eligibility_tests.rs
+++ b/autumn-harvest-plugin/tests/eligibility_tests.rs
@@ -815,6 +815,12 @@ async fn test_eligibility_optimizations_and_resilience() {
     .await;
     assert_eq!(status_multi, StatusCode::OK);
     assert_eq!(body_multi["summary"]["diagnosis"], "no_eligible_workers");
+    assert!(
+        body_multi["eligible_workers"]
+            .as_array()
+            .unwrap()
+            .is_empty()
+    );
 
     // 6. Test all_draining classification refinement
     // Clean up workers table to prevent interference
@@ -882,6 +888,94 @@ async fn test_eligibility_optimizations_and_resilience() {
     .await;
     assert_eq!(status_d2, StatusCode::OK);
     assert_eq!(body_d2["summary"]["diagnosis"], "no_eligible_workers");
+
+    // 7. Test concurrency saturation tied to task-level cap
+    // Clean up workers table
+    {
+        let mut conn = pool.get().await.expect("connection");
+        diesel::sql_query("DELETE FROM harvest_workers")
+            .execute(&mut conn)
+            .await
+            .expect("delete workers");
+    }
+
+    let state_mixed = api_state(
+        HarvestDbPool::from(pool.clone()),
+        runtime_for(&["test-queue-mixed"], ShardRouter::single()),
+    );
+    state_mixed.set_admin_auth_boundary(true);
+    let app_mixed =
+        harvest_api_router(state_mixed).with_state(AppState::for_test().with_profile("test"));
+
+    // Seed running task with mixed-key to occupy 1 slot
+    {
+        let mut conn = pool.get().await.expect("running task connection");
+        diesel::sql_query(
+            "INSERT INTO harvest_task_queue (
+                id, queue_name, task_type, input, state, priority, max_attempts, scheduled_at,
+                concurrency_key, concurrency_cap, worker_id
+             ) VALUES (
+                gen_random_uuid(), 'test-queue-mixed', 'workflow', '{}'::jsonb, 'RUNNING', 0, 1, NOW(),
+                'mixed-key', 1, 'worker-mixed-cap'
+             )",
+        )
+        .execute(&mut conn)
+        .await
+        .expect("failed to insert running task to saturate concurrency");
+    }
+
+    // Seed task A (cap = 1, saturated)
+    let _task_a = seed_task_detailed(
+        &pool,
+        "test-queue-mixed",
+        None,
+        None,
+        None,
+        Some("mixed-key"),
+        Some(1),
+    )
+    .await;
+
+    // Seed task B (cap = 5, not saturated)
+    let _task_b = seed_task_detailed(
+        &pool,
+        "test-queue-mixed",
+        None,
+        None,
+        None,
+        Some("mixed-key"),
+        Some(5),
+    )
+    .await;
+
+    // Register active worker
+    register_active_worker_with_build(
+        &pool,
+        "worker-mixed-cap",
+        &["test-queue-mixed"],
+        &[0],
+        "v1",
+        5,
+        0,
+    )
+    .await;
+
+    // Query queue eligibility. Since the worker is eligible for Task B (not saturated),
+    // the diagnosis should be "healthy" and the worker should be in the eligible_workers list.
+    let (status_mixed, body_mixed) = get_json_with_auth(
+        &app_mixed,
+        "/admin/queues/test-queue-mixed/eligibility",
+        true,
+    )
+    .await;
+    assert_eq!(status_mixed, StatusCode::OK);
+    assert_eq!(body_mixed["summary"]["diagnosis"], "healthy");
+    assert!(
+        !body_mixed["eligible_workers"]
+            .as_array()
+            .unwrap()
+            .is_empty()
+    );
 
     // Now test service unavailable: if we only query a broken queue, or if all shards fail
     let all_broken_pool = build_two_shard_pool(

--- a/autumn-harvest-plugin/tests/eligibility_tests.rs
+++ b/autumn-harvest-plugin/tests/eligibility_tests.rs
@@ -672,7 +672,7 @@ async fn test_eligibility_optimizations_and_resilience() {
     // pending_count should be exactly 1 (only the rate-limited one is claimable; scheduled in future and expired are excluded)
     assert_eq!(body["pending_count"], 1);
 
-    // worker-rate-limited should be marked ineligible with reason "concurrency_saturated"
+    // worker-rate-limited should be marked ineligible with reason "rate_limit_saturated"
     let ineligible_list = body["ineligible_workers"].as_array().unwrap();
     let w_rl = ineligible_list
         .iter()
@@ -683,7 +683,7 @@ async fn test_eligibility_optimizations_and_resilience() {
             .as_array()
             .unwrap()
             .iter()
-            .any(|v| v.as_str().unwrap() == "concurrency_saturated")
+            .any(|v| v.as_str().unwrap() == "rate_limit_saturated")
     );
 
     // 3. Test capacity limit: register a worker that has max capacity reached
@@ -755,6 +755,133 @@ async fn test_eligibility_optimizations_and_resilience() {
     .await;
     assert_eq!(status_queue, StatusCode::OK);
     assert_eq!(body_queue["queue_name"], "test-queue-cap");
+
+    // 5. Test multi-shard diagnosis aggregation (prevent stuck shard hiding)
+    // Clean up workers table to prevent interference
+    {
+        let mut conn = pool.get().await.expect("connection");
+        diesel::sql_query("DELETE FROM harvest_workers")
+            .execute(&mut conn)
+            .await
+            .expect("delete workers");
+    }
+
+    // Setup two healthy shards pointing to the same pool
+    let sharded_pool_healthy = build_two_shard_pool(pool.clone(), pool.clone());
+    let state_sharded_healthy = api_state(
+        sharded_pool_healthy,
+        runtime_for(&["test-queue-multi"], two_shard_router()),
+    );
+    state_sharded_healthy.set_admin_auth_boundary(true);
+    let app_sharded_healthy = harvest_api_router(state_sharded_healthy)
+        .with_state(AppState::for_test().with_profile("test"));
+
+    // Seed task on "test-queue-multi"
+    let _task_multi =
+        seed_task_detailed(&pool, "test-queue-multi", None, None, None, None, None).await;
+
+    // Register worker 0 assigned to shard 0, but stop it (so shard 0 has no eligible workers -> no_eligible_workers)
+    register_active_worker_with_build(
+        &pool,
+        "worker-shard0",
+        &["test-queue-multi"],
+        &[0],
+        "v1",
+        5,
+        0,
+    )
+    .await;
+    mark_worker_stopped(&pool, "worker-shard0").await;
+
+    // Register worker 1 assigned to shard 1, healthy (so shard 1 is healthy)
+    register_active_worker_with_build(
+        &pool,
+        "worker-shard1",
+        &["test-queue-multi"],
+        &[1],
+        "v1",
+        5,
+        0,
+    )
+    .await;
+
+    // Query global queue eligibility. Since shard 0 is stuck (no_eligible_workers) and shard 1 is healthy,
+    // the global diagnosis must bubble up the worst-case (no_eligible_workers), rather than "healthy".
+    let (status_multi, body_multi) = get_json_with_auth(
+        &app_sharded_healthy,
+        "/admin/queues/test-queue-multi/eligibility",
+        true,
+    )
+    .await;
+    assert_eq!(status_multi, StatusCode::OK);
+    assert_eq!(body_multi["summary"]["diagnosis"], "no_eligible_workers");
+
+    // 6. Test all_draining classification refinement
+    // Clean up workers table to prevent interference
+    {
+        let mut conn = pool.get().await.expect("connection");
+        diesel::sql_query("DELETE FROM harvest_workers")
+            .execute(&mut conn)
+            .await
+            .expect("delete workers");
+    }
+
+    let state_drain = api_state(
+        HarvestDbPool::from(pool.clone()),
+        runtime_for(&["test-queue-drain"], ShardRouter::single()),
+    );
+    state_drain.set_admin_auth_boundary(true);
+    let app_drain =
+        harvest_api_router(state_drain).with_state(AppState::for_test().with_profile("test"));
+
+    // Seed task
+    let _task_drain =
+        seed_task_detailed(&pool, "test-queue-drain", None, None, None, None, None).await;
+
+    // Register worker A: draining
+    register_active_worker_with_build(
+        &pool,
+        "worker-drain-only",
+        &["test-queue-drain"],
+        &[0],
+        "v1",
+        5,
+        0,
+    )
+    .await;
+    mark_worker_draining(&pool, "worker-drain-only").await;
+
+    // Query when only draining worker is present -> should be "all_draining"
+    let (status_d1, body_d1) = get_json_with_auth(
+        &app_drain,
+        "/admin/queues/test-queue-drain/eligibility",
+        true,
+    )
+    .await;
+    assert_eq!(status_d1, StatusCode::OK);
+    assert_eq!(body_d1["summary"]["diagnosis"], "all_draining");
+
+    // Now register worker B: not draining, but has wrong queue subscription (so ineligible for other reasons)
+    register_active_worker_with_build(
+        &pool,
+        "worker-wrong-sub",
+        &["test-queue-wrong"], // subscribed to wrong queue
+        &[0],
+        "v1",
+        5,
+        0,
+    )
+    .await;
+
+    // Query again -> since there is a worker ineligible for a non-drain reason, it should prefer "no_eligible_workers"
+    let (status_d2, body_d2) = get_json_with_auth(
+        &app_drain,
+        "/admin/queues/test-queue-drain/eligibility",
+        true,
+    )
+    .await;
+    assert_eq!(status_d2, StatusCode::OK);
+    assert_eq!(body_d2["summary"]["diagnosis"], "no_eligible_workers");
 
     // Now test service unavailable: if we only query a broken queue, or if all shards fail
     let all_broken_pool = build_two_shard_pool(

--- a/autumn-harvest-plugin/tests/eligibility_tests.rs
+++ b/autumn-harvest-plugin/tests/eligibility_tests.rs
@@ -1,0 +1,530 @@
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+use autumn_harvest::info::WorkflowInfo;
+use autumn_harvest::retention::RetentionConfig;
+use autumn_harvest::scheduler::DagCatalog;
+use autumn_harvest::shard::{ShardRouter, ShardedDbPool};
+use autumn_harvest::types::ShardId;
+use autumn_harvest::worker::{DbPool, HandlerRegistry};
+use autumn_harvest::workers::{WorkerStatus, register_worker};
+use autumn_harvest_plugin::HarvestDbPool;
+use autumn_harvest_plugin::api::{
+    HarvestApiRuntime, HarvestApiState, HarvestRetentionRuntime, harvest_api_router,
+};
+use autumn_web::AppState;
+use autumn_web::reexports::axum;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use diesel_async::AsyncConnection;
+use diesel_async::AsyncPgConnection;
+use diesel_async::RunQueryDsl;
+use diesel_async::pooled_connection::AsyncDieselConnectionManager;
+use serde_json::Value;
+use testcontainers::ContainerAsync;
+use testcontainers_modules::postgres::Postgres;
+use testcontainers_modules::testcontainers::runners::AsyncRunner;
+use tower::ServiceExt;
+
+type HarvestApiApp = axum::Router;
+
+fn build_test_pool(database_url: &str) -> DbPool {
+    let manager = AsyncDieselConnectionManager::<AsyncPgConnection>::new(database_url);
+    deadpool::managed::Pool::builder(manager)
+        .max_size(4)
+        .build()
+        .expect("failed to build test pool")
+}
+
+async fn setup_database_url_with_migrations() -> (String, ContainerAsync<Postgres>) {
+    let container = Postgres::default()
+        .start()
+        .await
+        .expect("failed to start Postgres container");
+    let host = container
+        .get_host()
+        .await
+        .expect("failed to get container host");
+    let port = container
+        .get_host_port_ipv4(5432)
+        .await
+        .expect("failed to get container port");
+    let url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+    autumn_web::migrate::run_pending(&url, autumn_harvest::MIGRATIONS)
+        .expect("failed to run Harvest migrations");
+    (url, container)
+}
+
+fn workflow_info() -> WorkflowInfo {
+    WorkflowInfo {
+        name: "test_workflow",
+        module: "tests",
+        handler: |_ctx, input| Box::pin(async move { Ok(input) }),
+        execution_timeout: None,
+        concurrency: None,
+        max_input_bytes: None,
+        owner: None,
+        runbook_url: None,
+        severity: None,
+        description: None,
+        input_schema: None,
+        output_schema: None,
+        error_schema: None,
+    }
+}
+
+fn runtime_for(queues: &[&str], router: ShardRouter) -> HarvestApiRuntime {
+    HarvestApiRuntime::new(
+        Arc::new(HandlerRegistry::new(vec![workflow_info()], Vec::new())),
+        Arc::new(DagCatalog::new()),
+        Arc::new(Vec::new()),
+        None,
+        queues.iter().map(|queue| (*queue).to_string()).collect(),
+        autumn_harvest::scheduler::SchedulerMonitor::offline(),
+        HarvestRetentionRuntime::disabled(RetentionConfig::default()),
+        router,
+    )
+}
+
+fn api_state(pool: HarvestDbPool, runtime: HarvestApiRuntime) -> HarvestApiState {
+    let state = HarvestApiState::new();
+    state.install_storage_pool(pool);
+    state.install(runtime);
+    state.set_worker_stale_threshold(Duration::from_secs(10));
+    state
+}
+
+async fn register_active_worker_with_build(
+    pool: &DbPool,
+    worker_id: &str,
+    queues: &[&str],
+    shards: &[i32],
+    build_id: &str,
+    max_concurrency: i32,
+    in_flight_count: i32,
+) {
+    let queue_names = queues
+        .iter()
+        .map(|queue| (*queue).to_string())
+        .collect::<Vec<_>>();
+    let mut conn = pool.get().await.expect("worker registration connection");
+    register_worker(
+        &mut conn,
+        worker_id,
+        &queue_names,
+        shards,
+        max_concurrency,
+        "localhost",
+        Some(env!("CARGO_PKG_VERSION")),
+        build_id,
+        Some("test-deploy"),
+    )
+    .await
+    .expect("worker registration should succeed");
+
+    // Force updates to status, in_flight_count since standard registration defaults them
+    diesel::sql_query(
+        "UPDATE harvest_workers
+         SET in_flight_count = $1
+         WHERE worker_id = $2",
+    )
+    .bind::<diesel::sql_types::Integer, _>(in_flight_count)
+    .bind::<diesel::sql_types::Text, _>(worker_id)
+    .execute(&mut conn)
+    .await
+    .expect("failed to set in_flight_count");
+}
+
+async fn mark_worker_stale(pool: &DbPool, worker_id: &str) {
+    let mut conn = pool.get().await.expect("stale update connection");
+    diesel::sql_query(
+        "UPDATE harvest_workers
+         SET last_heartbeat_at = NOW() - INTERVAL '10 minutes'
+         WHERE worker_id = $1",
+    )
+    .bind::<diesel::sql_types::Text, _>(worker_id)
+    .execute(&mut conn)
+    .await
+    .expect("worker should be marked stale");
+}
+
+async fn mark_worker_draining(pool: &DbPool, worker_id: &str) {
+    let mut conn = pool.get().await.expect("draining update connection");
+    diesel::sql_query(
+        "UPDATE harvest_workers
+         SET status = $1
+         WHERE worker_id = $2",
+    )
+    .bind::<diesel::sql_types::Text, _>(WorkerStatus::Draining.as_str())
+    .bind::<diesel::sql_types::Text, _>(worker_id)
+    .execute(&mut conn)
+    .await
+    .expect("worker should be marked draining");
+}
+
+async fn mark_worker_stopped(pool: &DbPool, worker_id: &str) {
+    let mut conn = pool.get().await.expect("stopped update connection");
+    diesel::sql_query(
+        "UPDATE harvest_workers
+         SET status = $1
+         WHERE worker_id = $2",
+    )
+    .bind::<diesel::sql_types::Text, _>(WorkerStatus::Stopped.as_str())
+    .bind::<diesel::sql_types::Text, _>(worker_id)
+    .execute(&mut conn)
+    .await
+    .expect("worker should be marked stopped");
+}
+
+async fn seed_task_detailed(
+    pool: &DbPool,
+    queue_name: &str,
+    required_build_id: Option<&str>,
+    sticky_worker_id: Option<&str>,
+    sticky_until_interval: Option<&str>,
+    concurrency_key: Option<&str>,
+    concurrency_cap: Option<i32>,
+) -> uuid::Uuid {
+    let mut conn = pool.get().await.expect("task seeding connection");
+    let id = uuid::Uuid::new_v4();
+
+    let required_build_clause = required_build_id
+        .map(|v| format!("'{}'", v))
+        .unwrap_or_else(|| "NULL".to_string());
+    let sticky_worker_clause = sticky_worker_id
+        .map(|v| format!("'{}'", v))
+        .unwrap_or_else(|| "NULL".to_string());
+    let sticky_until_clause = sticky_until_interval
+        .map(|v| format!("NOW() + INTERVAL '{}'", v))
+        .unwrap_or_else(|| "NULL".to_string());
+    let concurrency_key_clause = concurrency_key
+        .map(|v| format!("'{}'", v))
+        .unwrap_or_else(|| "NULL".to_string());
+    let concurrency_cap_clause = concurrency_cap
+        .map(|v| v.to_string())
+        .unwrap_or_else(|| "NULL".to_string());
+
+    diesel::sql_query(format!(
+        "INSERT INTO harvest_task_queue (
+            id, queue_name, task_type, input, state, priority, max_attempts, scheduled_at,
+            required_build_id, sticky_worker_id, sticky_until, concurrency_key, concurrency_cap
+         ) VALUES (
+            '{}', '{}', 'workflow', '{{}}'::jsonb, 'PENDING', 0, 1, NOW() - INTERVAL '5 seconds',
+            {}, {}, {}, {}, {}
+         )",
+        id,
+        queue_name,
+        required_build_clause,
+        sticky_worker_clause,
+        sticky_until_clause,
+        concurrency_key_clause,
+        concurrency_cap_clause
+    ))
+    .execute(&mut conn)
+    .await
+    .expect("failed to insert test task");
+
+    id
+}
+
+async fn read_response_body(response: axum::response::Response) -> Vec<u8> {
+    axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("failed to read response body")
+        .to_vec()
+}
+
+async fn get_json_with_auth(
+    app: &HarvestApiApp,
+    uri: impl Into<String>,
+    has_admin: bool,
+) -> (StatusCode, Value) {
+    let mut req = Request::builder()
+        .method("GET")
+        .uri(uri.into())
+        .body(Body::empty())
+        .expect("request should build");
+
+    if has_admin {
+        // harvest admin bypasses checking session if admin_auth_boundary is true in State.
+        // We set admin_auth_boundary=true in HarvestApiState to allow admin routes to execute
+        // without a session in tests, similar to existing security.rs tests.
+    }
+
+    let response = app
+        .clone()
+        .oneshot(req)
+        .await
+        .expect("request should complete");
+    let status = response.status();
+    let body_bytes = read_response_body(response).await;
+    let json = serde_json::from_slice(&body_bytes).expect("response must be JSON");
+    (status, json)
+}
+
+#[tokio::test]
+async fn test_queue_and_task_eligibility_scenarios() {
+    let (database_url, _container) = setup_database_url_with_migrations().await;
+    let pool = build_test_pool(&database_url);
+
+    // 1. Seed tasks representing different failure reasons on "test-queue"
+    // Task A: requires build v2
+    seed_task_detailed(&pool, "test-queue", Some("v2"), None, None, None, None).await;
+
+    // Task B: sticky to worker-sticky
+    seed_task_detailed(
+        &pool,
+        "test-queue",
+        None,
+        Some("worker-sticky"),
+        Some("5 minutes"),
+        None,
+        None,
+    )
+    .await;
+
+    // Task C: concurrency key "tenant-1" with cap 1. We'll also seed a RUNNING task with key "tenant-1" to saturate it.
+    seed_task_detailed(
+        &pool,
+        "test-queue",
+        None,
+        None,
+        None,
+        Some("tenant-1"),
+        Some(1),
+    )
+    .await;
+    let mut conn = pool.get().await.expect("running task connection");
+    diesel::sql_query(
+        "INSERT INTO harvest_task_queue (
+            id, queue_name, task_type, input, state, priority, max_attempts, scheduled_at,
+            concurrency_key, concurrency_cap, worker_id
+         ) VALUES (
+            gen_random_uuid(), 'test-queue', 'workflow', '{}'::jsonb, 'RUNNING', 0, 1, NOW(),
+            'tenant-1', 1, 'worker-concurrency'
+         )",
+    )
+    .execute(&mut conn)
+    .await
+    .expect("failed to insert running task to saturate concurrency");
+
+    // 2. Register workers
+    // worker-eligible: online, active, build v2, subscribed to "test-queue", shard 0
+    register_active_worker_with_build(&pool, "worker-eligible", &["test-queue"], &[0], "v2", 10, 0)
+        .await;
+
+    // worker-incompatible-build: online, active, build v1, subscribed to "test-queue", shard 0
+    register_active_worker_with_build(
+        &pool,
+        "worker-incompatible-build",
+        &["test-queue"],
+        &[0],
+        "v1",
+        10,
+        0,
+    )
+    .await;
+
+    // worker-wrong-queue: online, active, build v2, subscribed to "other-queue", shard 0
+    register_active_worker_with_build(
+        &pool,
+        "worker-wrong-queue",
+        &["other-queue"],
+        &[0],
+        "v2",
+        10,
+        0,
+    )
+    .await;
+
+    // worker-wrong-shard: online, active, build v2, subscribed to "test-queue", shard 1 (task is on shard 0)
+    register_active_worker_with_build(
+        &pool,
+        "worker-wrong-shard",
+        &["test-queue"],
+        &[1],
+        "v2",
+        10,
+        0,
+    )
+    .await;
+
+    // worker-draining: online, draining, build v2, subscribed to "test-queue", shard 0
+    register_active_worker_with_build(&pool, "worker-draining", &["test-queue"], &[0], "v2", 10, 0)
+        .await;
+    mark_worker_draining(&pool, "worker-draining").await;
+
+    // worker-stopped: online, stopped, build v2, subscribed to "test-queue", shard 0
+    register_active_worker_with_build(&pool, "worker-stopped", &["test-queue"], &[0], "v2", 10, 0)
+        .await;
+    mark_worker_stopped(&pool, "worker-stopped").await;
+
+    // worker-stale: stale/offline worker, should be excluded
+    register_active_worker_with_build(&pool, "worker-stale", &["test-queue"], &[0], "v2", 10, 0)
+        .await;
+    mark_worker_stale(&pool, "worker-stale").await;
+
+    // worker-full-capacity: online, active, but at max concurrency
+    register_active_worker_with_build(
+        &pool,
+        "worker-full-capacity",
+        &["test-queue"],
+        &[0],
+        "v2",
+        2,
+        2,
+    )
+    .await;
+
+    // Set up API router
+    let state = api_state(
+        HarvestDbPool::from(pool.clone()),
+        runtime_for(&["test-queue"], ShardRouter::single()),
+    );
+    // bypass admin auth check in tests
+    state.set_admin_auth_boundary(true);
+    let app = harvest_api_router(state).with_state(AppState::for_test().with_profile("test"));
+
+    // --- Validate Queue Eligibility Endpoint ---
+    let (status, body) =
+        get_json_with_auth(&app, "/admin/queues/test-queue/eligibility", true).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["queue_name"], "test-queue");
+    assert_eq!(body["pending_count"], 3); // A, B, C are pending
+    assert!(body["oldest_pending_age_secs"].as_i64().is_some());
+
+    // Distinct build IDs across pending rows: "v2" and null (null should be absent or represented, required_build_ids is a list of strings)
+    let req_builds: Vec<String> = body["required_build_ids"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap().to_string())
+        .collect();
+    assert!(req_builds.contains(&"v2".to_string()));
+
+    // Eligible workers check: worker-eligible passes all gates for at least one task (specifically Task A and C, wait, Task C has concurrency key saturated, but Task A doesn't).
+    let eligible_list = body["eligible_workers"].as_array().unwrap();
+    let eligible_ids: Vec<&str> = eligible_list
+        .iter()
+        .map(|w| w["worker_id"].as_str().unwrap())
+        .collect();
+    assert!(eligible_ids.contains(&"worker-eligible"));
+    // worker-stale is offline, should not be in either list
+    assert!(!eligible_ids.contains(&"worker-stale"));
+
+    // Ineligible workers check
+    let ineligible_list = body["ineligible_workers"].as_array().unwrap();
+    let ineligible_ids: Vec<&str> = ineligible_list
+        .iter()
+        .map(|w| w["worker_id"].as_str().unwrap())
+        .collect();
+    assert!(!ineligible_ids.contains(&"worker-stale"));
+
+    // Check wrong_queue_subscription
+    let w_wrong_q = ineligible_list
+        .iter()
+        .find(|w| w["worker_id"] == "worker-wrong-queue")
+        .unwrap();
+    let reasons: Vec<&str> = w_wrong_q["reason_codes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert!(reasons.contains(&"wrong_queue_subscription"));
+
+    // Check wrong_shard_assignment
+    let w_wrong_s = ineligible_list
+        .iter()
+        .find(|w| w["worker_id"] == "worker-wrong-shard")
+        .unwrap();
+    let reasons: Vec<&str> = w_wrong_s["reason_codes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert!(reasons.contains(&"wrong_shard_assignment"));
+
+    // Check worker_draining
+    let w_drain = ineligible_list
+        .iter()
+        .find(|w| w["worker_id"] == "worker-draining")
+        .unwrap();
+    let reasons: Vec<&str> = w_drain["reason_codes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert!(reasons.contains(&"worker_draining"));
+
+    // Check worker_stopped
+    let w_stop = ineligible_list
+        .iter()
+        .find(|w| w["worker_id"] == "worker-stopped")
+        .unwrap();
+    let reasons: Vec<&str> = w_stop["reason_codes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert!(reasons.contains(&"worker_stopped"));
+
+    // Check diagnosis is "healthy" since we have worker-eligible which is active, eligible, and has capacity
+    assert_eq!(body["summary"]["diagnosis"], "healthy");
+}
+
+#[tokio::test]
+async fn test_task_eligibility_endpoints() {
+    let (database_url, _container) = setup_database_url_with_migrations().await;
+    let pool = build_test_pool(&database_url);
+
+    // Seed task requiring build v2
+    let task_id = seed_task_detailed(&pool, "test-queue", Some("v2"), None, None, None, None).await;
+
+    // Register active worker with incompatible build
+    register_active_worker_with_build(
+        &pool,
+        "worker-incompatible",
+        &["test-queue"],
+        &[0],
+        "v1",
+        10,
+        0,
+    )
+    .await;
+
+    let state = api_state(
+        HarvestDbPool::from(pool.clone()),
+        runtime_for(&["test-queue"], ShardRouter::single()),
+    );
+    state.set_admin_auth_boundary(true);
+    let app = harvest_api_router(state).with_state(AppState::for_test().with_profile("test"));
+
+    let (status, body) =
+        get_json_with_auth(&app, format!("/admin/tasks/{}/eligibility", task_id), true).await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(body["task_id"], task_id.to_string());
+    assert_eq!(body["queue_name"], "test-queue");
+    assert_eq!(body["required_build_id"], "v2");
+    assert_eq!(body["assigned_shard"], 0);
+
+    let ineligible_list = body["ineligible_workers"].as_array().unwrap();
+    let w_incompat = ineligible_list
+        .iter()
+        .find(|w| w["worker_id"] == "worker-incompatible")
+        .unwrap();
+    let reasons: Vec<&str> = w_incompat["reason_codes"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|v| v.as_str().unwrap())
+        .collect();
+    assert!(reasons.contains(&"build_incompatible"));
+
+    // Since only worker-incompatible is online and it is incompatible, the diagnosis should be "no_eligible_workers"
+    assert_eq!(body["summary"]["diagnosis"], "no_eligible_workers");
+}

--- a/docs/api-contract.json
+++ b/docs/api-contract.json
@@ -3907,6 +3907,68 @@
         { "status": 401, "description": "Unauthenticated request." },
         { "status": 503, "description": "Database unavailable." }
       ]
+    },
+    {
+      "method": "GET",
+      "path": "/admin/queues/{queue_name}/eligibility",
+      "category": "queue",
+      "read_only": true,
+      "description": "Get detailed worker and queue status eligibility and diagnostic breakdown for triaging stuck tasks in a specific queue.",
+      "idempotency": "Read-only; always idempotent.",
+      "params": [
+        { "name": "queue_name", "in": "path", "required": true, "description": "Target task queue name." }
+      ],
+      "request_body": null,
+      "success_response": {
+        "status": 200,
+        "fields": [
+          "queue_name",
+          "pending_count",
+          "oldest_pending_age_secs",
+          "required_build_ids",
+          "eligible_workers",
+          "ineligible_workers",
+          "summary",
+          "shards",
+          "shard_errors"
+        ]
+      },
+      "error_responses": [
+        { "status": 401, "description": "Unauthenticated request." },
+        { "status": 503, "description": "Database or shard unavailable." }
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/admin/tasks/{id}/eligibility",
+      "category": "queue",
+      "read_only": true,
+      "description": "Get detailed worker eligibility and diagnostic breakdown narrowed to a single pending task.",
+      "idempotency": "Read-only; always idempotent.",
+      "params": [
+        { "name": "id", "in": "path", "required": true, "description": "Task UUID." }
+      ],
+      "request_body": null,
+      "success_response": {
+        "status": 200,
+        "fields": [
+          "task_id",
+          "queue_name",
+          "pending_count",
+          "oldest_pending_age_secs",
+          "required_build_id",
+          "assigned_shard",
+          "concurrency_key",
+          "eligible_workers",
+          "ineligible_workers",
+          "summary"
+        ]
+      },
+      "error_responses": [
+        { "status": 401, "description": "Unauthenticated request." },
+        { "status": 404, "description": "Task not found across any shard." },
+        { "status": 503, "description": "Database or shard unavailable." }
+      ]
     }
   ]
 }

--- a/docs/runbooks/triage-pending-tasks-idle-workers.md
+++ b/docs/runbooks/triage-pending-tasks-idle-workers.md
@@ -100,6 +100,12 @@ Common reason codes and their fixes:
   - Wait for in-flight tasks of that concurrency key to finish.
   - Or increase the concurrency cap for that key/workflow.
 
+#### `rate_limit_saturated`
+- **Meaning**: The tasks have a rate limit key, and the rate limit bucket for this key has fewer than 1.0 token.
+- **Fix**:
+  - Wait for the rate-limit bucket to refill.
+  - Or increase the rate limit refill rate or burst size.
+
 ---
 
 ### 5. `healthy`

--- a/docs/runbooks/triage-pending-tasks-idle-workers.md
+++ b/docs/runbooks/triage-pending-tasks-idle-workers.md
@@ -1,0 +1,114 @@
+# Triage: pending tasks, idle workers
+
+Use this runbook when an alert fires indicating that tasks are sitting in `PENDING` state on a queue while connected workers appear idle.
+
+To triage eligibility blocks, call the eligibility explainer API:
+
+```text
+GET /admin/queues/{queue_name}/eligibility
+```
+
+Or for a specific task ID:
+
+```text
+GET /admin/tasks/{task_id}/eligibility
+```
+
+The response contains a `summary.diagnosis` field which provides a headline explanation, along with lists of `eligible_workers` (workers passing all gates) and `ineligible_workers` (including reason codes for why they failed).
+
+---
+
+## Diagnoses and Corrective Actions
+
+### 1. `no_online_workers`
+
+**What it means**: There are no active workers polling this queue/shard that have sent a heartbeat recently.
+
+**How to verify**:
+Inspect the response body. `eligible_workers` and `ineligible_workers` will both be empty (or only show stale workers, which are excluded from the eligibility lists).
+
+**Corrective Actions**:
+- Check the worker processes. Are they running? Check their container/host logs.
+- Verify worker network connectivity to the Postgres database shard.
+- Scale up the replica count for worker deployments subscribed to the target queue.
+
+---
+
+### 2. `all_draining`
+
+**What it means**: Workers are connected, but they have all been placed into `Draining` state. They are completing their active in-flight tasks but are refusing to claim any new ones from the queue.
+
+**How to verify**:
+Look at the `ineligible_workers` list. You will see workers with the reason code `worker_draining`.
+
+**Corrective Actions**:
+- If a rolling deploy is in progress, this is normal; wait for new workers to start and register.
+- If this is accidental, or a deploy was canceled, undo the draining state on the worker fleet by restarting them or triggering a fresh deployment.
+
+---
+
+### 3. `all_capacity_full`
+
+**What it means**: Eligible workers are connected and polling the queue, but they are all running at their maximum concurrency limit (`in_flight_count >= max_concurrency`).
+
+**How to verify**:
+Verify that the `eligible_workers` list is non-empty, but all workers have `in_flight_count` equal to or exceeding their `max_concurrency` (visible via the standard `/workers` endpoint or worker logs).
+
+**Corrective Actions**:
+- Scale out the worker fleet (increase replica count) to add capacity.
+- If worker processes have spare CPU/RAM, consider increasing `max_concurrency` in the worker configuration.
+- Check if tasks are running slower than usual (downstream outage, slow database queries), causing worker slots to back up.
+
+---
+
+### 4. `no_eligible_workers`
+
+**What it means**: Workers are online and active, but none of them pass the gates required to claim the pending tasks.
+
+**How to verify**:
+Look at `ineligible_workers` and their `reason_codes`.
+
+Common reason codes and their fixes:
+
+#### `wrong_queue_subscription`
+- **Meaning**: None of the online workers are subscribed to the queue name.
+- **Fix**: Check the worker configuration and ensure they list this queue name in their queue subscriptions (e.g. `WorkerConfig::with_queues`).
+
+#### `wrong_shard_assignment`
+- **Meaning**: The workers are registered on this database, but their configured `shard_assignments` do not include the shard ID of the queue/task.
+- **Fix**: Check worker shard assignment configuration. Ensure worker fleet covers all active shards.
+
+#### `build_incompatible`
+- **Meaning**: The pending tasks require a specific build ID (due to an active build policy), but connected workers are running an incompatible build.
+- **Fix**: 
+  - Deploy workers running the required build.
+  - Or declare the current worker build compatible using:
+    ```bash
+    cargo run -p autumn-harvest-cli -- build-routing compat declare --build-id <worker-build> --compatible-with <task-required-build>
+    ```
+  - Or kick/update the build policy on the queue.
+
+#### `sticky_owned_by_other_worker`
+- **Meaning**: The task is sticky-pinned to a specific worker that is currently offline or busy, and the sticky preference window has not yet expired.
+- **Fix**: 
+  - Wait for the sticky window to expire (`sticky_until` timestamp in the task/eligibility response). Once expired, any worker can claim it.
+  - Or restart the targeted worker process to let it resume the task.
+
+#### `concurrency_saturated`
+- **Meaning**: The tasks have a concurrency group key, and the number of currently running tasks with that key has reached the configured limit.
+- **Fix**:
+  - Wait for in-flight tasks of that concurrency key to finish.
+  - Or increase the concurrency cap for that key/workflow.
+
+---
+
+### 5. `healthy`
+
+**What it means**: Eligible workers with available capacity are connected and polling.
+
+**How to verify**:
+`eligible_workers` is non-empty and has workers where `in_flight_count < max_concurrency`.
+
+**Corrective Actions**:
+- If tasks are still not being claimed, verify if Postgres lock contention or transaction isolation issues are blocking `claim_task` (e.g. locks held by another transaction).
+- Verify the Postgres LISTEN/NOTIFY channel is healthy and worker threads are waking up.


### PR DESCRIPTION
### Description
Implement queue and task eligibility explainer endpoints for triaging pending/stuck tasks in `autumn-harvest` (issue #380).

### Changes
- Implemented `GET /admin/queues/{queue_name}/eligibility` and `GET /admin/tasks/{id}/eligibility` in `autumn-harvest-plugin`.
- Gated endpoints with `require_admin`.
- Supported multi-shard queries with aggregation and per-shard breakdown.
- Evaluated stable eligibility reason codes (`wrong_queue_subscription`, `build_incompatible`, `wrong_shard_assignment`, `worker_draining`, `worker_stopped`, `concurrency_saturated`, `sticky_owned_by_other_worker`).
- Added operator runbook under `docs/runbooks/triage-pending-tasks-idle-workers.md`.
- Updated OpenAPI contract under `docs/api-contract.json` and ensured contract regression checks pass.
- Verified everything with comprehensive integration tests in `eligibility_tests.rs`.