### PR TITLE
⚡ Bolt: Pre-allocate vectors in command extractors

### DIFF
--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -717,7 +717,8 @@ fn extract_single_command<T>(
 fn extract_all_scheduled_activities(
     commands: &[WorkflowCommand],
 ) -> Option<Vec<ScheduledActivityCommand>> {
-    let mut scheduled = Vec::new();
+    // ⚡ Bolt: Pre-allocate vector capacity to avoid intermediate allocations
+    let mut scheduled = Vec::with_capacity(commands.len());
 
     for cmd in commands {
         match cmd {
@@ -756,7 +757,8 @@ fn extract_all_scheduled_activities(
 }
 
 fn extract_all_activity_waits(commands: &[WorkflowCommand]) -> Option<Vec<ActivityExecId>> {
-    let mut activity_ids = Vec::new();
+    // ⚡ Bolt: Pre-allocate vector capacity to avoid intermediate allocations
+    let mut activity_ids = Vec::with_capacity(commands.len());
 
     for cmd in commands {
         match cmd {
@@ -1112,8 +1114,9 @@ fn extract_signal_external_workflow(commands: Vec<WorkflowCommand>) -> Vec<Signa
 fn split_mixed_signal_batch(
     commands: Vec<WorkflowCommand>,
 ) -> (Vec<SignalBatchItem>, Vec<WorkflowCommand>) {
-    let mut signal_items = Vec::new();
-    let mut remaining = Vec::new();
+    // ⚡ Bolt: Pre-allocate vector capacity to avoid intermediate allocations
+    let mut signal_items = Vec::with_capacity(commands.len());
+    let mut remaining = Vec::with_capacity(commands.len());
     for cmd in commands {
         match cmd {
             WorkflowCommand::SignalExternalWorkflow {


### PR DESCRIPTION
💡 What: Switched `Vec::new()` to `Vec::with_capacity(commands.len())` in `extract_all_scheduled_activities`, `extract_all_activity_waits`, and `split_mixed_signal_batch`.
🎯 Why: These functions push elements into vectors based on the length of the input `commands` slice/vec. Pre-allocating avoids intermediate heap reallocations.
📊 Impact: Reduces heap allocations per command extraction execution on the hot path.
🔬 Measurement: Run existing worker tests to verify functionality.

---
*PR created automatically by Jules for task [9766419806702985874](https://jules.google.com/task/9766419806702985874) started by @madmax983*