### PR TITLE
Add per-execution context headers (issue #481)

### DIFF
--- a/autumn-harvest-macros/src/update.rs
+++ b/autumn-harvest-macros/src/update.rs
@@ -309,6 +309,7 @@ pub fn update_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                             owner: ::std::option::Option::None,
                             runbook_url: ::std::option::Option::None,
                             severity: ::std::option::Option::None,
+                            context_headers: opts.context_headers,
                         };
                         let _ = client;
                         ::autumn_harvest::update_with_start_workflow_execution(conn, params).await
@@ -428,6 +429,7 @@ pub fn update_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                                 owner: ::std::option::Option::None,
                                 runbook_url: ::std::option::Option::None,
                                 severity: ::std::option::Option::None,
+                                context_headers: opts.context_headers,
                             };
                             let _ = client;
                             ::autumn_harvest::update_with_start_workflow_execution(conn, params).await

--- a/autumn-harvest-macros/src/workflow.rs
+++ b/autumn-harvest-macros/src/workflow.rs
@@ -473,6 +473,7 @@ pub fn workflow_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         owner: info.owner,
                         runbook_url: info.runbook_url,
                         severity: info.severity,
+                        context_headers: opts.context_headers,
                     };
 
                     let started = client.start_or_load(conn, params).await?;
@@ -553,6 +554,7 @@ pub fn workflow_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                         owner: info.owner,
                         runbook_url: info.runbook_url,
                         severity: info.severity,
+                        context_headers: opts.context_headers,
                     };
 
                     let outcome = ::autumn_harvest::execution::signal_with_start_workflow_execution(conn, params).await?;

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -13214,6 +13214,9 @@ fn export_history_for_execution(
     events: Vec<WorkflowEvent>,
     query: &HistoryExportQuery,
 ) -> Result<HistoryExportDocument, HistoryExportError> {
+    let context_headers = execution.context_headers.as_ref().and_then(|v| {
+        serde_json::from_value::<std::collections::HashMap<String, String>>(v.clone()).ok()
+    });
     export_history(HistoryExportRequest {
         workflow_name: execution.workflow_name.clone(),
         execution_id: ExecutionId::from_uuid(execution.id),
@@ -13223,6 +13226,7 @@ fn export_history_for_execution(
         exported_at: chrono::Utc::now(),
         payload_policy: query.payload_policy,
         max_bytes: Some(query.max_bytes),
+        context_headers,
     })
 }
 
@@ -13240,6 +13244,7 @@ fn export_history_for_candidate(
         exported_at: chrono::Utc::now(),
         payload_policy: query.payload_policy,
         max_bytes: Some(query.max_bytes),
+        context_headers: None,
     })
 }
 

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -5447,6 +5447,7 @@ async fn start_workflow(
             owner,
             runbook_url,
             severity,
+            context_headers: None,
         },
     )
     .await;
@@ -5986,6 +5987,7 @@ async fn batch_start_workflows(
                     owner,
                     runbook_url,
                     severity,
+                    context_headers: None,
                 },
             )
             .await;
@@ -6543,6 +6545,7 @@ async fn signal_with_start_workflow(
             owner,
             runbook_url,
             severity,
+            context_headers: None,
         },
     )
     .await;
@@ -6991,6 +6994,7 @@ async fn update_with_start_workflow(
         owner,
         runbook_url,
         severity,
+        context_headers: None,
     };
 
     let result = update_with_start_workflow_execution(&mut conn, params).await;
@@ -10230,6 +10234,7 @@ async fn trigger_schedule_now(
             owner,
             runbook_url,
             severity,
+            context_headers: None,
         },
     )
     .await;
@@ -10854,6 +10859,7 @@ async fn schedule_backfill(
                         owner,
                         runbook_url,
                         severity,
+                        context_headers: None,
                     },
                 )
                 .await;
@@ -10995,6 +11001,7 @@ async fn schedule_backfill(
                         owner,
                         runbook_url,
                         severity,
+                        context_headers: None,
                     },
                 )
                 .await;
@@ -17912,6 +17919,7 @@ mod tests {
                 owner: None,
                 runbook_url: None,
                 severity: None,
+                context_headers: None,
             },
         )
         .await

--- a/autumn-harvest-plugin/src/outbox.rs
+++ b/autumn-harvest-plugin/src/outbox.rs
@@ -318,6 +318,7 @@ pub(crate) async fn dispatch_workflow_start_request(
             owner,
             runbook_url,
             severity,
+            context_headers: None,
         },
     )
     .await?;

--- a/autumn-harvest-plugin/src/plugin.rs
+++ b/autumn-harvest-plugin/src/plugin.rs
@@ -763,7 +763,6 @@ mod tests {
             owner: None,
             runbook_url: None,
             severity: None,
-            context_headers: None,
         }
     }
 

--- a/autumn-harvest-plugin/src/plugin.rs
+++ b/autumn-harvest-plugin/src/plugin.rs
@@ -422,6 +422,7 @@ async fn start_harvest_runtime(
                         owner,
                         runbook_url,
                         severity,
+                        context_headers: None,
                     };
 
                     let Some(harvest_db) = harvest_db else {

--- a/autumn-harvest-plugin/src/plugin.rs
+++ b/autumn-harvest-plugin/src/plugin.rs
@@ -763,6 +763,7 @@ mod tests {
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         }
     }
 

--- a/autumn-harvest-plugin/src/ui.rs
+++ b/autumn-harvest-plugin/src/ui.rs
@@ -7451,6 +7451,7 @@ mod tests {
             crash_strikes: 0,
             schedule_to_close_at: None,
             required_capabilities: None,
+            context_headers: None,
         }
     }
 
@@ -7581,6 +7582,7 @@ mod tests {
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
             paused_at: None,
             pause_reason: None,
             pause_actor: None,

--- a/autumn-harvest-plugin/src/ui.rs
+++ b/autumn-harvest-plugin/src/ui.rs
@@ -5853,6 +5853,7 @@ async fn execute_schedule_trigger_ui(
             owner,
             runbook_url,
             severity,
+            context_headers: None,
         },
     )
     .await;

--- a/autumn-harvest-plugin/tests/api_scheduler_integration.rs
+++ b/autumn-harvest-plugin/tests/api_scheduler_integration.rs
@@ -674,7 +674,6 @@ async fn insert_dead_letter_on_url(
 
             owner: None,
             severity: None,
-            context_headers: None,
         },
     )
     .await
@@ -701,7 +700,6 @@ fn manual_pipeline_info_named(name: &'static str) -> DagInfo {
         owner: None,
         runbook_url: None,
         severity: None,
-        context_headers: None,
     }
 }
 
@@ -1860,7 +1858,6 @@ fn manual_pipeline_info() -> DagInfo {
         owner: None,
         runbook_url: None,
         severity: None,
-        context_headers: None,
     }
 }
 
@@ -1880,7 +1877,6 @@ fn interval_pipeline_info() -> DagInfo {
         owner: None,
         runbook_url: None,
         severity: None,
-        context_headers: None,
     }
 }
 
@@ -1900,7 +1896,6 @@ fn classic_interval_pipeline_info() -> DagInfo {
         owner: None,
         runbook_url: None,
         severity: None,
-        context_headers: None,
     }
 }
 
@@ -1938,7 +1933,6 @@ fn unified_manual_dag_info_named(name: &'static str, default_queue: &'static str
         owner: None,
         runbook_url: None,
         severity: None,
-        context_headers: None,
     }
 }
 
@@ -1958,7 +1952,6 @@ fn manual_interval_pipeline_info() -> DagInfo {
         owner: None,
         runbook_url: None,
         severity: None,
-        context_headers: None,
     }
 }
 
@@ -3636,7 +3629,6 @@ async fn harvest_api_lists_and_replays_dead_letters() {
 
                 owner: None,
                 severity: None,
-                context_headers: None,
             },
         )
         .await
@@ -4038,7 +4030,6 @@ async fn harvest_api_defers_manual_dag_trigger_when_schedule_is_paused() {
             owner: None,
             runbook_url: None,
             severity: None,
-            context_headers: None,
         }])
         .expect("manual unified DAG should compile"),
     );
@@ -4340,7 +4331,6 @@ async fn harvest_api_rejects_non_dry_run_backfill_for_paused_dag_schedule() {
         owner: None,
         runbook_url: None,
         severity: None,
-        context_headers: None,
     };
     let workflow_schedule = dag_info
         .as_workflow_schedule()
@@ -4432,7 +4422,6 @@ async fn harvest_api_backfills_legacy_dag_schedule_null_queue_on_dag_default_que
         owner: None,
         runbook_url: None,
         severity: None,
-        context_headers: None,
     };
     let dag_catalog = Arc::new(
         compile_dag_catalog(vec![dag_info]).expect("scheduled unified DAG should compile"),
@@ -4522,7 +4511,6 @@ async fn harvest_api_backfill_matches_fractional_legacy_dag_workflow_id() {
         owner: None,
         runbook_url: None,
         severity: None,
-        context_headers: None,
     };
     let dag_catalog = Arc::new(
         compile_dag_catalog(vec![dag_info]).expect("scheduled unified DAG should compile"),
@@ -5188,7 +5176,6 @@ async fn ensure_dag_schedule_reuses_paused_legacy_workflow_only_dag_row() {
             owner: None,
             runbook_url: None,
             severity: None,
-            context_headers: None,
         }])
         .expect("unified DAG should compile"),
     );
@@ -5255,7 +5242,6 @@ async fn register_workflow_schedules_reuses_existing_dag_schedule_row_on_upgrade
         owner: None,
         runbook_url: None,
         severity: None,
-        context_headers: None,
     }])
     .expect("classic scheduled DAG should compile");
     register_test_schedules(
@@ -5334,7 +5320,6 @@ async fn register_workflow_schedules_merges_split_legacy_dag_rows_before_upgrade
         owner: None,
         runbook_url: None,
         severity: None,
-        context_headers: None,
     }])
     .expect("classic scheduled DAG should compile");
     register_test_schedules(
@@ -5440,7 +5425,6 @@ async fn register_workflow_schedules_preserves_pause_metadata_when_merging_split
         owner: None,
         runbook_url: None,
         severity: None,
-        context_headers: None,
     }])
     .expect("classic scheduled DAG should compile");
     register_test_schedules(
@@ -5548,7 +5532,6 @@ async fn scheduler_tick_dispatches_scheduled_unified_dag_on_dag_shard() {
             owner: None,
             runbook_url: None,
             severity: None,
-            context_headers: None,
         }])
         .expect("scheduled unified dag should compile"),
     );
@@ -5664,7 +5647,6 @@ async fn scheduler_tick_removes_stale_unified_dag_schedule_from_old_shard() {
             owner: None,
             runbook_url: None,
             severity: None,
-            context_headers: None,
         }])
         .expect("scheduled unified dag should compile"),
     );
@@ -5767,7 +5749,6 @@ async fn scheduler_tick_removes_legacy_workflow_only_dag_schedule_from_old_shard
             owner: None,
             runbook_url: None,
             severity: None,
-            context_headers: None,
         }])
         .expect("scheduled unified dag should compile"),
     );
@@ -5887,7 +5868,6 @@ async fn scheduler_tick_removes_stale_classic_dag_schedule_from_old_shard() {
             owner: None,
             runbook_url: None,
             severity: None,
-            context_headers: None,
         }])
         .expect("scheduled unified dag should compile"),
     );
@@ -5935,7 +5915,6 @@ async fn scheduler_tick_removes_stale_classic_dag_schedule_from_old_shard() {
             owner: None,
             runbook_url: None,
             severity: None,
-            context_headers: None,
         }])
         .expect("classic DAG schedule should compile");
         let mut conn = <AsyncPgConnection as AsyncConnection>::establish(&shard0_url)
@@ -6489,7 +6468,6 @@ async fn scheduler_tick_preserves_dag_metadata() {
         owner: Some("ops-team"),
         runbook_url: Some("http://ops-runbook"),
         severity: Some("sev2"),
-        context_headers: None,
     };
     let dag_catalog = Arc::new(compile_dag_catalog(vec![dag_info]).expect("dag compiles"));
 
@@ -6553,7 +6531,6 @@ async fn api_trigger_preserves_dag_metadata() {
         owner: Some("dev-team"),
         runbook_url: Some("http://dev-runbook"),
         severity: Some("sev1"),
-        context_headers: None,
     };
     let dag_catalog = Arc::new(compile_dag_catalog(vec![dag_info]).expect("dag compiles"));
     let registry = Arc::new(HandlerRegistry::new(

--- a/autumn-harvest-plugin/tests/api_scheduler_integration.rs
+++ b/autumn-harvest-plugin/tests/api_scheduler_integration.rs
@@ -548,6 +548,7 @@ async fn insert_workflow_on_url(
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         },
     )
     .await
@@ -625,6 +626,7 @@ async fn insert_child_workflow_on_url(fixture: ChildWorkflowFixture<'_>) -> Exec
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         },
     )
     .await
@@ -672,6 +674,7 @@ async fn insert_dead_letter_on_url(
 
             owner: None,
             severity: None,
+            context_headers: None,
         },
     )
     .await
@@ -698,6 +701,7 @@ fn manual_pipeline_info_named(name: &'static str) -> DagInfo {
         owner: None,
         runbook_url: None,
         severity: None,
+        context_headers: None,
     }
 }
 
@@ -781,6 +785,7 @@ async fn seed_dag_run_on_url(database_url: &str, dag_name: &str) -> uuid::Uuid {
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         })
         .execute(&mut conn)
         .await
@@ -1104,6 +1109,7 @@ async fn seed_scheduled_activity_task_from_url(
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         })
         .execute(&mut conn)
         .await
@@ -1854,6 +1860,7 @@ fn manual_pipeline_info() -> DagInfo {
         owner: None,
         runbook_url: None,
         severity: None,
+        context_headers: None,
     }
 }
 
@@ -1873,6 +1880,7 @@ fn interval_pipeline_info() -> DagInfo {
         owner: None,
         runbook_url: None,
         severity: None,
+        context_headers: None,
     }
 }
 
@@ -1892,6 +1900,7 @@ fn classic_interval_pipeline_info() -> DagInfo {
         owner: None,
         runbook_url: None,
         severity: None,
+        context_headers: None,
     }
 }
 
@@ -1929,6 +1938,7 @@ fn unified_manual_dag_info_named(name: &'static str, default_queue: &'static str
         owner: None,
         runbook_url: None,
         severity: None,
+        context_headers: None,
     }
 }
 
@@ -1948,6 +1958,7 @@ fn manual_interval_pipeline_info() -> DagInfo {
         owner: None,
         runbook_url: None,
         severity: None,
+        context_headers: None,
     }
 }
 
@@ -3625,6 +3636,7 @@ async fn harvest_api_lists_and_replays_dead_letters() {
 
                 owner: None,
                 severity: None,
+                context_headers: None,
             },
         )
         .await
@@ -4026,6 +4038,7 @@ async fn harvest_api_defers_manual_dag_trigger_when_schedule_is_paused() {
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         }])
         .expect("manual unified DAG should compile"),
     );
@@ -4327,6 +4340,7 @@ async fn harvest_api_rejects_non_dry_run_backfill_for_paused_dag_schedule() {
         owner: None,
         runbook_url: None,
         severity: None,
+        context_headers: None,
     };
     let workflow_schedule = dag_info
         .as_workflow_schedule()
@@ -4418,6 +4432,7 @@ async fn harvest_api_backfills_legacy_dag_schedule_null_queue_on_dag_default_que
         owner: None,
         runbook_url: None,
         severity: None,
+        context_headers: None,
     };
     let dag_catalog = Arc::new(
         compile_dag_catalog(vec![dag_info]).expect("scheduled unified DAG should compile"),
@@ -4507,6 +4522,7 @@ async fn harvest_api_backfill_matches_fractional_legacy_dag_workflow_id() {
         owner: None,
         runbook_url: None,
         severity: None,
+        context_headers: None,
     };
     let dag_catalog = Arc::new(
         compile_dag_catalog(vec![dag_info]).expect("scheduled unified DAG should compile"),
@@ -5172,6 +5188,7 @@ async fn ensure_dag_schedule_reuses_paused_legacy_workflow_only_dag_row() {
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         }])
         .expect("unified DAG should compile"),
     );
@@ -5238,6 +5255,7 @@ async fn register_workflow_schedules_reuses_existing_dag_schedule_row_on_upgrade
         owner: None,
         runbook_url: None,
         severity: None,
+        context_headers: None,
     }])
     .expect("classic scheduled DAG should compile");
     register_test_schedules(
@@ -5316,6 +5334,7 @@ async fn register_workflow_schedules_merges_split_legacy_dag_rows_before_upgrade
         owner: None,
         runbook_url: None,
         severity: None,
+        context_headers: None,
     }])
     .expect("classic scheduled DAG should compile");
     register_test_schedules(
@@ -5421,6 +5440,7 @@ async fn register_workflow_schedules_preserves_pause_metadata_when_merging_split
         owner: None,
         runbook_url: None,
         severity: None,
+        context_headers: None,
     }])
     .expect("classic scheduled DAG should compile");
     register_test_schedules(
@@ -5528,6 +5548,7 @@ async fn scheduler_tick_dispatches_scheduled_unified_dag_on_dag_shard() {
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         }])
         .expect("scheduled unified dag should compile"),
     );
