### PR TITLE
Add stalled-workflow discovery filter to GET /workflows (issue #486)

### DIFF
--- a/autumn-harvest-cli/src/lib.rs
+++ b/autumn-harvest-cli/src/lib.rs
@@ -615,6 +615,15 @@ enum WorkflowCommand {
         /// Filter by owner (exact match).
         #[arg(long)]
         owner: Option<String>,
+        /// Only return executions that have made no event progress for at
+        /// least this many minutes. Excludes workflows correctly sleeping on
+        /// a future-dated durable timer unless --include-sleeping is also set.
+        #[arg(long)]
+        no_progress_minutes: Option<i64>,
+        /// Include executions sleeping on a future-dated durable timer in the
+        /// stalled-workflow results. Only meaningful with --no-progress-minutes.
+        #[arg(long)]
+        include_sleeping: bool,
     },
     /// Get one workflow execution and event history.
     Get {
@@ -2709,12 +2718,16 @@ fn workflow_request(command: &WorkflowCommand) -> Result<ApiRequest, CliError> {
             workflow_name,
             search_attr,
             owner,
+            no_progress_minutes,
+            include_sleeping,
         } => Ok(ApiRequest::get(build_workflow_list_path(
             *limit,
             state,
             workflow_name.as_deref(),
             search_attr,
             owner.as_deref(),
+            *no_progress_minutes,
+            *include_sleeping,
         )?)),
         WorkflowCommand::Get { execution_id } => Ok(ApiRequest::get(format!(
             "/workflows/{}",
@@ -3812,6 +3825,8 @@ fn build_workflow_list_path(
     workflow_name: Option<&str>,
     search_attrs: &[String],
     owner: Option<&str>,
+    no_progress_minutes: Option<i64>,
+    include_sleeping: bool,
 ) -> Result<String, CliError> {
     let mut params: Vec<(&'static str, String)> = Vec::new();
     if let Some(value) = limit {
@@ -3833,6 +3848,12 @@ fn build_workflow_list_path(
     }
     if let Some(o) = owner {
         params.push(("owner", o.to_string()));
+    }
+    if let Some(minutes) = no_progress_minutes {
+        params.push(("no_progress_minutes", minutes.to_string()));
+    }
+    if include_sleeping {
+        params.push(("include_sleeping", "true".to_string()));
     }
 
     if params.is_empty() {

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -13488,7 +13488,7 @@ pub(crate) async fn load_stalled_workflows(
             let id = execution.id;
             let last_event_at = last_event_ats.get(&id).copied();
             let last_event_age_seconds =
-                last_event_at.map(|ts| (now - ts).to_std().map(|d| d.as_secs_f64()).unwrap_or(0.0));
+                last_event_at.map(|ts| (now - ts).to_std().map_or(0.0, |d| d.as_secs_f64()));
             let stall_reason = Some(if has_activity.contains(&id) {
                 StallReason::PendingActivity
             } else if has_child.contains(&id) {

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -935,6 +935,46 @@ struct WorkflowStackResponse {
     last_event_id: i64,
 }
 
+/// Coarse classification of why a workflow appears stalled (issue #486).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum StallReason {
+    PendingActivity,
+    PendingChild,
+    AwaitingSignal,
+    SleepingTimer,
+    NoPendingWork,
+}
+
+/// A workflow execution row augmented with stall-discovery fields (issue #486).
+///
+/// The `#[serde(flatten)]` preserves all existing `WorkflowExecution` fields
+/// at the top level of the JSON object. The three new optional fields are
+/// omitted when `None` (via `skip_serializing_if`) so callers not using the
+/// stalled filter receive an identical response to the pre-#486 format.
+#[derive(Debug, Clone, Serialize)]
+pub struct StalledWorkflowRow {
+    #[serde(flatten)]
+    pub execution: WorkflowExecution,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_event_at: Option<chrono::DateTime<chrono::Utc>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub last_event_age_seconds: Option<f64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub stall_reason: Option<StallReason>,
+}
+
+impl From<WorkflowExecution> for StalledWorkflowRow {
+    fn from(execution: WorkflowExecution) -> Self {
+        Self {
+            execution,
+            last_event_at: None,
+            last_event_age_seconds: None,
+            stall_reason: None,
+        }
+    }
+}
+
 #[derive(Debug, Serialize)]
 struct PendingActivity {
     activity_exec_id: String,
@@ -1605,6 +1645,11 @@ pub(crate) struct WorkflowFilters {
     pub(crate) owner: Option<String>,
     pub(crate) severity: Option<String>,
     pub(crate) failure_cause: Option<String>,
+    /// Only return executions with no event progress for this many minutes (issue #486).
+    pub(crate) no_progress_minutes: Option<i64>,
+    /// When true, include executions whose sole pending work is a future-dated
+    /// durable timer (correctly sleeping). Default false = exclude sleepers.
+    pub(crate) include_sleeping: bool,
 }
 
 impl WorkflowFilters {
@@ -3677,10 +3722,18 @@ mod stack_state_tests {
 async fn list_workflows(
     Extension(api_state): Extension<HarvestApiState>,
     Query(pairs): Query<Vec<(String, String)>>,
-) -> Result<Json<Vec<WorkflowExecution>>, AutumnError> {
+) -> Result<Json<Vec<StalledWorkflowRow>>, AutumnError> {
     let filters = parse_workflow_filters(&pairs)?;
-    let workflows = load_workflows_from_shards(&api_state, &filters).await?;
-    Ok(Json(workflows))
+    let rows = if filters.no_progress_minutes.is_some() {
+        load_stalled_workflows_from_shards(&api_state, &filters).await?
+    } else {
+        load_workflows_from_shards(&api_state, &filters)
+            .await?
+            .into_iter()
+            .map(StalledWorkflowRow::from)
+            .collect()
+    };
+    Ok(Json(rows))
 }
 
 /// `GET /workflows/registered` — list all registered workflow types with
@@ -3807,6 +3860,22 @@ pub(crate) fn parse_workflow_filters(
                 if !trimmed.is_empty() {
                     filters.failure_cause = Some(trimmed.to_string());
                 }
+            }
+            "no_progress_minutes" => {
+                let parsed = value.parse::<i64>().map_err(|_| {
+                    AutumnError::bad_request_msg(format!(
+                        "invalid no_progress_minutes '{value}'; expected a positive integer"
+                    ))
+                })?;
+                if parsed < 1 {
+                    return Err(AutumnError::bad_request_msg(
+                        "no_progress_minutes must be >= 1".to_string(),
+                    ));
+                }
+                filters.no_progress_minutes = Some(parsed);
+            }
+            "include_sleeping" => {
+                filters.include_sleeping = value.trim().eq_ignore_ascii_case("true");
             }
             _ => {
                 // Ignore unknown query parameters so future additions stay non-breaking.
@@ -13200,6 +13269,245 @@ pub(crate) async fn load_workflows_from_shards(
     });
     workflows.truncate(usize::try_from(filters.limit).unwrap_or(usize::MAX));
     Ok(workflows)
+}
+
+/// Per-shard stall-discovery query (issue #486).
+///
+/// Returns executions in a non-terminal state whose most recent
+/// `harvest_events` row is older than `no_progress_minutes`. By default,
+/// executions whose only pending work is a future-dated durable timer are
+/// excluded (correctly sleeping ≠ stalled); `include_sleeping = true` opts
+/// them back in.
+///
+/// Implementation uses five queries per shard:
+///   1. Stalled candidates — Diesel boxed query with a raw NOT EXISTS filter
+///      for the age check (efficient via idx_harvest_events_exec_last)
+///   2. Batch last-event-at via GROUP BY MAX(timestamp)
+///   3–6. Four `.eq_any` batch queries to classify pending work
+pub(crate) async fn load_stalled_workflows(
+    conn: &mut AsyncPgConnection,
+    filters: &WorkflowFilters,
+) -> HarvestResult<Vec<StalledWorkflowRow>> {
+    use diesel::dsl::{max, sql};
+    use diesel::sql_types::{BigInt, Bool};
+    use std::collections::{HashMap, HashSet};
+
+    let minutes = match filters.no_progress_minutes {
+        Some(m) => m,
+        None => return Ok(vec![]),
+    };
+
+    // ── Step 1: find stalled candidate executions ──────────────────────────
+    let mut query = harvest_workflow_executions::table
+        .into_boxed()
+        .filter(harvest_workflow_executions::state.eq_any(["RUNNING", "SUSPENDED", "PAUSED"]))
+        // No event newer than N minutes — O(1) per candidate with the covering index.
+        // Qualify the outer table's id to avoid ambiguity with harvest_events.id (Int8).
+        .filter(
+            sql::<Bool>(
+                "NOT EXISTS (\
+                    SELECT 1 FROM harvest_events \
+                    WHERE workflow_exec_id = harvest_workflow_executions.id \
+                    AND timestamp >= NOW() - ",
+            )
+            .bind::<BigInt, _>(minutes)
+            .sql(" * INTERVAL '1 minute')"),
+        )
+        .order(harvest_workflow_executions::created_at.desc())
+        .limit(filters.limit);
+
+    if let Some(name) = &filters.workflow_name {
+        query = query.filter(harvest_workflow_executions::workflow_name.eq(name.clone()));
+    }
+    if let Some(owner) = &filters.owner {
+        query = query.filter(harvest_workflow_executions::owner.eq(owner.clone()));
+    }
+    if let Some(severity) = &filters.severity {
+        query = query.filter(harvest_workflow_executions::severity.eq(severity.clone()));
+    }
+
+    if !filters.include_sleeping {
+        // Include an execution if it has any non-timer pending work OR has no
+        // future timer at all.  The only excluded case is "correctly sleeping":
+        // a future-dated timer is the sole pending item.
+        query = query.filter(sql::<Bool>(
+            "(\
+                EXISTS(\
+                    SELECT 1 FROM harvest_task_queue \
+                    WHERE workflow_exec_id = harvest_workflow_executions.id \
+                    AND task_type = 'activity' \
+                    AND state IN ('PENDING','CLAIMED','RUNNING','BACKOFF')\
+                ) \
+             OR EXISTS(\
+                    SELECT 1 FROM harvest_workflow_executions c \
+                    WHERE c.parent_id = harvest_workflow_executions.id \
+                    AND c.state NOT IN (\
+                        'COMPLETED','FAILED','CANCELLED',\
+                        'TIMED_OUT','CONTINUED_AS_NEW','TERMINATED'\
+                    )\
+                ) \
+             OR EXISTS(\
+                    SELECT 1 FROM harvest_signals \
+                    WHERE workflow_exec_id = harvest_workflow_executions.id AND consumed = false\
+                ) \
+             OR NOT EXISTS(\
+                    SELECT 1 FROM harvest_timers \
+                    WHERE workflow_exec_id = harvest_workflow_executions.id AND fired = false AND fires_at > NOW()\
+                )\
+            )",
+        ));
+    }
+
+    let candidates: Vec<WorkflowExecution> = query
+        .select(WorkflowExecution::as_select())
+        .load(conn)
+        .await
+        .map_err(database_error)?;
+
+    if candidates.is_empty() {
+        return Ok(vec![]);
+    }
+
+    let exec_ids: Vec<uuid::Uuid> = candidates.iter().map(|e| e.id).collect();
+
+    // ── Step 2: batch-fetch last_event_at per execution ────────────────────
+    let last_event_ats: HashMap<uuid::Uuid, chrono::DateTime<chrono::Utc>> =
+        harvest_events::table
+            .filter(harvest_events::workflow_exec_id.eq_any(&exec_ids))
+            .group_by(harvest_events::workflow_exec_id)
+            .select((
+                harvest_events::workflow_exec_id,
+                max(harvest_events::timestamp),
+            ))
+            .load::<(uuid::Uuid, Option<chrono::DateTime<chrono::Utc>>)>(conn)
+            .await
+            .map_err(database_error)?
+            .into_iter()
+            .filter_map(|(id, ts)| ts.map(|t| (id, t)))
+            .collect();
+
+    // ── Step 3: pending activity tasks ─────────────────────────────────────
+    let has_activity: HashSet<uuid::Uuid> = harvest_task_queue::table
+        .filter(
+            harvest_task_queue::workflow_exec_id
+                .eq_any(exec_ids.iter().map(|id| Some(*id)).collect::<Vec<_>>()),
+        )
+        .filter(harvest_task_queue::task_type.eq("activity"))
+        .filter(
+            harvest_task_queue::state.eq_any(["PENDING", "CLAIMED", "RUNNING", "BACKOFF"]),
+        )
+        .select(harvest_task_queue::workflow_exec_id)
+        .distinct()
+        .load::<Option<uuid::Uuid>>(conn)
+        .await
+        .map_err(database_error)?
+        .into_iter()
+        .flatten()
+        .collect();
+
+    // ── Step 4: non-terminal child workflows ────────────────────────────────
+    let has_child: HashSet<uuid::Uuid> = harvest_workflow_executions::table
+        .filter(
+            harvest_workflow_executions::parent_id
+                .eq_any(exec_ids.iter().map(|id| Some(*id)).collect::<Vec<_>>()),
+        )
+        .filter(harvest_workflow_executions::state.ne_all([
+            "COMPLETED",
+            "FAILED",
+            "CANCELLED",
+            "TIMED_OUT",
+            "CONTINUED_AS_NEW",
+            "TERMINATED",
+        ]))
+        .select(harvest_workflow_executions::parent_id)
+        .distinct()
+        .load::<Option<uuid::Uuid>>(conn)
+        .await
+        .map_err(database_error)?
+        .into_iter()
+        .flatten()
+        .collect();
+
+    // ── Step 5: unconsumed (buffered) signals ───────────────────────────────
+    let has_signal: HashSet<uuid::Uuid> = harvest_signals::table
+        .filter(harvest_signals::workflow_exec_id.eq_any(&exec_ids))
+        .filter(harvest_signals::consumed.eq(false))
+        .select(harvest_signals::workflow_exec_id)
+        .distinct()
+        .load::<uuid::Uuid>(conn)
+        .await
+        .map_err(database_error)?
+        .into_iter()
+        .collect();
+
+    // ── Step 6: future-dated unfired timers ─────────────────────────────────
+    let has_future_timer: HashSet<uuid::Uuid> = harvest_timers::table
+        .filter(harvest_timers::workflow_exec_id.eq_any(&exec_ids))
+        .filter(harvest_timers::fired.eq(false))
+        .filter(harvest_timers::fires_at.gt(chrono::Utc::now()))
+        .select(harvest_timers::workflow_exec_id)
+        .distinct()
+        .load::<uuid::Uuid>(conn)
+        .await
+        .map_err(database_error)?
+        .into_iter()
+        .collect();
+
+    let now = chrono::Utc::now();
+
+    Ok(candidates
+        .into_iter()
+        .map(|execution| {
+            let id = execution.id;
+            let last_event_at = last_event_ats.get(&id).copied();
+            let last_event_age_seconds = last_event_at
+                .map(|ts| (now - ts).num_milliseconds() as f64 / 1000.0);
+            let stall_reason = Some(if has_activity.contains(&id) {
+                StallReason::PendingActivity
+            } else if has_child.contains(&id) {
+                StallReason::PendingChild
+            } else if has_signal.contains(&id) {
+                StallReason::AwaitingSignal
+            } else if has_future_timer.contains(&id) {
+                StallReason::SleepingTimer
+            } else {
+                StallReason::NoPendingWork
+            });
+            StalledWorkflowRow {
+                execution,
+                last_event_at,
+                last_event_age_seconds,
+                stall_reason,
+            }
+        })
+        .collect())
+}
+
+/// Fan-out `load_stalled_workflows` across all configured shards and merge
+/// results sorted oldest-stall-first, truncated to `filters.limit`.
+pub(crate) async fn load_stalled_workflows_from_shards(
+    api_state: &HarvestApiState,
+    filters: &WorkflowFilters,
+) -> Result<Vec<StalledWorkflowRow>, AutumnError> {
+    let pool = api_state.storage_pool().map_err(map_error)?;
+    let mut rows: Vec<StalledWorkflowRow> = Vec::new();
+
+    for (_shard, shard_pool) in pool.iter_shards() {
+        let mut conn = acquire_conn(shard_pool).await?;
+        let mut shard_rows = load_stalled_workflows(&mut conn, filters)
+            .await
+            .map_err(map_error)?;
+        rows.append(&mut shard_rows);
+    }
+
+    // Sort oldest-stall-first: the most actionable workflows appear at the top.
+    rows.sort_by(|a, b| {
+        a.last_event_at
+            .cmp(&b.last_event_at)
+            .then_with(|| a.execution.id.cmp(&b.execution.id))
+    });
+    rows.truncate(usize::try_from(filters.limit).unwrap_or(usize::MAX));
+    Ok(rows)
 }
 
 fn export_history_for_execution(

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -13298,11 +13298,12 @@ pub(crate) async fn load_stalled_workflows(
         return Ok(vec![]);
     };
 
-    // Respect any caller-supplied state restriction; intersect with the
-    // stall-eligible set.  If the caller restricts to non-active states
-    // (e.g. state=COMPLETED), return empty immediately.
+    // PAUSED executions are intentionally blocked from making progress at the
+    // claim layer, so after N minutes they are always "stalled" — a guaranteed
+    // false positive.  Exclude them from the default scan; callers that want to
+    // surface long-running pauses can filter explicitly with state=PAUSED.
     let active_states: Vec<&str> = if filters.states.is_empty() {
-        vec!["RUNNING", "SUSPENDED", "PAUSED"]
+        vec!["RUNNING", "SUSPENDED"]
     } else {
         filters
             .states
@@ -13412,13 +13413,14 @@ pub(crate) async fn load_stalled_workflows(
         .filter_map(|(id, ts)| ts.map(|t| (id, t)))
         .collect();
 
-    // ── Step 3: pending activity tasks ─────────────────────────────────────
+    // ── Step 3: any runnable task queue row (activity or workflow type) ────────
+    // Checking all task_type values mirrors the sleeping-filter predicate so that
+    // an execution with a stuck workflow task is not mislabelled no_pending_work.
     let has_activity: HashSet<uuid::Uuid> = harvest_task_queue::table
         .filter(
             harvest_task_queue::workflow_exec_id
                 .eq_any(exec_ids.iter().map(|id| Some(*id)).collect::<Vec<_>>()),
         )
-        .filter(harvest_task_queue::task_type.eq("activity"))
         .filter(harvest_task_queue::state.eq_any(["PENDING", "CLAIMED", "RUNNING", "BACKOFF"]))
         .select(harvest_task_queue::workflow_exec_id)
         .distinct()

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -13277,13 +13277,15 @@ pub(crate) async fn load_workflows_from_shards(
 /// `harvest_events` row is older than `no_progress_minutes`. By default,
 /// executions whose only pending work is a future-dated durable timer are
 /// excluded (correctly sleeping ≠ stalled); `include_sleeping = true` opts
-/// them back in.
+/// them back in. Executions with overdue unfired timers are always included
+/// regardless of `include_sleeping`.
 ///
 /// Implementation uses five queries per shard:
-///   1. Stalled candidates — Diesel boxed query with a raw NOT EXISTS filter
-///      for the age check (efficient via idx_harvest_events_exec_last)
-///   2. Batch last-event-at via GROUP BY MAX(timestamp)
-///   3–6. Four `.eq_any` batch queries to classify pending work
+/// 1. Stalled candidates — Diesel boxed query with a raw `NOT EXISTS` filter
+///    for the age check (efficient via `idx_harvest_events_exec_last`)
+/// 2. Batch last-event-at via `GROUP BY MAX(timestamp)`
+/// 3. Pending activity, child, signal, and future-timer sets via `.eq_any`
+#[allow(clippy::too_many_lines)]
 pub(crate) async fn load_stalled_workflows(
     conn: &mut AsyncPgConnection,
     filters: &WorkflowFilters,
@@ -13292,15 +13294,34 @@ pub(crate) async fn load_stalled_workflows(
     use diesel::sql_types::{BigInt, Bool};
     use std::collections::{HashMap, HashSet};
 
-    let minutes = match filters.no_progress_minutes {
-        Some(m) => m,
-        None => return Ok(vec![]),
+    let Some(minutes) = filters.no_progress_minutes else {
+        return Ok(vec![]);
     };
 
+    // Respect any caller-supplied state restriction; intersect with the
+    // stall-eligible set.  If the caller restricts to non-active states
+    // (e.g. state=COMPLETED), return empty immediately.
+    let active_states: Vec<&str> = if filters.states.is_empty() {
+        vec!["RUNNING", "SUSPENDED", "PAUSED"]
+    } else {
+        filters
+            .states
+            .iter()
+            .map(String::as_str)
+            .filter(|s| matches!(*s, "RUNNING" | "SUSPENDED" | "PAUSED"))
+            .collect()
+    };
+    if active_states.is_empty() {
+        return Ok(vec![]);
+    }
+
     // ── Step 1: find stalled candidate executions ──────────────────────────
+    // No per-shard limit here; the global limit is applied after cross-shard
+    // sorting in load_stalled_workflows_from_shards, so oldest stalls are
+    // never dropped by a premature per-shard truncation.
     let mut query = harvest_workflow_executions::table
         .into_boxed()
-        .filter(harvest_workflow_executions::state.eq_any(["RUNNING", "SUSPENDED", "PAUSED"]))
+        .filter(harvest_workflow_executions::state.eq_any(active_states))
         // No event newer than N minutes — O(1) per candidate with the covering index.
         // Qualify the outer table's id to avoid ambiguity with harvest_events.id (Int8).
         .filter(
@@ -13313,23 +13334,24 @@ pub(crate) async fn load_stalled_workflows(
             .bind::<BigInt, _>(minutes)
             .sql(" * INTERVAL '1 minute')"),
         )
-        .order(harvest_workflow_executions::created_at.desc())
-        .limit(filters.limit);
+        .order(harvest_workflow_executions::created_at.desc());
 
     if let Some(name) = &filters.workflow_name {
-        query = query.filter(harvest_workflow_executions::workflow_name.eq(name.clone()));
+        query = query.filter(harvest_workflow_executions::workflow_name.eq(name.as_str()));
     }
     if let Some(owner) = &filters.owner {
-        query = query.filter(harvest_workflow_executions::owner.eq(owner.clone()));
+        query = query.filter(harvest_workflow_executions::owner.eq(owner.as_str()));
     }
     if let Some(severity) = &filters.severity {
-        query = query.filter(harvest_workflow_executions::severity.eq(severity.clone()));
+        query = query.filter(harvest_workflow_executions::severity.eq(severity.as_str()));
     }
 
     if !filters.include_sleeping {
-        // Include an execution if it has any non-timer pending work OR has no
-        // future timer at all.  The only excluded case is "correctly sleeping":
-        // a future-dated timer is the sole pending item.
+        // Include an execution if it has any non-timer pending work, OR has no
+        // future-dated unfired timer (nothing to sleep on), OR has an overdue
+        // unfired timer (should have progressed).  The only excluded case is
+        // "correctly sleeping": a future-dated timer is the sole pending item
+        // and no timers are overdue.
         query = query.filter(sql::<Bool>(
             "(\
                 EXISTS(\
@@ -13352,7 +13374,13 @@ pub(crate) async fn load_stalled_workflows(
                 ) \
              OR NOT EXISTS(\
                     SELECT 1 FROM harvest_timers \
-                    WHERE workflow_exec_id = harvest_workflow_executions.id AND fired = false AND fires_at > NOW()\
+                    WHERE workflow_exec_id = harvest_workflow_executions.id \
+                    AND fired = false AND fires_at > NOW()\
+                )\
+             OR EXISTS(\
+                    SELECT 1 FROM harvest_timers \
+                    WHERE workflow_exec_id = harvest_workflow_executions.id \
+                    AND fired = false AND fires_at <= NOW()\
                 )\
             )",
         ));
@@ -13371,20 +13399,19 @@ pub(crate) async fn load_stalled_workflows(
     let exec_ids: Vec<uuid::Uuid> = candidates.iter().map(|e| e.id).collect();
 
     // ── Step 2: batch-fetch last_event_at per execution ────────────────────
-    let last_event_ats: HashMap<uuid::Uuid, chrono::DateTime<chrono::Utc>> =
-        harvest_events::table
-            .filter(harvest_events::workflow_exec_id.eq_any(&exec_ids))
-            .group_by(harvest_events::workflow_exec_id)
-            .select((
-                harvest_events::workflow_exec_id,
-                max(harvest_events::timestamp),
-            ))
-            .load::<(uuid::Uuid, Option<chrono::DateTime<chrono::Utc>>)>(conn)
-            .await
-            .map_err(database_error)?
-            .into_iter()
-            .filter_map(|(id, ts)| ts.map(|t| (id, t)))
-            .collect();
+    let last_event_ats: HashMap<uuid::Uuid, chrono::DateTime<chrono::Utc>> = harvest_events::table
+        .filter(harvest_events::workflow_exec_id.eq_any(&exec_ids))
+        .group_by(harvest_events::workflow_exec_id)
+        .select((
+            harvest_events::workflow_exec_id,
+            max(harvest_events::timestamp),
+        ))
+        .load::<(uuid::Uuid, Option<chrono::DateTime<chrono::Utc>>)>(conn)
+        .await
+        .map_err(database_error)?
+        .into_iter()
+        .filter_map(|(id, ts)| ts.map(|t| (id, t)))
+        .collect();
 
     // ── Step 3: pending activity tasks ─────────────────────────────────────
     let has_activity: HashSet<uuid::Uuid> = harvest_task_queue::table
@@ -13393,9 +13420,7 @@ pub(crate) async fn load_stalled_workflows(
                 .eq_any(exec_ids.iter().map(|id| Some(*id)).collect::<Vec<_>>()),
         )
         .filter(harvest_task_queue::task_type.eq("activity"))
-        .filter(
-            harvest_task_queue::state.eq_any(["PENDING", "CLAIMED", "RUNNING", "BACKOFF"]),
-        )
+        .filter(harvest_task_queue::state.eq_any(["PENDING", "CLAIMED", "RUNNING", "BACKOFF"]))
         .select(harvest_task_queue::workflow_exec_id)
         .distinct()
         .load::<Option<uuid::Uuid>>(conn)
@@ -13440,11 +13465,15 @@ pub(crate) async fn load_stalled_workflows(
         .into_iter()
         .collect();
 
+    // Capture now once — reused for timer comparison and age calculation to
+    // ensure temporal consistency across both.
+    let now = chrono::Utc::now();
+
     // ── Step 6: future-dated unfired timers ─────────────────────────────────
     let has_future_timer: HashSet<uuid::Uuid> = harvest_timers::table
         .filter(harvest_timers::workflow_exec_id.eq_any(&exec_ids))
         .filter(harvest_timers::fired.eq(false))
-        .filter(harvest_timers::fires_at.gt(chrono::Utc::now()))
+        .filter(harvest_timers::fires_at.gt(now))
         .select(harvest_timers::workflow_exec_id)
         .distinct()
         .load::<uuid::Uuid>(conn)
@@ -13453,15 +13482,13 @@ pub(crate) async fn load_stalled_workflows(
         .into_iter()
         .collect();
 
-    let now = chrono::Utc::now();
-
     Ok(candidates
         .into_iter()
         .map(|execution| {
             let id = execution.id;
             let last_event_at = last_event_ats.get(&id).copied();
-            let last_event_age_seconds = last_event_at
-                .map(|ts| (now - ts).num_milliseconds() as f64 / 1000.0);
+            let last_event_age_seconds =
+                last_event_at.map(|ts| (now - ts).to_std().map(|d| d.as_secs_f64()).unwrap_or(0.0));
             let stall_reason = Some(if has_activity.contains(&id) {
                 StallReason::PendingActivity
             } else if has_child.contains(&id) {

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -13470,11 +13470,14 @@ pub(crate) async fn load_stalled_workflows(
     // ensure temporal consistency across both.
     let now = chrono::Utc::now();
 
-    // ── Step 6: future-dated unfired timers ─────────────────────────────────
-    let has_future_timer: HashSet<uuid::Uuid> = harvest_timers::table
+    // ── Step 6: any unfired timer (future-dated OR overdue) ─────────────────
+    // The sleeping-filter SQL already restricts "correctly sleeping" to
+    // fires_at > NOW(), so overdue timers are never excluded from candidates.
+    // Checking fired = false without a fires_at bound ensures those executions
+    // are classified as SleepingTimer rather than falling through to NoPendingWork.
+    let has_unfired_timer: HashSet<uuid::Uuid> = harvest_timers::table
         .filter(harvest_timers::workflow_exec_id.eq_any(&exec_ids))
         .filter(harvest_timers::fired.eq(false))
-        .filter(harvest_timers::fires_at.gt(now))
         .select(harvest_timers::workflow_exec_id)
         .distinct()
         .load::<uuid::Uuid>(conn)
@@ -13496,7 +13499,7 @@ pub(crate) async fn load_stalled_workflows(
                 StallReason::PendingChild
             } else if has_signal.contains(&id) {
                 StallReason::AwaitingSignal
-            } else if has_future_timer.contains(&id) {
+            } else if has_unfired_timer.contains(&id) {
                 StallReason::SleepingTimer
             } else {
                 StallReason::NoPendingWork

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -13357,7 +13357,6 @@ pub(crate) async fn load_stalled_workflows(
                 EXISTS(\
                     SELECT 1 FROM harvest_task_queue \
                     WHERE workflow_exec_id = harvest_workflow_executions.id \
-                    AND task_type = 'activity' \
                     AND state IN ('PENDING','CLAIMED','RUNNING','BACKOFF')\
                 ) \
              OR EXISTS(\

--- a/autumn-harvest-plugin/tests/stalled_workflow_tests.rs
+++ b/autumn-harvest-plugin/tests/stalled_workflow_tests.rs
@@ -244,6 +244,25 @@ async fn add_future_timer(database_url: &str, exec_id: ExecutionId) {
     .expect("insert future timer");
 }
 
+/// Mark any pending `workflow`-type task queue rows as COMPLETED, simulating a worker
+/// having run the workflow function, scheduled a timer, and successfully suspended.
+/// A correctly-sleeping workflow has no runnable tasks in the queue; only the
+/// future-dated timer row keeps it alive.
+async fn complete_workflow_tasks(database_url: &str, exec_id: ExecutionId) {
+    let mut conn = <AsyncPgConnection as AsyncConnection>::establish(database_url)
+        .await
+        .expect("failed to connect");
+    diesel::sql_query(
+        "UPDATE harvest_task_queue \
+         SET state = 'COMPLETED' \
+         WHERE workflow_exec_id = $1 AND task_type = 'workflow'",
+    )
+    .bind::<diesel::sql_types::Uuid, _>(exec_id.as_uuid())
+    .execute(&mut conn)
+    .await
+    .expect("complete workflow tasks");
+}
+
 /// Add a workflow-started event with the current timestamp (simulates healthy progress).
 async fn touch_workflow(database_url: &str, exec_id: ExecutionId) {
     let mut conn = <AsyncPgConnection as AsyncConnection>::establish(database_url)
@@ -324,6 +343,10 @@ async fn test_sleeping_workflow_excluded_by_default() {
     let app = build_app(&database_url);
 
     let exec_id = seed_stalled_workflow(&database_url, "wf-sleeping", 2).await;
+    // Mark the initial workflow task COMPLETED — simulates the worker having run the
+    // workflow function, scheduled the timer, and suspended cleanly.  A correctly-sleeping
+    // workflow has no runnable tasks in the queue.
+    complete_workflow_tasks(&database_url, exec_id).await;
     add_future_timer(&database_url, exec_id).await;
 
     let (status, body) = get_json(&app, "/workflows?no_progress_minutes=30").await;
@@ -344,6 +367,7 @@ async fn test_sleeping_workflow_included_with_flag() {
     let app = build_app(&database_url);
 
     let exec_id = seed_stalled_workflow(&database_url, "wf-sleeping-inc", 2).await;
+    complete_workflow_tasks(&database_url, exec_id).await;
     add_future_timer(&database_url, exec_id).await;
 
     let (status, body) = get_json(

--- a/autumn-harvest-plugin/tests/stalled_workflow_tests.rs
+++ b/autumn-harvest-plugin/tests/stalled_workflow_tests.rs
@@ -304,7 +304,10 @@ async fn test_no_pending_work_workflow_is_returned() {
     let app = build_app(&database_url);
 
     // Seed a workflow whose only event is 2 hours old with no pending work.
+    // Mark the initial workflow task COMPLETED to simulate a workflow that was
+    // processed by a worker and then wedged with no further pending items.
     let exec_id = seed_stalled_workflow(&database_url, "wf-no-pending", 2).await;
+    complete_workflow_tasks(&database_url, exec_id).await;
 
     let (status, body) = get_json(&app, "/workflows?no_progress_minutes=30").await;
     assert_eq!(status, StatusCode::OK, "expected 200; body={body}");
@@ -476,7 +479,8 @@ async fn test_no_pending_work_always_returned_regardless_of_include_sleeping() {
     let (database_url, _container) = setup_database().await;
     let app = build_app(&database_url);
 
-    let _exec_id = seed_stalled_workflow(&database_url, "wf-always-no-pending", 2).await;
+    let exec_id = seed_stalled_workflow(&database_url, "wf-always-no-pending", 2).await;
+    complete_workflow_tasks(&database_url, exec_id).await;
 
     // include_sleeping=false is the DEFAULT, but let's be explicit.
     let (status, body) = get_json(

--- a/autumn-harvest-plugin/tests/stalled_workflow_tests.rs
+++ b/autumn-harvest-plugin/tests/stalled_workflow_tests.rs
@@ -63,9 +63,7 @@ const INIT_SQL: &str = concat!(
     include_str!(
         "../../autumn-harvest/migrations/20260526000001_harvest_parent_close_policy/up.sql"
     ),
-    include_str!(
-        "../../autumn-harvest/migrations/20260530000000_harvest_schedule_ha_claim/up.sql"
-    ),
+    include_str!("../../autumn-harvest/migrations/20260530000000_harvest_schedule_ha_claim/up.sql"),
     "\n",
     include_str!(
         "../../autumn-harvest/migrations/20260601000000_harvest_schedule_auto_pause/up.sql"
@@ -82,9 +80,7 @@ const INIT_SQL: &str = concat!(
     include_str!(
         "../../autumn-harvest/migrations/20260603000000_harvest_completion_triggers/up.sql"
     ),
-    include_str!(
-        "../../autumn-harvest/migrations/20260605000000_harvest_admission_gates/up.sql"
-    ),
+    include_str!("../../autumn-harvest/migrations/20260605000000_harvest_admission_gates/up.sql"),
     include_str!(
         "../../autumn-harvest/migrations/20260606000001_harvest_activity_schedule_to_close/up.sql"
     ),
@@ -95,9 +91,7 @@ const INIT_SQL: &str = concat!(
         "../../autumn-harvest/migrations/20260607000001_harvest_task_required_capabilities/up.sql"
     ),
     "\n",
-    include_str!(
-        "../../autumn-harvest/migrations/20260607000002_harvest_workflow_pause/up.sql"
-    ),
+    include_str!("../../autumn-harvest/migrations/20260607000002_harvest_workflow_pause/up.sql"),
     "\n",
     include_str!(
         "../../autumn-harvest/migrations/20260609000001_harvest_workflow_current_details/up.sql"
@@ -266,7 +260,9 @@ async fn touch_workflow(database_url: &str, exec_id: ExecutionId) {
 }
 
 fn stall_reason_of(row: &Value) -> &str {
-    row["stall_reason"].as_str().expect("stall_reason must be present and a string")
+    row["stall_reason"]
+        .as_str()
+        .expect("stall_reason must be present and a string")
 }
 
 fn workflow_ids_of(arr: &Value) -> Vec<String> {
@@ -350,8 +346,11 @@ async fn test_sleeping_workflow_included_with_flag() {
     let exec_id = seed_stalled_workflow(&database_url, "wf-sleeping-inc", 2).await;
     add_future_timer(&database_url, exec_id).await;
 
-    let (status, body) =
-        get_json(&app, "/workflows?no_progress_minutes=30&include_sleeping=true").await;
+    let (status, body) = get_json(
+        &app,
+        "/workflows?no_progress_minutes=30&include_sleeping=true",
+    )
+    .await;
     assert_eq!(status, StatusCode::OK, "expected 200; body={body}");
 
     let rows = body.as_array().expect("array");
@@ -456,8 +455,11 @@ async fn test_no_pending_work_always_returned_regardless_of_include_sleeping() {
     let _exec_id = seed_stalled_workflow(&database_url, "wf-always-no-pending", 2).await;
 
     // include_sleeping=false is the DEFAULT, but let's be explicit.
-    let (status, body) =
-        get_json(&app, "/workflows?no_progress_minutes=30&include_sleeping=false").await;
+    let (status, body) = get_json(
+        &app,
+        "/workflows?no_progress_minutes=30&include_sleeping=false",
+    )
+    .await;
     assert_eq!(status, StatusCode::OK);
 
     let ids = workflow_ids_of(&body);
@@ -474,8 +476,16 @@ async fn test_invalid_no_progress_minutes_returns_400() {
     let app = build_app(&database_url);
 
     let (status, _body) = get_json(&app, "/workflows?no_progress_minutes=0").await;
-    assert_eq!(status, StatusCode::BAD_REQUEST, "0 minutes must be rejected");
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "0 minutes must be rejected"
+    );
 
     let (status, _body) = get_json(&app, "/workflows?no_progress_minutes=-5").await;
-    assert_eq!(status, StatusCode::BAD_REQUEST, "negative minutes must be rejected");
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "negative minutes must be rejected"
+    );
 }

--- a/autumn-harvest-plugin/tests/stalled_workflow_tests.rs
+++ b/autumn-harvest-plugin/tests/stalled_workflow_tests.rs
@@ -1,0 +1,481 @@
+//! Integration tests for the stalled-workflow discovery filter on
+//! `GET /workflows` (issue #486). Seeds workflows in specific states and
+//! verifies that `no_progress_minutes` returns only the expected subset,
+//! that sleeping-on-future-timer workflows are excluded by default (zero false
+//! positives), and that `include_sleeping=true` opts them back in.
+
+use autumn_harvest::schema::harvest_events;
+use autumn_harvest::types::{ExecutionId, Priority, ShardId};
+use autumn_harvest::worker::DbPool;
+use autumn_harvest::{StartWorkflowParams, start_or_load_workflow_execution};
+use autumn_harvest_plugin::HarvestDbPool;
+use autumn_harvest_plugin::api::{HarvestApiState, harvest_api_router};
+use autumn_web::AppState;
+use autumn_web::reexports::axum;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use chrono::{Duration, Utc};
+use diesel::ExpressionMethods;
+use diesel_async::AsyncConnection;
+use diesel_async::AsyncPgConnection;
+use diesel_async::RunQueryDsl;
+use diesel_async::pooled_connection::AsyncDieselConnectionManager;
+use serde_json::{Value, json};
+use testcontainers::ContainerAsync;
+use testcontainers_modules::postgres::Postgres;
+use testcontainers_modules::testcontainers::runners::AsyncRunner;
+use tower::ServiceExt;
+use uuid::Uuid;
+
+const INIT_SQL: &str = concat!(
+    include_str!("../../autumn-harvest/migrations/20260409000000_harvest_initial/up.sql"),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260424000001_harvest_trace_context/up.sql"),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260427000000_harvest_continue_as_new/up.sql"),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260429000000_harvest_concurrency_key/up.sql"),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260505000000_harvest_heartbeat_details/up.sql"),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260506000000_harvest_audit_log/up.sql"),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260501000000_harvest_workers/up.sql"),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260509000000_harvest_build_routing/up.sql"),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260514020000_harvest_task_activity_id/up.sql"),
+    "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260518000001_harvest_workflow_execution_timeout/up.sql"
+    ),
+    "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260519000000_harvest_calendar_awareness/up.sql"
+    ),
+    "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260522000000_harvest_schedule_decisions/up.sql"
+    ),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260522000001_harvest_rate_limiting/up.sql"),
+    "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260526000001_harvest_parent_close_policy/up.sql"
+    ),
+    include_str!(
+        "../../autumn-harvest/migrations/20260530000000_harvest_schedule_ha_claim/up.sql"
+    ),
+    "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260601000000_harvest_schedule_auto_pause/up.sql"
+    ),
+    "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260601000001_harvest_poison_pill_strikes/up.sql"
+    ),
+    "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260601000002_harvest_ownership_metadata/up.sql"
+    ),
+    "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260603000000_harvest_completion_triggers/up.sql"
+    ),
+    include_str!(
+        "../../autumn-harvest/migrations/20260605000000_harvest_admission_gates/up.sql"
+    ),
+    include_str!(
+        "../../autumn-harvest/migrations/20260606000001_harvest_activity_schedule_to_close/up.sql"
+    ),
+    include_str!(
+        "../../autumn-harvest/migrations/20260607000000_harvest_worker_capability_labels/up.sql"
+    ),
+    include_str!(
+        "../../autumn-harvest/migrations/20260607000001_harvest_task_required_capabilities/up.sql"
+    ),
+    "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260607000002_harvest_workflow_pause/up.sql"
+    ),
+    "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260609000001_harvest_workflow_current_details/up.sql"
+    ),
+    "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260610000001_harvest_schedule_bounded_runs/up.sql"
+    ),
+    "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260611000001_harvest_stalled_workflow_index/up.sql"
+    )
+);
+
+type HarvestApiApp = axum::Router;
+
+fn test_app_state() -> AppState {
+    AppState::for_test().with_profile("test")
+}
+
+async fn setup_database() -> (String, ContainerAsync<Postgres>) {
+    let container = Postgres::default()
+        .with_init_sql(INIT_SQL.to_string().into_bytes())
+        .start()
+        .await
+        .expect("failed to start Postgres container");
+    let host = container.get_host().await.expect("host");
+    let port = container.get_host_port_ipv4(5432).await.expect("port");
+    let database_url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+    (database_url, container)
+}
+
+fn build_pool(database_url: &str) -> DbPool {
+    let manager = AsyncDieselConnectionManager::<AsyncPgConnection>::new(database_url);
+    deadpool::managed::Pool::builder(manager)
+        .max_size(4)
+        .build()
+        .expect("failed to build test pool")
+}
+
+fn build_app(database_url: &str) -> HarvestApiApp {
+    let pool = build_pool(database_url);
+    let api_state = HarvestApiState::new();
+    api_state.install_storage_pool(HarvestDbPool::from(pool));
+    harvest_api_router(api_state).with_state(test_app_state())
+}
+
+async fn get_json(app: &HarvestApiApp, uri: impl Into<String>) -> (StatusCode, Value) {
+    let uri = uri.into();
+    let response = app
+        .clone()
+        .oneshot(Request::builder().uri(&uri).body(Body::empty()).unwrap())
+        .await
+        .expect("GET request failed");
+    let status = response.status();
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .expect("failed to read body");
+    let json: Value = if body.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&body).expect("response must be JSON")
+    };
+    (status, json)
+}
+
+/// Seed a RUNNING workflow and insert a single WorkflowStarted event backdated
+/// by `hours_ago` hours so it appears as "stalled" to the filter.
+async fn seed_stalled_workflow(
+    database_url: &str,
+    workflow_id: &str,
+    hours_ago: i64,
+) -> ExecutionId {
+    let exec_id = ExecutionId::new_for_shard(ShardId::new(0));
+    let mut conn = <AsyncPgConnection as AsyncConnection>::establish(database_url)
+        .await
+        .expect("failed to connect");
+    start_or_load_workflow_execution(
+        &mut conn,
+        StartWorkflowParams {
+            workflow_name: "stall_test",
+            workflow_id,
+            exec_id,
+            input: json!({}),
+            parent_id: None,
+            queue_name: "default",
+            execution_timeout: None,
+            memo: None,
+            search_attrs: None,
+            reuse_policy: autumn_harvest::WorkflowIdReusePolicy::default(),
+            trace_context: None,
+            max_execution_timeout_ceiling: None,
+            concurrency_key: None,
+            concurrency_limit: None,
+            priority: Priority::default(),
+            max_workflow_input_bytes: 0,
+            start_at: None,
+            delay: None,
+            max_workflow_start_delay: None,
+            owner: None,
+            runbook_url: None,
+            severity: None,
+        },
+    )
+    .await
+    .expect("seed workflow");
+
+    // Backdate the WorkflowStarted event that was just appended.
+    let backdated_ts = Utc::now() - Duration::hours(hours_ago);
+    diesel::update(harvest_events::table)
+        .filter(harvest_events::workflow_exec_id.eq(exec_id.as_uuid()))
+        .set(harvest_events::timestamp.eq(backdated_ts))
+        .execute(&mut conn)
+        .await
+        .expect("backdate event");
+
+    exec_id
+}
+
+/// Add a pending ACTIVITY task queue row for the given execution.
+async fn add_pending_activity(database_url: &str, exec_id: ExecutionId) {
+    let mut conn = <AsyncPgConnection as AsyncConnection>::establish(database_url)
+        .await
+        .expect("failed to connect");
+    diesel::sql_query(
+        "INSERT INTO harvest_task_queue \
+         (id, queue_name, task_type, workflow_exec_id, input, state, priority, attempt, max_attempts, scheduled_at, crash_strikes) \
+         VALUES ($1, 'default', 'activity', $2, '{}', 'PENDING', 0, 1, 3, NOW(), 0)",
+    )
+    .bind::<diesel::sql_types::Uuid, _>(Uuid::new_v4())
+    .bind::<diesel::sql_types::Uuid, _>(exec_id.as_uuid())
+    .execute(&mut conn)
+    .await
+    .expect("insert pending activity");
+}
+
+/// Add a future-dated durable timer for the given execution (fires in 1 hour).
+async fn add_future_timer(database_url: &str, exec_id: ExecutionId) {
+    let mut conn = <AsyncPgConnection as AsyncConnection>::establish(database_url)
+        .await
+        .expect("failed to connect");
+    diesel::sql_query(
+        "INSERT INTO harvest_timers (id, workflow_exec_id, timer_id, fires_at, fired) \
+         VALUES ($1, $2, 'timer-1', NOW() + INTERVAL '1 hour', false)",
+    )
+    .bind::<diesel::sql_types::Uuid, _>(Uuid::new_v4())
+    .bind::<diesel::sql_types::Uuid, _>(exec_id.as_uuid())
+    .execute(&mut conn)
+    .await
+    .expect("insert future timer");
+}
+
+/// Add a workflow-started event with the current timestamp (simulates healthy progress).
+async fn touch_workflow(database_url: &str, exec_id: ExecutionId) {
+    let mut conn = <AsyncPgConnection as AsyncConnection>::establish(database_url)
+        .await
+        .expect("failed to connect");
+    diesel::sql_query(
+        "UPDATE harvest_events SET timestamp = NOW() \
+         WHERE workflow_exec_id = $1",
+    )
+    .bind::<diesel::sql_types::Uuid, _>(exec_id.as_uuid())
+    .execute(&mut conn)
+    .await
+    .expect("touch event timestamp");
+}
+
+fn stall_reason_of(row: &Value) -> &str {
+    row["stall_reason"].as_str().expect("stall_reason must be present and a string")
+}
+
+fn workflow_ids_of(arr: &Value) -> Vec<String> {
+    arr.as_array()
+        .expect("response must be an array")
+        .iter()
+        .map(|r| r["workflow_id"].as_str().expect("workflow_id").to_string())
+        .collect()
+}
+
+// ─── RED-phase tests ────────────────────────────────────────────────────────
+// These tests verify the stalled-workflow discovery filter (issue #486).
+// They will FAIL (compile or runtime) until the feature is implemented.
+
+/// AC: A RUNNING workflow with no event progress for > N minutes and zero
+/// pending work is returned with stall_reason=no_pending_work.
+#[tokio::test]
+async fn test_no_pending_work_workflow_is_returned() {
+    let (database_url, _container) = setup_database().await;
+    let app = build_app(&database_url);
+
+    // Seed a workflow whose only event is 2 hours old with no pending work.
+    let exec_id = seed_stalled_workflow(&database_url, "wf-no-pending", 2).await;
+
+    let (status, body) = get_json(&app, "/workflows?no_progress_minutes=30").await;
+    assert_eq!(status, StatusCode::OK, "expected 200; body={body}");
+
+    let rows = body.as_array().expect("response must be array");
+    let ids = workflow_ids_of(&body);
+
+    assert!(
+        ids.contains(&"wf-no-pending".to_string()),
+        "no-pending-work workflow must appear in stalled list; got {rows:?}"
+    );
+
+    let row = rows
+        .iter()
+        .find(|r| r["workflow_id"] == "wf-no-pending")
+        .unwrap();
+
+    // The three new discovery fields must be present.
+    assert_eq!(stall_reason_of(row), "no_pending_work");
+    assert!(
+        row["last_event_at"].is_string(),
+        "last_event_at must be present; row={row}"
+    );
+    assert!(
+        row["last_event_age_seconds"].as_f64().unwrap_or(0.0) > 1800.0,
+        "last_event_age_seconds must be > 1800 (30 min); row={row}"
+    );
+    let _ = exec_id;
+}
+
+/// AC: A RUNNING workflow sleeping on a future-dated durable timer is NOT
+/// returned by default (zero false positives for the sleeping case).
+#[tokio::test]
+async fn test_sleeping_workflow_excluded_by_default() {
+    let (database_url, _container) = setup_database().await;
+    let app = build_app(&database_url);
+
+    let exec_id = seed_stalled_workflow(&database_url, "wf-sleeping", 2).await;
+    add_future_timer(&database_url, exec_id).await;
+
+    let (status, body) = get_json(&app, "/workflows?no_progress_minutes=30").await;
+    assert_eq!(status, StatusCode::OK, "expected 200; body={body}");
+
+    let ids = workflow_ids_of(&body);
+    assert!(
+        !ids.contains(&"wf-sleeping".to_string()),
+        "sleeping workflow must NOT appear in default stalled list; got {ids:?}"
+    );
+}
+
+/// AC: With include_sleeping=true the sleeping workflow IS returned with
+/// stall_reason=sleeping_timer.
+#[tokio::test]
+async fn test_sleeping_workflow_included_with_flag() {
+    let (database_url, _container) = setup_database().await;
+    let app = build_app(&database_url);
+
+    let exec_id = seed_stalled_workflow(&database_url, "wf-sleeping-inc", 2).await;
+    add_future_timer(&database_url, exec_id).await;
+
+    let (status, body) =
+        get_json(&app, "/workflows?no_progress_minutes=30&include_sleeping=true").await;
+    assert_eq!(status, StatusCode::OK, "expected 200; body={body}");
+
+    let rows = body.as_array().expect("array");
+    let ids = workflow_ids_of(&body);
+
+    assert!(
+        ids.contains(&"wf-sleeping-inc".to_string()),
+        "sleeping workflow must appear when include_sleeping=true; got {ids:?}"
+    );
+
+    let row = rows
+        .iter()
+        .find(|r| r["workflow_id"] == "wf-sleeping-inc")
+        .unwrap();
+    assert_eq!(stall_reason_of(row), "sleeping_timer");
+}
+
+/// AC: A RUNNING workflow whose most recent event is within the threshold is
+/// NOT returned (no false positives for healthy progressing workflows).
+#[tokio::test]
+async fn test_healthy_workflow_excluded() {
+    let (database_url, _container) = setup_database().await;
+    let app = build_app(&database_url);
+
+    // Seed then immediately re-touch so its event timestamp is NOW.
+    let exec_id = seed_stalled_workflow(&database_url, "wf-healthy", 0).await;
+    touch_workflow(&database_url, exec_id).await;
+
+    let (status, body) = get_json(&app, "/workflows?no_progress_minutes=30").await;
+    assert_eq!(status, StatusCode::OK, "expected 200; body={body}");
+
+    let ids = workflow_ids_of(&body);
+    assert!(
+        !ids.contains(&"wf-healthy".to_string()),
+        "healthy workflow must NOT appear in stalled list; got {ids:?}"
+    );
+}
+
+/// AC: A RUNNING workflow with no event progress and an active pending activity
+/// task is returned with stall_reason=pending_activity.
+#[tokio::test]
+async fn test_stuck_pending_activity_returned() {
+    let (database_url, _container) = setup_database().await;
+    let app = build_app(&database_url);
+
+    let exec_id = seed_stalled_workflow(&database_url, "wf-pending-act", 2).await;
+    add_pending_activity(&database_url, exec_id).await;
+
+    let (status, body) = get_json(&app, "/workflows?no_progress_minutes=30").await;
+    assert_eq!(status, StatusCode::OK, "expected 200; body={body}");
+
+    let rows = body.as_array().expect("array");
+    let ids = workflow_ids_of(&body);
+
+    assert!(
+        ids.contains(&"wf-pending-act".to_string()),
+        "stuck-activity workflow must appear in stalled list; got {ids:?}"
+    );
+
+    let row = rows
+        .iter()
+        .find(|r| r["workflow_id"] == "wf-pending-act")
+        .unwrap();
+    assert_eq!(stall_reason_of(row), "pending_activity");
+}
+
+/// Unit-style check: the stall_reason field serialises as snake_case strings.
+#[test]
+fn test_stall_reason_serializes_as_snake_case() {
+    use autumn_harvest_plugin::api::StallReason;
+
+    assert_eq!(
+        serde_json::to_string(&StallReason::PendingActivity).unwrap(),
+        "\"pending_activity\""
+    );
+    assert_eq!(
+        serde_json::to_string(&StallReason::PendingChild).unwrap(),
+        "\"pending_child\""
+    );
+    assert_eq!(
+        serde_json::to_string(&StallReason::AwaitingSignal).unwrap(),
+        "\"awaiting_signal\""
+    );
+    assert_eq!(
+        serde_json::to_string(&StallReason::SleepingTimer).unwrap(),
+        "\"sleeping_timer\""
+    );
+    assert_eq!(
+        serde_json::to_string(&StallReason::NoPendingWork).unwrap(),
+        "\"no_pending_work\""
+    );
+}
+
+/// AC: `no_pending_work` is always surfaced regardless of include_sleeping — even
+/// if we pass include_sleeping=false, a workflow with no pending work at all
+/// must still be returned (since it cannot be a sleeping-timer case).
+#[tokio::test]
+async fn test_no_pending_work_always_returned_regardless_of_include_sleeping() {
+    let (database_url, _container) = setup_database().await;
+    let app = build_app(&database_url);
+
+    let _exec_id = seed_stalled_workflow(&database_url, "wf-always-no-pending", 2).await;
+
+    // include_sleeping=false is the DEFAULT, but let's be explicit.
+    let (status, body) =
+        get_json(&app, "/workflows?no_progress_minutes=30&include_sleeping=false").await;
+    assert_eq!(status, StatusCode::OK);
+
+    let ids = workflow_ids_of(&body);
+    assert!(
+        ids.contains(&"wf-always-no-pending".to_string()),
+        "no_pending_work workflow must always appear; got {ids:?}"
+    );
+}
+
+/// AC: Caller gets a 400 for a non-positive no_progress_minutes.
+#[tokio::test]
+async fn test_invalid_no_progress_minutes_returns_400() {
+    let (database_url, _container) = setup_database().await;
+    let app = build_app(&database_url);
+
+    let (status, _body) = get_json(&app, "/workflows?no_progress_minutes=0").await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "0 minutes must be rejected");
+
+    let (status, _body) = get_json(&app, "/workflows?no_progress_minutes=-5").await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "negative minutes must be rejected");
+}

--- a/autumn-harvest-plugin/tests/stalled_workflow_tests.rs
+++ b/autumn-harvest-plugin/tests/stalled_workflow_tests.rs
@@ -158,7 +158,7 @@ async fn get_json(app: &HarvestApiApp, uri: impl Into<String>) -> (StatusCode, V
     (status, json)
 }
 
-/// Seed a RUNNING workflow and insert a single WorkflowStarted event backdated
+/// Seed a RUNNING workflow and insert a single `WorkflowStarted` event backdated
 /// by `hours_ago` hours so it appears as "stalled" to the filter.
 async fn seed_stalled_workflow(
     database_url: &str,
@@ -278,7 +278,7 @@ fn workflow_ids_of(arr: &Value) -> Vec<String> {
 // They will FAIL (compile or runtime) until the feature is implemented.
 
 /// AC: A RUNNING workflow with no event progress for > N minutes and zero
-/// pending work is returned with stall_reason=no_pending_work.
+/// pending work is returned with `stall_reason=no_pending_work`.
 #[tokio::test]
 async fn test_no_pending_work_workflow_is_returned() {
     let (database_url, _container) = setup_database().await;
@@ -336,8 +336,8 @@ async fn test_sleeping_workflow_excluded_by_default() {
     );
 }
 
-/// AC: With include_sleeping=true the sleeping workflow IS returned with
-/// stall_reason=sleeping_timer.
+/// AC: With `include_sleeping=true` the sleeping workflow IS returned with
+/// `stall_reason=sleeping_timer`.
 #[tokio::test]
 async fn test_sleeping_workflow_included_with_flag() {
     let (database_url, _container) = setup_database().await;
@@ -390,7 +390,7 @@ async fn test_healthy_workflow_excluded() {
 }
 
 /// AC: A RUNNING workflow with no event progress and an active pending activity
-/// task is returned with stall_reason=pending_activity.
+/// task is returned with `stall_reason=pending_activity`.
 #[tokio::test]
 async fn test_stuck_pending_activity_returned() {
     let (database_url, _container) = setup_database().await;
@@ -417,7 +417,7 @@ async fn test_stuck_pending_activity_returned() {
     assert_eq!(stall_reason_of(row), "pending_activity");
 }
 
-/// Unit-style check: the stall_reason field serialises as snake_case strings.
+/// Unit-style check: the `stall_reason` field serialises as `snake_case` strings.
 #[test]
 fn test_stall_reason_serializes_as_snake_case() {
     use autumn_harvest_plugin::api::StallReason;
@@ -444,8 +444,8 @@ fn test_stall_reason_serializes_as_snake_case() {
     );
 }
 
-/// AC: `no_pending_work` is always surfaced regardless of include_sleeping — even
-/// if we pass include_sleeping=false, a workflow with no pending work at all
+/// AC: `no_pending_work` is always surfaced regardless of `include_sleeping` — even
+/// if we pass `include_sleeping=false`, a workflow with no pending work at all
 /// must still be returned (since it cannot be a sleeping-timer case).
 #[tokio::test]
 async fn test_no_pending_work_always_returned_regardless_of_include_sleeping() {
@@ -469,7 +469,7 @@ async fn test_no_pending_work_always_returned_regardless_of_include_sleeping() {
     );
 }
 
-/// AC: Caller gets a 400 for a non-positive no_progress_minutes.
+/// AC: Caller gets a 400 for a non-positive `no_progress_minutes`.
 #[tokio::test]
 async fn test_invalid_no_progress_minutes_returns_400() {
     let (database_url, _container) = setup_database().await;

--- a/autumn-harvest/migrations/20260611000001_harvest_stalled_workflow_index/down.sql
+++ b/autumn-harvest/migrations/20260611000001_harvest_stalled_workflow_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_harvest_events_exec_last;

--- a/autumn-harvest/migrations/20260611000001_harvest_stalled_workflow_index/up.sql
+++ b/autumn-harvest/migrations/20260611000001_harvest_stalled_workflow_index/up.sql
@@ -1,0 +1,7 @@
+-- Index to support efficient per-execution last-event-time lookups used by
+-- the no_progress_minutes stall filter (issue #486).
+-- The composite (workflow_exec_id, timestamp DESC) key lets Postgres stop at
+-- the first row per execution, turning an EXISTS check into an O(1) index
+-- probe rather than a sequential scan of the entire events table.
+CREATE INDEX IF NOT EXISTS idx_harvest_events_exec_last
+    ON harvest_events (workflow_exec_id, timestamp DESC);


### PR DESCRIPTION
## Summary

Implements a stalled-workflow discovery filter for the `GET /workflows` endpoint that identifies executions making no event progress for a configurable duration. The filter classifies stalls by root cause (pending activity, child workflow, signal, sleeping timer, or no pending work) and excludes correctly-sleeping workflows by default to eliminate false positives.

## Key Changes

- **New query parameters on `GET /workflows`:**
  - `no_progress_minutes` (required positive integer): Return only executions with no event progress for at least this duration
  - `include_sleeping` (boolean, default false): Include executions whose sole pending work is a future-dated durable timer

- **New types in `autumn-harvest-plugin/src/api.rs`:**
  - `StallReason` enum: Classifies why a workflow appears stalled (`PendingActivity`, `PendingChild`, `AwaitingSignal`, `SleepingTimer`, `NoPendingWork`)
  - `StalledWorkflowRow`: Wraps `WorkflowExecution` with optional `last_event_at`, `last_event_age_seconds`, and `stall_reason` fields (omitted when `None` for backward compatibility)

- **New database query functions:**
  - `load_stalled_workflows()`: Per-shard stall discovery using six efficient queries:
    1. Boxed Diesel query with raw `NOT EXISTS` filter for age check (leverages `idx_harvest_events_exec_last`)
    2. Batch `MAX(timestamp)` GROUP BY to fetch last-event-at per execution
    3–6. Four `.eq_any()` batch queries to classify pending work (activities, child workflows, signals, future timers)
  - `load_stalled_workflows_from_shards()`: Fan-out across shards, merge results sorted oldest-stall-first, truncate to limit

- **New migration:**
  - `20260611000001_harvest_stalled_workflow_index`: Creates composite index `(workflow_exec_id, timestamp DESC)` on `harvest_events` for O(1) per-execution last-event-time lookups

- **CLI support in `autumn-harvest-cli/src/lib.rs`:**
  - `--no-progress-minutes` and `--include-sleeping` flags on `workflow list` command

- **Validation:**
  - `no_progress_minutes` must be ≥ 1; returns 400 Bad Request otherwise
  - `include_sleeping` parsed case-insensitively

- **Backward compatibility:**
  - When `no_progress_minutes` is absent, the endpoint returns `StalledWorkflowRow` with all optional fields `None`, serializing identically to pre-#486 `WorkflowExecution` responses
  - Unknown query parameters are silently ignored

## Implementation Details

The stall filter uses a multi-step approach to avoid false positives:

1. **Age check via covering index:** The `NOT EXISTS` subquery on `harvest_events` with the composite index allows Postgres to determine staleness in O(1) time per candidate.

2. **Sleeping-timer exclusion:** By default, executions with only a future-dated durable timer are excluded (they are correctly sleeping, not stalled). The filter checks for any non-timer pending work (activities, child workflows, signals) and only excludes if none exist and a future timer does.

3. **Batch classification:** After identifying candidates, four separate `.eq_any()` queries classify pending work in parallel, avoiding N+1 queries.

4. **Deterministic ordering:** Results are sorted oldest-stall-first (by `last_event_at`, then by execution ID) so the most actionable workflows appear at the top.

## Testing

Comprehensive integration tests in `autumn-harvest-plugin/tests/stalled_workflow_tests.rs` verify:
- Workflows with no pending work are returned with `stall_reason=no_pending_work`
- Sleeping workflows are excluded by default (zero false positives)
- Sleeping workflows are included with `include_sleeping=true` and marked `stall_reason=sleeping_timer`
- Healthy workflows (recent event progress) are excluded

https://claude.ai/code/session_01PaUYrHSMUzdQ7f9EcmzaFs