### PR TITLE
Add deterministic side-effect primitives to WorkflowContext (issue #384)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,7 @@ Two crates in the workspace. `autumn-harvest` is the public library. `autumn-har
 - **Phase 3.19** (implemented): Published workflow input/output JSON Schema for self-service triggering — see issue #373. `WorkflowInfo` gains four new optional fields: `description: Option<&'static str>`, `input_schema: Option<fn() -> serde_json::Value>`, `output_schema: Option<fn() -> serde_json::Value>`, `error_schema: Option<fn() -> serde_json::Value>`. Three fluent builder methods: `with_description`, `with_input_schema_fn`, `with_output_schema_fn`, `with_error_schema_fn` (all `#[must_use]`). Under the new `schema` Cargo feature, `with_schemas::<I, O, E>()` derives all three schemas automatically from types that implement `schemars::JsonSchema`. Two new management API routes: `GET /workflows/registered` (sorted list of all registered workflow types with optional schemas) and `GET /workflows/registered/{name}/schema` (404 for unknown names). `POST /workflows/{name}/start` validates input against the published schema when one is set; on failure returns `400` with a structured JSON body `{"error": "input validation failed", "violations": [{"message": "…", "field_path": "…"}]}` where `field_path` is a JSON Pointer (RFC 6901). `WorkflowInfo::validate_input` is the pure validation method — returns `Ok(())` or `Err(Vec<SchemaViolation>)`. `validate_against_schema` is the standalone recursive validator. `#[workflow(description = "…")]` attribute wires description through the companion function. Opt-in: workflows without a schema compile and run identically to today — no breakage. **No new `WorkflowEvent` variants, no migrations, no shard-routing changes, no replay-determinism impact.** `RegisteredWorkflowRecord` is the serialisable discovery record. Example: `autumn-harvest/examples/schema_workflow.rs` (requires `--features schema`). New types in `info.rs`: `SchemaViolation`, `RegisteredWorkflowRecord`, `validate_against_schema`.
 - **Phase 3.21** (implemented): Workflow terminal-outcome counter for success-rate SLOs and alerting — see issue #519. New counter `harvest.workflow.terminal` (`METRIC_WORKFLOW_TERMINAL`) incremented **exactly once** per terminal workflow outcome. Labels: `outcome` (6 bounded values: `completed`/`failed`/`cancelled`/`timed_out`/`terminated`/`continued_as_new`), `workflow` (= `METRIC_LABEL_WORKFLOW`), `queue`. `execution.id` is never a label (ADR-0001 §7 cardinality rule). Emission points: `worker.rs` (`process_workflow_task` for Completed/Failed/ContinuedAsNew and `fail_workflow_for_history_cap`), `timeout.rs` (`enforce_workflow_execution_timeouts` for TimedOut), `execution.rs` (`cancel_workflow_execution` for Cancelled, `terminate_workflow_execution` for Terminated). `WorkflowStatus` enum extended with `Cancelled`, `TimedOut`, `Terminated` variants. `record_workflow_terminal` added to `MetricsRecorder` trait as a no-op default (additive, no breaking change). Bridged in `metrics_rs_adapter` (`MetricsRsRecorder`). `BatchExecutorConfig` gains `metrics: Arc<dyn MetricsRecorder>` field (default `NoOpMetrics`). Suspended executor cycles never increment the counter. Workflow-failure-rate alert added to `docs/alerts/starter-pack-v0.1.0.json`. ADR-0001 §7 metric catalogue updated. **No new `WorkflowEvent` variant, no migration.**
 - **Phase 3.20** (implemented): Per-activity cross-retry wall-clock deadline (`schedule_to_close`) for SLA enforcement — see issue #378. `ActivityInfo.default_schedule_to_close: Option<Duration>` (`None` = unbounded, no regression for existing activities). `#[activity(schedule_to_close = "5m", start_to_close = "30s", retry = ...)]` parses cleanly (compile-time error if used on `local = true` activities). Migration `20260606000001_harvest_activity_schedule_to_close` adds `schedule_to_close_at TIMESTAMPTZ NULL` to `harvest_task_queue` with a partial index on `(schedule_to_close_at) WHERE state IN ('RUNNING', 'PENDING') AND schedule_to_close_at IS NOT NULL`. Worker sets `EnqueueParams::schedule_to_close_at = Some(Utc::now() + schedule_to_close)` at schedule time. Retry path: before calling `requeue_for_retry`, `schedule_to_close_deadline_exceeded(task, delay)` checks if `now + retry_delay >= deadline`; if so, `record_schedule_to_close_activity_timeout` appends `ActivityTimedOut { timeout_type: ScheduleToClose }` and fails the task instead of requeuing. Scanner: `TimeoutReason::ScheduleToClose` added to `find_timed_out_tasks`; `expected_task_states_for_timeout` returns `&["RUNNING", "PENDING"]` for this reason so both in-flight and queued-past-deadline tasks are caught. `TimeoutType::ScheduleToClose` already existed in `error.rs` — no new `WorkflowEvent` variant needed. Decision matrix documented in `docs/getting-started/07-reliability-knobs.md`. Integration tests in `tests/schedule_to_close_tests.rs`.
+- **Phase 3.22** (implemented): Deterministic side-effect primitives on `WorkflowContext` — see issue #384. New public methods `system_now() -> DateTime<Utc>` and `system_time_now() -> SystemTime` (per-call wall-clock captured at first execution; distinct from the pre-existing `now()` which returns the fixed `WorkflowStarted` start-time logical clock and is **unchanged** for backward + in-flight safety), `new_uuid() -> Uuid` (UUIDv7 idempotency keys), `random_u64()`/`random_f64()`/`random_range(range)` (sampling draws), plus the pre-existing `side_effect(name, f)` and `random_uuid(id)`. All of them lower onto a **single new** append-only `WorkflowEvent::SideEffectRecorded { kind: SideEffectKind, name: Option<String>, value }` variant (added at the end of the enum; `SideEffectKind` is a bounded enum `Now`/`Uuid`/`Random`/`Custom` with `as_str()` for OTel labels), so the event-schema cost is paid once forever. New internal `WorkflowCommand::RecordSideEffect` (bookkeeping, persisted by the worker exactly like `RecordMarker`). `HistoryMatcher::match_side_effect_event(kind, name)` matches them in command (cursor) order and surfaces drift as `HistoryMatch::Diverged`; `match_side_effect(id)` delegates to it and remains **backward-compatible** with pre-#384 executions that recorded `side_effect` as `MarkerRecorded { name: "side_effect:{id}" }`. The infallible built-ins (`system_now`/`new_uuid`/`random_*`) return plain values, so on a replay divergence they record a deferred non-determinism error (`WorkflowContext::take_deferred_nd_error`) that the executor converts to `WorkflowFailed`; `WorkflowReplayer` classifies it as the new `NonDeterminismKind::SideEffectDrift`. Guardrails HVG001/HVG002 now recommend these primitives by name. Deps: `uuid` gains the `v7` feature, new `rand` workspace dep. **No DB migration** (the variant is opaque JSON in `harvest_events`), no change to the adjacently-tagged event JSON contract, no macro-path change. Example: `autumn-harvest/examples/deterministic_primitives.rs`. Tests: unit tests in `event.rs`/`context.rs`/`replay.rs`, replayer drift tests in `tests/replayer_tests.rs`.
 - **Phase 4** (next): production hardening -- sharding, observability, metrics, dashboard (Vantage UI — Workers tab shipped in issue #142; DLQ, schedules, and DAG visualization pages remain); Step 5 of issue #256 (remove classic DAG executor, drop `harvest_dag_runs`). Note: the cancellation primitive and `Saga` both ship; their interaction semantics, idempotency contract, and replay-determinism contract are documented in `docs/saga.md` and locked in by three integration tests in `tests/saga_tests.rs` (issue #238).
 
 ---
@@ -187,7 +188,7 @@ Current implementation scope: `ExecutionId`/`ShardId` encoding, `ShardRouter`, `
 | `types.rs` | 1 | Newtypes: `WorkflowId` (String), `ExecutionId` (Uuid v4), `ActivityExecId` (Uuid v4), `TimerId` (String), `WorkerId` (String) |
 | `error.rs` | 1 | `HarvestError` (thiserror), `HarvestResult<T>`, `TimeoutType` enum |
 | `policy.rs` | 1 | `RetryPolicy`, `TriggerRule`, `Schedule`, `TaskStatus`, `compute_retry_delay` |
-| `event.rs` | 1 | `WorkflowEvent` enum (28 variants, adjacently-tagged serde), `type_name()`. Variants added in issue #140: `UpdateAdmitted`, `UpdateCompleted`, `UpdateFailed` |
+| `event.rs` | 1 | `WorkflowEvent` enum (35 variants, adjacently-tagged serde), `type_name()`. Variants added in issue #140: `UpdateAdmitted`, `UpdateCompleted`, `UpdateFailed`. `SideEffectRecorded` + bounded `SideEffectKind` enum added in issue #384 (deterministic primitives) |
 | `context.rs` | 1+2 | `WorkflowContext` (replay, suspension, version gate, timers), `ActivityContext` (heartbeat channel, cancellation) |
 | `info.rs` | 1 | `WorkflowInfo`, `ActivityInfo`, `WorkflowHandlerFn`, `ActivityHandlerFn` type aliases |
 | `builder.rs` | 1 | `HarvestBuilder` (fluent), `WorkerConfig` (queues, concurrency, timeouts) |
@@ -452,6 +453,41 @@ let results = ctx.execute_activity_fan_out_raw(vec![
 **Cancellation**: both methods check `ctx.is_cancelled()` before dispatching and return `HarvestError::Cancelled` if the workflow has been cancelled.
 
 See `autumn-harvest/examples/fanout_batch.rs` for a complete end-to-end example covering all three shapes (static N, dynamic N from a prior activity, and collect-all with partial failure).
+
+### Deterministic Primitives (issue #384)
+
+First-class, replay-safe alternatives to the non-deterministic APIs the guardrails (HVG001 wall-clock, HVG002 randomness) warn about. One `WorkflowContext` method call per value — no local-activity definition, no magic strings. Each helper captures its value on the **first** live execution, freezes it into a single `SideEffectRecorded` event, and replays the identical value on every subsequent pass and every worker.
+
+| Method | Returns | Captures |
+|--------|---------|----------|
+| `ctx.system_now()` | `DateTime<Utc>` | wall-clock instant at the call site |
+| `ctx.system_time_now()` | `std::time::SystemTime` | same instant as a `SystemTime` |
+| `ctx.new_uuid()` | `Uuid` | a fresh UUIDv7 (idempotency keys) |
+| `ctx.random_u64()` / `ctx.random_f64()` | `u64` / `f64` | a sampling draw |
+| `ctx.random_range(range)` | `T` | a uniform draw from `range` (e.g. `0..100`) |
+| `ctx.side_effect(name, f)` | `HarvestResult<T>` | any one-shot value; `name` dedups within an execution |
+
+`now()` (unchanged) returns the fixed `WorkflowStarted` timestamp — the workflow-logical *start* clock. Use `system_now()` when you need the *current* wall clock captured at the call site (e.g. "skip the notification if the event is older than 24h now").
+
+```rust
+#[workflow]
+async fn notify(ctx: &WorkflowContext, event: Event) -> Result<(), String> {
+    // Wall-clock decision — captured once, replayed verbatim.
+    let fresh = ctx.system_now().timestamp() - event.occurred_at < 24 * 60 * 60;
+    // Idempotency key — UUIDv7 captured once; safe across retries.
+    let key = ctx.new_uuid().to_string();
+    // Sampling — deterministic across replays.
+    let in_rollout = ctx.random_range(0..100) < 10;
+    // One-shot environment capture.
+    let region: String = ctx
+        .side_effect("region", || std::env::var("REGION").unwrap_or_default())
+        .map_err(|e| e.to_string())?;
+    // ...
+    Ok(())
+}
+```
+
+All six lower onto the single append-only `WorkflowEvent::SideEffectRecorded { kind, name, value }` variant (`kind: SideEffectKind` ∈ `Now`/`Uuid`/`Random`/`Custom`). The `HistoryMatcher` matches them in command order; a divergence (reorder/insert/remove/rename across a code change) is surfaced by `WorkflowReplayer` as `NonDeterminismKind::SideEffectDrift`. `side_effect`/`random_uuid` recorded under the pre-#384 engine (as `MarkerRecorded`) still replay correctly. Randomness is **not** cryptographically secure — for security-grade entropy, use a regular activity. See `autumn-harvest/examples/deterministic_primitives.rs`.
 
 ### Local Activities
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,6 +221,7 @@ dependencies = [
  "lru 0.16.4",
  "metrics",
  "proptest",
+ "rand 0.8.6",
  "schemars 0.8.22",
  "scoped-futures",
  "seahash",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,11 +26,12 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 toml = "1.1"
 thiserror = "2"
-uuid = { version = "1", features = ["v4", "v5", "serde"] }
+uuid = { version = "1", features = ["v4", "v5", "v7", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 chrono-tz = "0.10"
 tracing = "0.1"
 futures = "0.3"
+rand = "0.8"
 
 # Database
 diesel = { version = "2.3", features = ["postgres_backend", "uuid", "chrono", "serde_json", "64-column-tables"] }

--- a/autumn-harvest/Cargo.toml
+++ b/autumn-harvest/Cargo.toml
@@ -44,6 +44,7 @@ futures = { workspace = true }
 lru = "0.16"
 croner = "2.2"
 seahash = "4.1"
+rand = { workspace = true }
 deadpool = { workspace = true, optional = true }
 diesel = { workspace = true, optional = true }
 diesel-async = { workspace = true, optional = true }

--- a/autumn-harvest/examples/deterministic_primitives.rs
+++ b/autumn-harvest/examples/deterministic_primitives.rs
@@ -1,0 +1,110 @@
+#![allow(clippy::doc_markdown, clippy::missing_errors_doc, clippy::unused_async)]
+//! Deterministic side-effect primitives example (issue #384).
+//!
+//! Demonstrates the first-class, replay-safe alternatives to the unsafe APIs the
+//! determinism guardrails (HVG001 / HVG002) warn about — no local activity, no
+//! magic strings, one `WorkflowContext` method call per value:
+//!
+//! - `ctx.system_now()`  — wall-clock instant captured once and replayed verbatim
+//! - `ctx.new_uuid()`    — UUIDv7 idempotency key captured once
+//! - `ctx.random_range()`— a sampling draw captured once
+//! - `ctx.side_effect()` — any one-shot value (here, an environment lookup)
+//!
+//! Each helper lowers onto a single `SideEffectRecorded` event in
+//! `harvest_events`, so the engine replays the identical sequence on every
+//! worker, every time.
+//!
+//! Run with:
+//!   cargo run --example deterministic_primitives
+
+use autumn_harvest::prelude::*;
+use serde::{Deserialize, Serialize};
+
+// ── Domain types ────────────────────────────────────────────────────────────
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct NotificationEvent {
+    /// Unix-epoch seconds when the underlying event occurred.
+    pub occurred_at_epoch_secs: i64,
+    pub recipient: String,
+}
+
+#[derive(Debug, Serialize, Deserialize, Clone)]
+pub struct NotificationDecision {
+    pub idempotency_key: String,
+    pub send: bool,
+    /// 0–99 bucket used for a percentage rollout.
+    pub rollout_bucket: i32,
+    pub region: String,
+}
+
+// ── Activity ─────────────────────────────────────────────────────────────────
+
+#[activity(start_to_close = "10s", queue = "email-workers")]
+pub async fn send_email(_ctx: &ActivityContext, key: String) -> Result<(), String> {
+    println!("[Activity] sending email with idempotency key {key}");
+    Ok(())
+}
+
+// ── Workflow ─────────────────────────────────────────────────────────────────
+
+/// Decides whether to send a notification using only replay-safe primitives.
+///
+/// A real time-based decision: skip the notification if the event is already
+/// older than 24h *now* (not at workflow-start time). `system_now()` captures
+/// the current instant once and freezes it, so the comparison is deterministic
+/// across replays.
+#[workflow(description = "Replay-safe notification decision using ctx deterministic primitives")]
+pub async fn notify_decision(
+    ctx: &WorkflowContext,
+    event: NotificationEvent,
+) -> Result<NotificationDecision, String> {
+    // 1. Wall-clock decision — captured once, replayed verbatim.
+    let now = ctx.system_now();
+    let age_secs = now.timestamp() - event.occurred_at_epoch_secs;
+    let fresh = age_secs < 24 * 60 * 60;
+
+    // 2. Idempotency key — a UUIDv7 captured once. Safe to reuse across retries.
+    let idempotency_key = ctx.new_uuid().to_string();
+
+    // 3. Sampling draw — a 10% rollout. Deterministic across replays.
+    let rollout_bucket: i32 = ctx.random_range(0..100);
+    let in_rollout = rollout_bucket < 10;
+
+    // 4. Capture an environment lookup ONCE via side_effect. The closure runs
+    //    only on the first execution; replays return the recorded value.
+    let region: String = ctx
+        .side_effect("deploy_region", || {
+            std::env::var("DEPLOY_REGION").unwrap_or_else(|_| "us-east-1".to_string())
+        })
+        .map_err(|e| e.to_string())?;
+
+    let send = fresh && in_rollout;
+    if send {
+        let _: () = ctx
+            .execute_activity(&send_email_info(), idempotency_key.clone())
+            .await
+            .map_err(|e| e.to_string())?;
+    }
+
+    Ok(NotificationDecision {
+        idempotency_key,
+        send,
+        rollout_bucket,
+        region,
+    })
+}
+
+fn main() {
+    println!("deterministic_primitives example loaded successfully!");
+    println!();
+    println!("Replay-safe primitives demonstrated:");
+    println!("  ctx.system_now()        — wall-clock captured once, replayed verbatim");
+    println!("  ctx.new_uuid()          — UUIDv7 idempotency key captured once");
+    println!("  ctx.random_range(0..100)— sampling draw, deterministic across replays");
+    println!("  ctx.side_effect(name,f) — one-shot environment lookup captured once");
+    println!();
+    println!("Register on a HarvestBuilder:");
+    println!("  .workflows(workflows![notify_decision])");
+    println!("  .activities(activities![send_email])");
+}

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -1595,6 +1595,11 @@ impl WorkflowContext {
     /// implements [`rand::distributions::uniform::SampleUniform`] and round-trips
     /// through JSON (e.g. `0..100`, `1.0..2.0`).
     ///
+    /// On replay, if the recorded value falls outside the current `range` bounds a
+    /// deferred non-determinism error is recorded (the executor converts this to a
+    /// `WorkflowFailed` outcome), preventing a range-narrowing code change from
+    /// silently returning an out-of-bounds value.
+    ///
     /// # Panics
     ///
     /// Panics if `range` is empty, or if the internal matcher/commands mutex is
@@ -1603,12 +1608,65 @@ impl WorkflowContext {
     where
         T: serde::Serialize
             + serde::de::DeserializeOwned
-            + rand::distributions::uniform::SampleUniform,
-        R: rand::distributions::uniform::SampleRange<T>,
+            + rand::distributions::uniform::SampleUniform
+            + PartialOrd,
+        R: rand::distributions::uniform::SampleRange<T> + std::ops::RangeBounds<T>,
     {
-        self.capture_builtin(crate::event::SideEffectKind::Random, move || {
-            rand::Rng::gen_range(&mut rand::thread_rng(), range)
-        })
+        use crate::event::SideEffectKind;
+
+        let history_match =
+            self.match_history(|m| m.match_side_effect_event(SideEffectKind::Random, None));
+
+        match history_match {
+            HistoryMatch::Matched { output } => match serde_json::from_value::<T>(output) {
+                Ok(value) => {
+                    if range.contains(&value) {
+                        value
+                    } else {
+                        self.record_deferred_nd(
+                            "side-effect drift: replayed random_range value is outside \
+                             the current range bounds"
+                                .to_string(),
+                        );
+                        rand::Rng::gen_range(&mut rand::thread_rng(), range)
+                    }
+                }
+                Err(e) => {
+                    self.record_deferred_nd(format!(
+                        "side-effect drift mismatch: expected SideEffectRecorded(random), \
+                         got an undeserialisable recorded value ({e})"
+                    ));
+                    rand::Rng::gen_range(&mut rand::thread_rng(), range)
+                }
+            },
+            HistoryMatch::Diverged { expected, actual } => {
+                self.record_deferred_nd(format!(
+                    "side-effect drift mismatch: expected {expected}, got {actual}"
+                ));
+                rand::Rng::gen_range(&mut rand::thread_rng(), range)
+            }
+            HistoryMatch::NoMatch => {
+                if self.strict_replay {
+                    self.record_deferred_nd(
+                        "side-effect drift mismatch: expected <end of history>, \
+                         got SideEffectRecorded(random)"
+                            .to_string(),
+                    );
+                }
+                let result = rand::Rng::gen_range(&mut rand::thread_rng(), range);
+                let value = serde_json::to_value(&result)
+                    .expect("built-in side-effect value must serialise");
+                self.push_command(WorkflowCommand::RecordSideEffect {
+                    kind: SideEffectKind::Random,
+                    name: None,
+                    value,
+                });
+                result
+            }
+            _ => unreachable!(
+                "match_side_effect_event only returns Matched, Diverged or NoMatch"
+            ),
+        }
     }
 
     /// Convenience wrapper around `side_effect` for generating a deterministic UUID.

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -1663,9 +1663,7 @@ impl WorkflowContext {
                 });
                 result
             }
-            _ => unreachable!(
-                "match_side_effect_event only returns Matched, Diverged or NoMatch"
-            ),
+            _ => unreachable!("match_side_effect_event only returns Matched, Diverged or NoMatch"),
         }
     }
 

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -212,6 +212,22 @@ pub enum WorkflowCommand {
         /// Optional details or payload associated with the marker.
         details: Value,
     },
+    /// Record a deterministic side-effect value (issue #384).
+    ///
+    /// Emitted by the `WorkflowContext` deterministic primitives — `system_now()`,
+    /// `new_uuid()`, `random_*()`, and `side_effect()` — when running live (past
+    /// end of history). The worker persists this as a
+    /// [`WorkflowEvent::SideEffectRecorded`] so subsequent replays return the
+    /// recorded value. Like [`Self::RecordMarker`] it is a bookkeeping command:
+    /// it carries no result channel and never drives a suspension.
+    RecordSideEffect {
+        /// Which built-in helper produced the value.
+        kind: crate::event::SideEffectKind,
+        /// Author-supplied dedup key for `side_effect()`; `None` for built-ins.
+        name: Option<String>,
+        /// The recorded JSON value.
+        value: Value,
+    },
     /// Schedule an activity that completes externally via a task token.
     ScheduleExternalActivity {
         /// The unique execution ID of the activity.
@@ -408,6 +424,12 @@ impl std::fmt::Debug for WorkflowCommand {
                 .debug_struct("RecordMarker")
                 .field("name", name)
                 .field("details", details)
+                .finish(),
+            Self::RecordSideEffect { kind, name, value } => f
+                .debug_struct("RecordSideEffect")
+                .field("kind", kind)
+                .field("name", name)
+                .field("value", value)
                 .finish(),
             Self::ScheduleExternalActivity {
                 activity_id,
@@ -699,6 +721,15 @@ pub struct WorkflowContext {
     /// Per-activity input cap overrides: `activity_name → max_bytes`.
     /// When an entry exists, the effective cap is `max(global, override)`.
     activity_input_cap_overrides: HashMap<String, u64>,
+    /// First non-determinism error observed by an infallible deterministic
+    /// primitive (`system_now`, `new_uuid`, `random_*`). Those helpers return a
+    /// plain value (not a `Result`), so they cannot surface a divergence to the
+    /// caller directly. They record the first divergence here and the executor
+    /// converts the workflow outcome to `Failed` after the handler returns, so
+    /// the [`WorkflowReplayer`](crate::testing::WorkflowReplayer) reports a
+    /// structured `SideEffectDrift` non-determinism rather than a silent pass
+    /// (issue #384).
+    deferred_nd_error: Mutex<Option<String>>,
 }
 
 impl WorkflowContext {
@@ -811,6 +842,7 @@ impl WorkflowContext {
             payload_max_side_effect: DEFAULT_MAX_WORKFLOW_INPUT_BYTES,
             payload_max_signal: DEFAULT_MAX_SIGNAL_PAYLOAD_BYTES,
             activity_input_cap_overrides: HashMap::new(),
+            deferred_nd_error: Mutex::new(None),
         }
     }
 
@@ -893,6 +925,7 @@ impl WorkflowContext {
             payload_max_side_effect: DEFAULT_MAX_WORKFLOW_INPUT_BYTES,
             payload_max_signal: DEFAULT_MAX_SIGNAL_PAYLOAD_BYTES,
             activity_input_cap_overrides: HashMap::new(),
+            deferred_nd_error: Mutex::new(None),
         })
     }
 
@@ -925,6 +958,7 @@ impl WorkflowContext {
             payload_max_side_effect: DEFAULT_MAX_WORKFLOW_INPUT_BYTES,
             payload_max_signal: DEFAULT_MAX_SIGNAL_PAYLOAD_BYTES,
             activity_input_cap_overrides: HashMap::new(),
+            deferred_nd_error: Mutex::new(None),
         }
     }
 
@@ -1366,14 +1400,215 @@ impl WorkflowContext {
                     });
                 }
 
-                self.push_command(WorkflowCommand::RecordMarker {
-                    name: format!("side_effect:{id}"),
-                    details: output,
+                self.push_command(WorkflowCommand::RecordSideEffect {
+                    kind: crate::event::SideEffectKind::Custom,
+                    name: Some(id.to_string()),
+                    value: output,
                 });
 
                 Ok(result)
             }
         }
+    }
+
+    // ── Deterministic built-in primitives (issue #384) ────────────────────────
+
+    /// Record the first non-determinism error seen by an infallible primitive.
+    ///
+    /// Only the first error is retained; later divergences in the same execution
+    /// cycle do not overwrite it. The executor drains this via
+    /// [`take_deferred_nd_error`](Self::take_deferred_nd_error).
+    fn record_deferred_nd(&self, msg: String) {
+        let mut slot = self
+            .deferred_nd_error
+            .lock()
+            .expect("deferred_nd_error lock poisoned");
+        if slot.is_none() {
+            *slot = Some(msg);
+        }
+    }
+
+    /// Take the first deferred non-determinism error recorded by an infallible
+    /// primitive (`system_now`, `new_uuid`, `random_*`), if any.
+    ///
+    /// Called by the executor after the workflow handler returns so a divergence
+    /// absorbed by a plain-value primitive still fails the replay cleanly.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal `deferred_nd_error` mutex is poisoned.
+    #[must_use]
+    pub fn take_deferred_nd_error(&self) -> Option<String> {
+        self.deferred_nd_error
+            .lock()
+            .expect("deferred_nd_error lock poisoned")
+            .take()
+    }
+
+    /// Shared lowering for the infallible built-in primitives.
+    ///
+    /// Matches a [`WorkflowEvent::SideEffectRecorded`] of `kind` at the current
+    /// cursor during replay and returns the recorded value; on the first live
+    /// run it invokes `f`, records the value, and emits a `RecordSideEffect`
+    /// command. On a genuine divergence it records a deferred non-determinism
+    /// error (the executor converts the outcome to `Failed`) and falls back to a
+    /// freshly computed value so the rest of the cycle can still run.
+    fn capture_builtin<F, T>(&self, kind: crate::event::SideEffectKind, f: F) -> T
+    where
+        F: FnOnce() -> T,
+        T: serde::Serialize + serde::de::DeserializeOwned,
+    {
+        let history_match = self.match_history(|m| m.match_side_effect_event(kind, None));
+
+        match history_match {
+            HistoryMatch::Matched { output } => match serde_json::from_value(output) {
+                Ok(value) => value,
+                Err(e) => {
+                    self.record_deferred_nd(format!(
+                        "side-effect drift mismatch: expected SideEffectRecorded({}), \
+                         got an undeserialisable recorded value ({e})",
+                        kind.as_str()
+                    ));
+                    f()
+                }
+            },
+            HistoryMatch::Diverged { expected, actual } => {
+                self.record_deferred_nd(format!(
+                    "side-effect drift mismatch: expected {expected}, got {actual}"
+                ));
+                f()
+            }
+            HistoryMatch::NoMatch => {
+                if self.strict_replay {
+                    self.record_deferred_nd(format!(
+                        "side-effect drift mismatch: expected <end of history>, \
+                         got SideEffectRecorded({})",
+                        kind.as_str()
+                    ));
+                }
+                let result = f();
+                // Built-in values (timestamps, UUIDs, u64/f64) always serialise.
+                let value = serde_json::to_value(&result)
+                    .expect("built-in side-effect value must serialise");
+                self.push_command(WorkflowCommand::RecordSideEffect {
+                    kind,
+                    name: None,
+                    value,
+                });
+                result
+            }
+            _ => unreachable!("match_side_effect_event only returns Matched, Diverged or NoMatch"),
+        }
+    }
+
+    /// Deterministic wall-clock read, captured once and replayed verbatim.
+    ///
+    /// Unlike [`now`](Self::now) — which returns the fixed `WorkflowStarted`
+    /// timestamp (the workflow-logical start clock) — `system_now` captures the
+    /// *current* wall-clock instant the first time it executes at this point in
+    /// the workflow, freezes it into history as a
+    /// [`WorkflowEvent::SideEffectRecorded`], and returns that exact instant on
+    /// every subsequent replay. Use it for "is this event older than 24h *now*?"
+    /// style decisions inside a long-running workflow.
+    ///
+    /// This is the safe, replay-deterministic alternative to calling
+    /// `chrono::Utc::now()` directly (guardrail HVG001).
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal matcher or commands mutex is poisoned.
+    #[must_use]
+    pub fn system_now(&self) -> DateTime<Utc> {
+        let millis = self.capture_builtin(crate::event::SideEffectKind::Now, || {
+            Utc::now().timestamp_millis()
+        });
+        DateTime::from_timestamp_millis(millis).unwrap_or(self.start_time)
+    }
+
+    /// Deterministic wall-clock read as a [`std::time::SystemTime`].
+    ///
+    /// Identical capture semantics to [`system_now`](Self::system_now); use this
+    /// when you need a `SystemTime` rather than a `chrono` value. Each call
+    /// records its own [`WorkflowEvent::SideEffectRecorded`] event.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal matcher or commands mutex is poisoned.
+    #[must_use]
+    pub fn system_time_now(&self) -> std::time::SystemTime {
+        let millis = self.capture_builtin(crate::event::SideEffectKind::Now, || {
+            Utc::now().timestamp_millis()
+        });
+        let millis_u64 = u64::try_from(millis.max(0)).unwrap_or(0);
+        std::time::UNIX_EPOCH + std::time::Duration::from_millis(millis_u64)
+    }
+
+    /// Deterministic UUID (version 7), captured once and replayed verbatim.
+    ///
+    /// Mints a fresh time-ordered `UUIDv7` on the first live execution, records it
+    /// in history, and returns the same value on every replay. This is the safe,
+    /// replay-deterministic alternative to calling `Uuid::new_v4()` /
+    /// `Uuid::now_v7()` directly inside a workflow (guardrail HVG002) — ideal for
+    /// idempotency keys.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal matcher or commands mutex is poisoned.
+    #[must_use]
+    pub fn new_uuid(&self) -> uuid::Uuid {
+        self.capture_builtin(crate::event::SideEffectKind::Uuid, uuid::Uuid::now_v7)
+    }
+
+    /// Deterministic random `u64`, captured once and replayed verbatim.
+    ///
+    /// The draw is **not** cryptographically secure — it is intended for
+    /// sampling and idempotency-key style work. Security-grade entropy belongs in
+    /// a regular activity (see issue #384 "Out of Scope").
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal matcher or commands mutex is poisoned.
+    #[must_use]
+    pub fn random_u64(&self) -> u64 {
+        self.capture_builtin(crate::event::SideEffectKind::Random, || {
+            rand::random::<u64>()
+        })
+    }
+
+    /// Deterministic random `f64` in the half-open range `[0, 1)`, captured once
+    /// and replayed verbatim.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal matcher or commands mutex is poisoned.
+    #[must_use]
+    pub fn random_f64(&self) -> f64 {
+        self.capture_builtin(crate::event::SideEffectKind::Random, || {
+            rand::random::<f64>()
+        })
+    }
+
+    /// Deterministic random value drawn uniformly from `range`, captured once and
+    /// replayed verbatim.
+    ///
+    /// Mirrors [`rand::Rng::gen_range`]; works for any range whose element type
+    /// implements [`rand::distributions::uniform::SampleUniform`] and round-trips
+    /// through JSON (e.g. `0..100`, `1.0..2.0`).
+    ///
+    /// # Panics
+    ///
+    /// Panics if `range` is empty, or if the internal matcher/commands mutex is
+    /// poisoned.
+    pub fn random_range<T, R>(&self, range: R) -> T
+    where
+        T: serde::Serialize
+            + serde::de::DeserializeOwned
+            + rand::distributions::uniform::SampleUniform,
+        R: rand::distributions::uniform::SampleRange<T>,
+    {
+        self.capture_builtin(crate::event::SideEffectKind::Random, move || {
+            rand::Rng::gen_range(&mut rand::thread_rng(), range)
+        })
     }
 
     /// Convenience wrapper around `side_effect` for generating a deterministic UUID.
@@ -5134,11 +5369,12 @@ mod tests {
         let cmds = ctx.drain_commands();
         assert_eq!(cmds.len(), 1);
         match &cmds[0] {
-            WorkflowCommand::RecordMarker { name, details } => {
-                assert_eq!(name, "side_effect:random_num");
-                assert_eq!(details, &serde_json::json!(42));
+            WorkflowCommand::RecordSideEffect { kind, name, value } => {
+                assert_eq!(*kind, crate::event::SideEffectKind::Custom);
+                assert_eq!(name.as_deref(), Some("random_num"));
+                assert_eq!(value, &serde_json::json!(42));
             }
-            _ => panic!("Expected RecordMarker command"),
+            _ => panic!("Expected RecordSideEffect command"),
         }
     }
 
@@ -5170,12 +5406,222 @@ mod tests {
         let cmds = ctx.drain_commands();
         assert_eq!(cmds.len(), 1);
         match &cmds[0] {
-            WorkflowCommand::RecordMarker { name, details } => {
-                assert_eq!(name, "side_effect:txn_id");
-                assert_eq!(details, &serde_json::json!(result));
+            WorkflowCommand::RecordSideEffect { kind, name, value } => {
+                assert_eq!(*kind, crate::event::SideEffectKind::Custom);
+                assert_eq!(name.as_deref(), Some("txn_id"));
+                assert_eq!(value, &serde_json::json!(result));
             }
-            _ => panic!("Expected RecordMarker command"),
+            _ => panic!("Expected RecordSideEffect command"),
         }
+    }
+
+    // ── Deterministic built-in primitives (issue #384) ────────────────────────
+
+    use crate::event::SideEffectKind;
+
+    #[test]
+    fn system_now_emits_side_effect_event_during_live_execution() {
+        let ctx = WorkflowContext::new_test();
+        let t = ctx.system_now();
+        // The captured instant is a real wall-clock value (>= the year 2020).
+        assert!(t.timestamp() > 1_577_836_800);
+
+        let cmds = ctx.drain_commands();
+        assert_eq!(cmds.len(), 1);
+        match &cmds[0] {
+            WorkflowCommand::RecordSideEffect { kind, name, .. } => {
+                assert_eq!(*kind, SideEffectKind::Now);
+                assert_eq!(*name, None, "built-in primitives have no name");
+            }
+            other => panic!("expected RecordSideEffect, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn system_now_replays_recorded_value_verbatim() {
+        let frozen_millis = 1_700_000_123_456_i64;
+        let events = vec![
+            WorkflowEvent::WorkflowStarted {
+                input: Value::Null,
+                timestamp: Utc::now(),
+            },
+            WorkflowEvent::SideEffectRecorded {
+                kind: SideEffectKind::Now,
+                name: None,
+                value: serde_json::json!(frozen_millis),
+            },
+        ];
+        let ctx = WorkflowContext::for_replay(ExecutionId::new(), events);
+        let t = ctx.system_now();
+        assert_eq!(t.timestamp_millis(), frozen_millis);
+        // No command emitted on replay.
+        assert!(ctx.drain_commands().is_empty());
+        assert!(ctx.take_deferred_nd_error().is_none());
+    }
+
+    #[test]
+    fn new_uuid_is_v7_and_captured() {
+        let ctx = WorkflowContext::new_test();
+        let id = ctx.new_uuid();
+        assert_eq!(id.get_version_num(), 7, "new_uuid must mint a UUIDv7");
+        let cmds = ctx.drain_commands();
+        assert!(matches!(
+            &cmds[0],
+            WorkflowCommand::RecordSideEffect {
+                kind: SideEffectKind::Uuid,
+                name: None,
+                ..
+            }
+        ));
+    }
+
+    #[test]
+    fn new_uuid_replays_recorded_value() {
+        let expected = uuid::Uuid::now_v7();
+        let events = vec![
+            WorkflowEvent::WorkflowStarted {
+                input: Value::Null,
+                timestamp: Utc::now(),
+            },
+            WorkflowEvent::SideEffectRecorded {
+                kind: SideEffectKind::Uuid,
+                name: None,
+                value: serde_json::json!(expected),
+            },
+        ];
+        let ctx = WorkflowContext::for_replay(ExecutionId::new(), events);
+        assert_eq!(ctx.new_uuid(), expected);
+    }
+
+    #[test]
+    fn random_helpers_replay_recorded_values() {
+        let events = vec![
+            WorkflowEvent::WorkflowStarted {
+                input: Value::Null,
+                timestamp: Utc::now(),
+            },
+            WorkflowEvent::SideEffectRecorded {
+                kind: SideEffectKind::Random,
+                name: None,
+                value: serde_json::json!(42_u64),
+            },
+            WorkflowEvent::SideEffectRecorded {
+                kind: SideEffectKind::Random,
+                name: None,
+                value: serde_json::json!(7_i32),
+            },
+        ];
+        let ctx = WorkflowContext::for_replay(ExecutionId::new(), events);
+        assert_eq!(ctx.random_u64(), 42);
+        assert_eq!(ctx.random_range(0..100_i32), 7);
+        assert!(ctx.take_deferred_nd_error().is_none());
+    }
+
+    /// Replay safety (AC): a workflow that calls `system_now()` 1,000 times
+    /// produces a byte-identical sequence of recorded values on every replay.
+    #[test]
+    fn thousand_now_calls_replay_byte_identical() {
+        // Build a history with 1,000 distinct recorded Now values.
+        let mut events = vec![WorkflowEvent::WorkflowStarted {
+            input: Value::Null,
+            timestamp: Utc::now(),
+        }];
+        for i in 0..1000_i64 {
+            events.push(WorkflowEvent::SideEffectRecorded {
+                kind: SideEffectKind::Now,
+                name: None,
+                value: serde_json::json!(1_700_000_000_000_i64 + i),
+            });
+        }
+
+        // Replay twice; both passes must yield the identical ordered sequence.
+        let run = || {
+            let ctx = WorkflowContext::for_replay(ExecutionId::new(), events.clone());
+            let seq: Vec<i64> = (0..1000)
+                .map(|_| ctx.system_now().timestamp_millis())
+                .collect();
+            assert!(ctx.take_deferred_nd_error().is_none());
+            seq
+        };
+        let first = run();
+        let second = run();
+        assert_eq!(first, second);
+        assert_eq!(first[0], 1_700_000_000_000);
+        assert_eq!(first[999], 1_700_000_000_999);
+    }
+
+    /// Drift detection (AC): an infallible built-in that diverges from history
+    /// records a deferred non-determinism error the executor can surface.
+    #[test]
+    fn builtin_primitive_records_deferred_nd_on_divergence() {
+        let events = vec![
+            WorkflowEvent::WorkflowStarted {
+                input: Value::Null,
+                timestamp: Utc::now(),
+            },
+            // History expects an activity here, but the code calls system_now().
+            WorkflowEvent::ActivityScheduled {
+                activity_id: crate::types::ActivityExecId::new(),
+                name: "some_activity".into(),
+                input: Value::Null,
+                queue: "default".into(),
+            },
+        ];
+        let ctx = WorkflowContext::for_replay(ExecutionId::new(), events);
+        let _ = ctx.system_now(); // returns a fallback value, records the drift
+        let nd = ctx
+            .take_deferred_nd_error()
+            .expect("drift must be recorded");
+        assert!(
+            nd.contains("side-effect drift mismatch"),
+            "message must classify as side-effect drift: {nd}"
+        );
+        assert!(nd.contains("ActivityScheduled"), "actual event named: {nd}");
+    }
+
+    #[test]
+    fn builtin_kind_mismatch_records_drift() {
+        // History recorded a Uuid capture but the code now calls system_now().
+        let events = vec![
+            WorkflowEvent::WorkflowStarted {
+                input: Value::Null,
+                timestamp: Utc::now(),
+            },
+            WorkflowEvent::SideEffectRecorded {
+                kind: SideEffectKind::Uuid,
+                name: None,
+                value: serde_json::json!(uuid::Uuid::now_v7()),
+            },
+        ];
+        let ctx = WorkflowContext::for_replay(ExecutionId::new(), events);
+        let _ = ctx.system_now();
+        let nd = ctx
+            .take_deferred_nd_error()
+            .expect("kind drift must be recorded");
+        assert!(nd.contains("side-effect drift mismatch"), "{nd}");
+        assert!(
+            nd.contains("SideEffectRecorded(uuid)"),
+            "actual kind named: {nd}"
+        );
+    }
+
+    #[test]
+    fn side_effect_reads_legacy_marker_for_in_flight_compat() {
+        // In-flight executions recorded side effects as MarkerRecorded under the
+        // pre-#384 engine. The migrated matcher must still replay them.
+        let events = vec![
+            WorkflowEvent::WorkflowStarted {
+                input: Value::Null,
+                timestamp: Utc::now(),
+            },
+            WorkflowEvent::MarkerRecorded {
+                name: "side_effect:legacy".into(),
+                details: serde_json::json!("hello"),
+            },
+        ];
+        let ctx = WorkflowContext::for_replay(ExecutionId::new(), events);
+        let v: String = ctx.side_effect("legacy", || "fresh".to_string()).unwrap();
+        assert_eq!(v, "hello");
     }
 
     #[tokio::test]

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -1458,11 +1458,43 @@ impl WorkflowContext {
         F: FnOnce() -> T,
         T: serde::Serialize + serde::de::DeserializeOwned,
     {
+        self.capture_builtin_validated(kind, |_| true, f)
+    }
+
+    /// Like [`capture_builtin`](Self::capture_builtin) but additionally validates
+    /// a replayed value against `is_valid`.
+    ///
+    /// All random helpers lower onto the same `SideEffectKind::Random`, so a code
+    /// change that swaps one helper for another at a call site (e.g. `random_u64`
+    /// → `random_f64`) would otherwise deserialize the recorded JSON without
+    /// complaint — a `42` integer reads back as `42.0`, silently violating the new
+    /// helper's documented domain. `is_valid` lets a helper reject a replayed
+    /// value that falls outside its contract (e.g. `random_f64`'s `[0, 1)`),
+    /// recording it as a deferred non-determinism error instead.
+    fn capture_builtin_validated<F, V, T>(
+        &self,
+        kind: crate::event::SideEffectKind,
+        is_valid: V,
+        f: F,
+    ) -> T
+    where
+        F: FnOnce() -> T,
+        V: FnOnce(&T) -> bool,
+        T: serde::Serialize + serde::de::DeserializeOwned,
+    {
         let history_match = self.match_history(|m| m.match_side_effect_event(kind, None));
 
         match history_match {
-            HistoryMatch::Matched { output } => match serde_json::from_value(output) {
-                Ok(value) => value,
+            HistoryMatch::Matched { output } => match serde_json::from_value::<T>(output) {
+                Ok(value) if is_valid(&value) => value,
+                Ok(_) => {
+                    self.record_deferred_nd(format!(
+                        "side-effect drift mismatch: expected SideEffectRecorded({}) within its \
+                         documented domain, got an out-of-domain replayed value",
+                        kind.as_str()
+                    ));
+                    f()
+                }
                 Err(e) => {
                     self.record_deferred_nd(format!(
                         "side-effect drift mismatch: expected SideEffectRecorded({}), \
@@ -1578,14 +1610,21 @@ impl WorkflowContext {
     /// Deterministic random `f64` in the half-open range `[0, 1)`, captured once
     /// and replayed verbatim.
     ///
+    /// On replay a recorded value outside `[0, 1)` (e.g. because the call site was
+    /// changed from `random_u64()`, whose draw shares the same
+    /// `SideEffectKind::Random`) is rejected as a deferred non-determinism error
+    /// rather than silently returning an out-of-contract value.
+    ///
     /// # Panics
     ///
     /// Panics if the internal matcher or commands mutex is poisoned.
     #[must_use]
     pub fn random_f64(&self) -> f64 {
-        self.capture_builtin(crate::event::SideEffectKind::Random, || {
-            rand::random::<f64>()
-        })
+        self.capture_builtin_validated(
+            crate::event::SideEffectKind::Random,
+            |v: &f64| (0.0..1.0).contains(v),
+            rand::random::<f64>,
+        )
     }
 
     /// Deterministic random value drawn uniformly from `range`, captured once and
@@ -1624,8 +1663,8 @@ impl WorkflowContext {
                         value
                     } else {
                         self.record_deferred_nd(
-                            "side-effect drift: replayed random_range value is outside \
-                             the current range bounds"
+                            "side-effect drift mismatch: expected SideEffectRecorded(random) \
+                             within the current range, got an out-of-range replayed value"
                                 .to_string(),
                         );
                         rand::Rng::gen_range(&mut rand::thread_rng(), range)
@@ -5571,6 +5610,78 @@ mod tests {
         assert_eq!(ctx.random_u64(), 42);
         assert_eq!(ctx.random_range(0..100_i32), 7);
         assert!(ctx.take_deferred_nd_error().is_none());
+    }
+
+    #[test]
+    fn random_f64_rejects_out_of_domain_replayed_value() {
+        // A call site changed from random_u64() to random_f64(): the recorded
+        // draw (42) deserializes fine as 42.0 but violates the [0, 1) contract.
+        // It must be reported as drift, not silently returned.
+        let events = vec![
+            WorkflowEvent::WorkflowStarted {
+                input: Value::Null,
+                timestamp: Utc::now(),
+            },
+            WorkflowEvent::SideEffectRecorded {
+                kind: SideEffectKind::Random,
+                name: None,
+                value: serde_json::json!(42_u64),
+            },
+        ];
+        let ctx = WorkflowContext::for_replay(ExecutionId::new(), events);
+        let v = ctx.random_f64();
+        assert!(
+            (0.0..1.0).contains(&v),
+            "fallback draw must still honour the contract"
+        );
+        let nd = ctx
+            .take_deferred_nd_error()
+            .expect("out-of-domain replay must record drift");
+        assert!(nd.contains("side-effect drift mismatch"), "{nd}");
+        assert!(nd.contains("out-of-domain"), "{nd}");
+    }
+
+    #[test]
+    fn random_f64_replays_valid_recorded_value() {
+        let events = vec![
+            WorkflowEvent::WorkflowStarted {
+                input: Value::Null,
+                timestamp: Utc::now(),
+            },
+            WorkflowEvent::SideEffectRecorded {
+                kind: SideEffectKind::Random,
+                name: None,
+                value: serde_json::json!(0.25_f64),
+            },
+        ];
+        let ctx = WorkflowContext::for_replay(ExecutionId::new(), events);
+        assert!((ctx.random_f64() - 0.25).abs() < f64::EPSILON);
+        assert!(ctx.take_deferred_nd_error().is_none());
+    }
+
+    #[test]
+    fn random_range_rejects_out_of_range_replayed_value() {
+        // History captured 7 from random_range(0..100); the code now narrows to
+        // 0..5. The replayed 7 is outside the current range and must drift.
+        let events = vec![
+            WorkflowEvent::WorkflowStarted {
+                input: Value::Null,
+                timestamp: Utc::now(),
+            },
+            WorkflowEvent::SideEffectRecorded {
+                kind: SideEffectKind::Random,
+                name: None,
+                value: serde_json::json!(7_i32),
+            },
+        ];
+        let ctx = WorkflowContext::for_replay(ExecutionId::new(), events);
+        let v: i32 = ctx.random_range(0..5_i32);
+        assert!((0..5).contains(&v), "fallback draw must honour the range");
+        let nd = ctx
+            .take_deferred_nd_error()
+            .expect("out-of-range replay must record drift");
+        assert!(nd.contains("side-effect drift mismatch"), "{nd}");
+        assert!(nd.contains("out-of-range"), "{nd}");
     }
 
     /// Replay safety (AC): a workflow that calls `system_now()` 1,000 times

--- a/autumn-harvest/src/event.rs
+++ b/autumn-harvest/src/event.rs
@@ -21,6 +21,47 @@ fn default_error_type() -> String {
     "Error".to_string()
 }
 
+/// Which deterministic built-in produced a [`WorkflowEvent::SideEffectRecorded`]
+/// event (issue #384).
+///
+/// This is a **bounded** enum — it has a fixed, small set of variants and is
+/// safe to use as a low-cardinality `OTel` attribute value (ADR-0001 §7). Each of
+/// the `WorkflowContext` deterministic primitives lowers onto a single
+/// `SideEffectRecorded` event and stamps the originating helper here so replay
+/// diagnostics and metrics can distinguish a clock read from a UUID mint without
+/// inspecting the recorded value.
+///
+/// **Append-only invariant:** never remove or rename a variant. The serialised
+/// form is the bare variant name (`"Now"`, `"Uuid"`, …); stored events depend on
+/// it. New helper kinds are added at the end.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum SideEffectKind {
+    /// `ctx.system_now()` / `ctx.system_time_now()` — a captured wall-clock instant.
+    Now,
+    /// `ctx.new_uuid()` — a captured `UUIDv7`.
+    Uuid,
+    /// `ctx.random_u64()` / `ctx.random_f64()` / `ctx.random_range(..)` — a captured draw.
+    Random,
+    /// `ctx.side_effect(name, f)` — an author-named one-shot value capture.
+    Custom,
+}
+
+impl SideEffectKind {
+    /// Stable, low-cardinality string label for metrics / diagnostics.
+    ///
+    /// These values are bounded (one per variant) and safe to use as an `OTel`
+    /// attribute value per ADR-0001 §7.
+    #[must_use]
+    pub const fn as_str(&self) -> &'static str {
+        match self {
+            Self::Now => "now",
+            Self::Uuid => "uuid",
+            Self::Random => "random",
+            Self::Custom => "custom",
+        }
+    }
+}
+
 /// All possible events in a workflow's history.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", content = "data")]
@@ -440,6 +481,32 @@ pub enum WorkflowEvent {
         /// The actual wall-clock time when the scanner detected and enforced the timeout.
         timed_out_at: DateTime<Utc>,
     },
+
+    // ── Deterministic side-effect primitives (issue #384) ─────────────────────
+    /// A deterministic value was captured during live execution and frozen into
+    /// history so subsequent replays return the identical value.
+    ///
+    /// All of the `WorkflowContext` deterministic primitives — `system_now()`,
+    /// `system_time_now()`, `new_uuid()`, `random_u64()`, `random_f64()`,
+    /// `random_range()`, and `side_effect()` — lower onto this single variant so
+    /// the event-schema cost of the feature is paid exactly once. The `kind`
+    /// discriminator (a bounded enum) records which helper produced the value;
+    /// `name` is `Some` only for `side_effect()` (the author-supplied dedup key)
+    /// and `None` for the built-in unnamed helpers; `value` is the recorded JSON
+    /// result returned on every replay.
+    ///
+    /// This is an **append-only** variant added at the end of the enum. The
+    /// `harvest_events` table stores it as opaque JSON, so no migration is
+    /// required. `name` is omitted from the serialised form when `None`.
+    SideEffectRecorded {
+        /// Which built-in helper produced this value.
+        kind: SideEffectKind,
+        /// Author-supplied dedup key for `side_effect()`; `None` for built-ins.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        name: Option<String>,
+        /// The recorded JSON value, replayed verbatim on every subsequent pass.
+        value: serde_json::Value,
+    },
 }
 
 impl WorkflowEvent {
@@ -485,6 +552,7 @@ impl WorkflowEvent {
             Self::WorkflowExecutionTimedOut { .. } => "WorkflowExecutionTimedOut",
             Self::ChildWorkflowSpawnedDetached { .. } => "ChildWorkflowSpawnedDetached",
             Self::ChildWorkflowCascadeApplied { .. } => "ChildWorkflowCascadeApplied",
+            Self::SideEffectRecorded { .. } => "SideEffectRecorded",
         }
     }
 
@@ -840,11 +908,86 @@ mod tests {
                 deadline: Utc::now(),
                 timed_out_at: Utc::now(),
             },
+            WorkflowEvent::SideEffectRecorded {
+                kind: crate::event::SideEffectKind::Now,
+                name: None,
+                value: serde_json::Value::Null,
+            },
         ];
 
-        assert_eq!(events.len(), 34);
+        assert_eq!(events.len(), 35);
         let names: HashSet<_> = events.iter().map(WorkflowEvent::type_name).collect();
-        assert_eq!(names.len(), 34, "duplicate type names detected");
+        assert_eq!(names.len(), 35, "duplicate type names detected");
+    }
+
+    // ── SideEffectRecorded tests (issue #384) ─────────────────────────────────
+
+    #[test]
+    fn side_effect_recorded_round_trips_without_name() -> Result<(), serde_json::Error> {
+        let event = WorkflowEvent::SideEffectRecorded {
+            kind: SideEffectKind::Now,
+            name: None,
+            value: serde_json::json!(1_700_000_000_u64),
+        };
+        assert_eq!(event.type_name(), "SideEffectRecorded");
+        let json = serde_json::to_string(&event)?;
+        // `name: None` must be omitted from the serialised form.
+        assert!(
+            !json.contains("\"name\""),
+            "name should be skipped when None"
+        );
+        assert!(
+            json.contains("\"kind\":\"Now\""),
+            "kind tag must be present"
+        );
+        let back: WorkflowEvent = serde_json::from_str(&json)?;
+        match back {
+            WorkflowEvent::SideEffectRecorded { kind, name, value } => {
+                assert_eq!(kind, SideEffectKind::Now);
+                assert_eq!(name, None);
+                assert_eq!(value, serde_json::json!(1_700_000_000_u64));
+            }
+            _ => panic!("wrong variant"),
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn side_effect_recorded_round_trips_with_custom_name() -> Result<(), serde_json::Error> {
+        let event = WorkflowEvent::SideEffectRecorded {
+            kind: SideEffectKind::Custom,
+            name: Some("env_lookup".into()),
+            value: serde_json::json!({"region": "us-east-1"}),
+        };
+        let json = serde_json::to_string(&event)?;
+        assert!(json.contains("\"name\":\"env_lookup\""));
+        let back: WorkflowEvent = serde_json::from_str(&json)?;
+        assert!(matches!(
+            back,
+            WorkflowEvent::SideEffectRecorded {
+                kind: SideEffectKind::Custom,
+                ..
+            }
+        ));
+        Ok(())
+    }
+
+    #[test]
+    fn side_effect_recorded_is_not_terminal_lifecycle() {
+        let event = WorkflowEvent::SideEffectRecorded {
+            kind: SideEffectKind::Uuid,
+            name: None,
+            value: serde_json::Value::Null,
+        };
+        assert!(!event.is_terminal_lifecycle());
+    }
+
+    #[test]
+    fn side_effect_kind_labels_are_bounded() {
+        assert_eq!(SideEffectKind::Now.as_str(), "now");
+        assert_eq!(SideEffectKind::Uuid.as_str(), "uuid");
+        assert_eq!(SideEffectKind::Random.as_str(), "random");
+        assert_eq!(SideEffectKind::Custom.as_str(), "custom");
     }
 
     #[test]

--- a/autumn-harvest/src/executor.rs
+++ b/autumn-harvest/src/executor.rs
@@ -158,7 +158,16 @@ pub async fn run_workflow_strict(
                     error: format!("non-deterministic replay: {nd}"),
                 },
             ),
-            Ok(Err(error)) => WorkflowOutcome::Failed { error },
+            // A primitive may have drifted before the workflow returned Err from
+            // its own logic; prefer the non-determinism error (issue #384).
+            Ok(Err(error)) => {
+                ctx.take_deferred_nd_error()
+                    .map_or(WorkflowOutcome::Failed { error }, |nd| {
+                        WorkflowOutcome::Failed {
+                            error: format!("non-deterministic replay: {nd}"),
+                        }
+                    })
+            }
             Err(_elapsed) => {
                 // A plain-value built-in primitive (system_now/new_uuid/random_*)
                 // may have recorded a divergence before the workflow parked on an
@@ -354,7 +363,18 @@ pub async fn run_workflow_with_state_history_policy_and_caps(
                 );
                 (outcome, ctx.drain_commands())
             }
-            Ok(Err(error)) => (WorkflowOutcome::Failed { error }, ctx.drain_commands()),
+            // A primitive may have drifted before the workflow returned Err from
+            // its own logic; prefer the non-determinism error (issue #384).
+            Ok(Err(error)) => {
+                let outcome =
+                    ctx.take_deferred_nd_error()
+                        .map_or(WorkflowOutcome::Failed { error }, |nd| {
+                            WorkflowOutcome::Failed {
+                                error: format!("non-deterministic replay: {nd}"),
+                            }
+                        });
+                (outcome, ctx.drain_commands())
+            }
 
             // Timeout elapsed -- the handler is suspended on a oneshot channel.
             // Drain the commands it emitted before suspending. RecordUpdateResult
@@ -425,6 +445,18 @@ mod tests {
         Box::pin(async move { Err("something went wrong".to_string()) })
     }
 
+    /// A workflow that captures a side-effect (drifts against history) and then
+    /// returns Err from its own logic.
+    fn drift_then_error_workflow<'a>(
+        ctx: &'a WorkflowContext,
+        _input: Value,
+    ) -> Pin<Box<dyn std::future::Future<Output = Result<Value, String>> + Send + 'a>> {
+        Box::pin(async move {
+            let _ = ctx.system_now(); // diverges from the recorded activity event
+            Err("business rule violated".to_string())
+        })
+    }
+
     /// A workflow that calls an activity (will suspend if not in history).
     fn activity_workflow<'a>(
         ctx: &'a WorkflowContext,
@@ -475,6 +507,44 @@ mod tests {
                 assert!(error.contains("something went wrong"));
             }
             other => panic!("expected Failed, got {other:?}"),
+        }
+    }
+
+    #[tokio::test]
+    async fn executor_prefers_deferred_drift_over_workflow_error() {
+        // Regression (issue #384): a primitive that drifts before the workflow
+        // returns Err from its own logic must surface as non-determinism rather
+        // than masquerading as an ordinary workflow failure.
+        let exec_id = ExecutionId::new();
+        let history = vec![
+            WorkflowEvent::WorkflowStarted {
+                input: Value::Null,
+                timestamp: Utc::now(),
+            },
+            // The workflow calls system_now() here, but history recorded an
+            // activity — a genuine divergence.
+            WorkflowEvent::ActivityScheduled {
+                activity_id: ActivityExecId::new(),
+                name: "some_activity".into(),
+                input: Value::Null,
+                queue: "default".into(),
+            },
+        ];
+
+        let outcome = run_workflow(exec_id, history, drift_then_error_workflow, Value::Null).await;
+
+        match outcome {
+            WorkflowOutcome::Failed { error } => {
+                assert!(
+                    error.contains("non-deterministic replay"),
+                    "drift must win over the workflow's own error: {error}"
+                );
+                assert!(
+                    !error.contains("business rule violated"),
+                    "the workflow's Err must not mask the drift: {error}"
+                );
+            }
+            other => panic!("expected Failed(non-determinism), got {other:?}"),
         }
     }
 

--- a/autumn-harvest/src/executor.rs
+++ b/autumn-harvest/src/executor.rs
@@ -127,29 +127,37 @@ pub async fn run_workflow_strict(
     async {
         let timeout_result = tokio::time::timeout(SUSPENSION_TIMEOUT, handler(&ctx, input)).await;
         match timeout_result {
-            Ok(Ok(output)) => {
-                if ctx.history_has_unconsumed_events() {
-                    WorkflowOutcome::Failed {
-                        error: "non-deterministic replay: early completion mismatch: \
-                                expected <end of history>, got <workflow returned early>"
-                            .to_string(),
+            // An infallible built-in primitive (system_now/new_uuid/random_*) may
+            // have absorbed a divergence and returned a fallback value (issue #384);
+            // surface it before the other completion checks.
+            Ok(Ok(output)) => ctx.take_deferred_nd_error().map_or_else(
+                || {
+                    if ctx.history_has_unconsumed_events() {
+                        WorkflowOutcome::Failed {
+                            error: "non-deterministic replay: early completion mismatch: \
+                                    expected <end of history>, got <workflow returned early>"
+                                .to_string(),
+                        }
+                    } else if ctx.drain_commands().into_iter().any(|cmd| {
+                        // UpsertSearchAttributes is pure metadata and does not
+                        // affect replay determinism; exclude it from this check.
+                        !matches!(cmd, WorkflowCommand::UpsertSearchAttributes { .. })
+                    }) {
+                        // New commands emitted after history was fully consumed (e.g. a
+                        // newly-added version() or side_effect() call on an old history).
+                        WorkflowOutcome::Failed {
+                            error: "non-deterministic replay: new commands emitted beyond \
+                                    recorded history"
+                                .to_string(),
+                        }
+                    } else {
+                        WorkflowOutcome::Completed { output }
                     }
-                } else if ctx.drain_commands().into_iter().any(|cmd| {
-                    // UpsertSearchAttributes is pure metadata and does not
-                    // affect replay determinism; exclude it from this check.
-                    !matches!(cmd, WorkflowCommand::UpsertSearchAttributes { .. })
-                }) {
-                    // New commands emitted after history was fully consumed (e.g. a
-                    // newly-added version() or side_effect() call on an old history).
-                    WorkflowOutcome::Failed {
-                        error: "non-deterministic replay: new commands emitted beyond \
-                                recorded history"
-                            .to_string(),
-                    }
-                } else {
-                    WorkflowOutcome::Completed { output }
-                }
-            }
+                },
+                |nd| WorkflowOutcome::Failed {
+                    error: format!("non-deterministic replay: {nd}"),
+                },
+            ),
             Ok(Err(error)) => WorkflowOutcome::Failed { error },
             Err(_elapsed) => {
                 let mut commands = ctx.drain_commands();
@@ -324,7 +332,19 @@ pub async fn run_workflow_with_state_history_policy_and_caps(
             // emitted during live execution (e.g. RecordUpdateResult from
             // execute_admitted_update) so the worker can persist them before the
             // terminal WorkflowCompleted/WorkflowFailed event.
-            Ok(Ok(output)) => (WorkflowOutcome::Completed { output }, ctx.drain_commands()),
+            Ok(Ok(output)) => {
+                // A plain-value built-in primitive (system_now/new_uuid/random_*)
+                // may have absorbed a replay divergence and recorded it as a
+                // deferred non-determinism error (issue #384). Surface it as a
+                // failure rather than letting the workflow complete silently.
+                let outcome = ctx.take_deferred_nd_error().map_or_else(
+                    || WorkflowOutcome::Completed { output },
+                    |nd| WorkflowOutcome::Failed {
+                        error: format!("non-deterministic replay: {nd}"),
+                    },
+                );
+                (outcome, ctx.drain_commands())
+            }
             Ok(Err(error)) => (WorkflowOutcome::Failed { error }, ctx.drain_commands()),
 
             // Timeout elapsed -- the handler is suspended on a oneshot channel.

--- a/autumn-harvest/src/executor.rs
+++ b/autumn-harvest/src/executor.rs
@@ -160,6 +160,15 @@ pub async fn run_workflow_strict(
             ),
             Ok(Err(error)) => WorkflowOutcome::Failed { error },
             Err(_elapsed) => {
+                // A plain-value built-in primitive (system_now/new_uuid/random_*)
+                // may have recorded a divergence before the workflow parked on an
+                // await point. Fail the execution now rather than suspending from
+                // a non-deterministic state (issue #384).
+                if let Some(nd) = ctx.take_deferred_nd_error() {
+                    return WorkflowOutcome::Failed {
+                        error: format!("non-deterministic replay: {nd}"),
+                    };
+                }
                 let mut commands = ctx.drain_commands();
                 if let Some(idx) = commands
                     .iter()
@@ -352,6 +361,18 @@ pub async fn run_workflow_with_state_history_policy_and_caps(
             // commands emitted in this cycle are included in the commands list and
             // will be handled by the worker alongside the suspension side-effects.
             Err(_elapsed) => {
+                // A plain-value built-in primitive (system_now/new_uuid/random_*)
+                // may have recorded a divergence before the workflow parked on an
+                // await point. Fail the execution now rather than suspending from
+                // a non-deterministic state (issue #384).
+                if let Some(nd) = ctx.take_deferred_nd_error() {
+                    return (
+                        WorkflowOutcome::Failed {
+                            error: format!("non-deterministic replay: {nd}"),
+                        },
+                        ctx.drain_commands(),
+                    );
+                }
                 let mut commands = ctx.drain_commands();
                 // ContinueAsNew is terminal: when the workflow body parks on
                 // the dedicated suspension future, the latest command in the

--- a/autumn-harvest/src/guardrail.rs
+++ b/autumn-harvest/src/guardrail.rs
@@ -86,8 +86,11 @@ static CATALOG: &[RuleEntry] = &[
             non-determinism error.",
         alternative: "Use ctx.now() (WorkflowContext) to read the workflow-logical clock, \
             which returns the WorkflowStarted timestamp and replays identically on every \
-            subsequent run. If you need a real wall-clock timestamp as a side-effect, wrap it \
-            in an activity and return it as the activity output.",
+            subsequent run. For a real wall-clock instant captured at the call site (e.g. \
+            \"skip the notification if the event is older than 24h *now*\"), use \
+            ctx.system_now() -> DateTime<Utc> (or ctx.system_time_now() -> SystemTime), which \
+            captures the current time once and replays it deterministically via a recorded \
+            SideEffectRecorded event.",
     },
     RuleEntry {
         id: "HVG002",
@@ -97,10 +100,12 @@ static CATALOG: &[RuleEntry] = &[
             source of randomness directly in a workflow body produces a different value on each \
             replay pass. Since the workflow function is re-run from the top on every resume, the \
             random sequence diverges from what was recorded in harvest_events.",
-        alternative: "Generate random values inside an activity (ActivityContext) and return them \
-            as the activity result, which is durably recorded. Alternatively, pass pre-generated \
-            values as workflow input. For replay-safe UUIDs, use ctx.random_uuid(id) which \
-            records the generated UUID in history and replays it deterministically.",
+        alternative: "Use the deterministic primitives on WorkflowContext, which capture the \
+            value once and replay it verbatim: ctx.new_uuid() for a UUIDv7 (idempotency keys), \
+            ctx.random_u64() / ctx.random_f64() / ctx.random_range(range) for sampling draws, or \
+            ctx.side_effect(name, f) to capture any one-shot non-deterministic value. For \
+            cryptographically secure randomness, generate it inside an activity (ActivityContext) \
+            and return it as the durably-recorded activity result instead.",
     },
     RuleEntry {
         id: "HVG003",

--- a/autumn-harvest/src/history_export.rs
+++ b/autumn-harvest/src/history_export.rs
@@ -246,7 +246,12 @@ fn redact_value(value: &mut Value) -> Result<(), HistoryExportError> {
 }
 
 fn is_payload_field(key: &str) -> bool {
-    matches!(key, "input" | "output" | "payload" | "details")
+    // `value` is the arbitrary `ctx.side_effect(...)` result on a
+    // `SideEffectRecorded` event (issue #384). Before #384 custom side effects
+    // were stored under `MarkerRecorded.details` and redacted via "details"; the
+    // new field must be redacted too so secrets/PII captured by the closure are
+    // not leaked in a redacted export.
+    matches!(key, "input" | "output" | "payload" | "details" | "value")
 }
 
 fn is_token_field(key: &str) -> bool {
@@ -943,6 +948,48 @@ mod tests {
         assert_eq!(value["status"]["terminal"], false);
         assert_eq!(value["events"][0]["data"]["input"]["redacted"], true);
         assert_eq!(value["events"][3]["data"]["token"]["redacted"], true);
+    }
+
+    #[test]
+    fn redacted_history_export_redacts_side_effect_recorded_value() {
+        use crate::event::SideEffectKind;
+        use crate::types::ExecutionId;
+
+        let document = export_history(HistoryExportRequest {
+            workflow_name: "secret_capture".to_string(),
+            execution_id: ExecutionId::new(),
+            shard_id: 0,
+            state: "RUNNING".to_string(),
+            events: vec![
+                WorkflowEvent::WorkflowStarted {
+                    input: serde_json::json!({}),
+                    timestamp: Utc::now(),
+                },
+                // A custom side_effect that captured a secret in its closure. Pre
+                // #384 this lived under MarkerRecorded.details and was redacted;
+                // it must remain redacted under the new SideEffectRecorded.value.
+                WorkflowEvent::SideEffectRecorded {
+                    kind: SideEffectKind::Custom,
+                    name: Some("api_credential".to_string()),
+                    value: serde_json::json!({ "token": "super-secret-credential" }),
+                },
+            ],
+            exported_at: Utc::now(),
+            payload_policy: HistoryPayloadPolicy::Redacted,
+            max_bytes: Some(64 * 1024),
+        })
+        .expect("redacted export should fit under the limit");
+
+        let json = serde_json::to_string(&document).expect("export should serialize");
+        // Event shape and the side-effect name remain visible for debugging…
+        assert!(json.contains("SideEffectRecorded"));
+        assert!(json.contains("api_credential"));
+        // …but the captured value must not leak.
+        assert!(!json.contains("super-secret-credential"));
+
+        let value: serde_json::Value =
+            serde_json::from_str(&json).expect("redacted export should be valid JSON");
+        assert_eq!(value["events"][1]["data"]["value"]["redacted"], true);
     }
 
     #[test]

--- a/autumn-harvest/src/history_export.rs
+++ b/autumn-harvest/src/history_export.rs
@@ -356,7 +356,9 @@ impl MermaidExporter {
                 | WorkflowEvent::ChildWorkflowCascadeApplied { .. } => {
                     self.handle_child_workflow_event(event)?;
                 }
-                WorkflowEvent::SignalReceived { .. } | WorkflowEvent::MarkerRecorded { .. } => {
+                WorkflowEvent::SignalReceived { .. }
+                | WorkflowEvent::MarkerRecorded { .. }
+                | WorkflowEvent::SideEffectRecorded { .. } => {
                     self.handle_misc_event(event)?;
                 }
                 WorkflowEvent::ActivityAwaitingExternal { .. }
@@ -619,6 +621,10 @@ impl MermaidExporter {
             }
             WorkflowEvent::MarkerRecorded { name, .. } => {
                 writeln!(self.out, "    Note over WF: Marker: {name}")?;
+            }
+            WorkflowEvent::SideEffectRecorded { kind, name, .. } => {
+                let label = name.as_deref().unwrap_or(kind.as_str());
+                writeln!(self.out, "    Note over WF: Side Effect: {label}")?;
             }
             _ => unreachable!(),
         }

--- a/autumn-harvest/src/lib.rs
+++ b/autumn-harvest/src/lib.rs
@@ -201,7 +201,7 @@ pub use det_check::{
 };
 pub use diagnostic::{DiagnosticReport, SimulatorResultExt};
 pub use error::{HarvestError, HarvestResult, TimeoutType};
-pub use event::WorkflowEvent;
+pub use event::{SideEffectKind, WorkflowEvent};
 #[cfg(feature = "db")]
 pub use execution::{
     CancelledWorkflowExecution, SignalWithStartOutcome, SignalWithStartParams, StartWorkflowParams,

--- a/autumn-harvest/src/payload_codec.rs
+++ b/autumn-harvest/src/payload_codec.rs
@@ -199,7 +199,14 @@ impl PayloadCodecs {
         let Some(data) = root.get_mut("data") else {
             return Ok(());
         };
-        let keys = ["input", "output", "payload", "details"];
+        // `value` is the arbitrary `ctx.side_effect(...)` closure result on a
+        // SideEffectRecorded event (issue #384). Pre-#384 custom side effects
+        // were stored under MarkerRecorded.details and were codec-encoded; the
+        // new field must be encoded too so a configured codec still encrypts /
+        // compresses any secret or PII the closure captured. `value` is unique
+        // to SideEffectRecorded among event variants, so no other event is
+        // affected.
+        let keys = ["input", "output", "payload", "details", "value"];
         for key in keys {
             if let Some(payload) = data.get_mut(key) {
                 if encode {
@@ -303,6 +310,37 @@ mod tests {
         match decoded {
             crate::event::WorkflowEvent::WorkflowStarted { input, .. } => {
                 assert_eq!(input, serde_json::json!({"user":"alice"}));
+            }
+            _ => panic!("unexpected event"),
+        }
+    }
+
+    #[test]
+    fn encode_then_decode_round_trips_side_effect_recorded_value() {
+        // issue #384: a custom side_effect closure result lands in
+        // SideEffectRecorded.value and must be codec-encoded (encryption /
+        // compression) just like the MarkerRecorded.details it replaced.
+        let mut codecs = PayloadCodecs::default();
+        codecs.set_default(Arc::new(ReverseCodec));
+
+        let event = crate::event::WorkflowEvent::SideEffectRecorded {
+            kind: crate::event::SideEffectKind::Custom,
+            name: Some("api_credential".to_string()),
+            value: serde_json::json!({"token": "super-secret"}),
+        };
+
+        let encoded = codecs.encode_event(&event).expect("encode");
+        // The value field is wrapped in a codec envelope (not stored raw)…
+        assert_eq!(encoded["data"]["value"]["_harvest_codec_envelope"], 1);
+        assert_eq!(encoded["data"]["value"]["codec_id"], "reverse");
+        // …while the side-effect name (metadata) is left intact.
+        assert_eq!(encoded["data"]["name"], "api_credential");
+
+        let decoded = codecs.decode_event(encoded).expect("decode");
+        match decoded {
+            crate::event::WorkflowEvent::SideEffectRecorded { value, name, .. } => {
+                assert_eq!(value, serde_json::json!({"token": "super-secret"}));
+                assert_eq!(name.as_deref(), Some("api_credential"));
             }
             _ => panic!("unexpected event"),
         }

--- a/autumn-harvest/src/prelude.rs
+++ b/autumn-harvest/src/prelude.rs
@@ -17,7 +17,7 @@ pub use crate::dag::{
     DagBuildError, DagBuilder, DagDefinition, DagMapTaskRef, DagTask, DagTaskRef,
 };
 pub use crate::error::{HarvestError, HarvestResult, TimeoutType};
-pub use crate::event::WorkflowEvent;
+pub use crate::event::{SideEffectKind, WorkflowEvent};
 pub use crate::failure::{ActivityFailure, IntoActivityErrorString};
 #[cfg(feature = "db")]
 pub use crate::handle::{

--- a/autumn-harvest/src/replay.rs
+++ b/autumn-harvest/src/replay.rs
@@ -13,7 +13,7 @@ use serde_json::Value;
 use std::collections::{HashSet, VecDeque};
 
 use crate::error::TimeoutType;
-use crate::event::WorkflowEvent;
+use crate::event::{SideEffectKind, WorkflowEvent};
 use crate::types::{
     ActivityExecId, ExecutionId, ExternalActivityToken, ExternalSignalId, ParentClosePolicy,
     UpdateId,
@@ -274,6 +274,10 @@ impl HistoryMatcher {
     fn actual_event_name(event: &WorkflowEvent) -> String {
         match event {
             WorkflowEvent::MarkerRecorded { name, .. } => format!("MarkerRecorded({name})"),
+            WorkflowEvent::SideEffectRecorded { kind, name, .. } => name.as_ref().map_or_else(
+                || format!("SideEffectRecorded({})", kind.as_str()),
+                |n| format!("SideEffectRecorded({}:{n})", kind.as_str()),
+            ),
             other => other.type_name().to_string(),
         }
     }
@@ -441,8 +445,9 @@ impl HistoryMatcher {
                 // interleaved when a fan-out runs concurrently with this
                 // activity (e.g. via tokio::join!). Track as an interleaved
                 // command so the cursor returns to it after matching the
-                // terminal event.
-                WorkflowEvent::MarkerRecorded { .. } => {
+                // terminal event. Deterministic side-effect captures (issue
+                // #384) are cursor-ordered like markers and treated the same.
+                WorkflowEvent::MarkerRecorded { .. } | WorkflowEvent::SideEffectRecorded { .. } => {
                     first_interleaved_command.get_or_insert(scan_cursor);
                     scan_cursor += 1;
                 }
@@ -580,8 +585,9 @@ impl HistoryMatcher {
                 ev if Self::is_update_event(ev) => {
                     scan_cursor += 1;
                 }
-                // Fan-out markers can be interleaved during concurrent execution.
-                WorkflowEvent::MarkerRecorded { .. } => {
+                // Fan-out markers and deterministic side-effect captures (issue
+                // #384) can be interleaved during concurrent execution.
+                WorkflowEvent::MarkerRecorded { .. } | WorkflowEvent::SideEffectRecorded { .. } => {
                     first_interleaved_command.get_or_insert(scan_cursor);
                     scan_cursor += 1;
                 }
@@ -1850,30 +1856,72 @@ impl HistoryMatcher {
     /// - `max_version` if past end of history (new code path)
     #[must_use]
     pub fn match_side_effect(&mut self, side_effect_id: &str) -> HistoryMatch {
-        // Use prepare_match so drain_early_signals skips ExternalSignal events
-        // that may have been written before this marker in a mixed batch
-        // (e.g. tokio::join!(ctx.side_effect(...), ctx.signal_external_workflow(...))).
-        //
-        // Known limitation: the event pattern is identical for a concurrent
-        // mixed batch and a sequential call where signal_external historically
-        // preceded side_effect.  If a new workflow version reverses a sequential
-        // ordering, drain_early_signals absorbs the signal events and the marker
-        // still matches — silently accepting what should be Diverged.  Fixing
-        // this requires batch-ordering metadata in the history schema.
-        let marker_name = format!("side_effect:{side_effect_id}");
+        self.match_side_effect_event(SideEffectKind::Custom, Some(side_effect_id))
+    }
+
+    /// Match a deterministic side-effect capture against history (issue #384).
+    ///
+    /// All of the `WorkflowContext` deterministic primitives — `system_now()`,
+    /// `new_uuid()`, `random_*()`, and `side_effect()` — lower onto a single
+    /// [`WorkflowEvent::SideEffectRecorded`] variant and match through this
+    /// method in command (cursor) order. The recorded `value` is returned via
+    /// [`HistoryMatch::Matched`].
+    ///
+    /// `kind` distinguishes the built-in helper; `name` is `Some` only for the
+    /// author-named `side_effect()` path. A mismatch in either the `kind` or the
+    /// `name` at the current cursor surfaces as [`HistoryMatch::Diverged`] with
+    /// the same diagnostic quality as the activity-mismatch path.
+    ///
+    /// **Backward compatibility:** the pre-#384 `side_effect()` implementation
+    /// lowered onto `MarkerRecorded { name: "side_effect:{id}" }`. For the
+    /// `Custom` + named case this method also accepts that legacy marker so
+    /// in-flight executions recorded under the old engine replay unchanged.
+    ///
+    /// Uses `prepare_match` so `drain_early_signals` skips `ExternalSignal`
+    /// events that may have been written before this capture in a mixed batch.
+    #[must_use]
+    pub fn match_side_effect_event(
+        &mut self,
+        kind: SideEffectKind,
+        name: Option<&str>,
+    ) -> HistoryMatch {
         if !self.prepare_match() {
             return HistoryMatch::NoMatch;
         }
 
+        let expected = name.map_or_else(
+            || format!("SideEffectRecorded({})", kind.as_str()),
+            |n| format!("SideEffectRecorded({}:{n})", kind.as_str()),
+        );
+
+        // Legacy compatibility: the old side_effect() lowered to a MarkerRecorded
+        // with name "side_effect:{id}". Only the Custom+named path ever produced it.
+        let legacy_marker_name = name
+            .filter(|_| kind == SideEffectKind::Custom)
+            .map(|n| format!("side_effect:{n}"));
+
         match &self.events[self.cursor] {
-            WorkflowEvent::MarkerRecorded { name, details } if *name == marker_name => {
+            WorkflowEvent::SideEffectRecorded {
+                kind: recorded_kind,
+                name: recorded_name,
+                value,
+            } if *recorded_kind == kind && recorded_name.as_deref() == name => {
+                let output = value.clone();
+                self.cursor += 1;
+                self.advance_to_next_unconsumed_event();
+                HistoryMatch::Matched { output }
+            }
+            WorkflowEvent::MarkerRecorded {
+                name: marker_name,
+                details,
+            } if legacy_marker_name.as_deref() == Some(marker_name.as_str()) => {
                 let output = details.clone();
                 self.cursor += 1;
                 self.advance_to_next_unconsumed_event();
                 HistoryMatch::Matched { output }
             }
             other => HistoryMatch::Diverged {
-                expected: format!("MarkerRecorded({marker_name})"),
+                expected,
                 actual: Self::actual_event_name(other),
             },
         }

--- a/autumn-harvest/src/simulator.rs
+++ b/autumn-harvest/src/simulator.rs
@@ -278,6 +278,10 @@ impl WorkflowSimulator {
                     history.push(WorkflowEvent::MarkerRecorded { name, details });
                     advanced = true;
                 }
+                WorkflowCommand::RecordSideEffect { kind, name, value } => {
+                    history.push(WorkflowEvent::SideEffectRecorded { kind, name, value });
+                    advanced = true;
+                }
                 _ => {
                     // Commands like WaitForSignal, StartChildWorkflow are not yet fully supported.
                     // Complete and Fail are handled on the next loop iteration.

--- a/autumn-harvest/src/testing.rs
+++ b/autumn-harvest/src/testing.rs
@@ -75,6 +75,11 @@ pub enum NonDeterminismKind {
     ChildWorkflowMismatch,
     /// A side-effect ID did not match the recorded marker.
     SideEffectMismatch,
+    /// A deterministic built-in primitive (`ctx.system_now()`, `ctx.new_uuid()`,
+    /// `ctx.random_*()`) drifted from the recorded `SideEffectRecorded` history —
+    /// a captured value was reordered, renamed, inserted, or removed across a
+    /// code change (issue #384).
+    SideEffectDrift,
     /// An external activity name did not match the recorded event.
     ExternalActivityMismatch,
     /// A `signal_external_workflow` call did not match the recorded event.
@@ -100,6 +105,7 @@ impl std::fmt::Display for NonDeterminismKind {
             Self::SignalMismatch => write!(f, "SignalMismatch"),
             Self::ChildWorkflowMismatch => write!(f, "ChildWorkflowMismatch"),
             Self::SideEffectMismatch => write!(f, "SideEffectMismatch"),
+            Self::SideEffectDrift => write!(f, "SideEffectDrift"),
             Self::ExternalActivityMismatch => write!(f, "ExternalActivityMismatch"),
             Self::ExternalSignalMismatch => write!(f, "ExternalSignalMismatch"),
             Self::ContinueAsNewMismatch => write!(f, "ContinueAsNewMismatch"),
@@ -717,6 +723,7 @@ fn classify_kind(kind_str: &str, actual: &str) -> NonDeterminismKind {
         "signal" => NonDeterminismKind::SignalMismatch,
         "child workflow" => NonDeterminismKind::ChildWorkflowMismatch,
         "side effect" => NonDeterminismKind::SideEffectMismatch,
+        "side-effect drift" => NonDeterminismKind::SideEffectDrift,
         "external activity" => NonDeterminismKind::ExternalActivityMismatch,
         "external signal" => NonDeterminismKind::ExternalSignalMismatch,
         s if s.contains("continue") => NonDeterminismKind::ContinueAsNewMismatch,
@@ -1956,6 +1963,13 @@ impl WorkflowTestEnv {
                         details: details.clone(),
                     });
                 }
+                WorkflowCommand::RecordSideEffect { kind, name, value } => {
+                    history.push(WorkflowEvent::SideEffectRecorded {
+                        kind: *kind,
+                        name: name.clone(),
+                        value: value.clone(),
+                    });
+                }
                 WorkflowCommand::SpawnDetachedChildWorkflow {
                     child_id,
                     workflow_name,
@@ -2211,6 +2225,7 @@ impl WorkflowTestEnv {
             // its terminal event is already in history and will be matched on replay.
             WorkflowCommand::WaitForActivity { .. }
             | WorkflowCommand::RecordMarker { .. }
+            | WorkflowCommand::RecordSideEffect { .. }
             | WorkflowCommand::RecordUpdateResult { .. }
             | WorkflowCommand::UpsertSearchAttributes { .. }
             | WorkflowCommand::ScheduleExternalActivity { .. }
@@ -2571,6 +2586,10 @@ mod tests {
         assert_eq!(
             classify_kind("side effect", "ActivityScheduled"),
             NonDeterminismKind::SideEffectMismatch
+        );
+        assert_eq!(
+            classify_kind("side-effect drift", "ActivityScheduled"),
+            NonDeterminismKind::SideEffectDrift
         );
         assert_eq!(
             classify_kind("external activity", "ActivityScheduled"),

--- a/autumn-harvest/src/testing.rs
+++ b/autumn-harvest/src/testing.rs
@@ -2221,11 +2221,22 @@ impl WorkflowTestEnv {
                 Ok(true)
             }
 
+            // Deterministic side-effect capture (system_now/new_uuid/random_*/
+            // side_effect) emitted before a suspending command. The real worker
+            // persists these via build_suspension_events, so the harness must do
+            // the same — otherwise the next replay iteration sees the following
+            // event where it expects SideEffectRecorded and reports spurious drift.
+            // Pushed to `history` (not deferred_events) to preserve command order
+            // ahead of the suspending command's own scheduled event.
+            WorkflowCommand::RecordSideEffect { kind, name, value } => {
+                history.push(WorkflowEvent::SideEffectRecorded { kind, name, value });
+                Ok(false)
+            }
+
             // WaitForActivity: activity was scheduled in a previous iteration;
             // its terminal event is already in history and will be matched on replay.
             WorkflowCommand::WaitForActivity { .. }
             | WorkflowCommand::RecordMarker { .. }
-            | WorkflowCommand::RecordSideEffect { .. }
             | WorkflowCommand::RecordUpdateResult { .. }
             | WorkflowCommand::UpsertSearchAttributes { .. }
             | WorkflowCommand::ScheduleExternalActivity { .. }

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -437,6 +437,7 @@ const fn workflow_command_name(command: &WorkflowCommand) -> &'static str {
         WorkflowCommand::StartTimer { .. } => "StartTimer",
         WorkflowCommand::StartChildWorkflow { .. } => "StartChildWorkflow",
         WorkflowCommand::RecordMarker { .. } => "RecordMarker",
+        WorkflowCommand::RecordSideEffect { .. } => "RecordSideEffect",
         WorkflowCommand::WaitForSignal { .. } => "WaitForSignal",
         WorkflowCommand::Complete { .. } => "Complete",
         WorkflowCommand::Fail { .. } => "Fail",
@@ -491,6 +492,7 @@ fn should_requeue_signal_wait(commands: &[WorkflowCommand]) -> bool {
             WorkflowCommand::WaitForSignal { .. }
                 | WorkflowCommand::SignalExternalWorkflow { .. }
                 | WorkflowCommand::RecordMarker { .. }
+                | WorkflowCommand::RecordSideEffect { .. }
                 | WorkflowCommand::RecordUpdateResult { .. }
                 | WorkflowCommand::UpsertSearchAttributes { .. }
                 | WorkflowCommand::SpawnDetachedChildWorkflow { .. }
@@ -506,6 +508,7 @@ fn only_bookkeeping_commands(commands: &[WorkflowCommand]) -> bool {
             matches!(
                 cmd,
                 WorkflowCommand::RecordMarker { .. }
+                    | WorkflowCommand::RecordSideEffect { .. }
                     | WorkflowCommand::RecordUpdateResult { .. }
                     | WorkflowCommand::UpsertSearchAttributes { .. }
                     | WorkflowCommand::SpawnDetachedChildWorkflow { .. }
@@ -651,6 +654,13 @@ where
                     details: details.clone(),
                 })
             }
+            WorkflowCommand::RecordSideEffect { kind, name, value } => {
+                Some(WorkflowEvent::SideEffectRecorded {
+                    kind: *kind,
+                    name: name.clone(),
+                    value: value.clone(),
+                })
+            }
             WorkflowCommand::SpawnDetachedChildWorkflow {
                 child_id,
                 workflow_name,
@@ -686,6 +696,7 @@ fn extract_single_command<T>(
         !matches!(
             cmd,
             WorkflowCommand::RecordMarker { .. }
+                | WorkflowCommand::RecordSideEffect { .. }
                 | WorkflowCommand::RecordUpdateResult { .. }
                 | WorkflowCommand::UpsertSearchAttributes { .. }
                 | WorkflowCommand::SpawnDetachedChildWorkflow { .. }
@@ -711,6 +722,7 @@ fn extract_all_scheduled_activities(
     for cmd in commands {
         match cmd {
             WorkflowCommand::RecordMarker { .. }
+            | WorkflowCommand::RecordSideEffect { .. }
             | WorkflowCommand::RecordUpdateResult { .. }
             | WorkflowCommand::UpsertSearchAttributes { .. }
             | WorkflowCommand::SpawnDetachedChildWorkflow { .. } => {}
@@ -749,6 +761,7 @@ fn extract_all_activity_waits(commands: &[WorkflowCommand]) -> Option<Vec<Activi
     for cmd in commands {
         match cmd {
             WorkflowCommand::RecordMarker { .. }
+            | WorkflowCommand::RecordSideEffect { .. }
             | WorkflowCommand::RecordUpdateResult { .. }
             | WorkflowCommand::UpsertSearchAttributes { .. }
             | WorkflowCommand::SpawnDetachedChildWorkflow { .. } => {}
@@ -799,6 +812,7 @@ fn extract_started_timer_for_suspension(
                 | WorkflowCommand::WaitForSignal { .. }
                 | WorkflowCommand::SignalExternalWorkflow { .. }
                 | WorkflowCommand::RecordMarker { .. }
+                | WorkflowCommand::RecordSideEffect { .. }
                 | WorkflowCommand::RecordUpdateResult { .. }
                 | WorkflowCommand::UpsertSearchAttributes { .. }
                 | WorkflowCommand::SpawnDetachedChildWorkflow { .. }
@@ -821,6 +835,7 @@ fn extract_all_started_child_workflows(
             !matches!(
                 c,
                 WorkflowCommand::RecordMarker { .. }
+                    | WorkflowCommand::RecordSideEffect { .. }
                     | WorkflowCommand::RecordUpdateResult { .. }
                     | WorkflowCommand::UpsertSearchAttributes { .. }
                     | WorkflowCommand::SpawnDetachedChildWorkflow { .. }
@@ -946,6 +961,14 @@ fn extract_run_local_activity(commands: Vec<WorkflowCommand>) -> LocalActivityCo
                     pre_schedule_events.push(event);
                 }
             }
+            WorkflowCommand::RecordSideEffect { kind, name, value } => {
+                let event = WorkflowEvent::SideEffectRecorded { kind, name, value };
+                if local_run.is_some() {
+                    post_schedule_events.push(event);
+                } else {
+                    pre_schedule_events.push(event);
+                }
+            }
             WorkflowCommand::SpawnDetachedChildWorkflow {
                 child_id,
                 workflow_name,
@@ -1045,6 +1068,13 @@ fn extract_signal_external_workflow(commands: Vec<WorkflowCommand>) -> Vec<Signa
                 items.push(SignalBatchItem::Marker(WorkflowEvent::MarkerRecorded {
                     name,
                     details,
+                }));
+            }
+            WorkflowCommand::RecordSideEffect { kind, name, value } => {
+                items.push(SignalBatchItem::Marker(WorkflowEvent::SideEffectRecorded {
+                    kind,
+                    name,
+                    value,
                 }));
             }
             WorkflowCommand::SignalExternalWorkflow {
@@ -2526,6 +2556,14 @@ async fn persist_all_started_child_workflows(
                 WorkflowEvent::MarkerRecorded {
                     name: name.clone(),
                     details: details.clone(),
+                },
+            )),
+            WorkflowCommand::RecordSideEffect { kind, name, value } => Some((
+                i,
+                WorkflowEvent::SideEffectRecorded {
+                    kind: *kind,
+                    name: name.clone(),
+                    value: value.clone(),
                 },
             )),
             WorkflowCommand::SpawnDetachedChildWorkflow {
@@ -4676,6 +4714,7 @@ fn pre_suspension_event_count(commands: &[WorkflowCommand]) -> u64 {
                 matches!(
                     cmd,
                     WorkflowCommand::RecordMarker { .. }
+                        | WorkflowCommand::RecordSideEffect { .. }
                         | WorkflowCommand::SpawnDetachedChildWorkflow { .. }
                 )
             })
@@ -5251,6 +5290,7 @@ async fn process_workflow_task(
                             c,
                             WorkflowCommand::SignalExternalWorkflow { .. }
                                 | WorkflowCommand::RecordMarker { .. }
+                                | WorkflowCommand::RecordSideEffect { .. }
                                 | WorkflowCommand::RecordUpdateResult { .. }
                                 | WorkflowCommand::UpsertSearchAttributes { .. }
                         )

--- a/autumn-harvest/tests/replayer_tests.rs
+++ b/autumn-harvest/tests/replayer_tests.rs
@@ -1643,3 +1643,116 @@ async fn replay_backwards_compat_awaited_child_workflow() {
         "events_replayed must be positive"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Deterministic side-effect primitives (issue #384)
+// ---------------------------------------------------------------------------
+
+/// Calls `ctx.system_now()` then schedules an activity. The captured clock value
+/// lowers onto a `SideEffectRecorded` event, matched in command order.
+fn now_then_activity_workflow<'a>(
+    ctx: &'a WorkflowContext,
+    _input: Value,
+) -> Pin<Box<dyn Future<Output = Result<Value, String>> + Send + 'a>> {
+    Box::pin(async move {
+        let _t = ctx.system_now();
+        let r = ctx
+            .execute_activity_raw("step_one", Value::Null, "default")
+            .await
+            .map_err(|e| e.to_string())?;
+        Ok(serde_json::json!({ "step": r }))
+    })
+}
+
+fn now_then_activity_history() -> (ExecutionId, Vec<WorkflowEvent>) {
+    let exec_id = ExecutionId::new();
+    let activity_id = ActivityExecId::new();
+    let events = vec![
+        WorkflowEvent::WorkflowStarted {
+            input: Value::Null,
+            timestamp: Utc::now(),
+        },
+        WorkflowEvent::SideEffectRecorded {
+            kind: autumn_harvest::SideEffectKind::Now,
+            name: None,
+            value: serde_json::json!(1_700_000_000_000_i64),
+        },
+        WorkflowEvent::ActivityScheduled {
+            activity_id,
+            name: "step_one".to_string(),
+            input: Value::Null,
+            queue: "default".to_string(),
+        },
+        WorkflowEvent::ActivityCompleted {
+            activity_id,
+            output: serde_json::json!("ok"),
+        },
+    ];
+    (exec_id, events)
+}
+
+#[tokio::test]
+async fn replay_succeeds_for_recorded_side_effect() {
+    let (exec_id, events) = now_then_activity_history();
+    let replayer =
+        WorkflowReplayer::new().register_fn("now_then_activity", now_then_activity_workflow);
+
+    let report = replayer
+        .replay_from_snapshot(HistorySnapshot {
+            workflow_name: "now_then_activity".to_string(),
+            execution_id: exec_id,
+            events,
+        })
+        .await;
+
+    assert!(
+        matches!(report.status, ReplayStatus::ReplaySucceeded),
+        "side-effect history must replay cleanly: {report}"
+    );
+}
+
+#[tokio::test]
+async fn replay_detects_side_effect_drift() {
+    // History has NO recorded side effect — the activity sits where the workflow
+    // now calls system_now(). The built-in primitive must surface SideEffectDrift.
+    let exec_id = ExecutionId::new();
+    let activity_id = ActivityExecId::new();
+    let events = vec![
+        WorkflowEvent::WorkflowStarted {
+            input: Value::Null,
+            timestamp: Utc::now(),
+        },
+        WorkflowEvent::ActivityScheduled {
+            activity_id,
+            name: "step_one".to_string(),
+            input: Value::Null,
+            queue: "default".to_string(),
+        },
+        WorkflowEvent::ActivityCompleted {
+            activity_id,
+            output: serde_json::json!("ok"),
+        },
+    ];
+
+    let replayer =
+        WorkflowReplayer::new().register_fn("now_then_activity", now_then_activity_workflow);
+
+    let report = replayer
+        .replay_from_snapshot(HistorySnapshot {
+            workflow_name: "now_then_activity".to_string(),
+            execution_id: exec_id,
+            events,
+        })
+        .await;
+
+    match report.status {
+        ReplayStatus::NonDeterminismDetected { kind, .. } => {
+            assert_eq!(
+                kind,
+                NonDeterminismKind::SideEffectDrift,
+                "expected SideEffectDrift, got {kind:?}"
+            );
+        }
+        other => panic!("expected NonDeterminismDetected(SideEffectDrift), got {other:?}"),
+    }
+}

--- a/autumn-harvest/tests/workflow_test_env_tests.rs
+++ b/autumn-harvest/tests/workflow_test_env_tests.rs
@@ -80,6 +80,23 @@ fn race_workflow<'a>(
     })
 }
 
+/// Captures a deterministic side-effect (`system_now`) BEFORE suspending on an
+/// activity. Exercises that the test harness persists the pre-suspension
+/// `SideEffectRecorded` event so the next replay iteration does not see drift.
+fn side_effect_then_activity_workflow<'a>(
+    ctx: &'a WorkflowContext,
+    _input: Value,
+) -> Pin<Box<dyn Future<Output = Result<Value, String>> + Send + 'a>> {
+    Box::pin(async move {
+        let captured_at = ctx.system_now().timestamp_millis();
+        let result = ctx
+            .execute_activity_raw("send_email", json!({"to": "user@example.com"}), "default")
+            .await
+            .map_err(|e| e.to_string())?;
+        Ok(json!({"sent": result, "captured_at": captured_at}))
+    })
+}
+
 /// Two sequential activities, used for event-log ordering assertions.
 fn two_step_workflow<'a>(
     ctx: &'a WorkflowContext,
@@ -267,6 +284,48 @@ async fn test_happy_path_one_activity() {
             .any(|e| matches!(e, WorkflowEvent::ActivityCompleted { .. })),
         "expected ActivityCompleted"
     );
+}
+
+#[tokio::test]
+async fn test_side_effect_captured_before_suspension_is_persisted() {
+    // Regression (issue #384): a deterministic primitive emitted before parking
+    // on an activity must be persisted to history by the harness. If dropped,
+    // the next iteration would replay system_now() against ActivityScheduled and
+    // record spurious side-effect drift, failing the run.
+    let outcome = WorkflowTestEnv::new()
+        .mock_activity("send_email", |_| Ok(json!("delivered")))
+        .run(side_effect_then_activity_workflow, json!(null))
+        .await;
+
+    assert!(
+        outcome.result.is_ok(),
+        "workflow must not fail with spurious side-effect drift: {:?}",
+        outcome.result
+    );
+    assert_eq!(outcome.result.as_ref().unwrap()["sent"], json!("delivered"));
+
+    let events = outcome.events();
+    // The SideEffectRecorded event must be persisted, and ahead of the activity.
+    let se_idx = events
+        .iter()
+        .position(|e| matches!(e, WorkflowEvent::SideEffectRecorded { .. }))
+        .expect("SideEffectRecorded must be persisted in history");
+    let act_idx = events
+        .iter()
+        .position(
+            |e| matches!(e, WorkflowEvent::ActivityScheduled { name, .. } if name == "send_email"),
+        )
+        .expect("ActivityScheduled must be present");
+    assert!(
+        se_idx < act_idx,
+        "side effect must be recorded before the activity it precedes"
+    );
+    // Exactly one capture — not duplicated across replay iterations.
+    let se_count = events
+        .iter()
+        .filter(|e| matches!(e, WorkflowEvent::SideEffectRecorded { .. }))
+        .count();
+    assert_eq!(se_count, 1, "side effect must be recorded exactly once");
 }
 
 // ─────────────────────── (b) Retry test ──────────────────────────────────────


### PR DESCRIPTION
Ship first-class, replay-safe alternatives to the non-deterministic APIs the
determinism guardrails (HVG001/HVG002) warn about, so authors no longer have to
wrap every timestamp/UUID/RNG draw in a local activity.

New WorkflowContext methods (each lowers onto a single SideEffectRecorded event):
- system_now() -> DateTime<Utc> / system_time_now() -> SystemTime: per-call
  wall-clock captured once and replayed verbatim. The pre-existing now() (the
  fixed WorkflowStarted start-time clock) is left unchanged for backward and
  in-flight safety.
- new_uuid() -> Uuid: a UUIDv7 idempotency key captured once.
- random_u64()/random_f64()/random_range(range): sampling draws.
- side_effect(name, f) is migrated onto the new event; random_uuid stays.

Engine changes:
- event.rs: one new append-only WorkflowEvent::SideEffectRecorded { kind, name,
  value } variant plus a bounded SideEffectKind enum (Now/Uuid/Random/Custom).
  No DB migration; no change to the adjacently-tagged event JSON contract.
- replay.rs: HistoryMatcher::match_side_effect_event(kind, name) matches in
  command order and surfaces drift as Diverged; backward-compatible with
  pre-#384 side_effect executions recorded as MarkerRecorded.
- context.rs: WorkflowCommand::RecordSideEffect (bookkeeping) + a deferred
  non-determinism channel so infallible primitives surface replay drift.
- executor.rs: converts a deferred drift into WorkflowFailed.
- worker.rs/simulator.rs: persist/replay RecordSideEffect exactly like markers.
- testing.rs: new NonDeterminismKind::SideEffectDrift for WorkflowReplayer.
- guardrail.rs: HVG001/HVG002 now recommend the ctx.* primitives by name.

Docs/example: CLAUDE.md section + Phase 3.22, prelude/lib export of
SideEffectKind, examples/deterministic_primitives.rs. Tests: event/context/
replay unit tests (incl. 1k-call byte-identical replay) and replayer drift
tests. Deps: uuid gains v7, new rand workspace dep.

https://claude.ai/code/session_014aA5jY113RpBC5dqnrMnQH