@@ -5643,6 +5664,7 @@ async fn scheduler_tick_removes_stale_unified_dag_schedule_from_old_shard() {
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         }])
         .expect("scheduled unified dag should compile"),
     );
@@ -5745,6 +5767,7 @@ async fn scheduler_tick_removes_legacy_workflow_only_dag_schedule_from_old_shard
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         }])
         .expect("scheduled unified dag should compile"),
     );
@@ -5864,6 +5887,7 @@ async fn scheduler_tick_removes_stale_classic_dag_schedule_from_old_shard() {
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         }])
         .expect("scheduled unified dag should compile"),
     );
@@ -5911,6 +5935,7 @@ async fn scheduler_tick_removes_stale_classic_dag_schedule_from_old_shard() {
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         }])
         .expect("classic DAG schedule should compile");
         let mut conn = <AsyncPgConnection as AsyncConnection>::establish(&shard0_url)
@@ -6464,6 +6489,7 @@ async fn scheduler_tick_preserves_dag_metadata() {
         owner: Some("ops-team"),
         runbook_url: Some("http://ops-runbook"),
         severity: Some("sev2"),
+        context_headers: None,
     };
     let dag_catalog = Arc::new(compile_dag_catalog(vec![dag_info]).expect("dag compiles"));
 
@@ -6527,6 +6553,7 @@ async fn api_trigger_preserves_dag_metadata() {
         owner: Some("dev-team"),
         runbook_url: Some("http://dev-runbook"),
         severity: Some("sev1"),
+        context_headers: None,
     };
     let dag_catalog = Arc::new(compile_dag_catalog(vec![dag_info]).expect("dag compiles"));
     let registry = Arc::new(HandlerRegistry::new(

--- a/autumn-harvest-plugin/tests/api_scheduler_integration.rs
+++ b/autumn-harvest-plugin/tests/api_scheduler_integration.rs
@@ -159,7 +159,9 @@ const INIT_SQL: &str = concat!(
     "\n",
     include_str!(
         "../../autumn-harvest/migrations/20260610000001_harvest_schedule_bounded_runs/up.sql"
-    )
+    ),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260615000001_harvest_context_headers/up.sql")
 );
 type HarvestApiApp = axum::Router;
 

--- a/autumn-harvest-plugin/tests/archival_integration.rs
+++ b/autumn-harvest-plugin/tests/archival_integration.rs
@@ -130,7 +130,9 @@ const INIT_SQL: &str = concat!(
     "\n",
     include_str!(
         "../../autumn-harvest/migrations/20260610000001_harvest_schedule_bounded_runs/up.sql"
-    )
+    ),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260615000001_harvest_context_headers/up.sql")
 );
 
 struct TestArchiver {

--- a/autumn-harvest-plugin/tests/batch_operations_integration.rs
+++ b/autumn-harvest-plugin/tests/batch_operations_integration.rs
@@ -139,7 +139,9 @@ const INIT_SQL: &str = concat!(
     "\n",
     include_str!(
         "../../autumn-harvest/migrations/20260610000001_harvest_schedule_bounded_runs/up.sql"
-    )
+    ),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260615000001_harvest_context_headers/up.sql")
 );
 
 type HarvestApiApp = axum::Router;

--- a/autumn-harvest-plugin/tests/batch_operations_integration.rs
+++ b/autumn-harvest-plugin/tests/batch_operations_integration.rs
@@ -261,6 +261,7 @@ async fn seed_workflows(database_url: &str, workflow_name: &str, count: usize) -
                 owner: None,
                 runbook_url: None,
                 severity: None,
+                context_headers: None,
             },
         )
         .await

--- a/autumn-harvest-plugin/tests/build_routing_ui_integration.rs
+++ b/autumn-harvest-plugin/tests/build_routing_ui_integration.rs
@@ -137,7 +137,9 @@ const INIT_SQL: &str = concat!(
     "\n",
     include_str!(
         "../../autumn-harvest/migrations/20260610000001_harvest_schedule_bounded_runs/up.sql"
-    )
+    ),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260615000001_harvest_context_headers/up.sql")
 );
 
 async fn setup_test_database_url() -> (String, ContainerAsync<Postgres>) {

--- a/autumn-harvest-plugin/tests/build_routing_ui_integration.rs
+++ b/autumn-harvest-plugin/tests/build_routing_ui_integration.rs
@@ -591,6 +591,7 @@ async fn api_retire_build_returns_conflict_when_not_safe() {
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         },
     )
     .await
@@ -880,6 +881,7 @@ async fn two_build_rolling_deploy_full_lifecycle() {
                 owner: None,
                 runbook_url: None,
                 severity: None,
+                context_headers: None,
             },
         )
         .await

--- a/autumn-harvest-plugin/tests/completion_triggers_integration.rs
+++ b/autumn-harvest-plugin/tests/completion_triggers_integration.rs
@@ -151,7 +151,9 @@ const INIT_SQL: &str = concat!(
     "\n",
     include_str!(
         "../../autumn-harvest/migrations/20260610000001_harvest_schedule_bounded_runs/up.sql"
-    )
+    ),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260615000001_harvest_context_headers/up.sql")
 );
 
 type HarvestApiApp = axum::Router;

--- a/autumn-harvest-plugin/tests/completion_triggers_integration.rs
+++ b/autumn-harvest-plugin/tests/completion_triggers_integration.rs
@@ -243,7 +243,6 @@ fn test_registry() -> Arc<HandlerRegistry> {
                 owner: None,
                 runbook_url: None,
                 severity: None,
-                context_headers: None,
             },
             WorkflowInfo {
                 name: "target_wf",
@@ -259,7 +258,6 @@ fn test_registry() -> Arc<HandlerRegistry> {
                 owner: None,
                 runbook_url: None,
                 severity: None,
-                context_headers: None,
             },
             WorkflowInfo {
                 name: "target_with_schema_wf",
@@ -275,7 +273,6 @@ fn test_registry() -> Arc<HandlerRegistry> {
                 owner: None,
                 runbook_url: None,
                 severity: None,
-                context_headers: None,
             },
         ],
         vec![],

--- a/autumn-harvest-plugin/tests/completion_triggers_integration.rs
+++ b/autumn-harvest-plugin/tests/completion_triggers_integration.rs
@@ -243,6 +243,7 @@ fn test_registry() -> Arc<HandlerRegistry> {
                 owner: None,
                 runbook_url: None,
                 severity: None,
+                context_headers: None,
             },
             WorkflowInfo {
                 name: "target_wf",
@@ -258,6 +259,7 @@ fn test_registry() -> Arc<HandlerRegistry> {
                 owner: None,
                 runbook_url: None,
                 severity: None,
+                context_headers: None,
             },
             WorkflowInfo {
                 name: "target_with_schema_wf",
@@ -273,6 +275,7 @@ fn test_registry() -> Arc<HandlerRegistry> {
                 owner: None,
                 runbook_url: None,
                 severity: None,
+                context_headers: None,
             },
         ],
         vec![],
@@ -449,6 +452,7 @@ async fn test_trigger_evaluations_same_shard() {
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         },
     )
     .await
@@ -542,6 +546,7 @@ async fn test_trigger_input_mapping_static_and_projection() {
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         },
     )
     .await
@@ -613,6 +618,7 @@ async fn test_trigger_input_mapping_static_and_projection() {
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         },
     )
     .await
@@ -706,6 +712,7 @@ async fn test_trigger_state_matching_and_deduplication() {
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         },
     )
     .await
@@ -876,6 +883,7 @@ async fn test_trigger_cross_shard() {
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         },
     )
     .await
@@ -974,6 +982,7 @@ async fn test_completion_trigger_via_worker_run() {
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         },
     )
     .await
@@ -1086,6 +1095,7 @@ async fn test_trigger_with_custom_queue() {
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         },
     )
     .await
@@ -1266,6 +1276,7 @@ async fn test_trigger_outbox_retry_and_sweep() {
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         },
     )
     .await
@@ -1473,6 +1484,7 @@ async fn test_trigger_cross_shard_queue_preservation() {
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         },
     )
     .await
@@ -1893,6 +1905,7 @@ async fn test_trigger_evaluations_schema_validation() {
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         },
     )
     .await
@@ -1959,6 +1972,7 @@ async fn test_trigger_evaluations_schema_validation() {
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         },
     )
     .await

--- a/autumn-harvest-plugin/tests/dag_retry_integration.rs
+++ b/autumn-harvest-plugin/tests/dag_retry_integration.rs
@@ -354,6 +354,7 @@ async fn seed_run(
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         },
     )
     .await

--- a/autumn-harvest-plugin/tests/dag_retry_integration.rs
+++ b/autumn-harvest-plugin/tests/dag_retry_integration.rs
@@ -184,7 +184,9 @@ const INIT_SQL: &str = concat!(
     "\n",
     include_str!(
         "../../autumn-harvest/migrations/20260610000001_harvest_schedule_bounded_runs/up.sql"
-    )
+    ),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260615000001_harvest_context_headers/up.sql")
 );
 
 type HarvestApiApp = axum::Router;

--- a/autumn-harvest-plugin/tests/dlq_aggregate_integration.rs
+++ b/autumn-harvest-plugin/tests/dlq_aggregate_integration.rs
@@ -301,7 +301,6 @@ async fn insert_dlq_rows(
                 attempts: 3,
                 owner: None,
                 severity: None,
-                context_headers: None,
             },
         )
         .await

--- a/autumn-harvest-plugin/tests/dlq_aggregate_integration.rs
+++ b/autumn-harvest-plugin/tests/dlq_aggregate_integration.rs
@@ -266,6 +266,7 @@ async fn insert_execution(database_url: &str, shard: i32, workflow_name: &str) -
         owner: None,
         runbook_url: None,
         severity: None,
+        context_headers: None,
     };
     diesel::insert_into(autumn_harvest::schema::harvest_workflow_executions::table)
         .values(&row)
@@ -300,6 +301,7 @@ async fn insert_dlq_rows(
                 attempts: 3,
                 owner: None,
                 severity: None,
+                context_headers: None,
             },
         )
         .await

--- a/autumn-harvest-plugin/tests/dlq_aggregate_integration.rs
+++ b/autumn-harvest-plugin/tests/dlq_aggregate_integration.rs
@@ -109,7 +109,25 @@ const INIT_SQL: &str = concat!(
     include_str!("../../autumn-harvest/migrations/20260605000000_harvest_admission_gates/up.sql"),
     include_str!(
         "../../autumn-harvest/migrations/20260606000001_harvest_activity_schedule_to_close/up.sql"
-    )
+    ),
+    include_str!(
+        "../../autumn-harvest/migrations/20260607000000_harvest_worker_capability_labels/up.sql"
+    ),
+    include_str!(
+        "../../autumn-harvest/migrations/20260607000001_harvest_task_required_capabilities/up.sql"
+    ),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260607000002_harvest_workflow_pause/up.sql"),
+    "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260609000001_harvest_workflow_current_details/up.sql"
+    ),
+    "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260610000001_harvest_schedule_bounded_runs/up.sql"
+    ),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260615000001_harvest_context_headers/up.sql")
 );
 
 type HarvestApiApp = axum::Router;

--- a/autumn-harvest-plugin/tests/dlq_bulk_integration.rs
+++ b/autumn-harvest-plugin/tests/dlq_bulk_integration.rs
@@ -270,7 +270,6 @@ async fn insert_dlq_row(database_url: &str, activity_name: &str, task_type: &str
 
             owner: None,
             severity: None,
-            context_headers: None,
         },
     )
     .await

--- a/autumn-harvest-plugin/tests/dlq_bulk_integration.rs
+++ b/autumn-harvest-plugin/tests/dlq_bulk_integration.rs
@@ -123,7 +123,9 @@ const INIT_SQL: &str = concat!(
     "\n",
     include_str!(
         "../../autumn-harvest/migrations/20260610000001_harvest_schedule_bounded_runs/up.sql"
-    )
+    ),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260615000001_harvest_context_headers/up.sql")
 );
 
 type HarvestApiApp = axum::Router;

--- a/autumn-harvest-plugin/tests/dlq_bulk_integration.rs
+++ b/autumn-harvest-plugin/tests/dlq_bulk_integration.rs
@@ -270,6 +270,7 @@ async fn insert_dlq_row(database_url: &str, activity_name: &str, task_type: &str
 
             owner: None,
             severity: None,
+            context_headers: None,
         },
     )
     .await

--- a/autumn-harvest-plugin/tests/external_handoffs_integration.rs
+++ b/autumn-harvest-plugin/tests/external_handoffs_integration.rs
@@ -145,6 +145,7 @@ async fn seed_external_handoff(
         owner: None,
         runbook_url: None,
         severity: None,
+        context_headers: None,
     };
     diesel::insert_into(autumn_harvest::schema::harvest_workflow_executions::table)
         .values(&execution)

--- a/autumn-harvest-plugin/tests/history_export_integration.rs
+++ b/autumn-harvest-plugin/tests/history_export_integration.rs
@@ -201,6 +201,7 @@ async fn insert_execution(
         owner: None,
         runbook_url: None,
         severity: None,
+        context_headers: None,
     };
     diesel::insert_into(autumn_harvest::schema::harvest_workflow_executions::table)
         .values(&row)

--- a/autumn-harvest-plugin/tests/outbox_integration.rs
+++ b/autumn-harvest-plugin/tests/outbox_integration.rs
@@ -102,7 +102,9 @@ const HARVEST_INIT_SQL: &str = concat!(
     "\n",
     include_str!(
         "../../autumn-harvest/migrations/20260610000001_harvest_schedule_bounded_runs/up.sql"
-    )
+    ),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260615000001_harvest_context_headers/up.sql")
 );
 
 #[derive(Debug, QueryableByName)]

--- a/autumn-harvest-plugin/tests/retirement_check_integration.rs
+++ b/autumn-harvest-plugin/tests/retirement_check_integration.rs
@@ -176,6 +176,7 @@ async fn insert_versioned_execution(
         owner: None,
         runbook_url: None,
         severity: None,
+        context_headers: None,
     };
     diesel::insert_into(autumn_harvest::schema::harvest_workflow_executions::table)
         .values(&row)
@@ -246,6 +247,7 @@ async fn insert_execution_without_marker(
         owner: None,
         runbook_url: None,
         severity: None,
+        context_headers: None,
     };
     diesel::insert_into(autumn_harvest::schema::harvest_workflow_executions::table)
         .values(&row)

--- a/autumn-harvest-plugin/tests/signal_with_start_integration.rs
+++ b/autumn-harvest-plugin/tests/signal_with_start_integration.rs
@@ -130,7 +130,9 @@ const INIT_SQL: &str = concat!(
     "\n",
     include_str!(
         "../../autumn-harvest/migrations/20260610000001_harvest_schedule_bounded_runs/up.sql"
-    )
+    ),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260615000001_harvest_context_headers/up.sql")
 );
 
 type HarvestApiApp = axum::Router;

--- a/autumn-harvest-plugin/tests/telemetry_propagation_tests.rs
+++ b/autumn-harvest-plugin/tests/telemetry_propagation_tests.rs
@@ -145,7 +145,9 @@ const INIT_SQL: &str = concat!(
     "\n",
     include_str!(
         "../../autumn-harvest/migrations/20260610000001_harvest_schedule_bounded_runs/up.sql"
-    )
+    ),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260615000001_harvest_context_headers/up.sql")
 );
 
 // -------------------------------------------------------------------------

--- a/autumn-harvest-plugin/tests/ui_integration.rs
+++ b/autumn-harvest-plugin/tests/ui_integration.rs
@@ -435,7 +435,6 @@ async fn insert_dead_letter_on_url(
             attempts: i32::try_from(ordinal + 1).expect("ordinal fits i32"),
             owner: None,
             severity: None,
-            context_headers: None,
         },
     )
     .await
@@ -2790,7 +2789,6 @@ async fn ui_trigger_preserves_dag_metadata() {
         owner: Some("ui-team"),
         runbook_url: Some("http://ui-runbook"),
         severity: Some("sev3"),
-        context_headers: None,
     };
 
     let dag_catalog =

--- a/autumn-harvest-plugin/tests/ui_integration.rs
+++ b/autumn-harvest-plugin/tests/ui_integration.rs
@@ -141,7 +141,9 @@ const INIT_SQL: &str = concat!(
     "\n",
     include_str!(
         "../../autumn-harvest/migrations/20260610000001_harvest_schedule_bounded_runs/up.sql"
-    )
+    ),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260615000001_harvest_context_headers/up.sql")
 );
 
 async fn setup_test_database_url() -> (String, ContainerAsync<Postgres>) {

--- a/autumn-harvest-plugin/tests/ui_integration.rs
+++ b/autumn-harvest-plugin/tests/ui_integration.rs
@@ -374,6 +374,7 @@ async fn insert_workflow_on_url(
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         },
     )
     .await
@@ -434,6 +435,7 @@ async fn insert_dead_letter_on_url(
             attempts: i32::try_from(ordinal + 1).expect("ordinal fits i32"),
             owner: None,
             severity: None,
+            context_headers: None,
         },
     )
     .await
@@ -2129,6 +2131,7 @@ async fn insert_child_workflow_on_url(
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         },
     )
     .await
@@ -2787,6 +2790,7 @@ async fn ui_trigger_preserves_dag_metadata() {
         owner: Some("ui-team"),
         runbook_url: Some("http://ui-runbook"),
         severity: Some("sev3"),
+        context_headers: None,
     };
 
     let dag_catalog =

