### PR TITLE
⚡ Bolt: Remove intermediate Vec allocations on worker execution paths

### DIFF
--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -455,11 +455,19 @@ fn suspended_workflow_error(commands: &[WorkflowCommand]) -> String {
             .to_string();
     }
 
-    let command_names = commands
-        .iter()
-        .map(workflow_command_name)
-        .collect::<Vec<_>>()
-        .join(", ");
+    // ⚡ Bolt: Use `fold` to build the string directly without an intermediate Vec allocation
+    let command_names =
+        commands
+            .iter()
+            .map(workflow_command_name)
+            .fold(String::new(), |mut acc, name| {
+                if !acc.is_empty() {
+                    acc.push_str(", ");
+                }
+                acc.push_str(name);
+                acc
+            });
+
     format!(
         "workflow task suspended with unsupported commands ({command_names}); this command set is not implemented yet"
     )
@@ -706,7 +714,8 @@ fn extract_single_command<T>(
 fn extract_all_scheduled_activities(
     commands: &[WorkflowCommand],
 ) -> Option<Vec<ScheduledActivityCommand>> {
-    let mut scheduled = Vec::new();
+    // ⚡ Bolt: Pre-allocate vector capacity to avoid intermediate allocations
+    let mut scheduled = Vec::with_capacity(commands.len());
 
     for cmd in commands {
         match cmd {
@@ -744,7 +753,8 @@ fn extract_all_scheduled_activities(
 }
 
 fn extract_all_activity_waits(commands: &[WorkflowCommand]) -> Option<Vec<ActivityExecId>> {
-    let mut activity_ids = Vec::new();
+    // ⚡ Bolt: Pre-allocate vector capacity to avoid intermediate allocations
+    let mut activity_ids = Vec::with_capacity(commands.len());
 
     for cmd in commands {
         match cmd {
@@ -933,8 +943,8 @@ fn local_activity_history_cap_reached(next_event_id: i32, cap: Option<u64>) -> O
 fn extract_run_local_activity(commands: Vec<WorkflowCommand>) -> LocalActivityCommandBatch {
     // ⚡ Bolt: Pre-allocate vector capacity to avoid intermediate allocations
     let mut pre_schedule_events = Vec::with_capacity(commands.len());
-    let mut post_schedule_events = Vec::new();
-    let mut detached_commands = Vec::new();
+    let mut post_schedule_events = Vec::with_capacity(commands.len());
+    let mut detached_commands = Vec::with_capacity(commands.len());
     let mut local_run = None;
     for cmd in commands {
         match cmd {
@@ -1082,8 +1092,10 @@ fn extract_signal_external_workflow(commands: Vec<WorkflowCommand>) -> Vec<Signa
 fn split_mixed_signal_batch(
     commands: Vec<WorkflowCommand>,
 ) -> (Vec<SignalBatchItem>, Vec<WorkflowCommand>) {
-    let mut signal_items = Vec::new();
-    let mut remaining = Vec::new();
+    // ⚡ Bolt: Pre-allocate vector capacities to avoid intermediate allocations on the hot path
+    // where mixed signal batches are processed.
+    let mut signal_items = Vec::with_capacity(commands.len());
+    let mut remaining = Vec::with_capacity(commands.len());
     for cmd in commands {
         match cmd {
             WorkflowCommand::SignalExternalWorkflow {


### PR DESCRIPTION
💡 What
- Pre-allocated `Vec::with_capacity(commands.len())` for multiple intermediate vector collections in `autumn-harvest/src/worker.rs` command batch processors:
  - `extract_all_scheduled_activities`
  - `extract_all_activity_waits`
  - `extract_run_local_activity` (`post_schedule_events` and `detached_commands`)
  - `split_mixed_signal_batch`
- Replaced an intermediate `.collect::<Vec<_>>().join(", ")` allocation with an inline `fold(String::new(), ...)` in `suspended_workflow_error`.

🎯 Why
- The worker loop is the core hot path in Autumn Harvest. Batching routines were creating empty `Vec::new()` collections and repeatedly reallocating memory as workflow commands were pushed.
- The `suspended_workflow_error` routine allocated a completely unnecessary intermediate `Vec` simply to perform a string join.

📊 Impact
- Eliminates multi-step heap reallocations (growing from 0 to 4, 8, 16 elements, etc) during workflow command extraction, reducing memory thrash under high concurrency loads where workflows yield large command batches.

🔬 Measurement
- Run `cargo test -p autumn-harvest` to verify all worker command extraction logic continues to map exactly as before without behavioral regression.

---
*PR created automatically by Jules for task [8453511958917742237](https://jules.google.com/task/8453511958917742237) started by @madmax983*