### PR TITLE
🛡️ Sentry: [test coverage improvement] apply_skip_policy 365-day loop limits

### DIFF
--- a/autumn-harvest/src/calendar.rs
+++ b/autumn-harvest/src/calendar.rs
@@ -646,6 +646,36 @@ mod tests {
         );
     }
 
+    #[test]
+    fn apply_skip_policy_next_exceeds_365_days_returns_none() {
+        let start_date = date("2026-01-01");
+        let mut exc = Vec::new();
+        // Exclude start_date and the next 365 days
+        for i in 0..=365 {
+            exc.push(start_date + chrono::Duration::days(i));
+        }
+
+        assert_eq!(
+            apply_skip_policy(start_date, SkipPolicy::RunNextBusinessDay, &exc, false),
+            None
+        );
+    }
+
+    #[test]
+    fn apply_skip_policy_prev_exceeds_365_days_returns_none() {
+        let start_date = date("2026-12-31");
+        let mut exc = Vec::new();
+        // Exclude start_date and the previous 365 days
+        for i in 0..=365 {
+            exc.push(start_date - chrono::Duration::days(i));
+        }
+
+        assert_eq!(
+            apply_skip_policy(start_date, SkipPolicy::RunPrevBusinessDay, &exc, false),
+            None
+        );
+    }
+
     // ── preview_schedule_firings ──────────────────────────────────────────────
 
     #[cfg(feature = "db")]


### PR DESCRIPTION
🎯 Target: apply_skip_policy function in autumn-harvest/src/calendar.rs
💣 Risk: Untested edge case where the next or previous business day search exceeds the 365-day limit could fail silently or return incorrect results instead of returning None as expected.
🧪 Strategy: Added two tests apply_skip_policy_next_exceeds_365_days_returns_none and apply_skip_policy_prev_exceeds_365_days_returns_none using an array of over 365 excluded dates to verify the loop breaks correctly and returns None.
🔬 Verification: cargo test --package autumn-harvest --lib -- calendar::tests::apply_skip_policy

---
*PR created automatically by Jules for task [7476836267743486994](https://jules.google.com/task/7476836267743486994) started by @madmax983*