--- a/autumn-harvest-plugin/tests/version_usage_integration.rs
+++ b/autumn-harvest-plugin/tests/version_usage_integration.rs
@@ -194,6 +194,7 @@ async fn insert_version_execution_with_markers(
         owner: None,
         runbook_url: None,
         severity: None,
+        context_headers: None,
     };
     diesel::insert_into(autumn_harvest::schema::harvest_workflow_executions::table)
         .values(&row)

--- a/autumn-harvest-plugin/tests/workflow_filter_integration.rs
+++ b/autumn-harvest-plugin/tests/workflow_filter_integration.rs
@@ -104,7 +104,9 @@ const INIT_SQL: &str = concat!(
     "\n",
     include_str!(
         "../../autumn-harvest/migrations/20260610000001_harvest_schedule_bounded_runs/up.sql"
-    )
+    ),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260615000001_harvest_context_headers/up.sql")
 );
 
 type HarvestApiApp = axum::Router;

--- a/autumn-harvest-plugin/tests/workflow_filter_integration.rs
+++ b/autumn-harvest-plugin/tests/workflow_filter_integration.rs
@@ -230,6 +230,7 @@ async fn seed_workflow(
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         },
     )
     .await

--- a/autumn-harvest-plugin/tests/workflow_reset_integration.rs
+++ b/autumn-harvest-plugin/tests/workflow_reset_integration.rs
@@ -132,7 +132,9 @@ const INIT_SQL: &str = concat!(
     "\n",
     include_str!(
         "../../autumn-harvest/migrations/20260610000001_harvest_schedule_bounded_runs/up.sql"
-    )
+    ),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260615000001_harvest_context_headers/up.sql")
 );
 
 type HarvestApiApp = axum::Router;

--- a/autumn-harvest-plugin/tests/workflow_reset_integration.rs
+++ b/autumn-harvest-plugin/tests/workflow_reset_integration.rs
@@ -267,6 +267,7 @@ async fn seed_execution(
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         },
     )
     .await

--- a/autumn-harvest/benches/replay_verifier_bench.rs
+++ b/autumn-harvest/benches/replay_verifier_bench.rs
@@ -59,6 +59,7 @@ fn build_fixture_json(activity_count: usize) -> String {
         workflow_name: "sequential".to_string(),
         execution_id: exec_id,
         events,
+        context_headers: None,
     };
     serde_json::to_string(&snapshot).unwrap()
 }

--- a/autumn-harvest/examples/signal_with_start_webhook.rs
+++ b/autumn-harvest/examples/signal_with_start_webhook.rs
@@ -108,6 +108,7 @@ async fn handle_webhook_after(
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         },
     )
     .await?;

--- a/autumn-harvest/examples/update_with_start_cart.rs
+++ b/autumn-harvest/examples/update_with_start_cart.rs
@@ -154,6 +154,7 @@ async fn add_item_atomic(
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         },
     )
     .await?;

--- a/autumn-harvest/migrations/20260615000001_harvest_context_headers/down.sql
+++ b/autumn-harvest/migrations/20260615000001_harvest_context_headers/down.sql
@@ -1,0 +1,2 @@
+ALTER TABLE harvest_workflow_executions DROP COLUMN IF EXISTS context_headers;
+ALTER TABLE harvest_task_queue DROP COLUMN IF EXISTS context_headers;

--- a/autumn-harvest/migrations/20260615000001_harvest_context_headers/up.sql
+++ b/autumn-harvest/migrations/20260615000001_harvest_context_headers/up.sql
@@ -1,0 +1,10 @@
+-- issue #481: per-execution ambient context headers
+--
+-- context_headers: string key-value map attached at workflow start, propagated
+-- automatically to all activities and child workflows without threading through
+-- function signatures. Nullable JSONB (NULL = empty map for legacy executions).
+ALTER TABLE harvest_workflow_executions
+    ADD COLUMN IF NOT EXISTS context_headers JSONB NULL;
+
+ALTER TABLE harvest_task_queue
+    ADD COLUMN IF NOT EXISTS context_headers JSONB NULL;

--- a/autumn-harvest/src/completion_trigger.rs
+++ b/autumn-harvest/src/completion_trigger.rs
@@ -352,6 +352,7 @@ impl DeferredTriggerStart {
                     owner: self.owner.as_deref(),
                     runbook_url: self.runbook_url.as_deref(),
                     severity: self.severity.as_deref(),
+                    context_headers: None,
                 },
             )
             .await;
@@ -568,6 +569,7 @@ pub fn evaluate_triggers_for_execution<'a>(
                         owner: target_owner.as_deref(),
                         runbook_url: target_runbook_url.as_deref(),
                         severity: target_severity.as_deref(),
+                        context_headers: None,
                     },
                 )
                 .await
@@ -768,6 +770,7 @@ pub async fn enforce_completion_triggers_outbox(
                 owner: target_owner.as_deref(),
                 runbook_url: target_runbook_url.as_deref(),
                 severity: target_severity.as_deref(),
+                context_headers: None,
             },
         )
         .await;

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -761,6 +761,10 @@ pub struct WorkflowContext {
     /// longer than this cap are truncated to the cap boundary on a UTF-8
     /// character boundary. Configurable via `HarvestBuilder::with_current_details_cap`.
     current_details_cap: usize,
+    /// Ambient string key-value context attached at workflow start and propagated
+    /// automatically to all activities and child workflows (issue #481).
+    /// Immutable after construction; read via `header()` / `headers()`.
+    context_headers: std::sync::Arc<HashMap<String, String>>,
 }
 
 impl WorkflowContext {
@@ -907,6 +911,7 @@ impl WorkflowContext {
             activity_input_cap_overrides: HashMap::new(),
             deferred_nd_error: Mutex::new(None),
             current_details_cap: DEFAULT_CURRENT_DETAILS_CAP_BYTES,
+            context_headers: std::sync::Arc::new(HashMap::new()),
         }
     }
 
@@ -994,6 +999,7 @@ impl WorkflowContext {
             activity_input_cap_overrides: HashMap::new(),
             deferred_nd_error: Mutex::new(None),
             current_details_cap: DEFAULT_CURRENT_DETAILS_CAP_BYTES,
+            context_headers: std::sync::Arc::new(HashMap::new()),
         })
     }
 
@@ -1031,6 +1037,7 @@ impl WorkflowContext {
             activity_input_cap_overrides: HashMap::new(),
             deferred_nd_error: Mutex::new(None),
             current_details_cap: DEFAULT_CURRENT_DETAILS_CAP_BYTES,
+            context_headers: std::sync::Arc::new(HashMap::new()),
         }
     }
 
@@ -1143,6 +1150,37 @@ impl WorkflowContext {
     #[must_use]
     pub fn build_id(&self) -> Option<&str> {
         self.build_id.as_deref()
+    }
+
+    // ── Context headers (issue #481) ──────────────────────────────────────────
+
+    /// Attach ambient context headers to this workflow context (builder-style).
+    ///
+    /// Headers are fixed at workflow-start time and propagated automatically to
+    /// all activity and child-workflow dispatches without touching input types.
+    /// Typically called by the framework after loading the execution row; author
+    /// code reads headers via [`header`](Self::header) / [`headers`](Self::headers).
+    #[must_use]
+    pub fn with_context_headers(mut self, headers: HashMap<String, String>) -> Self {
+        self.context_headers = std::sync::Arc::new(headers);
+        self
+    }
+
+    /// Return the value of the named context header, or `None` if not set.
+    ///
+    /// Returns `None` (never panics) when `key` was never attached, including
+    /// for executions that were started before this feature was deployed.
+    #[must_use]
+    pub fn header(&self, key: &str) -> Option<&str> {
+        self.context_headers.get(key).map(String::as_str)
+    }
+
+    /// Return the full context header map for this execution.
+    ///
+    /// The map is empty for executions started before this feature shipped.
+    #[must_use]
+    pub fn headers(&self) -> &HashMap<String, String> {
+        &self.context_headers
     }
 
     /// Retrieve and clear the structured non-determinism details.
@@ -4016,6 +4054,7 @@ impl WorkflowContext {
         let name = info.name;
         let workflow_id = self.workflow_id.clone();
         let workflow_name = self.workflow_name.clone();
+        let context_headers = std::sync::Arc::clone(&self.context_headers);
 
         let boxed_handler: crate::update::BoxUpdateHandler = std::sync::Arc::new(move |input| {
             let mut ctx = Self::new_for_handler(
@@ -4030,6 +4069,7 @@ impl WorkflowContext {
                 let inner = std::sync::Arc::get_mut(&mut ctx).unwrap();
                 inner.workflow_id.clone_from(&workflow_id);
                 inner.workflow_name.clone_from(&workflow_name);
+                inner.context_headers = std::sync::Arc::clone(&context_headers);
             }
             handler_fn(ctx, input)
         });
@@ -4091,6 +4131,7 @@ impl WorkflowContext {
                 let inner = std::sync::Arc::get_mut(&mut ctx).unwrap();
                 inner.workflow_id.clone_from(&self.workflow_id);
                 inner.workflow_name.clone_from(&self.workflow_name);
+                inner.context_headers = std::sync::Arc::clone(&self.context_headers);
             }
             h(ctx, input)
         })
@@ -4505,6 +4546,10 @@ pub struct ActivityContext {
     /// was not constructed by the worker's regular activity dispatch path.
     #[cfg(feature = "db")]
     transactional_state: Option<TransactionalState>,
+    /// Ambient context headers propagated from the parent workflow (issue #481).
+    /// Read via `header()` / `headers()`. Empty for activities dispatched before
+    /// this feature was deployed.
+    context_headers: std::sync::Arc<HashMap<String, String>>,
 }
 
 impl ActivityContext {
@@ -4535,6 +4580,7 @@ impl ActivityContext {
             max_attempts: None,
             #[cfg(feature = "db")]
             transactional_state: None,
+            context_headers: std::sync::Arc::new(HashMap::new()),
         }
     }
 
@@ -4569,6 +4615,7 @@ impl ActivityContext {
             previous_failure: None,
             max_attempts: None,
             transactional_state: None,
+            context_headers: std::sync::Arc::new(HashMap::new()),
         }
     }
 
@@ -4592,6 +4639,7 @@ impl ActivityContext {
             max_attempts: None,
             #[cfg(feature = "db")]
             transactional_state: None,
+            context_headers: std::sync::Arc::new(HashMap::new()),
         }
     }
 
