### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -724,7 +724,7 @@ fn extract_single_command<T>(
 fn extract_all_scheduled_activities(
     commands: &[WorkflowCommand],
 ) -> Option<Vec<ScheduledActivityCommand>> {
-    let mut scheduled = Vec::new();
+    let mut scheduled = Vec::with_capacity(commands.len());
 
     for cmd in commands {
         match cmd {
@@ -763,7 +763,7 @@ fn extract_all_scheduled_activities(
 }
 
 fn extract_all_activity_waits(commands: &[WorkflowCommand]) -> Option<Vec<ActivityExecId>> {
-    let mut activity_ids = Vec::new();
+    let mut activity_ids = Vec::with_capacity(commands.len());
 
     for cmd in commands {
         match cmd {
@@ -1119,8 +1119,8 @@ fn extract_signal_external_workflow(commands: Vec<WorkflowCommand>) -> Vec<Signa
 fn split_mixed_signal_batch(
     commands: Vec<WorkflowCommand>,
 ) -> (Vec<SignalBatchItem>, Vec<WorkflowCommand>) {
-    let mut signal_items = Vec::new();
-    let mut remaining = Vec::new();
+    let mut signal_items = Vec::with_capacity(commands.len());
+    let mut remaining = Vec::with_capacity(commands.len());
     for cmd in commands {
         match cmd {
             WorkflowCommand::SignalExternalWorkflow {
@@ -1173,7 +1173,7 @@ async fn persist_external_signal_inline(
     items: Vec<SignalBatchItem>,
     next_event_id: &mut i32,
 ) -> HarvestResult<Vec<WorkflowEvent>> {
-    let mut new_events: Vec<WorkflowEvent> = Vec::new();
+    let mut new_events: Vec<WorkflowEvent> = Vec::with_capacity(items.len());
 
     for item in items {
         match item {

--- a/commit_msg.txt
+++ b/commit_msg.txt
@@ -1,0 +1,18 @@
+⚡ Bolt: [performance improvement]
+
+💡 What:
+Replaced `Vec::new()` with `Vec::with_capacity(len)` in multiple batch-processing functions in `autumn-harvest/src/worker.rs`:
+- `split_mixed_signal_batch`
+- `extract_all_scheduled_activities`
+- `extract_all_activity_waits`
+- `persist_external_signal_inline`
+
+🎯 Why:
+To avoid intermediate heap reallocations when building list of items derived from input collections.
+
+📊 Impact:
+Fewer transient memory allocations and minor CPU overhead reduction during vector growth in `autumn-harvest/src/worker.rs`.
+Note: In `split_mixed_signal_batch`, setting both target capacities to the total command length slightly over-allocates (allocating `2 * N` for `N` elements total), which is an acceptable trade-off for speed in small batch processing.
+
+🔬 Measurement:
+Run `cargo bench` and observe reduced allocation metrics, or check standard system profilers for reduced memory reallocation overhead on the event loop. Tests passed completely without errors.


### PR DESCRIPTION
💡 What:
Replaced `Vec::new()` with `Vec::with_capacity(len)` in multiple batch-processing functions in `autumn-harvest/src/worker.rs`:
- `split_mixed_signal_batch`
- `extract_all_scheduled_activities`
- `extract_all_activity_waits`
- `persist_external_signal_inline`

🎯 Why:
To avoid intermediate heap reallocations when building list of items derived from input collections.

📊 Impact:
Fewer transient memory allocations and minor CPU overhead reduction during vector growth in `autumn-harvest/src/worker.rs`.
Note: In `split_mixed_signal_batch`, setting both target capacities to the total command length slightly over-allocates (allocating `2 * N` for `N` elements total), which is an acceptable trade-off for speed in small batch processing.

🔬 Measurement:
Run `cargo bench` and observe reduced allocation metrics, or check standard system profilers for reduced memory reallocation overhead on the event loop. Tests passed completely without errors.

---
*PR created automatically by Jules for task [9380938687631363163](https://jules.google.com/task/9380938687631363163) started by @madmax983*