### PR TITLE
Add set_current_details() for durable workflow status breadcrumbs

### DIFF
--- a/autumn-harvest-plugin/src/ui.rs
+++ b/autumn-harvest-plugin/src/ui.rs
@@ -7578,6 +7578,7 @@ mod tests {
             paused_at: None,
             pause_reason: None,
             pause_actor: None,
+            current_details: None,
         }
     }
 

--- a/autumn-harvest-plugin/tests/api_scheduler_integration.rs
+++ b/autumn-harvest-plugin/tests/api_scheduler_integration.rs
@@ -151,7 +151,9 @@ const INIT_SQL: &str = concat!(
         "../../autumn-harvest/migrations/20260607000001_harvest_task_required_capabilities/up.sql"
     ),
     "\n",
-    include_str!("../../autumn-harvest/migrations/20260607000002_harvest_workflow_pause/up.sql")
+    include_str!("../../autumn-harvest/migrations/20260607000002_harvest_workflow_pause/up.sql"),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260609000001_harvest_workflow_current_details/up.sql")
 );
 type HarvestApiApp = axum::Router;
 

--- a/autumn-harvest-plugin/tests/api_scheduler_integration.rs
+++ b/autumn-harvest-plugin/tests/api_scheduler_integration.rs
@@ -153,7 +153,9 @@ const INIT_SQL: &str = concat!(
     "\n",
     include_str!("../../autumn-harvest/migrations/20260607000002_harvest_workflow_pause/up.sql"),
     "\n",
-    include_str!("../../autumn-harvest/migrations/20260609000001_harvest_workflow_current_details/up.sql")
+    include_str!(
+        "../../autumn-harvest/migrations/20260609000001_harvest_workflow_current_details/up.sql"
+    )
 );
 type HarvestApiApp = axum::Router;
 

--- a/autumn-harvest-plugin/tests/archival_integration.rs
+++ b/autumn-harvest-plugin/tests/archival_integration.rs
@@ -124,7 +124,9 @@ const INIT_SQL: &str = concat!(
     "\n",
     include_str!("../../autumn-harvest/migrations/20260607000002_harvest_workflow_pause/up.sql"),
     "\n",
-    include_str!("../../autumn-harvest/migrations/20260609000001_harvest_workflow_current_details/up.sql")
+    include_str!(
+        "../../autumn-harvest/migrations/20260609000001_harvest_workflow_current_details/up.sql"
+    )
 );
 
 struct TestArchiver {

--- a/autumn-harvest-plugin/tests/archival_integration.rs
+++ b/autumn-harvest-plugin/tests/archival_integration.rs
@@ -122,7 +122,9 @@ const INIT_SQL: &str = concat!(
         "../../autumn-harvest/migrations/20260607000001_harvest_task_required_capabilities/up.sql"
     ),
     "\n",
-    include_str!("../../autumn-harvest/migrations/20260607000002_harvest_workflow_pause/up.sql")
+    include_str!("../../autumn-harvest/migrations/20260607000002_harvest_workflow_pause/up.sql"),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260609000001_harvest_workflow_current_details/up.sql")
 );
 
 struct TestArchiver {

--- a/autumn-harvest-plugin/tests/batch_operations_integration.rs
+++ b/autumn-harvest-plugin/tests/batch_operations_integration.rs
@@ -131,7 +131,9 @@ const INIT_SQL: &str = concat!(
         "../../autumn-harvest/migrations/20260607000001_harvest_task_required_capabilities/up.sql"
     ),
     "\n",
-    include_str!("../../autumn-harvest/migrations/20260607000002_harvest_workflow_pause/up.sql")
+    include_str!("../../autumn-harvest/migrations/20260607000002_harvest_workflow_pause/up.sql"),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260609000001_harvest_workflow_current_details/up.sql")
 );
 
 type HarvestApiApp = axum::Router;

--- a/autumn-harvest-plugin/tests/batch_operations_integration.rs
+++ b/autumn-harvest-plugin/tests/batch_operations_integration.rs
@@ -133,7 +133,9 @@ const INIT_SQL: &str = concat!(
     "\n",
     include_str!("../../autumn-harvest/migrations/20260607000002_harvest_workflow_pause/up.sql"),
     "\n",
-    include_str!("../../autumn-harvest/migrations/20260609000001_harvest_workflow_current_details/up.sql")
+    include_str!(
+        "../../autumn-harvest/migrations/20260609000001_harvest_workflow_current_details/up.sql"
+    )
 );
 
 type HarvestApiApp = axum::Router;

--- a/autumn-harvest-plugin/tests/build_routing_ui_integration.rs
+++ b/autumn-harvest-plugin/tests/build_routing_ui_integration.rs
@@ -129,7 +129,9 @@ const INIT_SQL: &str = concat!(
         "../../autumn-harvest/migrations/20260607000001_harvest_task_required_capabilities/up.sql"
     ),
     "\n",
-    include_str!("../../autumn-harvest/migrations/20260607000002_harvest_workflow_pause/up.sql")
+    include_str!("../../autumn-harvest/migrations/20260607000002_harvest_workflow_pause/up.sql"),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260609000001_harvest_workflow_current_details/up.sql")
 );
 
 async fn setup_test_database_url() -> (String, ContainerAsync<Postgres>) {

--- a/autumn-harvest-plugin/tests/build_routing_ui_integration.rs
+++ b/autumn-harvest-plugin/tests/build_routing_ui_integration.rs
@@ -131,7 +131,9 @@ const INIT_SQL: &str = concat!(
     "\n",
     include_str!("../../autumn-harvest/migrations/20260607000002_harvest_workflow_pause/up.sql"),
     "\n",
-    include_str!("../../autumn-harvest/migrations/20260609000001_harvest_workflow_current_details/up.sql")
+    include_str!(
+        "../../autumn-harvest/migrations/20260609000001_harvest_workflow_current_details/up.sql"
+    )
 );
 
 async fn setup_test_database_url() -> (String, ContainerAsync<Postgres>) {

--- a/autumn-harvest-plugin/tests/completion_triggers_integration.rs
+++ b/autumn-harvest-plugin/tests/completion_triggers_integration.rs
@@ -143,7 +143,9 @@ const INIT_SQL: &str = concat!(
         "../../autumn-harvest/migrations/20260607000001_harvest_task_required_capabilities/up.sql"
     ),
     "\n",
-    include_str!("../../autumn-harvest/migrations/20260607000002_harvest_workflow_pause/up.sql")
+    include_str!("../../autumn-harvest/migrations/20260607000002_harvest_workflow_pause/up.sql"),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260609000001_harvest_workflow_current_details/up.sql")
 );
 
 type HarvestApiApp = axum::Router;

--- a/autumn-harvest-plugin/tests/completion_triggers_integration.rs
+++ b/autumn-harvest-plugin/tests/completion_triggers_integration.rs
@@ -145,7 +145,9 @@ const INIT_SQL: &str = concat!(
     "\n",
     include_str!("../../autumn-harvest/migrations/20260607000002_harvest_workflow_pause/up.sql"),
     "\n",
-    include_str!("../../autumn-harvest/migrations/20260609000001_harvest_workflow_current_details/up.sql")
+    include_str!(
+        "../../autumn-harvest/migrations/20260609000001_harvest_workflow_current_details/up.sql"
+    )
 );
 
 type HarvestApiApp = axum::Router;

--- a/autumn-harvest-plugin/tests/dag_retry_integration.rs
+++ b/autumn-harvest-plugin/tests/dag_retry_integration.rs
@@ -176,7 +176,9 @@ const INIT_SQL: &str = concat!(
         "../../autumn-harvest/migrations/20260607000001_harvest_task_required_capabilities/up.sql"
     ),
     "\n",
-    include_str!("../../autumn-harvest/migrations/20260607000002_harvest_workflow_pause/up.sql")
+    include_str!("../../autumn-harvest/migrations/20260607000002_harvest_workflow_pause/up.sql"),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260609000001_harvest_workflow_current_details/up.sql")
 );
 
 type HarvestApiApp = axum::Router;

--- a/autumn-harvest-plugin/tests/dag_retry_integration.rs
+++ b/autumn-harvest-plugin/tests/dag_retry_integration.rs
@@ -178,7 +178,9 @@ const INIT_SQL: &str = concat!(
     "\n",
     include_str!("../../autumn-harvest/migrations/20260607000002_harvest_workflow_pause/up.sql"),
     "\n",
-    include_str!("../../autumn-harvest/migrations/20260609000001_harvest_workflow_current_details/up.sql")
+    include_str!(
+        "../../autumn-harvest/migrations/20260609000001_harvest_workflow_current_details/up.sql"
+    )
 );
 
 type HarvestApiApp = axum::Router;

--- a/autumn-harvest-plugin/tests/dlq_bulk_integration.rs
+++ b/autumn-harvest-plugin/tests/dlq_bulk_integration.rs
@@ -117,7 +117,9 @@ const INIT_SQL: &str = concat!(
     "\n",
     include_str!("../../autumn-harvest/migrations/20260607000002_harvest_workflow_pause/up.sql"),
     "\n",
-    include_str!("../../autumn-harvest/migrations/20260609000001_harvest_workflow_current_details/up.sql")
+    include_str!(
+        "../../autumn-harvest/migrations/20260609000001_harvest_workflow_current_details/up.sql"
+    )
 );
 
 type HarvestApiApp = axum::Router;

--- a/autumn-harvest-plugin/tests/dlq_bulk_integration.rs
+++ b/autumn-harvest-plugin/tests/dlq_bulk_integration.rs
@@ -115,7 +115,9 @@ const INIT_SQL: &str = concat!(
         "../../autumn-harvest/migrations/20260607000001_harvest_task_required_capabilities/up.sql"
     ),
     "\n",
-    include_str!("../../autumn-harvest/migrations/20260607000002_harvest_workflow_pause/up.sql")
+    include_str!("../../autumn-harvest/migrations/20260607000002_harvest_workflow_pause/up.sql"),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260609000001_harvest_workflow_current_details/up.sql")
 );
 
 type HarvestApiApp = axum::Router;