@@ -4613,6 +4661,37 @@ impl ActivityContext {
     #[must_use]
     pub const fn trace_context(&self) -> Option<&crate::telemetry::TraceContextCarrier> {
         self.trace_context.as_ref()
+    }
+
+    // ── Context headers (issue #481) ──────────────────────────────────────────
+
+    /// Attach the parent workflow's context headers to this activity context.
+    ///
+    /// Called automatically by the worker at dispatch time; you only need it
+    /// when constructing an `ActivityContext` manually in tests.
+    #[must_use]
+    pub fn with_context_headers(
+        mut self,
+        headers: std::sync::Arc<HashMap<String, String>>,
+    ) -> Self {
+        self.context_headers = headers;
+        self
+    }
+
+    /// Return the value of the named context header, or `None` if not set.
+    ///
+    /// Returns `None` (never panics) when `key` was never attached.
+    #[must_use]
+    pub fn header(&self, key: &str) -> Option<&str> {
+        self.context_headers.get(key).map(String::as_str)
+    }
+
+    /// Return the full context header map propagated from the parent workflow.
+    ///
+    /// The map is empty for activities dispatched before this feature shipped.
+    #[must_use]
+    pub fn headers(&self) -> &HashMap<String, String> {
+        &self.context_headers
     }
 
     /// Attach a stable idempotency key to this context.
@@ -8243,5 +8322,74 @@ mod tests {
             "stored length {} exceeds cap 5",
             stored.len()
         );
+    }
+
+    // ── Context headers — WorkflowContext ────────────────────────────────────
+
+    #[test]
+    fn workflow_context_header_returns_set_value() {
+        let mut headers = std::collections::HashMap::new();
+        headers.insert("tenant_id".to_string(), "acme".to_string());
+        let ctx = WorkflowContext::new_test().with_context_headers(headers);
+        assert_eq!(ctx.header("tenant_id"), Some("acme"));
+    }
+
+    #[test]
+    fn workflow_context_header_missing_key_returns_none() {
+        let ctx = WorkflowContext::new_test();
+        assert!(ctx.header("tenant_id").is_none());
+    }
+
+    #[test]
+    fn workflow_context_headers_returns_all() {
+        let mut headers = std::collections::HashMap::new();
+        headers.insert("a".to_string(), "1".to_string());
+        headers.insert("b".to_string(), "2".to_string());
+        let ctx = WorkflowContext::new_test().with_context_headers(headers);
+        let map = ctx.headers();
+        assert_eq!(map.get("a").map(String::as_str), Some("1"));
+        assert_eq!(map.get("b").map(String::as_str), Some("2"));
+        assert_eq!(map.len(), 2);
+    }
+
+    #[test]
+    fn workflow_context_headers_empty_on_default() {
+        let ctx = WorkflowContext::new_test();
+        assert!(ctx.headers().is_empty());
+    }
+
+    // ── Context headers — ActivityContext ────────────────────────────────────
+
+    #[test]
+    fn activity_context_header_returns_set_value() {
+        let mut headers = std::collections::HashMap::new();
+        headers.insert("tenant_id".to_string(), "acme".to_string());
+        let ctx = ActivityContext::new_test()
+            .with_context_headers(std::sync::Arc::new(headers));
+        assert_eq!(ctx.header("tenant_id"), Some("acme"));
+    }
+
+    #[test]
+    fn activity_context_header_missing_key_returns_none() {
+        let ctx = ActivityContext::new_test();
+        assert!(ctx.header("tenant_id").is_none());
+    }
+
+    #[test]
+    fn activity_context_headers_returns_all() {
+        let mut headers = std::collections::HashMap::new();
+        headers.insert("x".to_string(), "foo".to_string());
+        headers.insert("y".to_string(), "bar".to_string());
+        let ctx = ActivityContext::new_test()
+            .with_context_headers(std::sync::Arc::new(headers));
+        let map = ctx.headers();
+        assert_eq!(map.get("x").map(String::as_str), Some("foo"));
+        assert_eq!(map.get("y").map(String::as_str), Some("bar"));
+    }
+
+    #[test]
+    fn activity_context_headers_empty_on_default() {
+        let ctx = ActivityContext::new_test();
+        assert!(ctx.headers().is_empty());
     }
 }

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -8364,8 +8364,7 @@ mod tests {
     fn activity_context_header_returns_set_value() {
         let mut headers = std::collections::HashMap::new();
         headers.insert("tenant_id".to_string(), "acme".to_string());
-        let ctx = ActivityContext::new_test()
-            .with_context_headers(std::sync::Arc::new(headers));
+        let ctx = ActivityContext::new_test().with_context_headers(std::sync::Arc::new(headers));
         assert_eq!(ctx.header("tenant_id"), Some("acme"));
     }
 
@@ -8380,8 +8379,7 @@ mod tests {
         let mut headers = std::collections::HashMap::new();
         headers.insert("x".to_string(), "foo".to_string());
         headers.insert("y".to_string(), "bar".to_string());
-        let ctx = ActivityContext::new_test()
-            .with_context_headers(std::sync::Arc::new(headers));
+        let ctx = ActivityContext::new_test().with_context_headers(std::sync::Arc::new(headers));
         let map = ctx.headers();
         assert_eq!(map.get("x").map(String::as_str), Some("foo"));
         assert_eq!(map.get("y").map(String::as_str), Some("bar"));

--- a/autumn-harvest/src/execution.rs
+++ b/autumn-harvest/src/execution.rs
@@ -89,6 +89,9 @@ pub struct StartWorkflowParams<'a> {
     pub owner: Option<&'a str>,
     pub runbook_url: Option<&'a str>,
     pub severity: Option<&'a str>,
+    /// Ambient string key-value context propagated to all activities and child
+    /// workflows without threading through function signatures (issue #481).
+    pub context_headers: Option<std::collections::HashMap<String, String>>,
 }
 
 impl StartWorkflowParams<'_> {
@@ -327,6 +330,10 @@ pub async fn start_or_load_workflow_execution(
         owner: request.owner,
         runbook_url: request.runbook_url,
         severity: request.severity,
+        context_headers: request
+            .context_headers
+            .as_ref()
+            .map(|h| serde_json::to_value(h).unwrap_or(serde_json::Value::Null)),
     };
     let mut enqueue = EnqueueParams::new(
         request.queue_name.to_owned(),
@@ -1546,6 +1553,7 @@ pub struct SignalWithStartParams<'a> {
     pub owner: Option<&'a str>,
     pub runbook_url: Option<&'a str>,
     pub severity: Option<&'a str>,
+    pub context_headers: Option<std::collections::HashMap<String, String>>,
 }
 
 /// Result of a [`signal_with_start_workflow_execution`] call.
@@ -1716,6 +1724,7 @@ pub async fn signal_with_start_workflow_execution(
                     owner: request.owner,
                     runbook_url: request.runbook_url,
                     severity: request.severity,
+                    context_headers: request.context_headers.clone(),
                 };
 
             let started = start_or_load_workflow_execution(
@@ -2007,6 +2016,7 @@ pub struct UpdateWithStartParams<'a> {
     pub owner: Option<&'a str>,
     pub runbook_url: Option<&'a str>,
     pub severity: Option<&'a str>,
+    pub context_headers: Option<std::collections::HashMap<String, String>>,
 }
 
 /// Result of an [`update_with_start_workflow_execution`] call.
@@ -2126,6 +2136,7 @@ pub async fn update_with_start_workflow_execution(
                     owner: request.owner,
                     runbook_url: request.runbook_url,
                     severity: request.severity,
+                    context_headers: request.context_headers.clone(),
                 };
 
             let started = start_or_load_workflow_execution(

--- a/autumn-harvest/src/executor.rs
+++ b/autumn-harvest/src/executor.rs
@@ -111,14 +111,17 @@ pub async fn run_workflow(
 /// returning a non-determinism error on any mismatch.  This is used by
 /// [`WorkflowReplayer`](crate::testing::WorkflowReplayer) to catch
 /// input-changing code changes before deployment.
+#[allow(clippy::implicit_hasher)]
 pub async fn run_workflow_strict(
     exec_id: ExecutionId,
     history: Vec<WorkflowEvent>,
     handler: WorkflowHandlerFn,
     input: Value,
     state: SharedState,
+    context_headers: std::collections::HashMap<String, String>,
 ) -> WorkflowOutcome {
-    let ctx = WorkflowContext::for_replay_strict_with_state(exec_id, history, state);
+    let ctx = WorkflowContext::for_replay_strict_with_state(exec_id, history, state)
+        .with_context_headers(context_headers);
 
     // ADR-0001 §2.1: strict mode is always a replay cycle.
     let span = tracing::info_span!(
@@ -298,13 +301,14 @@ pub async fn run_workflow_with_state_and_history_policy(
         crate::builder::DEFAULT_MAX_SIGNAL_PAYLOAD_BYTES,
         crate::builder::DEFAULT_MAX_WORKFLOW_INPUT_BYTES,
         crate::context::DEFAULT_CURRENT_DETAILS_CAP_BYTES,
+        std::collections::HashMap::new(),
     )
     .await
 }
 
 /// Full executor entry point used by the worker, which injects the workflow name
 /// and payload size caps configured on the `BuiltHarvest` instance.
-#[allow(clippy::too_many_arguments)]
+#[allow(clippy::too_many_arguments, clippy::implicit_hasher)]
 pub async fn run_workflow_with_state_history_policy_and_caps(
     exec_id: ExecutionId,
     history: Vec<WorkflowEvent>,
@@ -320,6 +324,7 @@ pub async fn run_workflow_with_state_history_policy_and_caps(
     max_signal_payload_bytes: u64,
     max_workflow_input_bytes: u64,
     max_current_details_bytes: usize,
+    context_headers: std::collections::HashMap<String, String>,
 ) -> (WorkflowOutcome, Vec<WorkflowCommand>, tracing::Span) {
     let ctx = WorkflowContext::for_replay_with_state_and_history_policy(
         exec_id,
@@ -336,7 +341,8 @@ pub async fn run_workflow_with_state_history_policy_and_caps(
         max_signal_payload_bytes,
         max_workflow_input_bytes,
     )
-    .with_current_details_cap(max_current_details_bytes);
+    .with_current_details_cap(max_current_details_bytes)
+    .with_context_headers(context_headers);
 
     // Auto-register declarative handlers before any workflow code runs.
     // This satisfies the AC: "authors do not call ctx.register_*_handler in

--- a/autumn-harvest/src/handle_typed.rs
+++ b/autumn-harvest/src/handle_typed.rs
@@ -144,6 +144,8 @@ pub struct TypedStartOptions {
     pub delay: Option<chrono::Duration>,
     /// Maximum allowed delay before starting.
     pub max_workflow_start_delay: Option<chrono::Duration>,
+    /// Per-execution context headers propagated automatically to activities and children.
+    pub context_headers: Option<std::collections::HashMap<String, String>>,
 }
 
 /// Optional configurations when invoking an update and starting a workflow atomically.
@@ -171,6 +173,8 @@ pub struct TypedUpdateWithStartOptions {
     /// (e.g. `UUIDv5` from this key) so that retried calls hit the dedupe lookup
     /// and return without re-starting or re-admitting the update.
     pub idempotency_key: Option<String>,
+    /// Per-execution context headers propagated automatically to activities and children.
+    pub context_headers: Option<std::collections::HashMap<String, String>>,
 }
 
 /// Optional configurations when signaling and starting a workflow atomically.
@@ -196,4 +200,6 @@ pub struct TypedSignalWithStartOptions {
     pub idempotency_key: Option<String>,
     /// Limit the maximum size of the signal payload (defaults to 256 KiB).
     pub max_signal_payload_bytes: Option<u64>,
+    /// Per-execution context headers propagated automatically to activities and children.
+    pub context_headers: Option<std::collections::HashMap<String, String>>,
 }

--- a/autumn-harvest/src/history_export.rs
+++ b/autumn-harvest/src/history_export.rs
@@ -5,6 +5,7 @@ use crate::types::ExecutionId;
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
 use serde_json::{Value, json};
+use std::collections::HashMap;
 use std::fmt::Write;
 use std::str::FromStr;
 
@@ -113,6 +114,12 @@ pub struct HistoryExportDocument {
     /// JSON. Redacted exports preserve event shape but summarize sensitive
     /// payload-bearing fields.
     pub events: Vec<Value>,
+    /// Per-execution context headers from the original run. `None` means the
+    /// export was produced before this field was introduced (legacy) or no
+    /// headers were attached. Used by `WorkflowReplayer::replay_from_json` to
+    /// restore the same ambient headers the workflow saw during live execution.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub context_headers: Option<HashMap<String, String>>,
 }
 
 /// Input needed to export one workflow execution history.
@@ -135,6 +142,10 @@ pub struct HistoryExportRequest {
     /// Optional serialized byte limit. Defaults to
     /// [`DEFAULT_HISTORY_EXPORT_MAX_BYTES`].
     pub max_bytes: Option<usize>,
+    /// Per-execution context headers attached at workflow start. When `Some`,
+    /// the headers are embedded in the export document so replaying the export
+    /// restores the same ambient headers the original execution saw.
+    pub context_headers: Option<HashMap<String, String>>,
 }
 
 /// History export failure modes.
@@ -187,6 +198,7 @@ pub fn export_history(
             truncation_behavior: "fail".to_string(),
         },
         events,
+        context_headers: request.context_headers,
     };
 
     let actual_bytes = measure_export_bytes(&mut document)?;
@@ -871,6 +883,7 @@ mod tests {
             exported_at: Utc::now(),
             payload_policy: HistoryPayloadPolicy::Full,
             max_bytes: Some(64 * 1024),
+            context_headers: None,
         })
         .expect("full export should fit under the limit");
 
@@ -936,6 +949,7 @@ mod tests {
             exported_at: Utc::now(),
             payload_policy: HistoryPayloadPolicy::Redacted,
             max_bytes: Some(64 * 1024),
+            context_headers: None,
         })
         .expect("redacted export should fit under the limit");
 
@@ -989,6 +1003,7 @@ mod tests {
             exported_at: Utc::now(),
             payload_policy: HistoryPayloadPolicy::Redacted,
             max_bytes: Some(64 * 1024),
+            context_headers: None,
         })
         .expect("redacted export should fit under the limit");
 
@@ -1020,6 +1035,7 @@ mod tests {
             exported_at: Utc::now(),
             payload_policy: HistoryPayloadPolicy::Full,
             max_bytes: Some(128),
+            context_headers: None,
         })
         .expect_err("oversized full export must fail unless limit is raised");
 

--- a/autumn-harvest/src/history_export.rs
+++ b/autumn-harvest/src/history_export.rs
@@ -198,7 +198,13 @@ pub fn export_history(
             truncation_behavior: "fail".to_string(),
         },
         events,
-        context_headers: request.context_headers,
+        // Omit header values under Redacted policy — they may contain auth
+        // tokens or tenant secrets that should not appear in shared exports.
+        context_headers: if request.payload_policy == HistoryPayloadPolicy::Redacted {
+            None
+        } else {
+            request.context_headers
+        },
     };
 
     let actual_bytes = measure_export_bytes(&mut document)?;

--- a/autumn-harvest/src/models.rs
+++ b/autumn-harvest/src/models.rs
@@ -115,6 +115,9 @@ pub struct WorkflowExecution {
     pub current_details: Option<String>,
     /// Ambient string key-value context attached at start and propagated to all
     /// activities and child workflows (issue #481). `None` = empty map.
+    /// Skipped in serde output: raw header values may contain auth tokens or
+    /// tenant secrets and must not be exposed via management API responses.
+    #[serde(skip)]
     pub context_headers: Option<serde_json::Value>,
 }
 
@@ -245,6 +248,7 @@ pub struct TaskQueueItem {
     /// Structured capability requirements JSONB payload (issue #382).
     pub required_capabilities: Option<serde_json::Value>,
     /// Ambient context headers propagated from the parent workflow (issue #481).
+    #[serde(skip)]
     pub context_headers: Option<serde_json::Value>,
 }
 

--- a/autumn-harvest/src/models.rs
+++ b/autumn-harvest/src/models.rs
@@ -113,6 +113,9 @@ pub struct WorkflowExecution {
     /// Last-write-wins human-readable status string set by the workflow author
     /// via `ctx.set_current_details(...)` (issue #473). `None` = never set.
     pub current_details: Option<String>,
+    /// Ambient string key-value context attached at start and propagated to all
+    /// activities and child workflows (issue #481). `None` = empty map.
+    pub context_headers: Option<serde_json::Value>,
 }
 
 /// Insert struct for creating a new workflow execution.
@@ -140,6 +143,8 @@ pub struct NewWorkflowExecution<'a> {
     pub owner: Option<&'a str>,
     pub runbook_url: Option<&'a str>,
     pub severity: Option<&'a str>,
+    /// Ambient context headers (issue #481). `None` = no headers.
+    pub context_headers: Option<serde_json::Value>,
 }
 
 // ── HarvestEvent ──────────────────────────────────────────────────────────────
@@ -239,6 +244,8 @@ pub struct TaskQueueItem {
     pub schedule_to_close_at: Option<DateTime<Utc>>,
     /// Structured capability requirements JSONB payload (issue #382).
     pub required_capabilities: Option<serde_json::Value>,
+    /// Ambient context headers propagated from the parent workflow (issue #481).
+    pub context_headers: Option<serde_json::Value>,
 }
 
 /// Insert struct for enqueuing a new task.
@@ -275,6 +282,8 @@ pub struct NewTaskQueueItem<'a> {
     pub schedule_to_close_at: Option<DateTime<Utc>>,
     /// Structured capability requirements JSONB payload (issue #382).
     pub required_capabilities: Option<serde_json::Value>,
+    /// Ambient context headers propagated from the parent workflow (issue #481).
+    pub context_headers: Option<serde_json::Value>,
 }
 
 /// Database representation of a rate limit bucket.

--- a/autumn-harvest/src/queue.rs
+++ b/autumn-harvest/src/queue.rs
@@ -109,6 +109,8 @@ pub struct EnqueueParams {
     pub schedule_to_close_at: Option<chrono::DateTime<Utc>>,
     /// Structured capability requirements JSONB payload (issue #382).
     pub required_capabilities: Option<serde_json::Value>,
+    /// Ambient context headers propagated from the parent workflow (issue #481).
+    pub context_headers: Option<serde_json::Value>,
 }
 
 impl EnqueueParams {
@@ -144,6 +146,7 @@ impl EnqueueParams {
             rate_limit_key: None,
             schedule_to_close_at: None,
             required_capabilities: None,
+            context_headers: None,
         }
     }
 
@@ -240,6 +243,7 @@ pub async fn enqueue(conn: &mut AsyncPgConnection, params: &EnqueueParams) -> Ha
         rate_limit_key: params.rate_limit_key.as_deref(),
         schedule_to_close_at: params.schedule_to_close_at,
         required_capabilities: params.required_capabilities.clone(),
+        context_headers: params.context_headers.clone(),
     };
 
     diesel::insert_into(harvest_task_queue::table)

