### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -1139,8 +1139,10 @@ fn extract_signal_external_workflow(commands: Vec<WorkflowCommand>) -> Vec<Signa
 fn split_mixed_signal_batch(
     commands: Vec<WorkflowCommand>,
 ) -> (Vec<SignalBatchItem>, Vec<WorkflowCommand>) {
-    let mut signal_items = Vec::new();
-    let mut remaining = Vec::new();
+    // ⚡ Bolt: Pre-allocate vectors using the maximum possible capacity to avoid intermediate heap reallocations.
+    let capacity = commands.len();
+    let mut signal_items = Vec::with_capacity(capacity);
+    let mut remaining = Vec::with_capacity(capacity);
     for cmd in commands {
         match cmd {
             WorkflowCommand::SignalExternalWorkflow {


### PR DESCRIPTION
⚡ Bolt: [performance improvement]

💡 What: Pre-allocate vectors in `split_mixed_signal_batch` using `Vec::with_capacity(commands.len())`.
🎯 Why: Avoids multiple heap reallocations when processing large batches of commands.
📊 Impact: Removes up to O(log n) heap allocations per batch processing. Minor memory over-allocation tradeoff (2*N) since both destinations use the total input length, which is acceptable for small batch performance.
🔭 Measurement: Run existing worker test suite to verify no regressions.

---
*PR created automatically by Jules for task [15514039451687956700](https://jules.google.com/task/15514039451687956700) started by @madmax983*