--- a/autumn-harvest-plugin/tests/outbox_integration.rs
+++ b/autumn-harvest-plugin/tests/outbox_integration.rs
@@ -94,7 +94,9 @@ const HARVEST_INIT_SQL: &str = concat!(
         "../../autumn-harvest/migrations/20260607000001_harvest_task_required_capabilities/up.sql"
     ),
     "\n",
-    include_str!("../../autumn-harvest/migrations/20260607000002_harvest_workflow_pause/up.sql")
+    include_str!("../../autumn-harvest/migrations/20260607000002_harvest_workflow_pause/up.sql"),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260609000001_harvest_workflow_current_details/up.sql")
 );
 
 #[derive(Debug, QueryableByName)]

--- a/autumn-harvest-plugin/tests/outbox_integration.rs
+++ b/autumn-harvest-plugin/tests/outbox_integration.rs
@@ -96,7 +96,9 @@ const HARVEST_INIT_SQL: &str = concat!(
     "\n",
     include_str!("../../autumn-harvest/migrations/20260607000002_harvest_workflow_pause/up.sql"),
     "\n",
-    include_str!("../../autumn-harvest/migrations/20260609000001_harvest_workflow_current_details/up.sql")
+    include_str!(
+        "../../autumn-harvest/migrations/20260609000001_harvest_workflow_current_details/up.sql"
+    )
 );
 
 #[derive(Debug, QueryableByName)]

--- a/autumn-harvest-plugin/tests/signal_with_start_integration.rs
+++ b/autumn-harvest-plugin/tests/signal_with_start_integration.rs
@@ -124,7 +124,9 @@ const INIT_SQL: &str = concat!(
     "\n",
     include_str!("../../autumn-harvest/migrations/20260607000002_harvest_workflow_pause/up.sql"),
     "\n",
-    include_str!("../../autumn-harvest/migrations/20260609000001_harvest_workflow_current_details/up.sql")
+    include_str!(
+        "../../autumn-harvest/migrations/20260609000001_harvest_workflow_current_details/up.sql"
+    )
 );
 
 type HarvestApiApp = axum::Router;

--- a/autumn-harvest-plugin/tests/signal_with_start_integration.rs
+++ b/autumn-harvest-plugin/tests/signal_with_start_integration.rs
@@ -122,7 +122,9 @@ const INIT_SQL: &str = concat!(
         "../../autumn-harvest/migrations/20260607000001_harvest_task_required_capabilities/up.sql"
     ),
     "\n",
-    include_str!("../../autumn-harvest/migrations/20260607000002_harvest_workflow_pause/up.sql")
+    include_str!("../../autumn-harvest/migrations/20260607000002_harvest_workflow_pause/up.sql"),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260609000001_harvest_workflow_current_details/up.sql")
 );
 
 type HarvestApiApp = axum::Router;

--- a/autumn-harvest-plugin/tests/telemetry_propagation_tests.rs
+++ b/autumn-harvest-plugin/tests/telemetry_propagation_tests.rs
@@ -139,7 +139,9 @@ const INIT_SQL: &str = concat!(
     "\n",
     include_str!("../../autumn-harvest/migrations/20260607000002_harvest_workflow_pause/up.sql"),
     "\n",
-    include_str!("../../autumn-harvest/migrations/20260609000001_harvest_workflow_current_details/up.sql")
+    include_str!(
+        "../../autumn-harvest/migrations/20260609000001_harvest_workflow_current_details/up.sql"
+    )
 );
 
 // -------------------------------------------------------------------------

--- a/autumn-harvest-plugin/tests/telemetry_propagation_tests.rs
+++ b/autumn-harvest-plugin/tests/telemetry_propagation_tests.rs
@@ -137,7 +137,9 @@ const INIT_SQL: &str = concat!(
         "../../autumn-harvest/migrations/20260607000001_harvest_task_required_capabilities/up.sql"
     ),
     "\n",
-    include_str!("../../autumn-harvest/migrations/20260607000002_harvest_workflow_pause/up.sql")
+    include_str!("../../autumn-harvest/migrations/20260607000002_harvest_workflow_pause/up.sql"),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260609000001_harvest_workflow_current_details/up.sql")
 );
 
 // -------------------------------------------------------------------------

--- a/autumn-harvest-plugin/tests/ui_integration.rs
+++ b/autumn-harvest-plugin/tests/ui_integration.rs
@@ -135,7 +135,9 @@ const INIT_SQL: &str = concat!(
     "\n",
     include_str!("../../autumn-harvest/migrations/20260607000002_harvest_workflow_pause/up.sql"),
     "\n",
-    include_str!("../../autumn-harvest/migrations/20260609000001_harvest_workflow_current_details/up.sql")
+    include_str!(
+        "../../autumn-harvest/migrations/20260609000001_harvest_workflow_current_details/up.sql"
+    )
 );
 
 async fn setup_test_database_url() -> (String, ContainerAsync<Postgres>) {

--- a/autumn-harvest-plugin/tests/ui_integration.rs
+++ b/autumn-harvest-plugin/tests/ui_integration.rs
@@ -133,7 +133,9 @@ const INIT_SQL: &str = concat!(
         "../../autumn-harvest/migrations/20260607000001_harvest_task_required_capabilities/up.sql"
     ),
     "\n",
-    include_str!("../../autumn-harvest/migrations/20260607000002_harvest_workflow_pause/up.sql")
+    include_str!("../../autumn-harvest/migrations/20260607000002_harvest_workflow_pause/up.sql"),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260609000001_harvest_workflow_current_details/up.sql")
 );
 
 async fn setup_test_database_url() -> (String, ContainerAsync<Postgres>) {

--- a/autumn-harvest-plugin/tests/workflow_filter_integration.rs
+++ b/autumn-harvest-plugin/tests/workflow_filter_integration.rs
@@ -96,7 +96,9 @@ const INIT_SQL: &str = concat!(
         "../../autumn-harvest/migrations/20260607000001_harvest_task_required_capabilities/up.sql"
     ),
     "\n",
-    include_str!("../../autumn-harvest/migrations/20260607000002_harvest_workflow_pause/up.sql")
+    include_str!("../../autumn-harvest/migrations/20260607000002_harvest_workflow_pause/up.sql"),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260609000001_harvest_workflow_current_details/up.sql")
 );
 
 type HarvestApiApp = axum::Router;

--- a/autumn-harvest-plugin/tests/workflow_filter_integration.rs
+++ b/autumn-harvest-plugin/tests/workflow_filter_integration.rs
@@ -98,7 +98,9 @@ const INIT_SQL: &str = concat!(
     "\n",
     include_str!("../../autumn-harvest/migrations/20260607000002_harvest_workflow_pause/up.sql"),
     "\n",
-    include_str!("../../autumn-harvest/migrations/20260609000001_harvest_workflow_current_details/up.sql")
+    include_str!(
+        "../../autumn-harvest/migrations/20260609000001_harvest_workflow_current_details/up.sql"
+    )
 );
 
 type HarvestApiApp = axum::Router;

--- a/autumn-harvest-plugin/tests/workflow_reset_integration.rs
+++ b/autumn-harvest-plugin/tests/workflow_reset_integration.rs
@@ -126,7 +126,9 @@ const INIT_SQL: &str = concat!(
     "\n",
     include_str!("../../autumn-harvest/migrations/20260607000002_harvest_workflow_pause/up.sql"),
     "\n",
-    include_str!("../../autumn-harvest/migrations/20260609000001_harvest_workflow_current_details/up.sql")
+    include_str!(
+        "../../autumn-harvest/migrations/20260609000001_harvest_workflow_current_details/up.sql"
+    )
 );
 
 type HarvestApiApp = axum::Router;

--- a/autumn-harvest-plugin/tests/workflow_reset_integration.rs
+++ b/autumn-harvest-plugin/tests/workflow_reset_integration.rs
@@ -124,7 +124,9 @@ const INIT_SQL: &str = concat!(
         "../../autumn-harvest/migrations/20260607000001_harvest_task_required_capabilities/up.sql"
     ),
     "\n",
-    include_str!("../../autumn-harvest/migrations/20260607000002_harvest_workflow_pause/up.sql")
+    include_str!("../../autumn-harvest/migrations/20260607000002_harvest_workflow_pause/up.sql"),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260609000001_harvest_workflow_current_details/up.sql")
 );
 
 type HarvestApiApp = axum::Router;

--- a/autumn-harvest/build.rs
+++ b/autumn-harvest/build.rs
@@ -15,7 +15,7 @@ fn main() {
         .read_dir()
         .into_iter()
         .flatten()
-        .filter_map(|e| e.ok())
+        .filter_map(Result::ok)
         .map(|e| e.file_name().to_string_lossy().to_string())
         .collect();
     names.sort();

--- a/autumn-harvest/build.rs
+++ b/autumn-harvest/build.rs
@@ -1,5 +1,34 @@
+use std::path::Path;
+
 fn main() {
-    // Ensure Cargo recompiles embed_migrations!() whenever any migration file
-    // is added or removed from the migrations/ directory.
+    let migrations_dir = Path::new("migrations");
+
+    // Watch the directory so Cargo re-runs this script when migrations are
+    // added or removed.
     println!("cargo:rerun-if-changed=migrations/");
+
+    // Collect and sort migration names, then emit them as a rustc-env so
+    // that the build-script *output* changes whenever a new migration
+    // appears.  A changed output invalidates the lib fingerprint and forces
+    // Cargo to recompile lib.rs (re-running embed_migrations!()).
+    let mut names: Vec<String> = migrations_dir
+        .read_dir()
+        .into_iter()
+        .flatten()
+        .filter_map(|e| e.ok())
+        .map(|e| e.file_name().to_string_lossy().to_string())
+        .collect();
+    names.sort();
+
+    // Each individual SQL file is also watched so edits to existing
+    // migrations trigger a recompile as well.
+    for name in &names {
+        let dir = migrations_dir.join(name);
+        println!("cargo:rerun-if-changed={}", dir.display());
+    }
+
+    println!(
+        "cargo:rustc-env=HARVEST_MIGRATIONS_LIST={}",
+        names.join(",")
+    );
 }

--- a/autumn-harvest/build.rs
+++ b/autumn-harvest/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    // Ensure Cargo recompiles embed_migrations!() whenever any migration file
+    // is added or removed from the migrations/ directory.
+    println!("cargo:rerun-if-changed=migrations/");
+}