--- a/autumn-harvest/src/reset.rs
+++ b/autumn-harvest/src/reset.rs
@@ -1076,6 +1076,7 @@ mod tests {
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
             paused_at: Some(Utc::now()),
             pause_reason: Some("operator pause".into()),
             pause_actor: Some("oncall".into()),

--- a/autumn-harvest/src/reset.rs
+++ b/autumn-harvest/src/reset.rs
@@ -833,6 +833,7 @@ async fn insert_fork_execution(
         owner: source.owner.as_deref(),
         runbook_url: source.runbook_url.as_deref(),
         severity: source.severity.as_deref(),
+        context_headers: source.context_headers.clone(),
     };
 
     diesel::insert_into(harvest_workflow_executions::table)

--- a/autumn-harvest/src/retention.rs
+++ b/autumn-harvest/src/retention.rs
@@ -499,6 +499,8 @@ struct CandidateExecution {
     workflow_id: String,
     #[diesel(sql_type = Text)]
     state: String,
+    #[diesel(sql_type = diesel::sql_types::Nullable<diesel::sql_types::Jsonb>)]
+    context_headers: Option<serde_json::Value>,
     #[diesel(sql_type = Nullable<Timestamptz>) ]
     completed_at: Option<DateTime<Utc>>,
 }
@@ -591,7 +593,7 @@ async fn run_shard_tick(
         let candidates = conn.transaction::<Vec<CandidateExecution>, HarvestError, _>(|conn| {
             Box::pin(async move {
                 let rows = diesel::sql_query(
-                    "SELECT id, workflow_name, workflow_id, state, completed_at
+                    "SELECT id, workflow_name, workflow_id, state, completed_at, context_headers
                      FROM harvest_workflow_executions
                      WHERE state IN ('COMPLETED','FAILED','CANCELLED','TIMED_OUT','CONTINUED_AS_NEW','TERMINATED')
                        AND completed_at IS NOT NULL
@@ -724,7 +726,10 @@ async fn run_shard_tick(
                             exported_at: chrono::Utc::now(),
                             payload_policy: crate::history_export::HistoryPayloadPolicy::Full,
                             max_bytes: Some(usize::MAX),
-                            context_headers: None,
+                            context_headers: candidate
+                                .context_headers
+                                .as_ref()
+                                .and_then(|v| serde_json::from_value(v.clone()).ok()),
                         };
                         match crate::history_export::export_history(req) {
                             Ok(document) => {
@@ -1070,6 +1075,7 @@ mod tests {
             workflow_id: "ok".to_string(),
             state: "COMPLETED".to_string(),
             completed_at: Some(Utc::now() - chrono::Duration::days(10)),
+            context_headers: None,
         };
         let candidate_skip = CandidateExecution {
             id: uuid::Uuid::new_v4(),
@@ -1077,6 +1083,7 @@ mod tests {
             workflow_id: "skip".to_string(),
             state: "COMPLETED".to_string(),
             completed_at: Some(Utc::now() - chrono::Duration::days(9)),
+            context_headers: None,
         };
 
         // When evaluating outcome next_cursor logic, if the first candidate completes,

--- a/autumn-harvest/src/retention.rs
+++ b/autumn-harvest/src/retention.rs
@@ -724,6 +724,7 @@ async fn run_shard_tick(
                             exported_at: chrono::Utc::now(),
                             payload_policy: crate::history_export::HistoryPayloadPolicy::Full,
                             max_bytes: Some(usize::MAX),
+                            context_headers: None,
                         };
                         match crate::history_export::export_history(req) {
                             Ok(document) => {

--- a/autumn-harvest/src/scheduler.rs
+++ b/autumn-harvest/src/scheduler.rs
@@ -784,6 +784,7 @@ pub async fn trigger_unified_dag(
             owner,
             runbook_url,
             severity,
+            context_headers: None,
         },
     )
     .await
@@ -2449,6 +2450,7 @@ async fn tick_one_workflow_schedule(
                 owner,
                 runbook_url,
                 severity,
+                context_headers: None,
             },
         )
         .await;
@@ -3044,6 +3046,7 @@ async fn drain_buffered_schedule_runs(
                     owner,
                     runbook_url,
                     severity,
+                    context_headers: None,
                 },
             )
             .await;

--- a/autumn-harvest/src/schema.rs
+++ b/autumn-harvest/src/schema.rs
@@ -48,6 +48,8 @@ diesel::table! {
         /// Last-write-wins human-readable status string set by the workflow author
         /// via `ctx.set_current_details(...)` (issue #473). NULL = never set.
         current_details -> Nullable<Text>,
+        /// Per-execution ambient context headers (issue #481). NULL = empty map.
+        context_headers -> Nullable<Jsonb>,
     }
 }
 
@@ -110,6 +112,8 @@ diesel::table! {
         schedule_to_close_at -> Nullable<Timestamptz>,
         /// Structured capability requirements JSONB payload (issue #382).
         required_capabilities -> Nullable<Jsonb>,
+        /// Per-execution ambient context headers propagated from the parent workflow (issue #481).
+        context_headers -> Nullable<Jsonb>,
     }
 }
 

--- a/autumn-harvest/src/testing.rs
+++ b/autumn-harvest/src/testing.rs
@@ -235,8 +235,14 @@ pub struct HistorySnapshot {
     /// The full ordered event log, as returned by `load_history`.
     pub events: Vec<WorkflowEvent>,
     /// Per-execution context headers attached at workflow start.
+    ///
+    /// `None` means the field was absent in the JSON (legacy snapshot or not
+    /// set by the caller) — `replay_from_snapshot` falls back to any headers
+    /// configured on the [`WorkflowReplayer`] itself.  `Some(map)` (including
+    /// `Some(HashMap::new())`) is used verbatim, so an explicitly-empty header
+    /// map is not overridden by the replayer's ambient headers.
     #[serde(default)]
-    pub context_headers: HashMap<String, String>,
+    pub context_headers: Option<HashMap<String, String>>,
 }
 
 // ---------------------------------------------------------------------------
@@ -386,11 +392,9 @@ impl WorkflowReplayer {
         let total_events = snapshot.events.len();
         let input = extract_input(&snapshot.events);
 
-        let headers = if snapshot.context_headers.is_empty() {
-            self.context_headers.clone()
-        } else {
-            snapshot.context_headers.clone()
-        };
+        let headers = snapshot
+            .context_headers
+            .unwrap_or_else(|| self.context_headers.clone());
         let outcome = run_workflow_strict(
             exec_id,
             snapshot.events.clone(),
@@ -574,14 +578,15 @@ impl WorkflowReplayer {
         // Load event history.
         let history = load_history(conn, exec_id).await?;
 
-        // Load workflow name from executions table.
-        let workflow_name = load_workflow_name(conn, exec_id).await?;
+        // Load workflow name and context headers from executions table.
+        let (workflow_name, context_headers) =
+            load_workflow_name_and_headers(conn, exec_id).await?;
 
         let snapshot = HistorySnapshot {
             workflow_name,
             execution_id: exec_id,
             events: history.events,
-            context_headers: HashMap::new(),
+            context_headers: Some(context_headers),
         };
         Ok(self.replay_from_snapshot(snapshot).await)
     }
@@ -592,22 +597,23 @@ impl WorkflowReplayer {
 // ---------------------------------------------------------------------------
 
 #[cfg(feature = "db")]
-async fn load_workflow_name(
+async fn load_workflow_name_and_headers(
     conn: &mut diesel_async::AsyncPgConnection,
     exec_id: ExecutionId,
-) -> crate::error::HarvestResult<String> {
+) -> crate::error::HarvestResult<(String, HashMap<String, String>)> {
     use crate::error::{HarvestError, database_error};
     use crate::schema::harvest_workflow_executions::dsl::{
-        harvest_workflow_executions, id as id_col, workflow_name,
+        context_headers as context_headers_col, harvest_workflow_executions, id as id_col,
+        workflow_name,
     };
     use diesel::prelude::*;
     use diesel_async::RunQueryDsl;
 
     let exec_uuid = exec_id.as_uuid();
 
-    let name: String = harvest_workflow_executions
+    let (name, raw_headers): (String, Option<serde_json::Value>) = harvest_workflow_executions
         .filter(id_col.eq(exec_uuid))
-        .select(workflow_name)
+        .select((workflow_name, context_headers_col))
         .first(conn)
         .await
         .map_err(|e| match e {
@@ -615,7 +621,18 @@ async fn load_workflow_name(
             other => database_error(other),
         })?;
 
-    Ok(name)
+    let headers = raw_headers
+        .and_then(|v| {
+            serde_json::from_value::<HashMap<String, String>>(v)
+                .map_err(|e| {
+                    tracing::warn!(error = %e, "replay_from_db: failed to deserialize context headers");
+                    e
+                })
+                .ok()
+        })
+        .unwrap_or_default();
+
+    Ok((name, headers))
 }
 
 // ---------------------------------------------------------------------------
@@ -1588,7 +1605,7 @@ impl TestRunOutcome {
             workflow_name: "__test__".to_string(),
             execution_id: self.exec_id,
             events: self.events.clone(),
-            context_headers: HashMap::new(),
+            context_headers: None,
         };
         WorkflowReplayer::new()
             .with_existing_state(self.state.clone())

--- a/autumn-harvest/src/testing.rs
+++ b/autumn-harvest/src/testing.rs
@@ -222,6 +222,7 @@ impl std::fmt::Display for ReplayReport {
 ///     events: vec![
 ///         WorkflowEvent::WorkflowStarted { input: Value::Null, timestamp: Utc::now() },
 ///     ],
+///     context_headers: None,
 /// };
 /// let json = serde_json::to_string(&snapshot).unwrap();
 /// // Store `json` as a fixture file.

--- a/autumn-harvest/src/testing.rs
+++ b/autumn-harvest/src/testing.rs
@@ -234,6 +234,9 @@ pub struct HistorySnapshot {
     pub execution_id: ExecutionId,
     /// The full ordered event log, as returned by `load_history`.
     pub events: Vec<WorkflowEvent>,
+    /// Per-execution context headers attached at workflow start.
+    #[serde(default)]
+    pub context_headers: HashMap<String, String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -253,6 +256,7 @@ pub struct HistorySnapshot {
 pub struct WorkflowReplayer {
     handlers: HashMap<String, WorkflowHandlerFn>,
     state: SharedState,
+    context_headers: HashMap<String, String>,
 }
 
 impl Default for WorkflowReplayer {
@@ -268,7 +272,15 @@ impl WorkflowReplayer {
         Self {
             handlers: HashMap::new(),
             state: empty_shared_state(),
+            context_headers: HashMap::new(),
         }
+    }
+
+    /// Set context headers to propagate into the replayed `WorkflowContext`.
+    #[must_use]
+    pub fn with_context_headers(mut self, headers: HashMap<String, String>) -> Self {
+        self.context_headers = headers;
+        self
     }
 
     /// Inject a typed shared-state value available to workflow handlers via
@@ -374,12 +386,18 @@ impl WorkflowReplayer {
         let total_events = snapshot.events.len();
         let input = extract_input(&snapshot.events);
 
+        let headers = if snapshot.context_headers.is_empty() {
+            self.context_headers.clone()
+        } else {
+            snapshot.context_headers.clone()
+        };
         let outcome = run_workflow_strict(
             exec_id,
             snapshot.events.clone(),
             handler,
             input,
             self.state.clone(),
+            headers,
         )
         .await;
         outcome_to_report(exec_id, total_events, &snapshot.events, outcome)
@@ -451,8 +469,15 @@ impl WorkflowReplayer {
         let total_events = events.len();
         let input = extract_input(&events);
 
-        let outcome =
-            run_workflow_strict(exec_id, events.clone(), handler, input, self.state.clone()).await;
+        let outcome = run_workflow_strict(
+            exec_id,
+            events.clone(),
+            handler,
+            input,
+            self.state.clone(),
+            self.context_headers.clone(),
+        )
+        .await;
         outcome_to_report(exec_id, total_events, &events, outcome)
     }
 
@@ -556,6 +581,7 @@ impl WorkflowReplayer {
             workflow_name,
             execution_id: exec_id,
             events: history.events,
+            context_headers: HashMap::new(),
         };
         Ok(self.replay_from_snapshot(snapshot).await)
     }
@@ -1453,6 +1479,7 @@ async fn replay_fixture_file(
     let replayer = WorkflowReplayer {
         handlers: handlers.clone(),
         state,
+        context_headers: HashMap::new(),
     };
 
     let replay_result =
@@ -1561,6 +1588,7 @@ impl TestRunOutcome {
             workflow_name: "__test__".to_string(),
             execution_id: self.exec_id,
             events: self.events.clone(),
+            context_headers: HashMap::new(),
         };
         WorkflowReplayer::new()
             .with_existing_state(self.state.clone())

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -1276,7 +1276,7 @@ async fn persist_external_signal_inline(
 /// `LocalActivityFailed` event; on success a `LocalActivityCompleted` event is
 /// appended. Returns all newly-appended events so the caller can extend its
 /// in-memory replay history and avoid a DB round-trip.
-#[allow(clippy::too_many_lines)]
+#[allow(clippy::too_many_lines, clippy::too_many_arguments)]
 async fn run_local_activity_inline(
     conn: &mut AsyncPgConnection,
     registry: &HandlerRegistry,
@@ -3859,8 +3859,10 @@ async fn process_activity_task(
                 }
             }
         })
-        .map(std::sync::Arc::new)
-        .unwrap_or_else(|| std::sync::Arc::new(std::collections::HashMap::new()));
+        .map_or_else(
+            || std::sync::Arc::new(std::collections::HashMap::new()),
+            std::sync::Arc::new,
+        );
     let ctx = ActivityContext::new_with_cancellation_check(
         registry.shared_state(),
         Some(heartbeat_tx),

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -5379,7 +5379,7 @@ async fn process_workflow_task(
                         per.max(registry.max_workflow_input_bytes)
                     }),
                 registry.max_current_details_bytes,
-                exec_context_headers,
+                exec_context_headers.clone(),
             )
             .await;
 

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -2338,6 +2338,7 @@ async fn persist_scheduled_activities(
     execute_span: &tracing::Span,
     assigned_build_id: Option<&str>,
     parent_priority: i32,
+    context_headers: Option<&serde_json::Value>,
 ) -> HarvestResult<()> {
     // activity_events is built in scheduled_activities order (= ScheduleActivity command order).
     // After the loop we interleave them with marker/detached-spawn events in full command order.
@@ -2459,6 +2460,7 @@ async fn persist_scheduled_activities(
             { ATTR_QUEUE } = %queue_name,
         )
         .in_scope(|| registry.telemetry().capture_trace_context());
+        params.context_headers = context_headers.cloned();
         enqueued.push(params);
     }
 
@@ -2864,6 +2866,7 @@ async fn persist_all_started_child_workflows(
                     owner,
                     runbook_url,
                     severity,
+                    context_headers: parent_execution.context_headers.clone(),
                 };
                 let child_started_event = WorkflowEvent::WorkflowStarted {
                     input: child.input.clone(),
@@ -3412,6 +3415,7 @@ async fn create_detached_child_executions(
             owner,
             runbook_url,
             severity,
+            context_headers: parent_execution.context_headers.clone(),
         };
 
         diesel::insert_into(harvest_workflow_executions::table)
@@ -3841,6 +3845,12 @@ async fn process_activity_task(
         .trace_context
         .as_ref()
         .and_then(TraceContextCarrier::from_json);
+    let activity_context_headers = task
+        .context_headers
+        .as_ref()
+        .and_then(|v| serde_json::from_value::<std::collections::HashMap<String, String>>(v.clone()).ok())
+        .map(std::sync::Arc::new)
+        .unwrap_or_else(|| std::sync::Arc::new(std::collections::HashMap::new()));
     let ctx = ActivityContext::new_with_cancellation_check(
         registry.shared_state(),
         Some(heartbeat_tx),
@@ -3850,6 +3860,7 @@ async fn process_activity_task(
         pool.clone(),
     )
     .with_trace_context(trace_carrier.clone())
+    .with_context_headers(activity_context_headers)
     .with_idempotency_key(IdempotencyKey::from_activity_exec_id(activity_id))
     .with_attempt(task_attempt(task))
     .with_max_attempts(u32::try_from(task.max_attempts.max(1)).unwrap_or(1))
@@ -4262,6 +4273,7 @@ async fn handle_suspended_workflow(
             context.execute_span,
             context.execution.assigned_build_id.as_deref(),
             context.persistence.task.priority,
+            context.execution.context_headers.as_ref(),
         )
         .await
     } else if let Some(activity_ids) = extract_all_activity_waits(commands) {
@@ -4589,6 +4601,7 @@ async fn persist_workflow_continue_as_new(
         owner: execution.owner.as_deref(),
         runbook_url: execution.runbook_url.as_deref(),
         severity: execution.severity.as_deref(),
+        context_headers: execution.context_headers.clone(),
     };
     let mut enqueue =
         queue::EnqueueParams::new(execution.queue_name.clone(), TaskType::Workflow, input);
@@ -5321,6 +5334,15 @@ async fn process_workflow_task(
             .filter(|h| h.workflow == wf_name)
             .collect();
 
+        let exec_context_headers = prepared
+            .execution
+            .context_headers
+            .as_ref()
+            .and_then(|v| {
+                serde_json::from_value::<std::collections::HashMap<String, String>>(v.clone()).ok()
+            })
+            .unwrap_or_default();
+
         let (run_outcome, pending_cmds, execute_span) =
             run_workflow_with_state_history_policy_and_caps(
                 prepared.exec_id,
@@ -5341,6 +5363,7 @@ async fn process_workflow_task(
                         per.max(registry.max_workflow_input_bytes)
                     }),
                 registry.max_current_details_bytes,
+                exec_context_headers,
             )
             .await;
 

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -1285,6 +1285,7 @@ async fn run_local_activity_inline(
     detached_spawns: DetachedSpawnPersistence<'_>,
     max_start_to_close: Duration,
     next_event_id: &mut i32,
+    context_headers: std::sync::Arc<std::collections::HashMap<String, String>>,
 ) -> HarvestResult<LocalActivityInlineOutcome> {
     let LocalActivityCommandBatch {
         pre_schedule_events,
@@ -1380,6 +1381,7 @@ async fn run_local_activity_inline(
     for attempt in start_attempt..=max_attempts {
         let ctx =
             ActivityContext::new_local_activity(registry.shared_state(), CancellationToken::new())
+                .with_context_headers(std::sync::Arc::clone(&context_headers))
                 .with_idempotency_key(local_idempotency_key.clone())
                 .with_attempt(attempt)
                 .with_max_attempts(max_attempts)
@@ -3848,7 +3850,15 @@ async fn process_activity_task(
     let activity_context_headers = task
         .context_headers
         .as_ref()
-        .and_then(|v| serde_json::from_value::<std::collections::HashMap<String, String>>(v.clone()).ok())
+        .and_then(|v| {
+            match serde_json::from_value::<std::collections::HashMap<String, String>>(v.clone()) {
+                Ok(h) => Some(h),
+                Err(e) => {
+                    tracing::warn!(error = %e, "failed to deserialize activity context headers; propagating empty map");
+                    None
+                }
+            }
+        })
         .map(std::sync::Arc::new)
         .unwrap_or_else(|| std::sync::Arc::new(std::collections::HashMap::new()));
     let ctx = ActivityContext::new_with_cancellation_check(
@@ -5339,7 +5349,13 @@ async fn process_workflow_task(
             .context_headers
             .as_ref()
             .and_then(|v| {
-                serde_json::from_value::<std::collections::HashMap<String, String>>(v.clone()).ok()
+                match serde_json::from_value::<std::collections::HashMap<String, String>>(v.clone()) {
+                    Ok(h) => Some(h),
+                    Err(e) => {
+                        tracing::warn!(error = %e, "failed to deserialize workflow execution context headers; propagating empty map");
+                        None
+                    }
+                }
             })
             .unwrap_or_default();
 
@@ -5454,6 +5470,7 @@ async fn process_workflow_task(
                     execute_span: &detached_execute_span,
                 };
                 let local_batch = extract_run_local_activity(commands);
+                let local_context_headers = std::sync::Arc::new(exec_context_headers.clone());
                 let inline_outcome = match run_local_activity_inline(
                     conn,
                     registry,
@@ -5462,6 +5479,7 @@ async fn process_workflow_task(
                     detached_spawns,
                     max_local_activity_start_to_close,
                     &mut next_event_id,
+                    local_context_headers,
                 )
                 .await
                 {

--- a/autumn-harvest/tests/activity_failure_tests.rs
+++ b/autumn-harvest/tests/activity_failure_tests.rs
@@ -282,7 +282,7 @@ mod replay_tests {
             workflow_name: "test_wf".into(),
             execution_id: exec_id,
             events,
-            context_headers: std::collections::HashMap::new(),
+            context_headers: None,
         };
 
         let report = WorkflowReplayer::new()

--- a/autumn-harvest/tests/activity_failure_tests.rs
+++ b/autumn-harvest/tests/activity_failure_tests.rs
@@ -282,6 +282,7 @@ mod replay_tests {
             workflow_name: "test_wf".into(),
             execution_id: exec_id,
             events,
+            context_headers: std::collections::HashMap::new(),
         };
 
         let report = WorkflowReplayer::new()

--- a/autumn-harvest/tests/audit_tests.rs
+++ b/autumn-harvest/tests/audit_tests.rs
@@ -83,7 +83,9 @@ const INIT_SQL: &str = concat!(
     "\n",
     include_str!("../migrations/20260609000001_harvest_workflow_current_details/up.sql"),
     "\n",
-    include_str!("../migrations/20260610000001_harvest_schedule_bounded_runs/up.sql")
+    include_str!("../migrations/20260610000001_harvest_schedule_bounded_runs/up.sql"),
+    "\n",
+    include_str!("../migrations/20260615000001_harvest_context_headers/up.sql")
 );
 
 async fn make_conn() -> (

--- a/autumn-harvest/tests/build_routing_tests.rs
+++ b/autumn-harvest/tests/build_routing_tests.rs
@@ -319,7 +319,9 @@ mod db_tests {
         "\n",
         include_str!("../migrations/20260609000001_harvest_workflow_current_details/up.sql"),
         "\n",
-        include_str!("../migrations/20260610000001_harvest_schedule_bounded_runs/up.sql")
+        include_str!("../migrations/20260610000001_harvest_schedule_bounded_runs/up.sql"),
+    "\n",
+    include_str!("../migrations/20260615000001_harvest_context_headers/up.sql")
     );
 
     async fn setup() -> (AsyncPgConnection, ContainerAsync<Postgres>) {

--- a/autumn-harvest/tests/build_routing_tests.rs
+++ b/autumn-harvest/tests/build_routing_tests.rs
@@ -320,8 +320,8 @@ mod db_tests {
         include_str!("../migrations/20260609000001_harvest_workflow_current_details/up.sql"),
         "\n",
         include_str!("../migrations/20260610000001_harvest_schedule_bounded_runs/up.sql"),
-    "\n",
-    include_str!("../migrations/20260615000001_harvest_context_headers/up.sql")
+        "\n",
+        include_str!("../migrations/20260615000001_harvest_context_headers/up.sql")
     );
 
     async fn setup() -> (AsyncPgConnection, ContainerAsync<Postgres>) {

--- a/autumn-harvest/tests/build_routing_tests.rs
+++ b/autumn-harvest/tests/build_routing_tests.rs
@@ -485,6 +485,7 @@ mod db_tests {
                 owner: None,
                 runbook_url: None,
                 severity: None,
+                context_headers: None,
             })
             .execute(conn)
             .await

--- a/autumn-harvest/tests/cache_delta_load_tests.rs
+++ b/autumn-harvest/tests/cache_delta_load_tests.rs
@@ -135,6 +135,7 @@ async fn insert_execution(conn: &mut AsyncPgConnection, name: &str) -> Execution
         owner: None,
         runbook_url: None,
         severity: None,
+        context_headers: None,
     };
     diesel::insert_into(harvest_workflow_executions::table)
         .values(&row)

--- a/autumn-harvest/tests/cache_delta_load_tests.rs
+++ b/autumn-harvest/tests/cache_delta_load_tests.rs
@@ -94,7 +94,9 @@ const INIT_SQL: &str = concat!(
     "\n",
     include_str!("../migrations/20260609000001_harvest_workflow_current_details/up.sql"),
     "\n",
-    include_str!("../migrations/20260610000001_harvest_schedule_bounded_runs/up.sql")
+    include_str!("../migrations/20260610000001_harvest_schedule_bounded_runs/up.sql"),
+    "\n",
+    include_str!("../migrations/20260615000001_harvest_context_headers/up.sql")
 );
 
 async fn setup_test_db() -> (AsyncPgConnection, ContainerAsync<Postgres>) {

--- a/autumn-harvest/tests/cancellation_tests.rs
+++ b/autumn-harvest/tests/cancellation_tests.rs
@@ -159,6 +159,7 @@ async fn start_test_workflow(conn: &mut AsyncPgConnection) -> autumn_harvest::Ex
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         },
     )
     .await
@@ -549,6 +550,7 @@ async fn running_activity_heartbeat_observes_workflow_cancellation() {
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         },
     )
     .await
@@ -747,6 +749,7 @@ async fn uncooperative_activity_is_hard_aborted_after_grace_period() {
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         },
     )
     .await
@@ -888,6 +891,7 @@ async fn activity_exits_early_on_workflow_cancellation() {
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         },
     )
     .await
@@ -1026,6 +1030,7 @@ async fn activity_without_cancellation_check_completes_normally() {
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         },
     )
     .await

--- a/autumn-harvest/tests/cancellation_tests.rs
+++ b/autumn-harvest/tests/cancellation_tests.rs
@@ -77,7 +77,9 @@ const INIT_SQL: &str = concat!(
     "\n",
     include_str!("../migrations/20260609000001_harvest_workflow_current_details/up.sql"),
     "\n",
-    include_str!("../migrations/20260610000001_harvest_schedule_bounded_runs/up.sql")
+    include_str!("../migrations/20260610000001_harvest_schedule_bounded_runs/up.sql"),
+    "\n",
+    include_str!("../migrations/20260615000001_harvest_context_headers/up.sql")
 );
 
 async fn setup_test_db() -> (AsyncPgConnection, ContainerAsync<Postgres>) {

--- a/autumn-harvest/tests/child_policy_tests.rs
+++ b/autumn-harvest/tests/child_policy_tests.rs
@@ -178,6 +178,7 @@ async fn start_workflow(
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         },
     )
     .await
@@ -366,6 +367,7 @@ async fn insert_detached_child_execution(
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         })
         .execute(conn)
         .await
@@ -949,6 +951,7 @@ async fn detached_child_execution_timeout_does_not_wake_parent() {
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         })
         .execute(&mut conn)
         .await

--- a/autumn-harvest/tests/child_policy_tests.rs
+++ b/autumn-harvest/tests/child_policy_tests.rs
@@ -86,7 +86,9 @@ const INIT_SQL: &str = concat!(
     "\n",
     include_str!("../migrations/20260609000001_harvest_workflow_current_details/up.sql"),
     "\n",
-    include_str!("../migrations/20260610000001_harvest_schedule_bounded_runs/up.sql")
+    include_str!("../migrations/20260610000001_harvest_schedule_bounded_runs/up.sql"),
+    "\n",
+    include_str!("../migrations/20260615000001_harvest_context_headers/up.sql")
 );
 
 async fn setup_test_db_url() -> (String, ContainerAsync<Postgres>) {

--- a/autumn-harvest/tests/context_headers_tests.rs
+++ b/autumn-harvest/tests/context_headers_tests.rs
@@ -100,15 +100,18 @@ async fn history_snapshot_context_headers_round_trips() {
         workflow_name: "echo_headers_workflow".to_string(),
         execution_id: exec_id,
         events: make_started_history(Value::Null),
-        context_headers: headers.clone(),
+        context_headers: Some(headers.clone()),
     };
 
     let json = serde_json::to_string(&snapshot).expect("serialize snapshot");
-    let recovered: HistorySnapshot =
-        serde_json::from_str(&json).expect("deserialize snapshot");
+    let recovered: HistorySnapshot = serde_json::from_str(&json).expect("deserialize snapshot");
 
     assert_eq!(
-        recovered.context_headers.get("tenant_id").map(String::as_str),
+        recovered
+            .context_headers
+            .as_ref()
+            .and_then(|m| m.get("tenant_id"))
+            .map(String::as_str),
         Some("round-trip-tenant")
     );
 }
@@ -126,7 +129,7 @@ async fn history_snapshot_without_context_headers_deserializes_to_empty() {
         serde_json::from_str(json).expect("old snapshot must still deserialize");
 
     assert!(
-        snapshot.context_headers.is_empty(),
-        "missing context_headers field must deserialize to empty map"
+        snapshot.context_headers.is_none(),
+        "missing context_headers field must deserialize to None"
     );
 }

--- a/autumn-harvest/tests/context_headers_tests.rs
+++ b/autumn-harvest/tests/context_headers_tests.rs
@@ -1,0 +1,132 @@
+//! Integration tests for per-execution context headers (issue #481).
+
+#![cfg(feature = "testing")]
+
+use std::collections::HashMap;
+use std::pin::Pin;
+
+use autumn_harvest::context::WorkflowContext;
+use autumn_harvest::event::WorkflowEvent;
+use autumn_harvest::testing::{HistorySnapshot, ReplayStatus, WorkflowReplayer};
+use autumn_harvest::types::ExecutionId;
+use chrono::Utc;
+use serde_json::Value;
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+fn make_started_history(input: Value) -> Vec<WorkflowEvent> {
+    vec![WorkflowEvent::WorkflowStarted {
+        input,
+        timestamp: Utc::now(),
+    }]
+}
+
+fn echo_headers_workflow<'a>(
+    ctx: &'a WorkflowContext,
+    _input: Value,
+) -> Pin<Box<dyn std::future::Future<Output = Result<Value, String>> + Send + 'a>> {
+    Box::pin(async move {
+        let tenant = ctx.header("tenant_id").unwrap_or("").to_string();
+        Ok(Value::String(tenant))
+    })
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[test]
+fn context_headers_empty_map_on_default_workflow_context() {
+    // A WorkflowContext without headers exposes empty map; no panic.
+    let exec_id = ExecutionId::new();
+    let ctx = WorkflowContext::for_replay(exec_id, make_started_history(Value::Null));
+    assert!(ctx.headers().is_empty());
+    assert!(ctx.header("anything").is_none());
+}
+
+#[test]
+fn context_headers_accessible_after_with_context_headers() {
+    let exec_id = ExecutionId::new();
+    let mut headers = HashMap::new();
+    headers.insert("tenant_id".to_string(), "acme".to_string());
+    let ctx = WorkflowContext::for_replay(exec_id, make_started_history(Value::Null))
+        .with_context_headers(headers);
+    assert_eq!(ctx.header("tenant_id"), Some("acme"));
+    assert!(ctx.header("missing").is_none());
+}
+
+#[tokio::test]
+async fn context_headers_replay_succeeds_with_headers() {
+    // WorkflowReplayer with headers injected must complete with ReplaySucceeded.
+    let mut headers = HashMap::new();
+    headers.insert("tenant_id".to_string(), "acme-corp".to_string());
+
+    let history = make_started_history(Value::Null);
+
+    let report = WorkflowReplayer::new()
+        .register_fn("echo_headers_workflow", echo_headers_workflow)
+        .with_context_headers(headers)
+        .replay_from_events(history)
+        .await;
+
+    assert!(
+        matches!(report.status, ReplayStatus::ReplaySucceeded),
+        "replay must succeed with headers: {report}"
+    );
+}
+
+#[tokio::test]
+async fn context_headers_replay_succeeds_without_headers() {
+    // No headers injected → still succeeds (backward compat).
+    let history = make_started_history(Value::Null);
+
+    let report = WorkflowReplayer::new()
+        .register_fn("echo_headers_workflow", echo_headers_workflow)
+        .replay_from_events(history)
+        .await;
+
+    assert!(
+        matches!(report.status, ReplayStatus::ReplaySucceeded),
+        "replay must succeed without headers: {report}"
+    );
+}
+
+#[tokio::test]
+async fn history_snapshot_context_headers_round_trips() {
+    // HistorySnapshot with context_headers serializes/deserializes correctly.
+    let mut headers = HashMap::new();
+    headers.insert("tenant_id".to_string(), "round-trip-tenant".to_string());
+
+    let exec_id = ExecutionId::new();
+    let snapshot = HistorySnapshot {
+        workflow_name: "echo_headers_workflow".to_string(),
+        execution_id: exec_id,
+        events: make_started_history(Value::Null),
+        context_headers: headers.clone(),
+    };
+
+    let json = serde_json::to_string(&snapshot).expect("serialize snapshot");
+    let recovered: HistorySnapshot =
+        serde_json::from_str(&json).expect("deserialize snapshot");
+
+    assert_eq!(
+        recovered.context_headers.get("tenant_id").map(String::as_str),
+        Some("round-trip-tenant")
+    );
+}
+
+#[tokio::test]
+async fn history_snapshot_without_context_headers_deserializes_to_empty() {
+    // Old JSON snapshots without the context_headers field must still parse.
+    let json = r#"{
+        "workflow_name": "echo_headers_workflow",
+        "execution_id": "00000000-0000-0000-0000-000000000001",
+        "events": []
+    }"#;
+
+    let snapshot: HistorySnapshot =
+        serde_json::from_str(json).expect("old snapshot must still deserialize");
+
+    assert!(
+        snapshot.context_headers.is_empty(),
+        "missing context_headers field must deserialize to empty map"
+    );
+}

--- a/autumn-harvest/tests/cross_workflow_signal_tests.rs
+++ b/autumn-harvest/tests/cross_workflow_signal_tests.rs
@@ -88,7 +88,9 @@ const INIT_SQL: &str = concat!(
     "\n",
     include_str!("../migrations/20260609000001_harvest_workflow_current_details/up.sql"),
     "\n",
-    include_str!("../migrations/20260610000001_harvest_schedule_bounded_runs/up.sql")
+    include_str!("../migrations/20260610000001_harvest_schedule_bounded_runs/up.sql"),
+    "\n",
+    include_str!("../migrations/20260615000001_harvest_context_headers/up.sql")
 );
 
 async fn setup_test_database_url() -> (String, ContainerAsync<Postgres>) {

--- a/autumn-harvest/tests/cross_workflow_signal_tests.rs
+++ b/autumn-harvest/tests/cross_workflow_signal_tests.rs
@@ -302,6 +302,7 @@ async fn test_same_shard_not_found_retry() {
         owner: None,
         runbook_url: None,
         severity: None,
+        context_headers: None,
     };
     start_or_load_workflow_execution(&mut conn, start_params)
         .await
@@ -339,6 +340,7 @@ async fn test_same_shard_not_found_retry() {
         owner: None,
         runbook_url: None,
         severity: None,
+        context_headers: None,
     };
     start_or_load_workflow_execution(&mut conn, start_target_params)
         .await
@@ -462,6 +464,7 @@ async fn test_cross_shard_outbox_delivery() {
         owner: None,
         runbook_url: None,
         severity: None,
+        context_headers: None,
     };
     start_or_load_workflow_execution(&mut conn, start_target_params)
         .await
@@ -492,6 +495,7 @@ async fn test_cross_shard_outbox_delivery() {
         owner: None,
         runbook_url: None,
         severity: None,
+        context_headers: None,
     };
     start_or_load_workflow_execution(&mut conn, start_params)
         .await
@@ -593,6 +597,7 @@ async fn test_grace_window_expiration() {
         owner: None,
         runbook_url: None,
         severity: None,
+        context_headers: None,
     };
     start_or_load_workflow_execution(&mut conn, start_params)
         .await
@@ -727,6 +732,7 @@ async fn test_mixed_timer_suspension_signal_wakes_timer() {
         owner: None,
         runbook_url: None,
         severity: None,
+        context_headers: None,
     };
     start_or_load_workflow_execution(&mut conn, start_params)
         .await
@@ -764,6 +770,7 @@ async fn test_mixed_timer_suspension_signal_wakes_timer() {
         owner: None,
         runbook_url: None,
         severity: None,
+        context_headers: None,
     };
     start_or_load_workflow_execution(&mut conn, start_target_params)
         .await

--- a/autumn-harvest/tests/delayed_start_tests.rs
+++ b/autumn-harvest/tests/delayed_start_tests.rs
@@ -71,7 +71,9 @@ const INIT_SQL: &str = concat!(
     "\n",
     include_str!("../migrations/20260609000001_harvest_workflow_current_details/up.sql"),
     "\n",
-    include_str!("../migrations/20260610000001_harvest_schedule_bounded_runs/up.sql")
+    include_str!("../migrations/20260610000001_harvest_schedule_bounded_runs/up.sql"),
+    "\n",
+    include_str!("../migrations/20260615000001_harvest_context_headers/up.sql")
 );
 
 async fn setup_test_db() -> (AsyncPgConnection, ContainerAsync<Postgres>) {

--- a/autumn-harvest/tests/delayed_start_tests.rs
+++ b/autumn-harvest/tests/delayed_start_tests.rs
@@ -191,6 +191,7 @@ async fn test_delayed_start_validation() {
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         },
     )
     .await
@@ -234,6 +235,7 @@ async fn test_delayed_start_validation() {
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         },
     )
     .await
@@ -331,6 +333,7 @@ async fn test_delayed_start_no_premature_dispatch() {
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         },
     )
     .await
@@ -405,6 +408,7 @@ async fn test_delayed_start_cancel_before_firing() {
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         },
     )
     .await
@@ -486,6 +490,7 @@ async fn test_delayed_start_workflow_started_event_timestamp() {
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         },
     )
     .await
@@ -535,6 +540,7 @@ async fn test_immediate_start_skew_tolerance() {
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         },
     )
     .await

--- a/autumn-harvest/tests/executor_span_tests.rs
+++ b/autumn-harvest/tests/executor_span_tests.rs
@@ -223,6 +223,7 @@ fn replay_executor_emits_harvest_workflow_execute_with_replay_true() {
             echo_workflow,
             Value::Null,
             empty_shared_state(),
+            std::collections::HashMap::new(),
         ));
 
     // 1. Span must be named correctly.

--- a/autumn-harvest/tests/integration_e2e.rs
+++ b/autumn-harvest/tests/integration_e2e.rs
@@ -119,7 +119,9 @@ const INIT_SQL: &str = concat!(
     "\n",
     include_str!("../migrations/20260609000001_harvest_workflow_current_details/up.sql"),
     "\n",
-    include_str!("../migrations/20260610000001_harvest_schedule_bounded_runs/up.sql")
+    include_str!("../migrations/20260610000001_harvest_schedule_bounded_runs/up.sql"),
+    "\n",
+    include_str!("../migrations/20260615000001_harvest_context_headers/up.sql")
 );
 
 /// The minimal "legacy" migration set used by the upgrade-path regression
@@ -173,6 +175,8 @@ const LEGACY_INIT_SQL: &str = concat!(
     "ALTER TABLE harvest_workflow_executions ADD COLUMN IF NOT EXISTS pause_reason TEXT NULL;\n",
     "ALTER TABLE harvest_workflow_executions ADD COLUMN IF NOT EXISTS pause_actor TEXT NULL;\n",
     "ALTER TABLE harvest_workflow_executions ADD COLUMN IF NOT EXISTS current_details TEXT NULL;\n",
+    "ALTER TABLE harvest_workflow_executions ADD COLUMN IF NOT EXISTS context_headers JSONB NULL;\n",
+    "ALTER TABLE harvest_task_queue ADD COLUMN IF NOT EXISTS context_headers JSONB NULL;\n",
 );
 
 /// Start a Postgres container with the harvest schema applied and return

--- a/autumn-harvest/tests/integration_e2e.rs
+++ b/autumn-harvest/tests/integration_e2e.rs
@@ -531,6 +531,7 @@ async fn insert_workflow_execution(conn: &mut AsyncPgConnection) -> ExecutionId 
         owner: None,
         runbook_url: None,
         severity: None,
+        context_headers: None,
     };
 
     diesel::insert_into(harvest_workflow_executions::table)
@@ -586,6 +587,7 @@ async fn legacy_workflow_uniqueness_schema_can_be_upgraded_for_idempotent_starts
         owner: None,
         runbook_url: None,
         severity: None,
+        context_headers: None,
     };
 
     // On the legacy schema there is no `(workflow_name, workflow_id)`
@@ -3367,6 +3369,7 @@ async fn insert_named_workflow_execution(
         owner: None,
         runbook_url: None,
         severity: None,
+        context_headers: None,
     };
     diesel::insert_into(harvest_workflow_executions::table)
         .values(&row)
@@ -3902,6 +3905,7 @@ mod reuse_policy_helpers {
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         }
     }
 
@@ -5153,6 +5157,7 @@ async fn search_attrs_upsert_visible_after_update_and_filterable() {
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         },
     )
     .await
@@ -5306,6 +5311,7 @@ async fn search_attrs_survive_worker_crash_and_resume() {
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         },
     )
     .await
@@ -6733,6 +6739,7 @@ async fn signal_blocked_workflow_times_out_at_deadline() {
         owner: None,
         runbook_url: None,
         severity: None,
+        context_headers: None,
     };
     diesel::insert_into(harvest_workflow_executions::table)
         .values(&row)

--- a/autumn-harvest/tests/metrics_integration.rs
+++ b/autumn-harvest/tests/metrics_integration.rs
@@ -621,6 +621,7 @@ async fn workflow_and_activity_metrics_are_recorded() {
         owner: None,
         runbook_url: None,
         severity: None,
+        context_headers: None,
     };
     diesel::insert_into(harvest_workflow_executions::table)
         .values(&exec_row)
@@ -829,6 +830,7 @@ async fn continue_as_new_records_history_size_and_rotation_metrics() {
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         })
         .execute(&mut conn)
         .await
@@ -946,6 +948,7 @@ async fn workflow_hard_cap_moves_offender_to_dlq() {
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         })
         .execute(&mut conn)
         .await
@@ -1076,6 +1079,7 @@ async fn workflow_hard_cap_dlq_preserves_terminal_attempt_count() {
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         })
         .execute(&mut conn)
         .await
@@ -1205,6 +1209,7 @@ async fn suspended_commands_that_reach_hard_cap_move_to_dlq_immediately() {
                 owner: None,
                 runbook_url: None,
                 severity: None,
+                context_headers: None,
             })
             .execute(&mut conn)
             .await
@@ -1406,6 +1411,7 @@ async fn local_activity_retries_stop_when_hard_cap_is_reached() {
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         })
         .execute(&mut conn)
         .await
@@ -1570,6 +1576,7 @@ async fn detached_parent_close_cascade_counts_against_history_cap() {
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         })
         .execute(&mut conn)
         .await
@@ -1737,6 +1744,7 @@ async fn child_hard_cap_dlq_notifies_parent_and_stops_inline_growth() {
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         })
         .execute(&mut conn)
         .await
@@ -2035,6 +2043,7 @@ async fn workflow_non_determinism_metric_and_search_attrs_are_recorded() {
         owner: None,
         runbook_url: None,
         severity: None,
+        context_headers: None,
     };
     diesel::insert_into(harvest_workflow_executions::table)
         .values(&exec_row)

--- a/autumn-harvest/tests/metrics_integration.rs
+++ b/autumn-harvest/tests/metrics_integration.rs
@@ -102,7 +102,9 @@ const INIT_SQL: &str = concat!(
     "\n",
     include_str!("../migrations/20260609000001_harvest_workflow_current_details/up.sql"),
     "\n",
-    include_str!("../migrations/20260610000001_harvest_schedule_bounded_runs/up.sql")
+    include_str!("../migrations/20260610000001_harvest_schedule_bounded_runs/up.sql"),
+    "\n",
+    include_str!("../migrations/20260615000001_harvest_context_headers/up.sql")
 );
 
 // ---------------------------------------------------------------------------

--- a/autumn-harvest/tests/pause_tests.rs
+++ b/autumn-harvest/tests/pause_tests.rs
@@ -205,6 +205,7 @@ async fn start(conn: &mut AsyncPgConnection, name: &str, id: &str) -> ExecutionI
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         },
     )
     .await

