### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/autumn-harvest/src/build_routing.rs
+++ b/autumn-harvest/src/build_routing.rs
@@ -653,9 +653,9 @@ pub fn merge_reachability(per_shard: Vec<Vec<BuildReachability>>) -> Vec<BuildRe
     for shard_results in per_shard {
         for r in shard_results {
             let entry = merged
-                .entry(r.build_id.clone())
-                .or_insert_with(|| BuildReachability {
-                    build_id: r.build_id.clone(),
+                .entry(r.build_id)
+                .or_insert_with_key(|k| BuildReachability {
+                    build_id: k.clone(),
                     open_executions: 0,
                     pending_tasks: 0,
                     active_workers: 0,

--- a/autumn-harvest/src/dlq.rs
+++ b/autumn-harvest/src/dlq.rs
@@ -1079,15 +1079,13 @@ pub fn merge_dlq_aggregates(
         total += partial.total;
         filtered_total += partial.filtered_total;
         for group in partial.groups {
-            let entry = merged
-                .entry(group.key.clone())
-                .or_insert_with(|| DlqRawGroup {
-                    key: group.key.clone(),
-                    count: 0,
-                    first_seen: None,
-                    last_seen: None,
-                    sample_ids: Vec::new(),
-                });
+            let entry = merged.entry(group.key).or_insert_with_key(|k| DlqRawGroup {
+                key: k.clone(),
+                count: 0,
+                first_seen: None,
+                last_seen: None,
+                sample_ids: Vec::new(),
+            });
             entry.count += group.count;
             entry.first_seen = min_instant(entry.first_seen, group.first_seen);
             entry.last_seen = max_instant(entry.last_seen, group.last_seen);
@@ -1256,8 +1254,8 @@ pub async fn aggregate_dead_letters(
             })
             .collect();
 
-        let entry = groups.entry(key.clone()).or_insert_with(|| DlqRawGroup {
-            key,
+        let entry = groups.entry(key).or_insert_with_key(|k| DlqRawGroup {
+            key: k.clone(),
             count: 0,
             first_seen: None,
             last_seen: None,


### PR DESCRIPTION
💡 What:
Switched `HashMap` and `BTreeMap` aggregation loops in `dlq.rs` and `build_routing.rs` to use `Entry::or_insert_with_key`.

🎯 Why:
The previous implementation performed an unnecessary `.clone()` on the map key (often a `String` or `Vec`) for every row processed, even if the key already existed in the aggregation map. By moving the owned key into the `.entry()` API and cloning it only inside the closure of `.or_insert_with_key()` (which only executes if the entry is vacant), we eliminate this overhead.

📊 Impact:
Removes 1 heap allocation (for a cloned String or Vec) per aggregated row/record when merging DLQ aggregates, building reachability, or aggregating DLQ by shard.

🔬 Measurement:
Run `cargo test --lib -p autumn-harvest` to verify logic remains exactly the same.

---
*PR created automatically by Jules for task [17592885558130568697](https://jules.google.com/task/17592885558130568697) started by @madmax983*