### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -3503,7 +3503,7 @@ async fn list_workflows(
 /// `GET /workflows/registered` — list all registered workflow types with
 /// their optional JSON Schema, description, and type information (issue #373).
 ///
-/// Returns an array of [`RegisteredWorkflowRecord`] objects sorted by name.
+/// Returns an array of [`autumn_harvest::info::RegisteredWorkflowRecord`] objects sorted by name.
 /// Workflows that have not opted into schema publishing return `null` for
 /// `input_schema`, `output_schema`, and `error_schema`.
 async fn list_registered_workflows(
@@ -3523,7 +3523,7 @@ async fn list_registered_workflows(
 /// `GET /workflows/registered/{name}/schema` — return the schema record for a
 /// single registered workflow type (issue #373).
 ///
-/// Returns `200` with the [`RegisteredWorkflowRecord`] when the workflow is
+/// Returns `200` with the [`autumn_harvest::info::RegisteredWorkflowRecord`] when the workflow is
 /// known, or `404` when the name is not registered.
 async fn get_registered_workflow_schema(
     Extension(api_state): Extension<HarvestApiState>,

--- a/autumn-harvest/src/replay.rs
+++ b/autumn-harvest/src/replay.rs
@@ -36,7 +36,7 @@ pub enum HistoryMatch {
         /// Stable, low-cardinality error-type class recorded with the failure
         /// (issue #227 / #369), e.g. `"CircuitOpen"`. `"Error"` for legacy
         /// `Err(String)` failures. Carried so the consumer can build a typed
-        /// [`HarvestError::ActivityFailed`] without parsing the message.
+        /// [`crate::error::HarvestError::ActivityFailed`] without parsing the message.
         error_type: String,
         /// Optional structured details recorded with a typed failure (e.g.
         /// `retry_after_secs` / `forced` for `CircuitOpen`). `None` otherwise.

--- a/autumn-harvest/src/schedule_decision.rs
+++ b/autumn-harvest/src/schedule_decision.rs
@@ -53,7 +53,7 @@ pub async fn record_decision_graceful(
 ///
 /// # Errors
 ///
-/// Returns a [`database_error`] if the database query execution fails.
+/// Returns a [`crate::error::database_error`] if the database query execution fails.
 pub async fn purge_old_schedule_decisions(
     conn: &mut AsyncPgConnection,
     retention_days: i64,

--- a/autumn-harvest/src/types.rs
+++ b/autumn-harvest/src/types.rs
@@ -769,7 +769,7 @@ impl fmt::Display for IdempotencyKey {
 /// execution-timeout).
 ///
 /// This is only relevant for children spawned via
-/// [`WorkflowContext::spawn_child_workflow_detached_raw`]. Children spawned via
+/// [`crate::context::WorkflowContext::spawn_child_workflow_detached_raw`]. Children spawned via
 /// the await path (`spawn_child_workflow_raw`) pin the parent alive until the
 /// child terminates — no cascade policy is needed.
 ///


### PR DESCRIPTION
📖 Chapter: Unresolved intra-doc links
🔦 Insight: Fixed various unresolved intra-doc links in the codebase by using fully qualified paths or converting them to inline code blocks where appropriate.
🧪 Example: Clean cargo doc output with no warnings.

---
*PR created automatically by Jules for task [9081986084741073410](https://jules.google.com/task/9081986084741073410) started by @madmax983*