--- a/autumn-harvest/migrations/20260609000001_harvest_workflow_current_details/down.sql
+++ b/autumn-harvest/migrations/20260609000001_harvest_workflow_current_details/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE harvest_workflow_executions
+    DROP COLUMN IF EXISTS current_details;

--- a/autumn-harvest/migrations/20260609000001_harvest_workflow_current_details/up.sql
+++ b/autumn-harvest/migrations/20260609000001_harvest_workflow_current_details/up.sql
@@ -1,0 +1,17 @@
+-- Durable workflow status breadcrumb (issue #473).
+--
+-- Workflow authors call ctx.set_current_details("Step 3/5: awaiting approval")
+-- to push a last-write-wins human-readable string that operators can read
+-- directly from the execution list (GET /workflows) or detail (GET /workflows/{id})
+-- without a live worker or per-row Query fan-out.
+--
+-- Properties:
+--   - NULL when the workflow author never called set_current_details.
+--   - Frozen at terminal state: completed/failed/cancelled/timed_out executions
+--     retain the last-set value so post-mortem inspection is possible.
+--   - Replay-safe: the worker suppresses the DB write during replay cycles
+--     (same zero-footprint contract as Query handlers, #234).
+--   - Capped at 1 KiB at the application layer; TEXT has no additional DB limit.
+
+ALTER TABLE harvest_workflow_executions
+    ADD COLUMN IF NOT EXISTS current_details TEXT NULL;

--- a/autumn-harvest/src/builder.rs
+++ b/autumn-harvest/src/builder.rs
@@ -85,6 +85,10 @@ pub struct HarvestBuilder {
     /// Maximum allowed byte length for a workflow start input payload (issue #252).
     /// Default: 2 MiB.
     max_workflow_input_bytes: u64,
+    /// Maximum byte length for `current_details` strings set via
+    /// `ctx.set_current_details(...)` (issue #473).
+    /// Default: 1 KiB.
+    max_current_details_bytes: usize,
     /// Server-side ceiling on workflow start delay (issue #322).
     /// Default: 365 days.
     max_workflow_start_delay: Option<Duration>,
@@ -118,6 +122,7 @@ impl Default for HarvestBuilder {
             max_activity_result_bytes: DEFAULT_MAX_ACTIVITY_RESULT_BYTES,
             max_signal_payload_bytes: DEFAULT_MAX_SIGNAL_PAYLOAD_BYTES,
             max_workflow_input_bytes: DEFAULT_MAX_WORKFLOW_INPUT_BYTES,
+            max_current_details_bytes: crate::context::DEFAULT_CURRENT_DETAILS_CAP_BYTES,
             max_workflow_start_delay: None,
             unknown_target_grace_window: None,
             batch_start_config: BatchStartConfig::default(),
@@ -194,6 +199,9 @@ pub struct BuiltHarvest {
     /// Maximum allowed byte length for a workflow start input payload (issue #252).
     /// Default: 2 MiB.
     pub max_workflow_input_bytes: u64,
+    /// Maximum byte length for `current_details` strings (issue #473).
+    /// Default: 1 KiB.
+    pub max_current_details_bytes: usize,
     /// Server-side ceiling on workflow start delay (issue #322).
     /// Default: 365 days.
     pub max_workflow_start_delay: Duration,
@@ -228,6 +236,7 @@ impl std::fmt::Debug for BuiltHarvest {
             .field("max_activity_result_bytes", &self.max_activity_result_bytes)
             .field("max_signal_payload_bytes", &self.max_signal_payload_bytes)
             .field("max_workflow_input_bytes", &self.max_workflow_input_bytes)
+            .field("max_current_details_bytes", &self.max_current_details_bytes)
             .field("max_workflow_start_delay", &self.max_workflow_start_delay)
             .field(
                 "unknown_target_grace_window",
@@ -601,7 +610,8 @@ impl BuiltHarvest {
                 self.max_workflow_input_bytes,
                 self.max_activity_result_bytes,
                 self.max_signal_payload_bytes,
-            ),
+            )
+            .with_current_details_cap(self.max_current_details_bytes),
             self.dags,
             self.workflow_schedules,
             self.worker_config,
@@ -636,7 +646,8 @@ impl BuiltHarvest {
                 self.max_workflow_input_bytes,
                 self.max_activity_result_bytes,
                 self.max_signal_payload_bytes,
-            ),
+            )
+            .with_current_details_cap(self.max_current_details_bytes),
             self.dags,
             self.workflow_schedules,
             self.worker_config,
@@ -932,6 +943,21 @@ impl HarvestBuilder {
         self
     }
 
+    /// Set the global maximum byte length for `current_details` strings set via
+    /// `ctx.set_current_details(...)` (issue #473).
+    ///
+    /// Values longer than the cap are silently truncated to the nearest valid
+    /// UTF-8 character boundary at or before the cap. The truncation happens
+    /// identically on the live and replay paths so it cannot itself cause a
+    /// non-determinism divergence.
+    ///
+    /// Default: 1 KiB.
+    #[must_use]
+    pub const fn with_current_details_cap(mut self, cap_bytes: usize) -> Self {
+        self.max_current_details_bytes = cap_bytes;
+        self
+    }
+
     /// Set the global maximum allowed start delay for a workflow (issue #322).
     ///
     /// Default: 365 days.
@@ -1070,6 +1096,7 @@ impl HarvestBuilder {
             max_activity_result_bytes: self.max_activity_result_bytes,
             max_signal_payload_bytes: self.max_signal_payload_bytes,
             max_workflow_input_bytes: self.max_workflow_input_bytes,
+            max_current_details_bytes: self.max_current_details_bytes,
             max_workflow_start_delay,
             unknown_target_grace_window,
             batch_start_config: self.batch_start_config,

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -3924,7 +3924,13 @@ impl WorkflowContext {
         }
         let raw = details.into();
         let capped = if raw.len() > self.current_details_cap {
-            raw[..raw.floor_char_boundary(self.current_details_cap)].to_string()
+            // floor_char_boundary is not yet stable (tracking #93743); scan back
+            // manually to the nearest valid UTF-8 character boundary.
+            let mut boundary = self.current_details_cap;
+            while !raw.is_char_boundary(boundary) {
+                boundary -= 1;
+            }
+            raw[..boundary].to_string()
         } else {
             raw
         };

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -45,6 +45,10 @@ pub fn empty_shared_state() -> SharedState {
 /// Default soft history-size threshold for recommending `continue_as_new`.
 pub const DEFAULT_HISTORY_CONTINUE_AS_NEW_THRESHOLD: u64 = 10_000;
 
+/// Default maximum byte length for the `current_details` string (issue #473).
+/// Values longer than this cap are truncated to this length on the byte boundary.
+pub const DEFAULT_CURRENT_DETAILS_CAP_BYTES: usize = 1024;
+
 /// Replay-safe history guardrails made available to workflow code.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct WorkflowHistoryPolicy {
@@ -332,6 +336,17 @@ pub enum WorkflowCommand {
         /// Per-key merge patch: `Some(v)` → set/overwrite, `None` → remove.
         patch: std::collections::HashMap<String, Option<Value>>,
     },
+    /// Overwrite the `current_details` column on the execution row (issue #473).
+    ///
+    /// Emitted by [`WorkflowContext::set_current_details`] during live execution.
+    /// Suppressed during replay so the DB write is idempotent across worker
+    /// restarts. Last-write-wins: the worker takes the **last** `SetCurrentDetails`
+    /// command from the drained list and persists only that value.
+    /// No `WorkflowEvent` is appended — zero footprint in `harvest_events`.
+    SetCurrentDetails {
+        /// The human-readable status string, already capped by the context.
+        value: String,
+    },
     /// Spawn a child workflow in detached mode and return its `ExecutionId`
     /// immediately without suspending the parent.
     ///
@@ -472,6 +487,10 @@ impl std::fmt::Debug for WorkflowCommand {
             Self::UpsertSearchAttributes { patch } => f
                 .debug_struct("UpsertSearchAttributes")
                 .field("keys", &patch.keys())
+                .finish(),
+            Self::SetCurrentDetails { value } => f
+                .debug_struct("SetCurrentDetails")
+                .field("value", value)
                 .finish(),
             Self::RecordUpdateResult { update_id, result } => f
                 .debug_struct("RecordUpdateResult")
@@ -730,6 +749,10 @@ pub struct WorkflowContext {
     /// structured `SideEffectDrift` non-determinism rather than a silent pass
     /// (issue #384).
     deferred_nd_error: Mutex<Option<String>>,
+    /// Maximum byte length for `current_details` strings (issue #473). Values
+    /// longer than this cap are truncated to the cap boundary on a UTF-8
+    /// character boundary. Configurable via `HarvestBuilder::with_current_details_cap`.
+    current_details_cap: usize,
 }
 
 impl WorkflowContext {
@@ -843,6 +866,7 @@ impl WorkflowContext {
             payload_max_signal: DEFAULT_MAX_SIGNAL_PAYLOAD_BYTES,
             activity_input_cap_overrides: HashMap::new(),
             deferred_nd_error: Mutex::new(None),
+            current_details_cap: DEFAULT_CURRENT_DETAILS_CAP_BYTES,
         }
     }
 
@@ -926,6 +950,7 @@ impl WorkflowContext {
             payload_max_signal: DEFAULT_MAX_SIGNAL_PAYLOAD_BYTES,
             activity_input_cap_overrides: HashMap::new(),
             deferred_nd_error: Mutex::new(None),
+            current_details_cap: DEFAULT_CURRENT_DETAILS_CAP_BYTES,
         })
     }
 
@@ -959,6 +984,7 @@ impl WorkflowContext {
             payload_max_signal: DEFAULT_MAX_SIGNAL_PAYLOAD_BYTES,
             activity_input_cap_overrides: HashMap::new(),
             deferred_nd_error: Mutex::new(None),
+            current_details_cap: DEFAULT_CURRENT_DETAILS_CAP_BYTES,
         }
     }
 
@@ -994,6 +1020,16 @@ impl WorkflowContext {
     pub fn with_activity_input_override(mut self, activity_name: &str, max_bytes: u64) -> Self {
         self.activity_input_cap_overrides
             .insert(activity_name.to_string(), max_bytes);
+        self
+    }
+
+    /// Set the maximum byte length for `current_details` strings (issue #473).
+    ///
+    /// Overrides [`DEFAULT_CURRENT_DETAILS_CAP_BYTES`]. The executor calls this
+    /// with the value from [`crate::builder::BuiltHarvest::max_current_details_bytes`].
+    #[must_use]
+    pub const fn with_current_details_cap(mut self, cap_bytes: usize) -> Self {
+        self.current_details_cap = cap_bytes;
         self
     }
 
@@ -3866,6 +3902,39 @@ impl WorkflowContext {
     }
 
     // ── Command drain ─────────────────────────────────────────────────
+
+    /// Set a durable, human-readable status breadcrumb for this execution (issue #473).
+    ///
+    /// Calls are **last-write-wins**: the worker takes the most recently emitted
+    /// value and overwrites `harvest_workflow_executions.current_details`.
+    ///
+    /// The value is **suppressed during replay** (zero new `harvest_events` rows,
+    /// zero replay-determinism impact), mirroring the zero-footprint contract of
+    /// Query handlers (#234) and `upsert_search_attrs`.
+    ///
+    /// The value is capped at [`DEFAULT_CURRENT_DETAILS_CAP_BYTES`] (configurable
+    /// via `HarvestBuilder::with_current_details_cap`). Values longer than the cap
+    /// are truncated to the cap boundary on a UTF-8 character boundary.
+    ///
+    /// Operators can read the latest value from `GET /workflows/{id}` and
+    /// `GET /workflows` without fan-out queries or a live worker.
+    pub fn set_current_details(&self, details: impl Into<String>) {
+        if self.is_replaying() {
+            return;
+        }
+        let raw = details.into();
+        let capped = if raw.len() > self.current_details_cap {
+            // Truncate to the nearest valid UTF-8 boundary at or before the cap.
+            let mut boundary = self.current_details_cap;
+            while !raw.is_char_boundary(boundary) {
+                boundary -= 1;
+            }
+            raw[..boundary].to_string()
+        } else {
+            raw
+        };
+        self.push_command(WorkflowCommand::SetCurrentDetails { value: capped });
+    }
 
     /// Drain all accumulated commands. Called by the worker after the
     /// workflow coroutine suspends or completes.
@@ -7392,5 +7461,104 @@ mod tests {
 
         assert_eq!(result.unwrap(), Approval { approved: true });
         assert!(ctx.drain_commands().is_empty());
+    }
+
+    // ── set_current_details tests (issue #473) ────────────────────────────
+
+    /// Helper: extract the last `SetCurrentDetails` value from a command list.
+    fn last_set_current_details(cmds: &[WorkflowCommand]) -> Option<&str> {
+        cmds.iter().rev().find_map(|cmd| {
+            if let WorkflowCommand::SetCurrentDetails { value } = cmd {
+                Some(value.as_str())
+            } else {
+                None
+            }
+        })
+    }
+
+    #[test]
+    fn set_current_details_pushes_set_current_details_command() {
+        let ctx = WorkflowContext::new_test();
+        ctx.set_current_details("Step 3/5: awaiting vendor approval");
+        let cmds = ctx.drain_commands();
+        assert_eq!(cmds.len(), 1, "exactly one command should be pushed");
+        assert!(
+            matches!(&cmds[0], WorkflowCommand::SetCurrentDetails { value } if value == "Step 3/5: awaiting vendor approval"),
+            "command must be SetCurrentDetails with the correct value"
+        );
+    }
+
+    #[test]
+    fn set_current_details_last_write_wins() {
+        let ctx = WorkflowContext::new_test();
+        ctx.set_current_details("first status");
+        ctx.set_current_details("second status");
+        ctx.set_current_details("third status");
+        let cmds = ctx.drain_commands();
+        // The worker takes the LAST SetCurrentDetails command.
+        assert_eq!(
+            last_set_current_details(&cmds),
+            Some("third status"),
+            "last-write-wins: the last command value wins"
+        );
+    }
+
+    #[test]
+    fn set_current_details_no_command_when_never_set() {
+        let ctx = WorkflowContext::new_test();
+        let cmds = ctx.drain_commands();
+        assert_eq!(
+            last_set_current_details(&cmds),
+            None,
+            "no SetCurrentDetails command when never set"
+        );
+    }
+
+    #[test]
+    fn set_current_details_suppressed_during_replay() {
+        let events = vec![
+            WorkflowEvent::WorkflowStarted {
+                input: Value::Null,
+                timestamp: Utc::now(),
+            },
+            WorkflowEvent::MarkerRecorded {
+                name: "some-marker".into(),
+                details: Value::Null,
+            },
+        ];
+        let ctx = WorkflowContext::for_replay(ExecutionId::new(), events);
+        assert!(ctx.is_replaying(), "context must be in replay mode");
+        ctx.set_current_details("status during replay");
+        // During replay, set_current_details is a no-op: zero commands pushed.
+        let cmds = ctx.drain_commands();
+        assert!(
+            cmds.is_empty(),
+            "set_current_details must be suppressed during replay: no commands emitted"
+        );
+    }
+
+    #[test]
+    fn set_current_details_cap_truncates_over_limit() {
+        let ctx = WorkflowContext::new_test();
+        // Build a string just over the 1 KiB default cap.
+        let over_cap = "x".repeat(DEFAULT_CURRENT_DETAILS_CAP_BYTES + 10);
+        ctx.set_current_details(over_cap);
+        let cmds = ctx.drain_commands();
+        let stored = last_set_current_details(&cmds).expect("SetCurrentDetails command must be present");
+        assert!(
+            stored.len() <= DEFAULT_CURRENT_DETAILS_CAP_BYTES,
+            "stored value length {} exceeds cap {}",
+            stored.len(),
+            DEFAULT_CURRENT_DETAILS_CAP_BYTES
+        );
+    }
+
+    #[test]
+    fn set_current_details_within_cap_stored_unchanged() {
+        let ctx = WorkflowContext::new_test();
+        let msg = "Step 2/4: processing payment";
+        ctx.set_current_details(msg);
+        let cmds = ctx.drain_commands();
+        assert_eq!(last_set_current_details(&cmds), Some(msg));
     }
 }

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -3924,12 +3924,7 @@ impl WorkflowContext {
         }
         let raw = details.into();
         let capped = if raw.len() > self.current_details_cap {
-            // Truncate to the nearest valid UTF-8 boundary at or before the cap.
-            let mut boundary = self.current_details_cap;
-            while !raw.is_char_boundary(boundary) {
-                boundary -= 1;
-            }
-            raw[..boundary].to_string()
+            raw[..raw.floor_char_boundary(self.current_details_cap)].to_string()
         } else {
             raw
         };
@@ -7561,5 +7556,26 @@ mod tests {
         ctx.set_current_details(msg);
         let cmds = ctx.drain_commands();
         assert_eq!(last_set_current_details(&cmds), Some(msg));
+    }
+
+    #[test]
+    fn set_current_details_cap_truncates_on_utf8_boundary() {
+        // "ä" is U+00E4, encoded as 2 bytes (0xC3 0xA4) in UTF-8.
+        // "äää" = 6 bytes. A cap of 5 must not split the 3rd char,
+        // so floor_char_boundary(5) = 4 → "ää" is the result.
+        let ctx = WorkflowContext::new_test().with_current_details_cap(5);
+        ctx.set_current_details("äää");
+        let cmds = ctx.drain_commands();
+        let stored =
+            last_set_current_details(&cmds).expect("SetCurrentDetails command must be present");
+        assert_eq!(
+            stored, "ää",
+            "truncation must land on a valid char boundary"
+        );
+        assert!(
+            stored.len() <= 5,
+            "stored length {} exceeds cap 5",
+            stored.len()
+        );
     }
 }

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -7544,7 +7544,8 @@ mod tests {
         let over_cap = "x".repeat(DEFAULT_CURRENT_DETAILS_CAP_BYTES + 10);
         ctx.set_current_details(over_cap);
         let cmds = ctx.drain_commands();
-        let stored = last_set_current_details(&cmds).expect("SetCurrentDetails command must be present");
+        let stored =
+            last_set_current_details(&cmds).expect("SetCurrentDetails command must be present");
         assert!(
             stored.len() <= DEFAULT_CURRENT_DETAILS_CAP_BYTES,
             "stored value length {} exceeds cap {}",

--- a/autumn-harvest/src/executor.rs
+++ b/autumn-harvest/src/executor.rs
@@ -139,9 +139,13 @@ pub async fn run_workflow_strict(
                                 .to_string(),
                         }
                     } else if ctx.drain_commands().into_iter().any(|cmd| {
-                        // UpsertSearchAttributes is pure metadata and does not
-                        // affect replay determinism; exclude it from this check.
-                        !matches!(cmd, WorkflowCommand::UpsertSearchAttributes { .. })
+                        // UpsertSearchAttributes and SetCurrentDetails are pure metadata
+                        // and do not affect replay determinism; exclude from this check.
+                        !matches!(
+                            cmd,
+                            WorkflowCommand::UpsertSearchAttributes { .. }
+                                | WorkflowCommand::SetCurrentDetails { .. }
+                        )
                     }) {
                         // New commands emitted after history was fully consumed (e.g. a
                         // newly-added version() or side_effect() call on an old history).
@@ -258,6 +262,7 @@ pub async fn run_workflow_with_state_and_history_policy(
         crate::builder::DEFAULT_MAX_ACTIVITY_INPUT_BYTES,
         crate::builder::DEFAULT_MAX_SIGNAL_PAYLOAD_BYTES,
         crate::builder::DEFAULT_MAX_WORKFLOW_INPUT_BYTES,
+        crate::context::DEFAULT_CURRENT_DETAILS_CAP_BYTES,
     )
     .await
 }
@@ -279,6 +284,7 @@ pub async fn run_workflow_with_state_history_policy_and_caps(
     max_activity_input_bytes: u64,
     max_signal_payload_bytes: u64,
     max_workflow_input_bytes: u64,
+    max_current_details_bytes: usize,
 ) -> (WorkflowOutcome, Vec<WorkflowCommand>, tracing::Span) {
     let ctx = WorkflowContext::for_replay_with_state_and_history_policy(
         exec_id,
@@ -293,7 +299,8 @@ pub async fn run_workflow_with_state_history_policy_and_caps(
         0,
         max_signal_payload_bytes,
         max_workflow_input_bytes,
-    );
+    )
+    .with_current_details_cap(max_current_details_bytes);
 
     // Auto-register declarative handlers before any workflow code runs.
     // This satisfies the AC: "authors do not call ctx.register_*_handler in

--- a/autumn-harvest/src/lib.rs
+++ b/autumn-harvest/src/lib.rs
@@ -24,9 +24,20 @@ macro_rules! cfg_db {
     ($($item:item)*) => {};
 }
 
+/// The set of migrations currently embedded by `embed_migrations!()`. Keyed
+/// at compile time by `HARVEST_MIGRATIONS_LIST` (set by `build.rs`) so that
+/// adding or removing a migration directory invalidates the cached artifact
+/// and forces a fresh `embed_migrations!()` expansion.
 #[cfg(feature = "db")]
 pub const MIGRATIONS: diesel_migrations::EmbeddedMigrations =
     diesel_migrations::embed_migrations!();
+
+// Consume the env var emitted by build.rs so that Cargo recompiles this
+// crate (and re-runs embed_migrations!()) whenever a migration is added or
+// removed — even when only the migrations/ directory changed and no Rust
+// source file was edited.
+#[cfg(feature = "db")]
+const _MIGRATIONS_LIST: &str = env!("HARVEST_MIGRATIONS_LIST");
 
 /// Admission gate primitive for incident-response operators (issue #377).
 pub mod admission_gate;

--- a/autumn-harvest/src/lib.rs
+++ b/autumn-harvest/src/lib.rs
@@ -24,10 +24,6 @@ macro_rules! cfg_db {
     ($($item:item)*) => {};
 }
 
-/// The set of migrations currently embedded by `embed_migrations!()`. Keyed
-/// at compile time by `HARVEST_MIGRATIONS_LIST` (set by `build.rs`) so that
-/// adding or removing a migration directory invalidates the cached artifact
-/// and forces a fresh `embed_migrations!()` expansion.
 #[cfg(feature = "db")]
 pub const MIGRATIONS: diesel_migrations::EmbeddedMigrations =
     diesel_migrations::embed_migrations!();

--- a/autumn-harvest/src/models.rs
+++ b/autumn-harvest/src/models.rs
@@ -110,6 +110,9 @@ pub struct WorkflowExecution {
     pub pause_reason: Option<String>,
     /// Identity that requested the active pause (issue #383).
     pub pause_actor: Option<String>,
+    /// Last-write-wins human-readable status string set by the workflow author
+    /// via `ctx.set_current_details(...)` (issue #473). `None` = never set.
+    pub current_details: Option<String>,
 }
 
 /// Insert struct for creating a new workflow execution.

--- a/autumn-harvest/src/reset.rs
+++ b/autumn-harvest/src/reset.rs
@@ -1078,6 +1078,7 @@ mod tests {
             paused_at: Some(Utc::now()),
             pause_reason: Some("operator pause".into()),
             pause_actor: Some("oncall".into()),
+            current_details: None,
         }
     }
 

--- a/autumn-harvest/src/schema.rs
+++ b/autumn-harvest/src/schema.rs
@@ -45,6 +45,9 @@ diesel::table! {
         pause_reason -> Nullable<Text>,
         /// Identity that requested the active pause, from the audit trail (issue #383).
         pause_actor -> Nullable<Text>,
+        /// Last-write-wins human-readable status string set by the workflow author
+        /// via `ctx.set_current_details(...)` (issue #473). NULL = never set.
+        current_details -> Nullable<Text>,
     }
 }
 

--- a/autumn-harvest/src/store.rs
+++ b/autumn-harvest/src/store.rs
@@ -665,6 +665,28 @@ pub async fn update_search_attrs<S: std::hash::BuildHasher + Sync>(
     Ok(())
 }
 
+/// Overwrite `current_details` on the execution row (issue #473).
+///
+/// Called by the worker after each execution cycle when the workflow author
+/// called `ctx.set_current_details(...)` during live (non-replay) execution.
+/// Uses a simple overwrite; the application layer enforces last-write-wins by
+/// calling `take_current_details()` on the context, which drains the field.
+pub async fn update_current_details(
+    conn: &mut AsyncPgConnection,
+    exec_id: crate::types::ExecutionId,
+    details: &str,
+) -> crate::error::HarvestResult<()> {
+    use crate::schema::harvest_workflow_executions::dsl;
+
+    diesel::update(dsl::harvest_workflow_executions.find(exec_id.as_uuid()))
+        .set(dsl::current_details.eq(Some(details)))
+        .execute(conn)
+        .await
+        .map_err(crate::error::database_error)?;
+
+    Ok(())
+}
+
 fn summarize_error(error: Option<String>) -> Option<String> {
     const MAX_ERROR_SUMMARY_CHARS: usize = 240;
 

--- a/autumn-harvest/src/testing.rs
+++ b/autumn-harvest/src/testing.rs
@@ -2239,6 +2239,7 @@ impl WorkflowTestEnv {
             | WorkflowCommand::RecordMarker { .. }
             | WorkflowCommand::RecordUpdateResult { .. }
             | WorkflowCommand::UpsertSearchAttributes { .. }
+            | WorkflowCommand::SetCurrentDetails { .. }
             | WorkflowCommand::ScheduleExternalActivity { .. }
             | WorkflowCommand::Complete { .. }
             | WorkflowCommand::Fail { .. }

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -215,6 +215,9 @@ pub struct HandlerRegistry {
     /// in-process state. Built from the registered activities' declared
     /// [`CircuitBreakerPolicy`](crate::policy::CircuitBreakerPolicy)s.
     circuit_breakers: Arc<crate::circuit_breaker::CircuitBreakerRegistry>,
+    /// Maximum byte length for `current_details` strings passed to the
+    /// workflow context (issue #473). Default: 1 KiB.
+    pub max_current_details_bytes: usize,
 }
 
 impl HandlerRegistry {
@@ -302,6 +305,7 @@ impl HandlerRegistry {
             max_workflow_input_bytes: crate::builder::DEFAULT_MAX_WORKFLOW_INPUT_BYTES,
             max_activity_result_bytes: crate::builder::DEFAULT_MAX_ACTIVITY_RESULT_BYTES,
             max_signal_payload_bytes: crate::builder::DEFAULT_MAX_SIGNAL_PAYLOAD_BYTES,
+            max_current_details_bytes: crate::context::DEFAULT_CURRENT_DETAILS_CAP_BYTES,
             circuit_breakers: Arc::new(crate::circuit_breaker::CircuitBreakerRegistry::new(
                 circuit_policies,
             )),
@@ -356,6 +360,13 @@ impl HandlerRegistry {
         if let Ok(mut lock) = crate::completion_trigger::GLOBAL_MAX_WORKFLOW_INPUT_BYTES.write() {
             *lock = max_workflow_input_bytes;
         }
+        self
+    }
+
+    /// Set the max byte length for `current_details` strings (issue #473).
+    #[must_use]
+    pub const fn with_current_details_cap(mut self, cap_bytes: usize) -> Self {
+        self.max_current_details_bytes = cap_bytes;
         self
     }
 
@@ -452,6 +463,7 @@ const fn workflow_command_name(command: &WorkflowCommand) -> &'static str {
         WorkflowCommand::RunLocalActivity { .. } => "RunLocalActivity",
         WorkflowCommand::RecordUpdateResult { .. } => "RecordUpdateResult",
         WorkflowCommand::UpsertSearchAttributes { .. } => "UpsertSearchAttributes",
+        WorkflowCommand::SetCurrentDetails { .. } => "SetCurrentDetails",
         WorkflowCommand::SignalExternalWorkflow { .. } => "SignalExternalWorkflow",
         WorkflowCommand::SpawnDetachedChildWorkflow { .. } => "SpawnDetachedChildWorkflow",
     }
@@ -502,6 +514,7 @@ fn should_requeue_signal_wait(commands: &[WorkflowCommand]) -> bool {
                 | WorkflowCommand::RecordSideEffect { .. }
                 | WorkflowCommand::RecordUpdateResult { .. }
                 | WorkflowCommand::UpsertSearchAttributes { .. }
+                | WorkflowCommand::SetCurrentDetails { .. }
                 | WorkflowCommand::SpawnDetachedChildWorkflow { .. }
         )
     });
@@ -518,6 +531,7 @@ fn only_bookkeeping_commands(commands: &[WorkflowCommand]) -> bool {
                     | WorkflowCommand::RecordSideEffect { .. }
                     | WorkflowCommand::RecordUpdateResult { .. }
                     | WorkflowCommand::UpsertSearchAttributes { .. }
+                    | WorkflowCommand::SetCurrentDetails { .. }
                     | WorkflowCommand::SpawnDetachedChildWorkflow { .. }
             )
         })
@@ -695,7 +709,7 @@ fn extract_single_command<T>(
     commands: &[WorkflowCommand],
     extractor: impl Fn(&WorkflowCommand) -> Option<T>,
 ) -> Option<T> {
-    // RecordUpdateResult, RecordMarker, UpsertSearchAttributes, and
+    // RecordUpdateResult, RecordMarker, UpsertSearchAttributes, SetCurrentDetails, and
     // SpawnDetachedChildWorkflow are bookkeeping / fire-and-forget commands
     // that have already been (or are about to be) processed; they do not count
     // toward the suspension-type determination.
@@ -706,6 +720,7 @@ fn extract_single_command<T>(
                 | WorkflowCommand::RecordSideEffect { .. }
                 | WorkflowCommand::RecordUpdateResult { .. }
                 | WorkflowCommand::UpsertSearchAttributes { .. }
+                | WorkflowCommand::SetCurrentDetails { .. }
                 | WorkflowCommand::SpawnDetachedChildWorkflow { .. }
         )
     });
@@ -732,6 +747,7 @@ fn extract_all_scheduled_activities(
             | WorkflowCommand::RecordSideEffect { .. }
             | WorkflowCommand::RecordUpdateResult { .. }
             | WorkflowCommand::UpsertSearchAttributes { .. }
+            | WorkflowCommand::SetCurrentDetails { .. }
             | WorkflowCommand::SpawnDetachedChildWorkflow { .. } => {}
             WorkflowCommand::ScheduleActivity {
                 activity_id,
@@ -822,6 +838,7 @@ fn extract_started_timer_for_suspension(
                 | WorkflowCommand::RecordSideEffect { .. }
                 | WorkflowCommand::RecordUpdateResult { .. }
                 | WorkflowCommand::UpsertSearchAttributes { .. }
+                | WorkflowCommand::SetCurrentDetails { .. }
                 | WorkflowCommand::SpawnDetachedChildWorkflow { .. }
         )
     });
@@ -845,6 +862,7 @@ fn extract_all_started_child_workflows(
                     | WorkflowCommand::RecordSideEffect { .. }
                     | WorkflowCommand::RecordUpdateResult { .. }
                     | WorkflowCommand::UpsertSearchAttributes { .. }
+                    | WorkflowCommand::SetCurrentDetails { .. }
                     | WorkflowCommand::SpawnDetachedChildWorkflow { .. }
             )
         })
