### PR TITLE
🌟 Nova: [Gantt DAG Exporter]

### DIFF
--- a/autumn-harvest/src/dag_export.rs
+++ b/autumn-harvest/src/dag_export.rs
@@ -4,7 +4,87 @@
 //! and tool-compatible diagram formats such as Mermaid.js and Graphviz DOT.
 //! This is useful for debugging, documentation, and visualizing dependencies.
 use crate::dag::DagDefinition;
+#[cfg(feature = "testing")]
+use crate::dag_profiler::{DagProfile, ProfilerEventKind};
 use std::fmt::Write;
+
+/// Exports the DAG execution profile to a Mermaid.js Gantt chart.
+///
+/// # Examples
+///
+/// ```rust
+/// use autumn_harvest::dag::DagBuilder;
+/// use autumn_harvest::dag_profiler::DagProfiler;
+/// use autumn_harvest::dag_export::export_mermaid_gantt;
+/// use std::time::Duration;
+///
+/// fn my_activity() {}
+/// fn my_other_activity() {}
+///
+/// let mut builder = DagBuilder::new();
+/// let a = builder.activity(my_activity);
+/// let b = builder.activity(my_other_activity).upstream(&a);
+/// let dag = builder.build().unwrap();
+///
+/// let profiler = DagProfiler::new(dag.clone())
+///     .mock_duration("my_activity", Duration::from_secs(2))
+///     .mock_duration("my_other_activity", Duration::from_secs(3));
+/// let profile = profiler.profile();
+///
+/// let gantt = export_mermaid_gantt(&dag, &profile).unwrap();
+/// assert!(gantt.contains("gantt"));
+/// assert!(gantt.contains("my_activity"));
+/// assert!(gantt.contains("my_other_activity"));
+/// ```
+///
+/// # Errors
+/// Returns `std::fmt::Error` if string formatting fails.
+#[cfg(feature = "testing")]
+pub fn export_mermaid_gantt(
+    dag: &DagDefinition,
+    profile: &DagProfile,
+) -> Result<String, std::fmt::Error> {
+    use std::time::Duration;
+
+    let mut out = String::new();
+    writeln!(out, "gantt")?;
+    writeln!(out, "    title DAG Execution Profile")?;
+    writeln!(out, "    dateFormat x")?; // x represents Unix epoch time (or milliseconds from start)
+    writeln!(out, "    axisFormat %S.%L")?; // seconds.milliseconds
+
+    writeln!(out, "    section Tasks")?;
+
+    let tasks = dag.tasks();
+    let mut task_starts: Vec<Option<Duration>> = vec![None; tasks.len()];
+    let mut task_ends: Vec<Option<Duration>> = vec![None; tasks.len()];
+
+    for event in &profile.timeline {
+        match &event.kind {
+            ProfilerEventKind::TaskStarted(idx, _) => task_starts[*idx] = Some(event.time),
+            ProfilerEventKind::TaskCompleted(idx, _) => task_ends[*idx] = Some(event.time),
+        }
+    }
+
+    for (i, task) in tasks.iter().enumerate() {
+        if let (Some(start), Some(end)) = (task_starts[i], task_ends[i]) {
+            let start_ms = start.as_millis();
+            let end_ms = end.as_millis();
+            // Mermaid requires duration or end time. For 0-duration tasks, we'll give them 1ms to render something.
+            let render_end_ms = if start_ms == end_ms {
+                start_ms + 1
+            } else {
+                end_ms
+            };
+            writeln!(
+                out,
+                "    {} : t{}, {}, {}",
+                task.activity_name, i, start_ms, render_end_ms
+            )?;
+        }
+    }
+
+    Ok(out)
+}
 
 /// Exports the DAG definition to a Mermaid.js flowchart.
 ///
@@ -100,6 +180,11 @@ mod tests {
     fn dummy_activity2() {}
     fn dummy_activity3() {}
 
+    #[cfg(feature = "testing")]
+    use crate::dag_profiler::DagProfiler;
+    #[cfg(feature = "testing")]
+    use std::time::Duration;
+
     #[test]
     fn test_export_empty_dag() {
         let builder = DagBuilder::new();
@@ -110,6 +195,36 @@ mod tests {
 
         let dot = export_dot(&dag).unwrap();
         assert_eq!(dot, "digraph DAG {\n}\n");
+    }
+
+    #[test]
+    #[cfg(feature = "testing")]
+    fn test_export_gantt() {
+        let mut builder = DagBuilder::new();
+        let a = builder.activity(dummy_activity);
+        let b = builder.activity(dummy_activity2).upstream(&a);
+        let _c = builder.activity(dummy_activity3).upstream(&b);
+        let dag = builder.build().unwrap();
+
+        let profiler = DagProfiler::new(dag.clone())
+            .mock_duration("dummy_activity", Duration::from_millis(100))
+            .mock_duration("dummy_activity2", Duration::from_millis(150))
+            .mock_duration("dummy_activity3", Duration::from_millis(50));
+
+        let profile = profiler.profile();
+        let gantt = export_mermaid_gantt(&dag, &profile).unwrap();
+
+        let expected_gantt = "\
+gantt
+    title DAG Execution Profile
+    dateFormat x
+    axisFormat %S.%L
+    section Tasks
+    dummy_activity : t0, 0, 100
+    dummy_activity2 : t1, 100, 250
+    dummy_activity3 : t2, 250, 300
+";
+        assert_eq!(gantt, expected_gantt);
     }
 
     #[test]

--- a/autumn-harvest/src/lib.rs
+++ b/autumn-harvest/src/lib.rs
@@ -194,6 +194,8 @@ pub use context::{
 };
 pub use critical_path::{CriticalPathAnalyzer, CriticalPathResult};
 pub use dag::{DagBuildError, DagBuilder, DagDefinition, DagMapTaskRef, DagTask, DagTaskRef};
+#[cfg(feature = "testing")]
+pub use dag_export::export_mermaid_gantt;
 pub use dag_export::{export_dot, export_mermaid};
 pub use dag_linter::{
     DagLinter, DagRule, DagWarning, ExcessiveParallelismRule, MissingRetryPolicyRule,


### PR DESCRIPTION
🌟 Nova: [Gantt DAG Exporter]

💡 The Spark: I notice we can simulate DAGs and profile them to determine peak concurrency and total duration. What if we could visualize that execution timeline directly? A Mermaid Gantt chart is perfect for displaying tasks, their durations, and dependencies over a timeline.
🚀 The Feature: Created a new export function `export_mermaid_gantt` in `dag_export.rs` that accepts a `DagProfile` and a `DagDefinition`. It will format a valid Mermaid Gantt chart visualizing when each activity runs.
🔭 The Potential: Allows users and UI tools to natively render Gantt timelines of DAG simulations.
⚠️ Risk: Low, additive only, contained within `dag_export.rs`.

---
*PR created automatically by Jules for task [7882882906124134429](https://jules.google.com/task/7882882906124134429) started by @madmax983*