--- a/autumn-harvest/tests/pause_tests.rs
+++ b/autumn-harvest/tests/pause_tests.rs
@@ -98,7 +98,9 @@ const INIT_SQL: &str = concat!(
     "\n",
     include_str!("../migrations/20260609000001_harvest_workflow_current_details/up.sql"),
     "\n",
-    include_str!("../migrations/20260610000001_harvest_schedule_bounded_runs/up.sql")
+    include_str!("../migrations/20260610000001_harvest_schedule_bounded_runs/up.sql"),
+    "\n",
+    include_str!("../migrations/20260615000001_harvest_context_headers/up.sql")
 );
 
 async fn setup() -> (String, ContainerAsync<Postgres>) {

--- a/autumn-harvest/tests/poison_pill_tests.rs
+++ b/autumn-harvest/tests/poison_pill_tests.rs
@@ -92,7 +92,9 @@ const INIT_SQL: &str = concat!(
     "\n",
     include_str!("../migrations/20260609000001_harvest_workflow_current_details/up.sql"),
     "\n",
-    include_str!("../migrations/20260610000001_harvest_schedule_bounded_runs/up.sql")
+    include_str!("../migrations/20260610000001_harvest_schedule_bounded_runs/up.sql"),
+    "\n",
+    include_str!("../migrations/20260615000001_harvest_context_headers/up.sql")
 );
 
 #[derive(Debug, Default)]

--- a/autumn-harvest/tests/priority_tests.rs
+++ b/autumn-harvest/tests/priority_tests.rs
@@ -247,6 +247,7 @@ fn start_workflow_params_has_priority_field() {
         owner: None,
         runbook_url: None,
         severity: None,
+        context_headers: None,
     };
 
     assert_eq!(params.priority, Priority::High);
@@ -282,6 +283,7 @@ fn start_workflow_params_default_priority_is_normal() {
         owner: None,
         runbook_url: None,
         severity: None,
+        context_headers: None,
     };
 
     assert_eq!(params.priority, Priority::Normal);

--- a/autumn-harvest/tests/replay_tests.rs
+++ b/autumn-harvest/tests/replay_tests.rs
@@ -829,7 +829,7 @@ async fn replay_await_condition_non_deterministic_divergence_fails() {
             workflow_name: "non_deterministic".to_string(),
             execution_id: exec_id,
             events: history,
-            context_headers: std::collections::HashMap::new(),
+            context_headers: None,
         })
         .await;
 

