### PR TITLE
⚡ Bolt: Pre-allocate vectors in mixed signal batch split

### DIFF
--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -1139,8 +1139,8 @@ fn extract_signal_external_workflow(commands: Vec<WorkflowCommand>) -> Vec<Signa
 fn split_mixed_signal_batch(
     commands: Vec<WorkflowCommand>,
 ) -> (Vec<SignalBatchItem>, Vec<WorkflowCommand>) {
-    let mut signal_items = Vec::new();
-    let mut remaining = Vec::new();
+    let mut signal_items = Vec::with_capacity(commands.len());
+    let mut remaining = Vec::with_capacity(commands.len());
     for cmd in commands {
         match cmd {
             WorkflowCommand::SignalExternalWorkflow {


### PR DESCRIPTION
💡 What:
Replaced `Vec::new()` with `Vec::with_capacity(commands.len())` when splitting a mixed signal batch in `autumn-harvest/src/worker.rs`.

🎯 Why:
To avoid multiple heap reallocations when partitioning the input `commands` collection. The exact split isn't known upfront, so pre-allocating the total length for both vectors is a standard idiom to guarantee zero reallocations.

📊 Impact:
Removes multiple `Vec` growth allocations per batch split. This trades a minor memory over-allocation (2 * N capacity) for guaranteed O(1) insertion latency without reallocations, an acceptable tradeoff for small batch performance.

🔬 Measurement:
Run `cargo bench process_data` or profile the worker loop during heavy external signaling to observe reduced allocation overhead.

---
*PR created automatically by Jules for task [7351192254727712376](https://jules.google.com/task/7351192254727712376) started by @madmax983*