@@ -1141,7 +1159,8 @@ fn split_mixed_signal_batch(
                 }));
             }
             WorkflowCommand::RecordUpdateResult { .. }
-            | WorkflowCommand::UpsertSearchAttributes { .. } => {}
+            | WorkflowCommand::UpsertSearchAttributes { .. }
+            | WorkflowCommand::SetCurrentDetails { .. } => {}
             other => remaining.push(other),
         }
     }
@@ -2143,6 +2162,32 @@ async fn persist_search_attrs_from_commands(
     };
 
     store::update_search_attrs(conn, exec_id, &merged).await
+}
+
+/// Persist the last `SetCurrentDetails` command to the execution row (issue #473).
+///
+/// Scans `commands` for [`WorkflowCommand::SetCurrentDetails`] variants and
+/// writes the **last** value (last-write-wins) to
+/// `harvest_workflow_executions.current_details` in a single `UPDATE`.
+/// Does nothing when no `SetCurrentDetails` command is present.
+async fn persist_current_details_from_commands(
+    conn: &mut AsyncPgConnection,
+    exec_id: ExecutionId,
+    commands: &[WorkflowCommand],
+) -> HarvestResult<()> {
+    // Last-write-wins: take the last SetCurrentDetails value in the command list.
+    let last = commands.iter().rev().find_map(|cmd| {
+        if let WorkflowCommand::SetCurrentDetails { value } = cmd {
+            Some(value.as_str())
+        } else {
+            None
+        }
+    });
+
+    if let Some(details) = last {
+        store::update_current_details(conn, exec_id, details).await?;
+    }
+    Ok(())
 }
 
 async fn persist_signal_wait_park(
@@ -4045,6 +4090,19 @@ async fn handle_suspended_workflow(
         .await;
     }
 
+    // Persist the last current_details breadcrumb from this execution cycle (issue #473).
+    if let Err(e) =
+        persist_current_details_from_commands(conn, context.persistence.exec_id, commands).await
+    {
+        return fail_execution_on_error(
+            conn,
+            context.persistence.task,
+            context.persistence.worker_id,
+            Err(e),
+        )
+        .await;
+    }
+
     let sticky = context.persistence.sticky_hint();
     let detached_spawns = DetachedSpawnPersistence {
         registry,
@@ -4696,6 +4754,7 @@ async fn persist_terminal_outcome_commands(
     persist_update_result_commands(conn, persistence.exec_id, pending_cmds, &mut next_event_id)
         .await?;
     persist_search_attrs_from_commands(conn, persistence.exec_id, pending_cmds).await?;
+    persist_current_details_from_commands(conn, persistence.exec_id, pending_cmds).await?;
 
     let pre_terminal = pre_suspension_events_from_commands(pending_cmds);
     if !pre_terminal.is_empty() {
@@ -5156,6 +5215,7 @@ async fn process_workflow_task(
                     .map_or(registry.max_workflow_input_bytes, |per| {
                         per.max(registry.max_workflow_input_bytes)
                     }),
+                registry.max_current_details_bytes,
             )
             .await;
 
@@ -5169,6 +5229,8 @@ async fn process_workflow_task(
                 // activity so that attributes are visible even if the worker
                 // crashes during inline execution.
                 persist_search_attrs_from_commands(conn, prepared.exec_id, &commands).await?;
+                // Persist the current_details breadcrumb before inline execution (issue #473).
+                persist_current_details_from_commands(conn, prepared.exec_id, &commands).await?;
                 // Sync in-memory snapshot so a subsequent continue_as_new in the
                 // same task copies the patched attrs to the successor row.
                 prepared.execution.search_attrs = apply_search_attrs_patch_in_memory(
@@ -5327,6 +5389,7 @@ async fn process_workflow_task(
                                 | WorkflowCommand::RecordSideEffect { .. }
                                 | WorkflowCommand::RecordUpdateResult { .. }
                                 | WorkflowCommand::UpsertSearchAttributes { .. }
+                                | WorkflowCommand::SetCurrentDetails { .. }
                         )
                     }) =>
             {
@@ -5349,6 +5412,11 @@ async fn process_workflow_task(
                 }
                 if let Err(e) =
                     persist_search_attrs_from_commands(conn, prepared.exec_id, &commands).await
+                {
+                    return fail_execution_on_error(conn, task, worker_id, Err::<(), _>(e)).await;
+                }
+                if let Err(e) =
+                    persist_current_details_from_commands(conn, prepared.exec_id, &commands).await
                 {
                     return fail_execution_on_error(conn, task, worker_id, Err::<(), _>(e)).await;
                 }
@@ -5475,6 +5543,11 @@ async fn process_workflow_task(
                 }
                 if let Err(e) =
                     persist_search_attrs_from_commands(conn, prepared.exec_id, &commands).await
+                {
+                    return fail_execution_on_error(conn, task, worker_id, Err::<(), _>(e)).await;
+                }
+                if let Err(e) =
+                    persist_current_details_from_commands(conn, prepared.exec_id, &commands).await
                 {
                     return fail_execution_on_error(conn, task, worker_id, Err::<(), _>(e)).await;
                 }

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -788,6 +788,7 @@ fn extract_all_activity_waits(commands: &[WorkflowCommand]) -> Option<Vec<Activi
             | WorkflowCommand::RecordSideEffect { .. }
             | WorkflowCommand::RecordUpdateResult { .. }
             | WorkflowCommand::UpsertSearchAttributes { .. }
+            | WorkflowCommand::SetCurrentDetails { .. }
             | WorkflowCommand::SpawnDetachedChildWorkflow { .. } => {}
             WorkflowCommand::WaitForActivity { activity_id, .. } => activity_ids.push(*activity_id),
             _ => return None,

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -418,6 +418,7 @@ impl std::fmt::Debug for HandlerRegistry {
             .field("max_workflow_input_bytes", &self.max_workflow_input_bytes)
             .field("max_activity_result_bytes", &self.max_activity_result_bytes)
             .field("max_signal_payload_bytes", &self.max_signal_payload_bytes)
+            .field("max_current_details_bytes", &self.max_current_details_bytes)
             .field("circuit_breakers", &self.circuit_breakers)
             .finish()
     }

--- a/autumn-harvest/tests/audit_tests.rs
+++ b/autumn-harvest/tests/audit_tests.rs
@@ -79,7 +79,9 @@ const INIT_SQL: &str = concat!(
     include_str!("../migrations/20260607000000_harvest_worker_capability_labels/up.sql"),
     include_str!("../migrations/20260607000001_harvest_task_required_capabilities/up.sql"),
     "\n",
-    include_str!("../migrations/20260607000002_harvest_workflow_pause/up.sql")
+    include_str!("../migrations/20260607000002_harvest_workflow_pause/up.sql"),
+    "\n",
+    include_str!("../migrations/20260609000001_harvest_workflow_current_details/up.sql")
 );
 
 async fn make_conn() -> (

--- a/autumn-harvest/tests/build_routing_tests.rs
+++ b/autumn-harvest/tests/build_routing_tests.rs
@@ -316,8 +316,8 @@ mod db_tests {
         include_str!("../migrations/20260607000001_harvest_task_required_capabilities/up.sql"),
         "\n",
         include_str!("../migrations/20260607000002_harvest_workflow_pause/up.sql"),
-    "\n",
-    include_str!("../migrations/20260609000001_harvest_workflow_current_details/up.sql")
+        "\n",
+        include_str!("../migrations/20260609000001_harvest_workflow_current_details/up.sql")
     );
 
     async fn setup() -> (AsyncPgConnection, ContainerAsync<Postgres>) {

--- a/autumn-harvest/tests/build_routing_tests.rs
+++ b/autumn-harvest/tests/build_routing_tests.rs
@@ -315,7 +315,9 @@ mod db_tests {
         include_str!("../migrations/20260607000000_harvest_worker_capability_labels/up.sql"),
         include_str!("../migrations/20260607000001_harvest_task_required_capabilities/up.sql"),
         "\n",
-        include_str!("../migrations/20260607000002_harvest_workflow_pause/up.sql")
+        include_str!("../migrations/20260607000002_harvest_workflow_pause/up.sql"),
+    "\n",
+    include_str!("../migrations/20260609000001_harvest_workflow_current_details/up.sql")
     );
 
     async fn setup() -> (AsyncPgConnection, ContainerAsync<Postgres>) {

--- a/autumn-harvest/tests/cache_delta_load_tests.rs
+++ b/autumn-harvest/tests/cache_delta_load_tests.rs
@@ -90,7 +90,9 @@ const INIT_SQL: &str = concat!(
     include_str!("../migrations/20260607000000_harvest_worker_capability_labels/up.sql"),
     include_str!("../migrations/20260607000001_harvest_task_required_capabilities/up.sql"),
     "\n",
-    include_str!("../migrations/20260607000002_harvest_workflow_pause/up.sql")
+    include_str!("../migrations/20260607000002_harvest_workflow_pause/up.sql"),
+    "\n",
+    include_str!("../migrations/20260609000001_harvest_workflow_current_details/up.sql")
 );
 
 async fn setup_test_db() -> (AsyncPgConnection, ContainerAsync<Postgres>) {

--- a/autumn-harvest/tests/cancellation_tests.rs
+++ b/autumn-harvest/tests/cancellation_tests.rs
@@ -73,7 +73,9 @@ const INIT_SQL: &str = concat!(
     include_str!("../migrations/20260607000000_harvest_worker_capability_labels/up.sql"),
     include_str!("../migrations/20260607000001_harvest_task_required_capabilities/up.sql"),
     "\n",
-    include_str!("../migrations/20260607000002_harvest_workflow_pause/up.sql")
+    include_str!("../migrations/20260607000002_harvest_workflow_pause/up.sql"),
+    "\n",
+    include_str!("../migrations/20260609000001_harvest_workflow_current_details/up.sql")
 );
 
 async fn setup_test_db() -> (AsyncPgConnection, ContainerAsync<Postgres>) {

--- a/autumn-harvest/tests/child_policy_tests.rs
+++ b/autumn-harvest/tests/child_policy_tests.rs
@@ -82,7 +82,9 @@ const INIT_SQL: &str = concat!(
     include_str!("../migrations/20260607000000_harvest_worker_capability_labels/up.sql"),
     include_str!("../migrations/20260607000001_harvest_task_required_capabilities/up.sql"),
     "\n",
-    include_str!("../migrations/20260607000002_harvest_workflow_pause/up.sql")
+    include_str!("../migrations/20260607000002_harvest_workflow_pause/up.sql"),
+    "\n",
+    include_str!("../migrations/20260609000001_harvest_workflow_current_details/up.sql")
 );
 
 async fn setup_test_db_url() -> (String, ContainerAsync<Postgres>) {

--- a/autumn-harvest/tests/cross_workflow_signal_tests.rs
+++ b/autumn-harvest/tests/cross_workflow_signal_tests.rs
@@ -84,7 +84,9 @@ const INIT_SQL: &str = concat!(
     include_str!("../migrations/20260607000000_harvest_worker_capability_labels/up.sql"),
     include_str!("../migrations/20260607000001_harvest_task_required_capabilities/up.sql"),
     "\n",
-    include_str!("../migrations/20260607000002_harvest_workflow_pause/up.sql")
+    include_str!("../migrations/20260607000002_harvest_workflow_pause/up.sql"),
+    "\n",
+    include_str!("../migrations/20260609000001_harvest_workflow_current_details/up.sql")
 );
 
 async fn setup_test_database_url() -> (String, ContainerAsync<Postgres>) {

--- a/autumn-harvest/tests/delayed_start_tests.rs
+++ b/autumn-harvest/tests/delayed_start_tests.rs
@@ -67,7 +67,9 @@ const INIT_SQL: &str = concat!(
     include_str!("../migrations/20260607000000_harvest_worker_capability_labels/up.sql"),
     include_str!("../migrations/20260607000001_harvest_task_required_capabilities/up.sql"),
     "\n",
-    include_str!("../migrations/20260607000002_harvest_workflow_pause/up.sql")
+    include_str!("../migrations/20260607000002_harvest_workflow_pause/up.sql"),
+    "\n",
+    include_str!("../migrations/20260609000001_harvest_workflow_current_details/up.sql")
 );
 
 async fn setup_test_db() -> (AsyncPgConnection, ContainerAsync<Postgres>) {

--- a/autumn-harvest/tests/integration_e2e.rs
+++ b/autumn-harvest/tests/integration_e2e.rs
@@ -170,6 +170,7 @@ const LEGACY_INIT_SQL: &str = concat!(
     "ALTER TABLE harvest_workflow_executions ADD COLUMN IF NOT EXISTS paused_at TIMESTAMPTZ NULL;\n",
     "ALTER TABLE harvest_workflow_executions ADD COLUMN IF NOT EXISTS pause_reason TEXT NULL;\n",
     "ALTER TABLE harvest_workflow_executions ADD COLUMN IF NOT EXISTS pause_actor TEXT NULL;\n",
+    "ALTER TABLE harvest_workflow_executions ADD COLUMN IF NOT EXISTS current_details TEXT NULL;\n",
 );
 
 /// Start a Postgres container with the harvest schema applied and return

--- a/autumn-harvest/tests/integration_e2e.rs
+++ b/autumn-harvest/tests/integration_e2e.rs
@@ -115,7 +115,9 @@ const INIT_SQL: &str = concat!(
     include_str!("../migrations/20260607000000_harvest_worker_capability_labels/up.sql"),
     include_str!("../migrations/20260607000001_harvest_task_required_capabilities/up.sql"),
     "\n",
-    include_str!("../migrations/20260607000002_harvest_workflow_pause/up.sql")
+    include_str!("../migrations/20260607000002_harvest_workflow_pause/up.sql"),
+    "\n",
+    include_str!("../migrations/20260609000001_harvest_workflow_current_details/up.sql")
 );
 
 /// The minimal "legacy" migration set used by the upgrade-path regression

--- a/autumn-harvest/tests/metrics_integration.rs
+++ b/autumn-harvest/tests/metrics_integration.rs
@@ -97,7 +97,9 @@ const INIT_SQL: &str = concat!(
     include_str!("../migrations/20260607000000_harvest_worker_capability_labels/up.sql"),
     include_str!("../migrations/20260607000001_harvest_task_required_capabilities/up.sql"),
     "\n",
-    include_str!("../migrations/20260607000002_harvest_workflow_pause/up.sql")
+    include_str!("../migrations/20260607000002_harvest_workflow_pause/up.sql"),
+    "\n",
+    include_str!("../migrations/20260609000001_harvest_workflow_current_details/up.sql")
 );
 
 // ---------------------------------------------------------------------------

--- a/autumn-harvest/tests/pause_tests.rs
+++ b/autumn-harvest/tests/pause_tests.rs
@@ -75,6 +75,8 @@ const INIT_SQL: &str = concat!(
     include_str!("../migrations/20260606000001_harvest_activity_schedule_to_close/up.sql"),
     "\n",
     include_str!("../migrations/20260607000002_harvest_workflow_pause/up.sql"),
+    "\n",
+    include_str!("../migrations/20260609000001_harvest_workflow_current_details/up.sql")
 );
 
 async fn setup() -> (String, ContainerAsync<Postgres>) {

--- a/autumn-harvest/tests/poison_pill_tests.rs
+++ b/autumn-harvest/tests/poison_pill_tests.rs
@@ -88,7 +88,9 @@ const INIT_SQL: &str = concat!(
     include_str!("../migrations/20260607000000_harvest_worker_capability_labels/up.sql"),
     include_str!("../migrations/20260607000001_harvest_task_required_capabilities/up.sql"),
     "\n",
-    include_str!("../migrations/20260607000002_harvest_workflow_pause/up.sql")
+    include_str!("../migrations/20260607000002_harvest_workflow_pause/up.sql"),
+    "\n",
+    include_str!("../migrations/20260609000001_harvest_workflow_current_details/up.sql")
 );
 
 #[derive(Debug, Default)]

--- a/autumn-harvest/tests/replayer_integration_tests.rs
+++ b/autumn-harvest/tests/replayer_integration_tests.rs
@@ -82,7 +82,9 @@ const INIT_SQL: &str = concat!(
     include_str!("../migrations/20260607000000_harvest_worker_capability_labels/up.sql"),
     include_str!("../migrations/20260607000001_harvest_task_required_capabilities/up.sql"),
     "\n",
-    include_str!("../migrations/20260607000002_harvest_workflow_pause/up.sql")
+    include_str!("../migrations/20260607000002_harvest_workflow_pause/up.sql"),
+    "\n",
+    include_str!("../migrations/20260609000001_harvest_workflow_current_details/up.sql")
 );
 
 // ---------------------------------------------------------------------------

--- a/autumn-harvest/tests/schedule_decisions.rs
+++ b/autumn-harvest/tests/schedule_decisions.rs
@@ -49,7 +49,9 @@ const INIT_SQL: &str = concat!(
     include_str!("../migrations/20260607000000_harvest_worker_capability_labels/up.sql"),
     include_str!("../migrations/20260607000001_harvest_task_required_capabilities/up.sql"),
     "\n",
-    include_str!("../migrations/20260607000002_harvest_workflow_pause/up.sql")
+    include_str!("../migrations/20260607000002_harvest_workflow_pause/up.sql"),
+    "\n",
+    include_str!("../migrations/20260609000001_harvest_workflow_current_details/up.sql")
 );
 
 #[derive(Debug, Default, Clone)]

--- a/autumn-harvest/tests/schedule_to_close_tests.rs
+++ b/autumn-harvest/tests/schedule_to_close_tests.rs
@@ -90,7 +90,9 @@ const INIT_SQL: &str = concat!(
     include_str!("../migrations/20260607000000_harvest_worker_capability_labels/up.sql"),
     include_str!("../migrations/20260607000001_harvest_task_required_capabilities/up.sql"),
     "\n",
-    include_str!("../migrations/20260607000002_harvest_workflow_pause/up.sql")
+    include_str!("../migrations/20260607000002_harvest_workflow_pause/up.sql"),
+    "\n",
+    include_str!("../migrations/20260609000001_harvest_workflow_current_details/up.sql")
 );
 
 async fn setup_db() -> (AsyncPgConnection, ContainerAsync<Postgres>) {

--- a/autumn-harvest/tests/scheduler_auto_pause_tests.rs
+++ b/autumn-harvest/tests/scheduler_auto_pause_tests.rs
@@ -88,7 +88,9 @@ const INIT_SQL: &str = concat!(
     include_str!("../migrations/20260607000000_harvest_worker_capability_labels/up.sql"),
     include_str!("../migrations/20260607000001_harvest_task_required_capabilities/up.sql"),
     "\n",
-    include_str!("../migrations/20260607000002_harvest_workflow_pause/up.sql")
+    include_str!("../migrations/20260607000002_harvest_workflow_pause/up.sql"),
+    "\n",
+    include_str!("../migrations/20260609000001_harvest_workflow_current_details/up.sql")
 );
 
 // ── Recording metrics ──────────────────────────────────────────────────────

--- a/autumn-harvest/tests/scheduler_ha_tests.rs
+++ b/autumn-harvest/tests/scheduler_ha_tests.rs
@@ -90,7 +90,9 @@ const INIT_SQL: &str = concat!(
     include_str!("../migrations/20260607000000_harvest_worker_capability_labels/up.sql"),
     include_str!("../migrations/20260607000001_harvest_task_required_capabilities/up.sql"),
     "\n",
-    include_str!("../migrations/20260607000002_harvest_workflow_pause/up.sql")
+    include_str!("../migrations/20260607000002_harvest_workflow_pause/up.sql"),
+    "\n",
+    include_str!("../migrations/20260609000001_harvest_workflow_current_details/up.sql")
 );
 
 // ── Recording metrics ──────────────────────────────────────────────────────

--- a/autumn-harvest/tests/signal_tests.rs
+++ b/autumn-harvest/tests/signal_tests.rs
@@ -49,7 +49,9 @@ const INIT_SQL: &str = concat!(
     include_str!("../migrations/20260607000000_harvest_worker_capability_labels/up.sql"),
     include_str!("../migrations/20260607000001_harvest_task_required_capabilities/up.sql"),
     "\n",
-    include_str!("../migrations/20260607000002_harvest_workflow_pause/up.sql")
+    include_str!("../migrations/20260607000002_harvest_workflow_pause/up.sql"),
+    "\n",
+    include_str!("../migrations/20260609000001_harvest_workflow_current_details/up.sql")
 );
 
 async fn setup_test_db() -> (

--- a/autumn-harvest/tests/signal_with_start_tests.rs
+++ b/autumn-harvest/tests/signal_with_start_tests.rs
@@ -64,7 +64,9 @@ const INIT_SQL: &str = concat!(
     include_str!("../migrations/20260607000000_harvest_worker_capability_labels/up.sql"),
     include_str!("../migrations/20260607000001_harvest_task_required_capabilities/up.sql"),
     "\n",
-    include_str!("../migrations/20260607000002_harvest_workflow_pause/up.sql")
+    include_str!("../migrations/20260607000002_harvest_workflow_pause/up.sql"),
+    "\n",
+    include_str!("../migrations/20260609000001_harvest_workflow_current_details/up.sql")
 );
 
 async fn setup_test_db() -> (

--- a/autumn-harvest/tests/sticky_routing_tests.rs
+++ b/autumn-harvest/tests/sticky_routing_tests.rs
@@ -423,8 +423,8 @@ mod db_tests {
         include_str!("../migrations/20260607000001_harvest_task_required_capabilities/up.sql"),
         "\n",
         include_str!("../migrations/20260607000002_harvest_workflow_pause/up.sql"),
-    "\n",
-    include_str!("../migrations/20260609000001_harvest_workflow_current_details/up.sql")
+        "\n",
+        include_str!("../migrations/20260609000001_harvest_workflow_current_details/up.sql")
     );
 
     async fn setup() -> (AsyncPgConnection, ContainerAsync<Postgres>) {

--- a/autumn-harvest/tests/sticky_routing_tests.rs
+++ b/autumn-harvest/tests/sticky_routing_tests.rs
@@ -422,7 +422,9 @@ mod db_tests {
         include_str!("../migrations/20260607000000_harvest_worker_capability_labels/up.sql"),
         include_str!("../migrations/20260607000001_harvest_task_required_capabilities/up.sql"),
         "\n",
-        include_str!("../migrations/20260607000002_harvest_workflow_pause/up.sql")
+        include_str!("../migrations/20260607000002_harvest_workflow_pause/up.sql"),
+    "\n",
+    include_str!("../migrations/20260609000001_harvest_workflow_current_details/up.sql")
     );
 
     async fn setup() -> (AsyncPgConnection, ContainerAsync<Postgres>) {

--- a/autumn-harvest/tests/telemetry_span_tests.rs
+++ b/autumn-harvest/tests/telemetry_span_tests.rs
@@ -98,7 +98,9 @@ const INIT_SQL: &str = concat!(
     include_str!("../migrations/20260607000000_harvest_worker_capability_labels/up.sql"),
     include_str!("../migrations/20260607000001_harvest_task_required_capabilities/up.sql"),
     "\n",
-    include_str!("../migrations/20260607000002_harvest_workflow_pause/up.sql")
+    include_str!("../migrations/20260607000002_harvest_workflow_pause/up.sql"),
+    "\n",
+    include_str!("../migrations/20260609000001_harvest_workflow_current_details/up.sql")
 );
 
 // -------------------------------------------------------------------------

--- a/autumn-harvest/tests/transactional_activity_tests.rs
+++ b/autumn-harvest/tests/transactional_activity_tests.rs
@@ -99,7 +99,9 @@ const INIT_SQL: &str = concat!(
     include_str!("../migrations/20260607000000_harvest_worker_capability_labels/up.sql"),
     include_str!("../migrations/20260607000001_harvest_task_required_capabilities/up.sql"),
     "\n",
-    include_str!("../migrations/20260607000002_harvest_workflow_pause/up.sql")
+    include_str!("../migrations/20260607000002_harvest_workflow_pause/up.sql"),
+    "\n",
+    include_str!("../migrations/20260609000001_harvest_workflow_current_details/up.sql")
 );
 
 const CREATE_USER_RECORDS: &str = "

--- a/autumn-harvest/tests/typed_stubs_tests.rs
+++ b/autumn-harvest/tests/typed_stubs_tests.rs
@@ -87,7 +87,9 @@ const INIT_SQL: &str = concat!(
     include_str!("../migrations/20260607000000_harvest_worker_capability_labels/up.sql"),
     include_str!("../migrations/20260607000001_harvest_task_required_capabilities/up.sql"),
     "\n",
-    include_str!("../migrations/20260607000002_harvest_workflow_pause/up.sql")
+    include_str!("../migrations/20260607000002_harvest_workflow_pause/up.sql"),
+    "\n",
+    include_str!("../migrations/20260609000001_harvest_workflow_current_details/up.sql")
 );
 
 async fn setup_database_url() -> (String, ContainerAsync<Postgres>) {

--- a/autumn-harvest/tests/workflow_handle_tests.rs
+++ b/autumn-harvest/tests/workflow_handle_tests.rs
@@ -87,7 +87,9 @@ const INIT_SQL: &str = concat!(
     include_str!("../migrations/20260607000000_harvest_worker_capability_labels/up.sql"),
     include_str!("../migrations/20260607000001_harvest_task_required_capabilities/up.sql"),
     "\n",
-    include_str!("../migrations/20260607000002_harvest_workflow_pause/up.sql")
+    include_str!("../migrations/20260607000002_harvest_workflow_pause/up.sql"),
+    "\n",
+    include_str!("../migrations/20260609000001_harvest_workflow_current_details/up.sql")
 );
 
 async fn setup_database_url() -> (String, ContainerAsync<Postgres>) {


### PR DESCRIPTION
## Summary

Implements issue #473: a new `set_current_details()` API that allows workflow authors to set a durable, human-readable status breadcrumb on the execution row. This enables operators to read the latest workflow progress directly from `GET /workflows` and `GET /workflows/{id}` without a live worker or per-row Query fan-out.

## Key Changes

- **New `WorkflowCommand::SetCurrentDetails`**: Fire-and-forget command that overwrites `harvest_workflow_executions.current_details` with last-write-wins semantics. Suppressed during replay (zero footprint in `harvest_events`).

- **`WorkflowContext::set_current_details(details: impl Into<String>)`**: Public API for workflow authors. Automatically caps values at 1 KiB (configurable) with UTF-8 boundary-aware truncation. No-op during replay.

- **Database schema**: New nullable `TEXT` column `current_details` on `harvest_workflow_executions` table via migration `20260609000001_harvest_workflow_current_details`.

- **Builder configuration**: `HarvestBuilder::with_current_details_cap(cap_bytes: usize)` and `HandlerRegistry::with_current_details_cap()` allow operators to override the 1 KiB default. Value flows through to `WorkflowContext` initialization.

- **Persistence layer**: New `store::update_current_details()` function and `persist_current_details_from_commands()` worker helper that extracts the last `SetCurrentDetails` command and persists it to the database. Called after each execution cycle (suspended, inline, terminal).

- **Worker integration**: `SetCurrentDetails` treated as a bookkeeping command (like `UpsertSearchAttributes`) in all command filtering/extraction logic (`should_requeue_signal_wait`, `only_bookkeeping_commands`, `extract_single_command`, etc.).

- **Comprehensive tests**: Six new test cases covering command emission, last-write-wins behavior, replay suppression, cap enforcement, and UTF-8 boundary handling.

## Implementation Details

- **Replay safety**: `set_current_details()` checks `is_replaying()` and returns early, ensuring zero new events and determinism parity with live execution.

- **UTF-8 truncation**: When a value exceeds the cap, the context walks backward from the cap boundary to find the nearest valid UTF-8 character boundary, preventing mid-character truncation.

- **Last-write-wins**: The worker scans the command list in reverse to find the final `SetCurrentDetails` value, ensuring only the most recent status is persisted even if the workflow calls the API multiple times in one cycle.

- **Zero event footprint**: Unlike side effects or markers, `SetCurrentDetails` does not append a `WorkflowEvent`, keeping the history clean and avoiding replay determinism issues.

- **Frozen at terminal state**: Once a workflow completes/fails/times out, the `current_details` value is retained for post-mortem inspection.

https://claude.ai/code/session_01E6zRL3j7WArpTsCSJgvAiD