--- a/autumn-harvest/tests/replay_tests.rs
+++ b/autumn-harvest/tests/replay_tests.rs
@@ -829,6 +829,7 @@ async fn replay_await_condition_non_deterministic_divergence_fails() {
             workflow_name: "non_deterministic".to_string(),
             execution_id: exec_id,
             events: history,
+            context_headers: std::collections::HashMap::new(),
         })
         .await;
 

--- a/autumn-harvest/tests/replay_verifier_tests.rs
+++ b/autumn-harvest/tests/replay_verifier_tests.rs
@@ -100,7 +100,7 @@ fn canonical_snapshot_json(workflow_name: &str) -> String {
         workflow_name: workflow_name.to_string(),
         execution_id: exec_id,
         events,
-        context_headers: std::collections::HashMap::new(),
+        context_headers: None,
     };
     serde_json::to_string(&snapshot).unwrap()
 }
@@ -114,7 +114,7 @@ fn unregistered_snapshot_json() -> String {
             input: Value::Null,
             timestamp: Utc::now(),
         }],
-        context_headers: std::collections::HashMap::new(),
+        context_headers: None,
     };
     serde_json::to_string(&snapshot).unwrap()
 }

--- a/autumn-harvest/tests/replay_verifier_tests.rs
+++ b/autumn-harvest/tests/replay_verifier_tests.rs
@@ -100,6 +100,7 @@ fn canonical_snapshot_json(workflow_name: &str) -> String {
         workflow_name: workflow_name.to_string(),
         execution_id: exec_id,
         events,
+        context_headers: std::collections::HashMap::new(),
     };
     serde_json::to_string(&snapshot).unwrap()
 }
@@ -113,6 +114,7 @@ fn unregistered_snapshot_json() -> String {
             input: Value::Null,
             timestamp: Utc::now(),
         }],
+        context_headers: std::collections::HashMap::new(),
     };
     serde_json::to_string(&snapshot).unwrap()
 }

--- a/autumn-harvest/tests/replayer_integration_tests.rs
+++ b/autumn-harvest/tests/replayer_integration_tests.rs
@@ -86,7 +86,9 @@ const INIT_SQL: &str = concat!(
     "\n",
     include_str!("../migrations/20260609000001_harvest_workflow_current_details/up.sql"),
     "\n",
-    include_str!("../migrations/20260610000001_harvest_schedule_bounded_runs/up.sql")
+    include_str!("../migrations/20260610000001_harvest_schedule_bounded_runs/up.sql"),
+    "\n",
+    include_str!("../migrations/20260615000001_harvest_context_headers/up.sql")
 );
 
 // ---------------------------------------------------------------------------

--- a/autumn-harvest/tests/replayer_integration_tests.rs
+++ b/autumn-harvest/tests/replayer_integration_tests.rs
@@ -138,6 +138,7 @@ async fn insert_execution(conn: &mut AsyncPgConnection, exec_id: ExecutionId, na
         owner: None,
         runbook_url: None,
         severity: None,
+        context_headers: None,
     };
     diesel::insert_into(harvest_workflow_executions::table)
         .values(&row)

--- a/autumn-harvest/tests/replayer_tests.rs
+++ b/autumn-harvest/tests/replayer_tests.rs
@@ -208,7 +208,7 @@ fn make_snapshot(name: &str, exec_id: ExecutionId, events: Vec<WorkflowEvent>) -
         workflow_name: name.to_string(),
         execution_id: exec_id,
         events,
-        context_headers: std::collections::HashMap::new(),
+        context_headers: None,
     }
 }
 
@@ -398,7 +398,7 @@ async fn replay_from_json_succeeds_with_unchanged_workflow() {
         workflow_name: "canonical_workflow".to_string(),
         execution_id: exec_id,
         events,
-        context_headers: std::collections::HashMap::new(),
+        context_headers: None,
     };
     let json = serde_json::to_string(&snapshot).expect("serialization must succeed");
 
@@ -423,7 +423,7 @@ async fn replay_from_json_detects_non_determinism() {
         workflow_name: "reordered_workflow".to_string(),
         execution_id: exec_id,
         events,
-        context_headers: std::collections::HashMap::new(),
+        context_headers: None,
     };
     let json = serde_json::to_string(&snapshot).expect("serialization must succeed");
 
@@ -607,7 +607,7 @@ async fn replay_activity_with_changed_input_detects_non_determinism() {
             workflow_name: "changed".to_string(),
             execution_id: exec_id,
             events,
-        context_headers: std::collections::HashMap::new(),
+            context_headers: None,
         })
         .await;
 
@@ -1461,7 +1461,7 @@ async fn replay_detached_spawn_returns_recorded_child_id() {
             workflow_name: "detached_spawn_abandon_workflow".to_string(),
             execution_id: exec_id,
             events,
-        context_headers: std::collections::HashMap::new(),
+            context_headers: None,
         })
         .await;
 
@@ -1491,7 +1491,7 @@ async fn replay_detached_spawn_request_cancel_policy_succeeds() {
             workflow_name: "detached_spawn_request_cancel_workflow".to_string(),
             execution_id: exec_id,
             events,
-        context_headers: std::collections::HashMap::new(),
+            context_headers: None,
         })
         .await;
 
@@ -1514,7 +1514,7 @@ async fn replay_detached_spawn_policy_mismatch_detects_non_determinism() {
             workflow_name: "detached_spawn_abandon_workflow".to_string(),
             execution_id: exec_id,
             events,
-        context_headers: std::collections::HashMap::new(),
+            context_headers: None,
         })
         .await;
 
@@ -1539,7 +1539,7 @@ async fn replay_detached_spawn_then_activity_succeeds() {
             workflow_name: "detached_spawn_then_activity_workflow".to_string(),
             execution_id: exec_id,
             events,
-        context_headers: std::collections::HashMap::new(),
+            context_headers: None,
         })
         .await;
 
@@ -1581,7 +1581,7 @@ async fn replay_reordered_detached_spawn_detects_non_determinism() {
             workflow_name: "reordered_detached_spawn_workflow".to_string(),
             execution_id: exec_id,
             events,
-        context_headers: std::collections::HashMap::new(),
+            context_headers: None,
         })
         .await;
 
@@ -1640,7 +1640,7 @@ async fn replay_backwards_compat_awaited_child_workflow() {
             workflow_name: "awaited_child_workflow".to_string(),
             execution_id: exec_id,
             events,
-        context_headers: std::collections::HashMap::new(),
+            context_headers: None,
         })
         .await;
 
@@ -1712,7 +1712,7 @@ async fn replay_succeeds_for_recorded_side_effect() {
             workflow_name: "now_then_activity".to_string(),
             execution_id: exec_id,
             events,
-        context_headers: std::collections::HashMap::new(),
+            context_headers: None,
         })
         .await;
 
@@ -1753,7 +1753,7 @@ async fn replay_detects_side_effect_drift() {
             workflow_name: "now_then_activity".to_string(),
             execution_id: exec_id,
             events,
-        context_headers: std::collections::HashMap::new(),
+            context_headers: None,
         })
         .await;
 

--- a/autumn-harvest/tests/replayer_tests.rs
+++ b/autumn-harvest/tests/replayer_tests.rs
@@ -208,6 +208,7 @@ fn make_snapshot(name: &str, exec_id: ExecutionId, events: Vec<WorkflowEvent>) -
         workflow_name: name.to_string(),
         execution_id: exec_id,
         events,
+        context_headers: std::collections::HashMap::new(),
     }
 }
 
@@ -397,6 +398,7 @@ async fn replay_from_json_succeeds_with_unchanged_workflow() {
         workflow_name: "canonical_workflow".to_string(),
         execution_id: exec_id,
         events,
+        context_headers: std::collections::HashMap::new(),
     };
     let json = serde_json::to_string(&snapshot).expect("serialization must succeed");
 
@@ -421,6 +423,7 @@ async fn replay_from_json_detects_non_determinism() {
         workflow_name: "reordered_workflow".to_string(),
         execution_id: exec_id,
         events,
+        context_headers: std::collections::HashMap::new(),
     };
     let json = serde_json::to_string(&snapshot).expect("serialization must succeed");
 
@@ -604,6 +607,7 @@ async fn replay_activity_with_changed_input_detects_non_determinism() {
             workflow_name: "changed".to_string(),
             execution_id: exec_id,
             events,
+        context_headers: std::collections::HashMap::new(),
         })
         .await;
 
@@ -1457,6 +1461,7 @@ async fn replay_detached_spawn_returns_recorded_child_id() {
             workflow_name: "detached_spawn_abandon_workflow".to_string(),
             execution_id: exec_id,
             events,
+        context_headers: std::collections::HashMap::new(),
         })
         .await;
 
@@ -1486,6 +1491,7 @@ async fn replay_detached_spawn_request_cancel_policy_succeeds() {
             workflow_name: "detached_spawn_request_cancel_workflow".to_string(),
             execution_id: exec_id,
             events,
+        context_headers: std::collections::HashMap::new(),
         })
         .await;
 
@@ -1508,6 +1514,7 @@ async fn replay_detached_spawn_policy_mismatch_detects_non_determinism() {
             workflow_name: "detached_spawn_abandon_workflow".to_string(),
             execution_id: exec_id,
             events,
+        context_headers: std::collections::HashMap::new(),
         })
         .await;
 
@@ -1532,6 +1539,7 @@ async fn replay_detached_spawn_then_activity_succeeds() {
             workflow_name: "detached_spawn_then_activity_workflow".to_string(),
             execution_id: exec_id,
             events,
+        context_headers: std::collections::HashMap::new(),
         })
         .await;
 
@@ -1573,6 +1581,7 @@ async fn replay_reordered_detached_spawn_detects_non_determinism() {
             workflow_name: "reordered_detached_spawn_workflow".to_string(),
             execution_id: exec_id,
             events,
+        context_headers: std::collections::HashMap::new(),
         })
         .await;
 
@@ -1631,6 +1640,7 @@ async fn replay_backwards_compat_awaited_child_workflow() {
             workflow_name: "awaited_child_workflow".to_string(),
             execution_id: exec_id,
             events,
+        context_headers: std::collections::HashMap::new(),
         })
         .await;
 
@@ -1702,6 +1712,7 @@ async fn replay_succeeds_for_recorded_side_effect() {
             workflow_name: "now_then_activity".to_string(),
             execution_id: exec_id,
             events,
+        context_headers: std::collections::HashMap::new(),
         })
         .await;
 
@@ -1742,6 +1753,7 @@ async fn replay_detects_side_effect_drift() {
             workflow_name: "now_then_activity".to_string(),
             execution_id: exec_id,
             events,
+        context_headers: std::collections::HashMap::new(),
         })
         .await;
 

--- a/autumn-harvest/tests/schedule_decisions.rs
+++ b/autumn-harvest/tests/schedule_decisions.rs
@@ -61,7 +61,9 @@ const INIT_SQL: &str = concat!(
     "\n",
     include_str!("../migrations/20260609000001_harvest_workflow_current_details/up.sql"),
     "\n",
-    include_str!("../migrations/20260610000001_harvest_schedule_bounded_runs/up.sql")
+    include_str!("../migrations/20260610000001_harvest_schedule_bounded_runs/up.sql"),
+    "\n",
+    include_str!("../migrations/20260615000001_harvest_context_headers/up.sql")
 );
 
 #[derive(Debug, Default, Clone)]

--- a/autumn-harvest/tests/schedule_to_close_tests.rs
+++ b/autumn-harvest/tests/schedule_to_close_tests.rs
@@ -94,7 +94,9 @@ const INIT_SQL: &str = concat!(
     "\n",
     include_str!("../migrations/20260609000001_harvest_workflow_current_details/up.sql"),
     "\n",
-    include_str!("../migrations/20260610000001_harvest_schedule_bounded_runs/up.sql")
+    include_str!("../migrations/20260610000001_harvest_schedule_bounded_runs/up.sql"),
+    "\n",
+    include_str!("../migrations/20260615000001_harvest_context_headers/up.sql")
 );
 
 async fn setup_db() -> (AsyncPgConnection, ContainerAsync<Postgres>) {

--- a/autumn-harvest/tests/schedule_to_close_tests.rs
+++ b/autumn-harvest/tests/schedule_to_close_tests.rs
@@ -128,6 +128,7 @@ async fn insert_workflow_execution(conn: &mut AsyncPgConnection) -> ExecutionId 
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         })
         .execute(conn)
         .await

--- a/autumn-harvest/tests/scheduler_auto_pause_tests.rs
+++ b/autumn-harvest/tests/scheduler_auto_pause_tests.rs
@@ -92,7 +92,9 @@ const INIT_SQL: &str = concat!(
     "\n",
     include_str!("../migrations/20260609000001_harvest_workflow_current_details/up.sql"),
     "\n",
-    include_str!("../migrations/20260610000001_harvest_schedule_bounded_runs/up.sql")
+    include_str!("../migrations/20260610000001_harvest_schedule_bounded_runs/up.sql"),
+    "\n",
+    include_str!("../migrations/20260615000001_harvest_context_headers/up.sql")
 );
 
 // ── Recording metrics ──────────────────────────────────────────────────────

--- a/autumn-harvest/tests/scheduler_bounded_runs_tests.rs
+++ b/autumn-harvest/tests/scheduler_bounded_runs_tests.rs
@@ -89,6 +89,8 @@ const INIT_SQL: &str = concat!(
     "\n",
     // Bounded runs (issue #478)
     include_str!("../migrations/20260610000001_harvest_schedule_bounded_runs/up.sql"),
+    "\n",
+    include_str!("../migrations/20260615000001_harvest_context_headers/up.sql")
 );
 
 // ── Unit tests (no DB) ─────────────────────────────────────────────────────

--- a/autumn-harvest/tests/scheduler_ha_tests.rs
+++ b/autumn-harvest/tests/scheduler_ha_tests.rs
@@ -94,7 +94,9 @@ const INIT_SQL: &str = concat!(
     "\n",
     include_str!("../migrations/20260609000001_harvest_workflow_current_details/up.sql"),
     "\n",
-    include_str!("../migrations/20260610000001_harvest_schedule_bounded_runs/up.sql")
+    include_str!("../migrations/20260610000001_harvest_schedule_bounded_runs/up.sql"),
+    "\n",
+    include_str!("../migrations/20260615000001_harvest_context_headers/up.sql")
 );
 
 // ── Recording metrics ──────────────────────────────────────────────────────

--- a/autumn-harvest/tests/signal_tests.rs
+++ b/autumn-harvest/tests/signal_tests.rs
@@ -53,7 +53,9 @@ const INIT_SQL: &str = concat!(
     "\n",
     include_str!("../migrations/20260609000001_harvest_workflow_current_details/up.sql"),
     "\n",
-    include_str!("../migrations/20260610000001_harvest_schedule_bounded_runs/up.sql")
+    include_str!("../migrations/20260610000001_harvest_schedule_bounded_runs/up.sql"),
+    "\n",
+    include_str!("../migrations/20260615000001_harvest_context_headers/up.sql")
 );
 
 async fn setup_test_db() -> (

--- a/autumn-harvest/tests/signal_tests.rs
+++ b/autumn-harvest/tests/signal_tests.rs
@@ -110,6 +110,7 @@ async fn test_send_and_load_signals() {
         owner: None,
         runbook_url: None,
         severity: None,
+        context_headers: None,
     };
     diesel::insert_into(harvest_workflow_executions::table)
         .values(&new_exec)
@@ -160,6 +161,7 @@ async fn test_mark_signals_consumed() {
         owner: None,
         runbook_url: None,
         severity: None,
+        context_headers: None,
     };
     diesel::insert_into(harvest_workflow_executions::table)
         .values(&new_exec)

--- a/autumn-harvest/tests/signal_with_start_tests.rs
+++ b/autumn-harvest/tests/signal_with_start_tests.rs
@@ -121,6 +121,7 @@ fn params<'a>(
         owner: None,
         runbook_url: None,
         severity: None,
+        context_headers: None,
     }
 }
 

--- a/autumn-harvest/tests/signal_with_start_tests.rs
+++ b/autumn-harvest/tests/signal_with_start_tests.rs
@@ -68,7 +68,9 @@ const INIT_SQL: &str = concat!(
     "\n",
     include_str!("../migrations/20260609000001_harvest_workflow_current_details/up.sql"),
     "\n",
-    include_str!("../migrations/20260610000001_harvest_schedule_bounded_runs/up.sql")
+    include_str!("../migrations/20260610000001_harvest_schedule_bounded_runs/up.sql"),
+    "\n",
+    include_str!("../migrations/20260615000001_harvest_context_headers/up.sql")
 );
 
 async fn setup_test_db() -> (

--- a/autumn-harvest/tests/sticky_routing_tests.rs
+++ b/autumn-harvest/tests/sticky_routing_tests.rs
@@ -463,6 +463,7 @@ mod db_tests {
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         };
         diesel::insert_into(harvest_workflow_executions::table)
             .values(&row)

--- a/autumn-harvest/tests/sticky_routing_tests.rs
+++ b/autumn-harvest/tests/sticky_routing_tests.rs
@@ -427,8 +427,8 @@ mod db_tests {
         include_str!("../migrations/20260609000001_harvest_workflow_current_details/up.sql"),
         "\n",
         include_str!("../migrations/20260610000001_harvest_schedule_bounded_runs/up.sql"),
-    "\n",
-    include_str!("../migrations/20260615000001_harvest_context_headers/up.sql")
+        "\n",
+        include_str!("../migrations/20260615000001_harvest_context_headers/up.sql")
     );
 
     async fn setup() -> (AsyncPgConnection, ContainerAsync<Postgres>) {

--- a/autumn-harvest/tests/sticky_routing_tests.rs
+++ b/autumn-harvest/tests/sticky_routing_tests.rs
@@ -426,7 +426,9 @@ mod db_tests {
         "\n",
         include_str!("../migrations/20260609000001_harvest_workflow_current_details/up.sql"),
         "\n",
-        include_str!("../migrations/20260610000001_harvest_schedule_bounded_runs/up.sql")
+        include_str!("../migrations/20260610000001_harvest_schedule_bounded_runs/up.sql"),
+    "\n",
+    include_str!("../migrations/20260615000001_harvest_context_headers/up.sql")
     );
 
     async fn setup() -> (AsyncPgConnection, ContainerAsync<Postgres>) {

--- a/autumn-harvest/tests/telemetry_span_tests.rs
+++ b/autumn-harvest/tests/telemetry_span_tests.rs
@@ -367,6 +367,7 @@ fn all_adr_0001_span_kinds_are_emitted() {
                     owner: None,
                     runbook_url: None,
                     severity: None,
+                    context_headers: None,
                 },
             )
             .await
@@ -559,6 +560,7 @@ fn replay_span_has_replay_true_and_no_activity_execute_span() {
                     telemetry_master_workflow,
                     Value::Null,
                     state,
+                    std::collections::HashMap::new(),
                 )
                 .await;
             });

--- a/autumn-harvest/tests/telemetry_span_tests.rs
+++ b/autumn-harvest/tests/telemetry_span_tests.rs
@@ -102,7 +102,9 @@ const INIT_SQL: &str = concat!(
     "\n",
     include_str!("../migrations/20260609000001_harvest_workflow_current_details/up.sql"),
     "\n",
-    include_str!("../migrations/20260610000001_harvest_schedule_bounded_runs/up.sql")
+    include_str!("../migrations/20260610000001_harvest_schedule_bounded_runs/up.sql"),
+    "\n",
+    include_str!("../migrations/20260615000001_harvest_context_headers/up.sql")
 );
 
 // -------------------------------------------------------------------------

--- a/autumn-harvest/tests/transactional_activity_tests.rs
+++ b/autumn-harvest/tests/transactional_activity_tests.rs
@@ -349,6 +349,7 @@ async fn transactional_activity_happy_path_atomic_commit() {
                 owner: None,
                 runbook_url: None,
                 severity: None,
+                context_headers: None,
             },
         )
         .await
@@ -426,6 +427,7 @@ async fn transactional_activity_err_rolls_back_user_writes() {
                 owner: None,
                 runbook_url: None,
                 severity: None,
+                context_headers: None,
             },
         )
         .await

--- a/autumn-harvest/tests/transactional_activity_tests.rs
+++ b/autumn-harvest/tests/transactional_activity_tests.rs
@@ -103,7 +103,9 @@ const INIT_SQL: &str = concat!(
     "\n",
     include_str!("../migrations/20260609000001_harvest_workflow_current_details/up.sql"),
     "\n",
-    include_str!("../migrations/20260610000001_harvest_schedule_bounded_runs/up.sql")
+    include_str!("../migrations/20260610000001_harvest_schedule_bounded_runs/up.sql"),
+    "\n",
+    include_str!("../migrations/20260615000001_harvest_context_headers/up.sql")
 );
 
 const CREATE_USER_RECORDS: &str = "

--- a/autumn-harvest/tests/typed_stubs_tests.rs
+++ b/autumn-harvest/tests/typed_stubs_tests.rs
@@ -91,7 +91,9 @@ const INIT_SQL: &str = concat!(
     "\n",
     include_str!("../migrations/20260609000001_harvest_workflow_current_details/up.sql"),
     "\n",
-    include_str!("../migrations/20260610000001_harvest_schedule_bounded_runs/up.sql")
+    include_str!("../migrations/20260610000001_harvest_schedule_bounded_runs/up.sql"),
+    "\n",
+    include_str!("../migrations/20260615000001_harvest_context_headers/up.sql")
 );
 
 async fn setup_database_url() -> (String, ContainerAsync<Postgres>) {

--- a/autumn-harvest/tests/update_with_start_tests.rs
+++ b/autumn-harvest/tests/update_with_start_tests.rs
@@ -194,7 +194,11 @@ mod db_tests {
         "\n",
         include_str!("../migrations/20260607000002_harvest_workflow_pause/up.sql"),
         "\n",
-        include_str!("../migrations/20260609000001_harvest_workflow_current_details/up.sql")
+        include_str!("../migrations/20260609000001_harvest_workflow_current_details/up.sql"),
+        "\n",
+        include_str!("../migrations/20260610000001_harvest_schedule_bounded_runs/up.sql"),
+        "\n",
+        include_str!("../migrations/20260615000001_harvest_context_headers/up.sql")
     );
 
     async fn setup_test_db() -> (

--- a/autumn-harvest/tests/update_with_start_tests.rs
+++ b/autumn-harvest/tests/update_with_start_tests.rs
@@ -41,6 +41,7 @@ fn update_with_start_params_is_cloneable_and_debug() {
         owner: None,
         runbook_url: None,
         severity: None,
+        context_headers: None,
     };
 
     let _cloned = params.clone();
@@ -103,6 +104,7 @@ fn update_with_start_outcome_idempotency_key_roundtrip() {
         owner: None,
         runbook_url: None,
         severity: None,
+        context_headers: None,
     };
     assert_eq!(
         params.idempotency_key.as_deref(),
@@ -244,6 +246,7 @@ mod db_tests {
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         }
     }
 

--- a/autumn-harvest/tests/update_with_start_tests.rs
+++ b/autumn-harvest/tests/update_with_start_tests.rs
@@ -319,6 +319,7 @@ mod db_tests {
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         };
         start_or_load_workflow_execution(&mut conn, first_params)
             .await
@@ -380,6 +381,7 @@ mod db_tests {
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         };
         start_or_load_workflow_execution(&mut conn, start_params)
             .await

--- a/autumn-harvest/tests/workflow_handle_tests.rs
+++ b/autumn-harvest/tests/workflow_handle_tests.rs
@@ -91,7 +91,9 @@ const INIT_SQL: &str = concat!(
     "\n",
     include_str!("../migrations/20260609000001_harvest_workflow_current_details/up.sql"),
     "\n",
-    include_str!("../migrations/20260610000001_harvest_schedule_bounded_runs/up.sql")
+    include_str!("../migrations/20260610000001_harvest_schedule_bounded_runs/up.sql"),
+    "\n",
+    include_str!("../migrations/20260615000001_harvest_context_headers/up.sql")
 );
 
 async fn setup_database_url() -> (String, ContainerAsync<Postgres>) {

--- a/autumn-harvest/tests/workflow_handle_tests.rs
+++ b/autumn-harvest/tests/workflow_handle_tests.rs
@@ -149,6 +149,7 @@ async fn start_running_workflow(
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         },
     )
     .await

--- a/examples/quickstart/src/main.rs
+++ b/examples/quickstart/src/main.rs
@@ -147,6 +147,7 @@ async fn greet(
                 owner: None,
                 runbook_url: None,
                 severity: None,
+                context_headers: None,
             },
         )
         .await

--- a/examples/saga-choreography/src/main.rs
+++ b/examples/saga-choreography/src/main.rs
@@ -252,6 +252,7 @@ mod tests {
             workflow_name: workflow_name.to_string(),
             execution_id: exec_id,
             events,
+            context_headers: None,
         };
         let json = serde_json::to_string(&snapshot).unwrap();
         WorkflowReplayer::new()


### PR DESCRIPTION
## Summary

Implement ambient string key-value context headers that are attached at workflow start and automatically propagated to all activities and child workflows without threading through function signatures. This enables cross-cutting concerns like tenant isolation, request tracing, and feature flags to flow through the entire execution tree.

## Key Changes

- **WorkflowContext & ActivityContext**: Added `context_headers: Arc<HashMap<String, String>>` field to both contexts with builder methods `with_context_headers()` and accessor methods `header(key)` / `headers()`.

- **Database schema**: Added nullable JSONB `context_headers` column to `harvest_workflow_executions` and `harvest_task_queue` tables via migration `20260615000001_harvest_context_headers`.

- **Execution flow**: 
  - `StartWorkflowParams` and `SignalWithStartParams` now accept optional `context_headers`
  - Headers are stored in the workflow execution row and propagated to all scheduled activities via `persist_scheduled_activities()`
  - Headers are propagated to child workflows in `persist_all_started_child_workflows()` and `create_detached_child_executions()`
  - Activity task processing extracts headers from the queue item and attaches them to `ActivityContext`

- **Update & Query handlers**: Headers are automatically propagated to handler contexts via closure capture in `register_update_handler()` and `register_query_handler()`.

- **Testing support**:
  - `WorkflowReplayer::with_context_headers()` builder method for injecting headers during replay
  - `HistorySnapshot` now includes `context_headers` field (with `#[serde(default)]` for backward compatibility)
  - Comprehensive unit tests in `context.rs` and integration tests in new `context_headers_tests.rs`

- **Type-safe API**: `TypedStartOptions` and `TypedUpdateWithStartOptions` include optional `context_headers` field.

## Implementation Details

- Headers are immutable after workflow construction; they cannot be modified during execution
- Empty map is used for executions started before this feature was deployed (backward compatible)
- Headers are stored as JSONB in the database and deserialized on-demand
- Arc-wrapped HashMap enables cheap cloning across handler closures and child workflow dispatch
- All context constructors initialize with empty Arc-wrapped HashMap by default
- Serialization uses `#[serde(default)]` to handle legacy snapshots without the field

## Testing

- Unit tests verify `header()` returns set values and `None` for missing keys
- Unit tests verify `headers()` returns the full map and empty map on default
- Integration tests verify headers flow through `WorkflowReplayer` with and without injection
- Integration tests verify `HistorySnapshot` round-trips correctly and deserializes legacy JSON

https://claude.ai/code/session_01BHxe4RH1LNpqEE6pGpgY7D