### PR TITLE
Issue #482: Data-dependent DAG branching with condition predicates

### DIFF
--- a/autumn-harvest-macros/src/dag.rs
+++ b/autumn-harvest-macros/src/dag.rs
@@ -191,21 +191,21 @@ pub fn dag_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                                 .unwrap_or_default();
                             let __upstreams: ::std::vec::Vec<usize> =
                                 __tasks[__task_idx].upstreams.clone();
-                            let __trigger_rule = __tasks[__task_idx].trigger_rule.clone();
                             let __retry_override = __tasks[__task_idx].retry_policy.clone();
                             let __stc_override = __tasks[__task_idx].start_to_close;
 
-                            let __ups: ::std::vec::Vec<
-                                ::autumn_harvest::policy::TaskStatus,
-                            > = __upstreams
-                                .iter()
-                                .map(|&__i| __statuses[__i])
-                                .collect();
-                            let __should_run: bool = __trigger_rule.should_run(&__ups);
-
-                            if !__should_run {
-                                __statuses[__task_idx] = ::autumn_harvest::policy::TaskStatus::Skipped;
-                                continue;
+                            match __tasks[__task_idx].dispatch_decision(&__statuses, &__outputs) {
+                                ::autumn_harvest::DagDispatchDecision::SkipByTriggerRule => {
+                                    __statuses[__task_idx] = ::autumn_harvest::policy::TaskStatus::Skipped;
+                                    continue;
+                                }
+                                ::autumn_harvest::DagDispatchDecision::SkipByCondition => {
+                                    ctx.dag_skip_marker(__task_idx, &__activity_name)
+                                        .map_err(|e| e.to_string())?;
+                                    __statuses[__task_idx] = ::autumn_harvest::policy::TaskStatus::Skipped;
+                                    continue;
+                                }
+                                ::autumn_harvest::DagDispatchDecision::Run => {}
                             }
 
                             let __map_upstream_opt = __tasks[__task_idx].map_upstream;
@@ -522,24 +522,23 @@ fn emit_workflow_companion(
                                     .unwrap_or_default();
                                 let __upstreams: ::std::vec::Vec<usize> =
                                     __tasks[__task_idx].upstreams.clone();
-                                let __trigger_rule =
-                                    __tasks[__task_idx].trigger_rule.clone();
                                 let __retry_override =
                                     __tasks[__task_idx].retry_policy.clone();
                                 let __stc_override =
                                     __tasks[__task_idx].start_to_close;
 
-                                let __ups: ::std::vec::Vec<
-                                    ::autumn_harvest::policy::TaskStatus,
-                                > = __upstreams
-                                    .iter()
-                                    .map(|&__i| __statuses[__i])
-                                    .collect();
-                                let __should_run: bool = __trigger_rule.should_run(&__ups);
-
-                                if !__should_run {
-                                    __statuses[__task_idx] = ::autumn_harvest::policy::TaskStatus::Skipped;
-                                    continue; // skip to next task in this level
+                                match __tasks[__task_idx].dispatch_decision(&__statuses, &__outputs) {
+                                    ::autumn_harvest::DagDispatchDecision::SkipByTriggerRule => {
+                                        __statuses[__task_idx] = ::autumn_harvest::policy::TaskStatus::Skipped;
+                                        continue;
+                                    }
+                                    ::autumn_harvest::DagDispatchDecision::SkipByCondition => {
+                                        ctx.dag_skip_marker(__task_idx, &__activity_name)
+                                            .map_err(|e| e.to_string())?;
+                                        __statuses[__task_idx] = ::autumn_harvest::policy::TaskStatus::Skipped;
+                                        continue;
+                                    }
+                                    ::autumn_harvest::DagDispatchDecision::Run => {}
                                 }
 
                                 let __map_upstream_opt = __tasks[__task_idx].map_upstream;

--- a/autumn-harvest-macros/src/dag.rs
+++ b/autumn-harvest-macros/src/dag.rs
@@ -200,7 +200,7 @@ pub fn dag_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                                     continue;
                                 }
                                 ::autumn_harvest::DagDispatchDecision::SkipByCondition => {
-                                    ctx.dag_skip_marker(__task_idx, &__activity_name)
+                                    ctx.dag_skip_marker(__task_idx, &__activity_name, &__upstreams)
                                         .map_err(|e| e.to_string())?;
                                     __statuses[__task_idx] = ::autumn_harvest::policy::TaskStatus::Skipped;
                                     continue;
@@ -533,7 +533,7 @@ fn emit_workflow_companion(
                                         continue;
                                     }
                                     ::autumn_harvest::DagDispatchDecision::SkipByCondition => {
-                                        ctx.dag_skip_marker(__task_idx, &__activity_name)
+                                        ctx.dag_skip_marker(__task_idx, &__activity_name, &__upstreams)
                                             .map_err(|e| e.to_string())?;
                                         __statuses[__task_idx] = ::autumn_harvest::policy::TaskStatus::Skipped;
                                         continue;

--- a/autumn-harvest-plugin/src/ui.rs
+++ b/autumn-harvest-plugin/src/ui.rs
@@ -692,8 +692,10 @@ async fn dag_detail_ui(
         let condition_skipped: std::collections::HashSet<usize> = marker_events
             .iter()
             .filter_map(|e| {
-                e.event_data["name"]
-                    .as_str()
+                // event_data is adjacently-tagged: {"type":"MarkerRecorded","data":{...}}
+                e.event_data
+                    .get("data")
+                    .and_then(|d| d["name"].as_str())
                     .and_then(parse_dag_skip_marker_index)
             })
             .collect();

--- a/autumn-harvest-plugin/src/ui.rs
+++ b/autumn-harvest-plugin/src/ui.rs
@@ -4209,7 +4209,7 @@ enum DagNodeState {
 }
 
 /// Human-readable label for a [`DagNodeState`] used in the timeline table.
-fn dag_node_state_label(state: DagNodeState) -> &'static str {
+const fn dag_node_state_label(state: DagNodeState) -> &'static str {
     match state {
         DagNodeState::Succeeded => "Succeeded",
         DagNodeState::Failed => "Failed",
@@ -8020,7 +8020,7 @@ mod tests {
 
     #[test]
     fn map_node_states_seeds_condition_skipped_nodes() {
-        use autumn_harvest::{DagBuilder, DagDefinition};
+        use autumn_harvest::DagBuilder;
 
         fn dummy() {}
         fn dummy2() {}

--- a/autumn-harvest-plugin/src/ui.rs
+++ b/autumn-harvest-plugin/src/ui.rs
@@ -693,10 +693,19 @@ async fn dag_detail_ui(
             .iter()
             .filter_map(|e| {
                 // event_data is adjacently-tagged: {"type":"MarkerRecorded","data":{...}}
-                e.event_data
-                    .get("data")
-                    .and_then(|d| d["name"].as_str())
-                    .and_then(parse_dag_skip_marker_index)
+                let data = e.event_data.get("data")?;
+                let name = data["name"].as_str()?;
+                let idx = parse_dag_skip_marker_index(name)?;
+                // Guard against task rename/reorder across deploys: only mark
+                // the node as condition-skipped when the recorded activity name
+                // still matches the task at that index in the current definition.
+                let recorded_task = data.get("task").and_then(|v| v.as_str())?;
+                let current_name = dag.definition.tasks().get(idx)?.activity_name.as_str();
+                if recorded_task == current_name {
+                    Some(idx)
+                } else {
+                    None
+                }
             })
             .collect();
 

--- a/autumn-harvest-plugin/src/ui.rs
+++ b/autumn-harvest-plugin/src/ui.rs
@@ -702,12 +702,26 @@ async fn dag_detail_ui(
                 // MarkerRecorded serializes as {"type":…,"data":{"name":…,"details":{…}}},
                 // so the task field lives under data.details.task.
                 let recorded_task = data.get("details").and_then(|d| d["task"].as_str())?;
-                let current_name = dag.definition.tasks().get(idx)?.activity_name.as_str();
-                if recorded_task == current_name {
-                    Some(idx)
-                } else {
-                    None
+                let current_task = dag.definition.tasks().get(idx)?;
+                if recorded_task != current_task.activity_name.as_str() {
+                    return None;
                 }
+                // Also validate upstream fingerprint when present (new-format markers).
+                // Old markers without "upstreams" pass through for backward compat.
+                if let Some(arr) = data
+                    .get("details")
+                    .and_then(|d| d.get("upstreams"))
+                    .and_then(|v| v.as_array())
+                {
+                    let recorded: Vec<usize> = arr
+                        .iter()
+                        .filter_map(|v| v.as_u64().and_then(|n| usize::try_from(n).ok()))
+                        .collect();
+                    if recorded != current_task.upstreams {
+                        return None;
+                    }
+                }
+                Some(idx)
             })
             .collect();
 
@@ -4390,6 +4404,12 @@ fn map_node_states(
 }
 
 fn merge_dag_task_state(current: DagNodeState, task_state: &str) -> DagNodeState {
+    // A condition-skip is backed by a recorded marker; task-row inference must
+    // never overwrite it, even when a same-named node at a different index has
+    // a FAILED/RUNNING/etc row (duplicate-activity-name scenario).
+    if current == DagNodeState::SkippedByCondition {
+        return current;
+    }
     match task_state {
         "FAILED" => DagNodeState::Failed,
         "CANCELLED" if !matches!(current, DagNodeState::Failed) => DagNodeState::Cancelled,

--- a/autumn-harvest-plugin/src/ui.rs
+++ b/autumn-harvest-plugin/src/ui.rs
@@ -679,7 +679,26 @@ async fn dag_detail_ui(
             .await
             .map_err(database_error)
             .map_err(map_error)?;
-        map_node_states(&dag.definition, &task_rows)
+
+        // Load dag_skip: markers to distinguish condition-skipped nodes (issue #482).
+        let marker_events: Vec<HarvestEvent> = harvest_events::table
+            .filter(harvest_events::workflow_exec_id.eq(exec_id))
+            .filter(harvest_events::event_type.eq("MarkerRecorded"))
+            .select(HarvestEvent::as_select())
+            .load(&mut conn)
+            .await
+            .map_err(database_error)
+            .map_err(map_error)?;
+        let condition_skipped: std::collections::HashSet<usize> = marker_events
+            .iter()
+            .filter_map(|e| {
+                e.event_data["name"]
+                    .as_str()
+                    .and_then(parse_dag_skip_marker_index)
+            })
+            .collect();
+
+        map_node_states(&dag.definition, &task_rows, &condition_skipped)
     } else {
         HashMap::<usize, DagNodeState>::new()
     };
@@ -4178,8 +4197,32 @@ enum DagNodeState {
     Cancelled,
     Running,
     Queued,
+    /// Skipped because a trigger rule evaluated to false over upstream statuses.
     Skipped,
+    /// Skipped because a data-dependent condition predicate evaluated to false
+    /// (issue #482).  Distinct from [`Skipped`] so the UI can show a different
+    /// label ("Skipped (condition)").
+    SkippedByCondition,
     Unknown,
+}
+
+/// Human-readable label for a [`DagNodeState`] used in the timeline table.
+fn dag_node_state_label(state: DagNodeState) -> &'static str {
+    match state {
+        DagNodeState::Succeeded => "Succeeded",
+        DagNodeState::Failed => "Failed",
+        DagNodeState::Cancelled => "Cancelled",
+        DagNodeState::Running => "Running",
+        DagNodeState::Queued => "Queued",
+        DagNodeState::Skipped => "Skipped (upstream)",
+        DagNodeState::SkippedByCondition => "Skipped (condition)",
+        DagNodeState::Unknown => "Unknown",
+    }
+}
+
+/// Parse `dag_skip:{idx}` from a marker event name; returns `Some(idx)` on match.
+fn parse_dag_skip_marker_index(name: &str) -> Option<usize> {
+    name.strip_prefix("dag_skip:").and_then(|s| s.parse().ok())
 }
 
 fn render_dag_detail(
@@ -4219,7 +4262,7 @@ fn render_dag_detail(
                             }
                             td { (task.activity_name.as_str()) }
                             td { (format!("{:?}", task.trigger_rule)) }
-                            td { (format!("{:?}", node_states.get(&idx).copied().unwrap_or(DagNodeState::Unknown))) }
+                            td { (dag_node_state_label(node_states.get(&idx).copied().unwrap_or(DagNodeState::Unknown))) }
                             td {
                                 @for (n, upstream) in task.upstreams.iter().enumerate() {
                                     @if n > 0 { ", " }
@@ -4234,7 +4277,7 @@ fn render_dag_detail(
                 h3 { "Node panel" }
                 p { "Activity: " code { (task.activity_name.as_str()) } }
                 p { "Trigger rule: " (format!("{:?}", task.trigger_rule)) }
-                p { "Current state: " (format!("{selected_node_state:?}")) }
+                p { "Current state: " (dag_node_state_label(selected_node_state)) }
             }
         }
         table {
@@ -4294,12 +4337,19 @@ fn layout_dag_detail(title: &str, body: &Markup, base_href: &str, refresh: Optio
 fn map_node_states(
     dag: &autumn_harvest::dag::DagDefinition,
     tasks: &[TaskQueueItem],
+    condition_skipped: &std::collections::HashSet<usize>,
 ) -> HashMap<usize, DagNodeState> {
     let mut out = HashMap::new();
     let mut has_task_row = vec![false; dag.tasks().len()];
 
+    // Seed condition-skipped nodes first (highest-priority: they have a recorded
+    // marker telling us *why* they were skipped).
+    for &idx in condition_skipped {
+        out.insert(idx, DagNodeState::SkippedByCondition);
+    }
+
     for (idx, node) in dag.tasks().iter().enumerate() {
-        let mut state = DagNodeState::Unknown;
+        let mut state = out.get(&idx).copied().unwrap_or(DagNodeState::Unknown);
         for task in tasks
             .iter()
             .filter(|t| t.activity_name.as_deref() == Some(node.activity_name.as_str()))
@@ -4312,6 +4362,8 @@ fn map_node_states(
 
     for level in dag.execution_levels() {
         for idx in level {
+            // Only infer trigger-rule skips for nodes that aren't already
+            // identified as condition-skipped or have task queue rows.
             if !has_task_row[*idx]
                 && out.get(idx).copied() == Some(DagNodeState::Unknown)
                 && let Some(state) = infer_skipped_node_state(dag, *idx, &out)
@@ -4362,7 +4414,9 @@ const fn dag_node_terminal_status(state: DagNodeState) -> Option<TaskStatus> {
     match state {
         DagNodeState::Succeeded => Some(TaskStatus::Succeeded),
         DagNodeState::Failed | DagNodeState::Cancelled => Some(TaskStatus::Failed),
-        DagNodeState::Skipped => Some(TaskStatus::Skipped),
+        // Both skip variants count as Skipped for trigger-rule propagation so
+        // downstream AllDone/AllSuccess rules see the correct upstream status.
+        DagNodeState::Skipped | DagNodeState::SkippedByCondition => Some(TaskStatus::Skipped),
         DagNodeState::Running | DagNodeState::Queued | DagNodeState::Unknown => None,
     }
 }
@@ -7479,7 +7533,7 @@ mod tests {
             dag.tasks()[upstream_idx].activity_name.as_str(),
             "FAILED",
         )];
-        let states = map_node_states(&dag, &task_rows);
+        let states = map_node_states(&dag, &task_rows, &std::collections::HashSet::new());
 
         assert_eq!(states.get(&downstream_idx), Some(&DagNodeState::Skipped));
     }
@@ -7921,6 +7975,74 @@ mod tests {
         assert!(
             q.contains("build_id=abc123"),
             "query string must include build_id"
+        );
+    }
+
+    // ── Issue #482 — DagNodeState label and condition-skip inference ──────────
+
+    #[test]
+    fn dag_node_state_label_distinguishes_skip_variants() {
+        assert_eq!(
+            dag_node_state_label(DagNodeState::Skipped),
+            "Skipped (upstream)"
+        );
+        assert_eq!(
+            dag_node_state_label(DagNodeState::SkippedByCondition),
+            "Skipped (condition)"
+        );
+        assert_eq!(dag_node_state_label(DagNodeState::Succeeded), "Succeeded");
+        assert_eq!(dag_node_state_label(DagNodeState::Unknown), "Unknown");
+    }
+
+    #[test]
+    fn parse_dag_skip_marker_index_matches_prefix() {
+        assert_eq!(parse_dag_skip_marker_index("dag_skip:3"), Some(3));
+        assert_eq!(parse_dag_skip_marker_index("dag_skip:0"), Some(0));
+        assert_eq!(parse_dag_skip_marker_index("dag_skip:42"), Some(42));
+        assert_eq!(parse_dag_skip_marker_index("fan_out:3"), None);
+        assert_eq!(parse_dag_skip_marker_index("dag_skip:"), None);
+        assert_eq!(parse_dag_skip_marker_index("dag_skip:abc"), None);
+    }
+
+    #[test]
+    fn dag_node_terminal_status_treats_both_skip_variants_as_skipped() {
+        assert_eq!(
+            dag_node_terminal_status(DagNodeState::Skipped),
+            Some(autumn_harvest::policy::TaskStatus::Skipped),
+        );
+        assert_eq!(
+            dag_node_terminal_status(DagNodeState::SkippedByCondition),
+            Some(autumn_harvest::policy::TaskStatus::Skipped),
+        );
+    }
+
+    #[test]
+    fn map_node_states_seeds_condition_skipped_nodes() {
+        use autumn_harvest::{DagBuilder, DagDefinition};
+
+        fn dummy() {}
+        fn dummy2() {}
+
+        let mut builder = DagBuilder::new();
+        let a = builder.activity(dummy);
+        let _b = builder.activity(dummy2).upstream(&a);
+        let dag = builder.build().unwrap();
+
+        let mut condition_skipped = std::collections::HashSet::new();
+        condition_skipped.insert(1usize); // task idx 1 condition-skipped
+
+        let states = map_node_states(&dag, &[], &condition_skipped);
+        assert_eq!(
+            states.get(&1),
+            Some(&DagNodeState::SkippedByCondition),
+            "condition-skipped node must be SkippedByCondition"
+        );
+        // SkippedByCondition is still Skipped for terminal status → AllSuccess
+        // downstream stays Skipped (trigger-rule inference), not SkippedByCondition.
+        assert_eq!(
+            states.get(&0),
+            Some(&DagNodeState::Unknown),
+            "root with no task rows should remain Unknown"
         );
     }
 }

--- a/autumn-harvest-plugin/src/ui.rs
+++ b/autumn-harvest-plugin/src/ui.rs
@@ -699,7 +699,9 @@ async fn dag_detail_ui(
                 // Guard against task rename/reorder across deploys: only mark
                 // the node as condition-skipped when the recorded activity name
                 // still matches the task at that index in the current definition.
-                let recorded_task = data.get("task").and_then(|v| v.as_str())?;
+                // MarkerRecorded serializes as {"type":…,"data":{"name":…,"details":{…}}},
+                // so the task field lives under data.details.task.
+                let recorded_task = data.get("details").and_then(|d| d["task"].as_str())?;
                 let current_name = dag.definition.tasks().get(idx)?.activity_name.as_str();
                 if recorded_task == current_name {
                     Some(idx)

--- a/autumn-harvest-plugin/tests/stalled_workflow_tests.rs
+++ b/autumn-harvest-plugin/tests/stalled_workflow_tests.rs
@@ -194,6 +194,7 @@ async fn seed_stalled_workflow(
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         },
     )
     .await

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -3352,17 +3352,23 @@ impl WorkflowContext {
     /// diverges from the current code — the condition predicate is not a pure
     /// function of upstream outputs, or a code change altered the branch
     /// decision for an in-flight execution.
-    pub fn dag_skip_marker(&self, task_index: usize, activity_name: &str) -> HarvestResult<()> {
+    pub fn dag_skip_marker(
+        &self,
+        task_index: usize,
+        activity_name: &str,
+        upstreams: &[usize],
+    ) -> HarvestResult<()> {
         let marker_name = format!("dag_skip:{task_index}");
         let match_result =
-            self.match_history(|m| m.match_named_marker(&marker_name, activity_name));
+            self.match_history(|m| m.match_named_marker(&marker_name, activity_name, upstreams));
         match match_result {
             HistoryMatch::NoMatch => {
                 self.push_command(WorkflowCommand::RecordMarker {
                     name: marker_name,
                     details: serde_json::json!({
                         "task": activity_name,
-                        "reason": "condition_false"
+                        "reason": "condition_false",
+                        "upstreams": upstreams,
                     }),
                 });
                 Ok(())

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -3354,7 +3354,8 @@ impl WorkflowContext {
     /// decision for an in-flight execution.
     pub fn dag_skip_marker(&self, task_index: usize, activity_name: &str) -> HarvestResult<()> {
         let marker_name = format!("dag_skip:{task_index}");
-        let match_result = self.match_history(|m| m.match_named_marker(&marker_name));
+        let match_result =
+            self.match_history(|m| m.match_named_marker(&marker_name, activity_name));
         match match_result {
             HistoryMatch::NoMatch => {
                 self.push_command(WorkflowCommand::RecordMarker {

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -3336,6 +3336,57 @@ impl WorkflowContext {
         }
     }
 
+    /// Record or verify a condition-skip decision for a DAG node in event history.
+    ///
+    /// Called by the unified-DAG dispatch loop when a node's condition predicate
+    /// returns `false`.  On **live execution** (past end of history) it pushes a
+    /// `RecordMarker` command so future replays know the branch decision.  On
+    /// **replay** it matches the existing `MarkerRecorded` event; if the event
+    /// at the cursor position is something else (the condition returned a
+    /// different value than during the first run), a `NonDeterministic` error is
+    /// returned.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HarvestError::NonDeterministic`] when the recorded history
+    /// diverges from the current code — the condition predicate is not a pure
+    /// function of upstream outputs, or a code change altered the branch
+    /// decision for an in-flight execution.
+    pub fn dag_skip_marker(&self, task_index: usize, activity_name: &str) -> HarvestResult<()> {
+        let marker_name = format!("dag_skip:{task_index}");
+        let match_result = self.match_history(|m| m.match_named_marker(&marker_name));
+        match match_result {
+            HistoryMatch::NoMatch => {
+                self.push_command(WorkflowCommand::RecordMarker {
+                    name: marker_name,
+                    details: serde_json::json!({
+                        "task": activity_name,
+                        "reason": "condition_false"
+                    }),
+                });
+                Ok(())
+            }
+            HistoryMatch::Matched { .. } => Ok(()),
+            HistoryMatch::Diverged {
+                expected,
+                actual,
+                event_index,
+            } => Err(self.nd_error(
+                format!(
+                    "dag condition skip for task {task_index} ({activity_name}) diverged from \
+                     history — the condition predicate must be a pure function of upstream outputs \
+                     and must not change across deploys for in-flight executions; \
+                     use ctx.version() to guard branch changes: \
+                     expected {expected}, got {actual}"
+                ),
+                event_index,
+                Some(expected),
+                Some(actual),
+            )),
+            _ => unreachable!("match_named_marker only returns Matched, NoMatch, or Diverged"),
+        }
+    }
+
     /// Execute N activities **in parallel** (fail-fast variant).
     ///
     /// Dispatches every `(name, input, queue)` tuple concurrently and returns

--- a/autumn-harvest/src/dag.rs
+++ b/autumn-harvest/src/dag.rs
@@ -8,11 +8,76 @@ use std::any::type_name_of_val;
 use std::cell::RefCell;
 use std::fmt;
 use std::rc::Rc;
+use std::sync::Arc;
 use std::time::Duration;
 
-use crate::policy::{MapFailurePolicy, RetryPolicy, TriggerRule};
+use serde_json::Value;
 
-#[derive(Debug, Clone)]
+use crate::policy::{MapFailurePolicy, RetryPolicy, TaskStatus, TriggerRule};
+
+/// A data-dependent node condition: a predicate over the deserialized outputs
+/// of upstream nodes, evaluated at dispatch time.
+///
+/// Upstream outputs are passed in upstream-declaration order.  Nodes whose
+/// upstream failed or was itself skipped contribute [`Value::Null`].
+///
+/// When the predicate returns `false` the node is skipped
+/// (`DagDispatchDecision::SkipByCondition`) without ever dispatching the
+/// activity.  The skip is recorded as a [`MarkerRecorded`] event so replay
+/// always selects the same branch.
+///
+/// # Example
+///
+/// ```rust
+/// use autumn_harvest::DagCondition;
+///
+/// let high_risk = DagCondition::new(|ups| {
+///     ups[0]["fraud_score"].as_f64().is_some_and(|s| s > 0.8)
+/// });
+/// ```
+#[allow(clippy::type_complexity)]
+#[derive(Clone)]
+pub struct DagCondition(Arc<dyn Fn(&[Value]) -> bool + Send + Sync>);
+
+impl DagCondition {
+    /// Create a new condition from a predicate closure.
+    pub fn new<F>(f: F) -> Self
+    where
+        F: Fn(&[Value]) -> bool + Send + Sync + 'static,
+    {
+        Self(Arc::new(f))
+    }
+
+    /// Evaluate the predicate against the given upstream outputs.
+    #[must_use]
+    pub fn evaluate(&self, upstream_outputs: &[Value]) -> bool {
+        (self.0)(upstream_outputs)
+    }
+}
+
+impl fmt::Debug for DagCondition {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("DagCondition(<fn>)")
+    }
+}
+
+/// The dispatch decision for a single DAG task, combining trigger-rule and
+/// condition-predicate checks.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DagDispatchDecision {
+    /// The task should be dispatched.
+    Run,
+    /// The task is skipped because its trigger rule evaluated to `false` over
+    /// upstream statuses.  No marker is recorded (replay-compat with pre-#482
+    /// histories).
+    SkipByTriggerRule,
+    /// The task is skipped because its condition predicate evaluated to
+    /// `false` over upstream outputs.  A `dag_skip:` marker is recorded in
+    /// event history to make the branch decision deterministic on replay.
+    SkipByCondition,
+}
+
+#[derive(Clone)]
 struct PendingDagTask {
     activity_name: String,
     upstreams: Vec<usize>,
@@ -22,6 +87,23 @@ struct PendingDagTask {
     queue: Option<String>,
     map_upstream: Option<usize>,
     map_failure_policy: MapFailurePolicy,
+    condition: Option<DagCondition>,
+}
+
+impl fmt::Debug for PendingDagTask {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("PendingDagTask")
+            .field("activity_name", &self.activity_name)
+            .field("upstreams", &self.upstreams)
+            .field("trigger_rule", &self.trigger_rule)
+            .field("retry_policy", &self.retry_policy)
+            .field("start_to_close", &self.start_to_close)
+            .field("queue", &self.queue)
+            .field("map_upstream", &self.map_upstream)
+            .field("map_failure_policy", &self.map_failure_policy)
+            .field("condition", &self.condition)
+            .finish()
+    }
 }
 
 /// Immutable task definition produced by [`DagBuilder::build`].
@@ -43,6 +125,38 @@ pub struct DagTask {
     pub map_upstream: Option<usize>,
     /// Failure policy for mapped tasks.
     pub map_failure_policy: MapFailurePolicy,
+    /// Optional data-dependent condition predicate.  When `Some`, the
+    /// predicate is evaluated against upstream outputs after the trigger rule
+    /// passes; `false` → `DagDispatchDecision::SkipByCondition`.
+    pub condition: Option<DagCondition>,
+}
+
+impl DagTask {
+    /// Compute the dispatch decision for this task.
+    ///
+    /// `statuses` and `outputs` are indexed by global task index.
+    #[must_use]
+    pub fn dispatch_decision(
+        &self,
+        statuses: &[TaskStatus],
+        outputs: &[Value],
+    ) -> DagDispatchDecision {
+        // Collect upstream statuses for the trigger rule.
+        let upstream_statuses: Vec<TaskStatus> =
+            self.upstreams.iter().map(|&i| statuses[i]).collect();
+        if !self.trigger_rule.should_run(&upstream_statuses) {
+            return DagDispatchDecision::SkipByTriggerRule;
+        }
+        // Trigger rule passed — evaluate the condition if present.
+        if let Some(cond) = &self.condition {
+            let upstream_outputs: Vec<Value> =
+                self.upstreams.iter().map(|&i| outputs[i].clone()).collect();
+            if !cond.evaluate(&upstream_outputs) {
+                return DagDispatchDecision::SkipByCondition;
+            }
+        }
+        DagDispatchDecision::Run
+    }
 }
 
 impl From<PendingDagTask> for DagTask {
@@ -56,6 +170,7 @@ impl From<PendingDagTask> for DagTask {
             queue: task.queue,
             map_upstream: task.map_upstream,
             map_failure_policy: task.map_failure_policy,
+            condition: task.condition,
         }
     }
 }
@@ -162,6 +277,42 @@ impl DagTaskRef {
     #[must_use]
     pub fn map_failure_policy(self, policy: MapFailurePolicy) -> Self {
         self.mutate(|task| task.map_failure_policy = policy)
+    }
+
+    /// Attach a data-dependent condition predicate to this task.
+    ///
+    /// The predicate receives upstream outputs in upstream-declaration order.
+    /// Upstream nodes that failed or were skipped contribute [`Value::Null`].
+    /// When the predicate returns `false`, the node is skipped
+    /// ([`DagDispatchDecision::SkipByCondition`]) and a `dag_skip:` marker is
+    /// recorded in event history so replay selects the identical branch.
+    ///
+    /// # Example
+    ///
+    /// ```rust,no_run
+    /// # use autumn_harvest::prelude::*;
+    /// # use autumn_harvest::DagCondition;
+    /// # fn score_payment() {}
+    /// # fn manual_review() {}
+    /// # fn auto_approve() {}
+    /// fn fraud_routing(dag: &mut DagBuilder) {
+    ///     let score = dag.activity(score_payment);
+    ///     let _review = dag
+    ///         .activity(manual_review)
+    ///         .upstream(&score)
+    ///         .condition(|ups| ups[0]["fraud_score"].as_f64().is_some_and(|s| s > 0.8));
+    ///     let _auto = dag
+    ///         .activity(auto_approve)
+    ///         .upstream(&score)
+    ///         .condition(|ups| ups[0]["fraud_score"].as_f64().is_some_and(|s| s <= 0.8));
+    /// }
+    /// ```
+    #[must_use]
+    pub fn condition<F>(self, predicate: F) -> Self
+    where
+        F: Fn(&[Value]) -> bool + Send + Sync + 'static,
+    {
+        self.mutate(|task| task.condition = Some(DagCondition::new(predicate)))
     }
 
     fn mutate(self, update: impl FnOnce(&mut PendingDagTask)) -> Self {
@@ -285,6 +436,7 @@ impl DagBuilder {
             queue: self.default_queue.clone(),
             map_upstream: None,
             map_failure_policy: MapFailurePolicy::FailFast,
+            condition: None,
         });
 
         DagTaskRef {
@@ -311,6 +463,7 @@ impl DagBuilder {
             queue: self.default_queue.clone(),
             map_upstream: None,
             map_failure_policy: MapFailurePolicy::FailFast,
+            condition: None,
         });
 
         DagMapTaskRef {
@@ -621,5 +774,168 @@ mod tests {
         let dag = builder.build().unwrap();
         let tasks = dag.tasks();
         assert_eq!(tasks[1].map_failure_policy, MapFailurePolicy::CollectAll);
+    }
+
+    // ── Phase 1 / Issue #482 — DagCondition + DagDispatchDecision ──────────
+
+    #[test]
+    fn condition_is_stored_on_task() {
+        let mut builder = DagBuilder::new();
+        let a = builder.activity(dummy_activity);
+        let _b = builder
+            .activity(dummy_activity2)
+            .upstream(&a)
+            .condition(|_| true);
+
+        let dag = builder.build().unwrap();
+        let tasks = dag.tasks();
+        assert!(
+            tasks[0].condition.is_none(),
+            "root task should have no condition"
+        );
+        assert!(
+            tasks[1].condition.is_some(),
+            "conditioned task should have condition set"
+        );
+    }
+
+    #[test]
+    fn dispatch_decision_run_when_no_condition() {
+        let mut builder = DagBuilder::new();
+        let _ = builder.activity(dummy_activity);
+        let dag = builder.build().unwrap();
+        let statuses = [TaskStatus::Succeeded];
+        let outputs = [Value::Null];
+        assert_eq!(
+            dag.tasks()[0].dispatch_decision(&statuses, &outputs),
+            DagDispatchDecision::Run,
+        );
+    }
+
+    #[test]
+    fn dispatch_decision_skip_by_trigger_rule() {
+        let mut builder = DagBuilder::new();
+        let a = builder.activity(dummy_activity);
+        let _b = builder.activity(dummy_activity2).upstream(&a); // AllSuccess default
+        let dag = builder.build().unwrap();
+        // upstream failed → trigger rule should block; condition must NOT run
+        let statuses = [TaskStatus::Failed, TaskStatus::Succeeded];
+        let outputs = [Value::Null, Value::Null];
+        assert_eq!(
+            dag.tasks()[1].dispatch_decision(&statuses, &outputs),
+            DagDispatchDecision::SkipByTriggerRule,
+        );
+    }
+
+    #[test]
+    fn dispatch_decision_condition_not_invoked_when_trigger_fails() {
+        use std::sync::Arc;
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        let invoked = Arc::new(AtomicBool::new(false));
+        let invoked_clone = Arc::clone(&invoked);
+
+        let mut builder = DagBuilder::new();
+        let a = builder.activity(dummy_activity);
+        let _b = builder
+            .activity(dummy_activity2)
+            .upstream(&a)
+            .condition(move |_| {
+                invoked_clone.store(true, Ordering::SeqCst);
+                true
+            });
+        let dag = builder.build().unwrap();
+        // upstream failed → trigger rule (AllSuccess) should be false
+        let statuses = [TaskStatus::Failed, TaskStatus::Succeeded];
+        let outputs = [Value::Null, Value::Null];
+        let decision = dag.tasks()[1].dispatch_decision(&statuses, &outputs);
+        assert_eq!(decision, DagDispatchDecision::SkipByTriggerRule);
+        assert!(
+            !invoked.load(Ordering::SeqCst),
+            "condition must NOT be invoked when trigger fails"
+        );
+    }
+
+    #[test]
+    fn dispatch_decision_skip_by_condition_when_predicate_false() {
+        let mut builder = DagBuilder::new();
+        let a = builder.activity(dummy_activity);
+        let _b = builder
+            .activity(dummy_activity2)
+            .upstream(&a)
+            .condition(|ups| ups[0]["score"].as_f64().is_some_and(|s| s > 0.8));
+        let dag = builder.build().unwrap();
+        let statuses = [TaskStatus::Succeeded, TaskStatus::Succeeded];
+        let outputs = [serde_json::json!({"score": 0.2}), Value::Null];
+        assert_eq!(
+            dag.tasks()[1].dispatch_decision(&statuses, &outputs),
+            DagDispatchDecision::SkipByCondition,
+        );
+    }
+
+    #[test]
+    fn dispatch_decision_run_when_condition_true() {
+        let mut builder = DagBuilder::new();
+        let a = builder.activity(dummy_activity);
+        let _b = builder
+            .activity(dummy_activity2)
+            .upstream(&a)
+            .condition(|ups| ups[0]["score"].as_f64().is_some_and(|s| s > 0.8));
+        let dag = builder.build().unwrap();
+        let statuses = [TaskStatus::Succeeded, TaskStatus::Succeeded];
+        let outputs = [serde_json::json!({"score": 0.95}), Value::Null];
+        assert_eq!(
+            dag.tasks()[1].dispatch_decision(&statuses, &outputs),
+            DagDispatchDecision::Run,
+        );
+    }
+
+    #[test]
+    fn dispatch_decision_upstream_outputs_in_declaration_order() {
+        let mut builder = DagBuilder::new();
+        let a = builder.activity(dummy_activity);
+        let b = builder.activity(dummy_activity2);
+        // c depends on both a (index 0) and b (index 1), in that order
+        let _c = builder
+            .activity(dummy_activity3)
+            .upstream(&a)
+            .upstream(&b)
+            .condition(|ups| {
+                // ups[0] should be a's output, ups[1] should be b's output
+                ups[0] == serde_json::json!("from_a") && ups[1] == serde_json::json!("from_b")
+            });
+        let dag = builder.build().unwrap();
+        let statuses = [TaskStatus::Succeeded; 3];
+        let outputs = [
+            serde_json::json!("from_a"),
+            serde_json::json!("from_b"),
+            Value::Null,
+        ];
+        assert_eq!(
+            dag.tasks()[2].dispatch_decision(&statuses, &outputs),
+            DagDispatchDecision::Run,
+        );
+    }
+
+    #[test]
+    fn mapped_task_supports_condition() {
+        let mut builder = DagBuilder::new();
+        let a = builder.activity(dummy_activity);
+        let _b = builder
+            .map_activity(dummy_activity2)
+            .over(&a)
+            .condition(|_| false); // always skip
+
+        let dag = builder.build().unwrap();
+        assert!(
+            dag.tasks()[1].condition.is_some(),
+            "mapped task should support condition"
+        );
+        let statuses = [TaskStatus::Succeeded, TaskStatus::Succeeded];
+        let outputs = [serde_json::json!([1, 2, 3]), Value::Null];
+        assert_eq!(
+            dag.tasks()[1].dispatch_decision(&statuses, &outputs),
+            DagDispatchDecision::SkipByCondition,
+        );
     }
 }

--- a/autumn-harvest/src/dag.rs
+++ b/autumn-harvest/src/dag.rs
@@ -142,15 +142,21 @@ impl DagTask {
         outputs: &[Value],
     ) -> DagDispatchDecision {
         // Collect upstream statuses for the trigger rule.
-        let upstream_statuses: Vec<TaskStatus> =
-            self.upstreams.iter().map(|&i| statuses[i]).collect();
+        let upstream_statuses: Vec<TaskStatus> = self
+            .upstreams
+            .iter()
+            .map(|&i| statuses.get(i).copied().unwrap_or(TaskStatus::Skipped))
+            .collect();
         if !self.trigger_rule.should_run(&upstream_statuses) {
             return DagDispatchDecision::SkipByTriggerRule;
         }
         // Trigger rule passed — evaluate the condition if present.
         if let Some(cond) = &self.condition {
-            let upstream_outputs: Vec<Value> =
-                self.upstreams.iter().map(|&i| outputs[i].clone()).collect();
+            let upstream_outputs: Vec<Value> = self
+                .upstreams
+                .iter()
+                .map(|&i| outputs.get(i).cloned().unwrap_or(Value::Null))
+                .collect();
             if !cond.evaluate(&upstream_outputs) {
                 return DagDispatchDecision::SkipByCondition;
             }

--- a/autumn-harvest/src/lib.rs
+++ b/autumn-harvest/src/lib.rs
@@ -193,7 +193,10 @@ pub use context::{
     WorkflowHistoryPolicy,
 };
 pub use critical_path::{CriticalPathAnalyzer, CriticalPathResult};
-pub use dag::{DagBuildError, DagBuilder, DagDefinition, DagMapTaskRef, DagTask, DagTaskRef};
+pub use dag::{
+    DagBuildError, DagBuilder, DagCondition, DagDefinition, DagDispatchDecision, DagMapTaskRef,
+    DagTask, DagTaskRef,
+};
 pub use dag_export::{export_dot, export_mermaid};
 pub use dag_linter::{
     DagLinter, DagRule, DagWarning, ExcessiveParallelismRule, MissingRetryPolicyRule,

--- a/autumn-harvest/src/prelude.rs
+++ b/autumn-harvest/src/prelude.rs
@@ -14,7 +14,8 @@ pub use crate::circuit_breaker::{
 };
 pub use crate::context::{ActivityContext, WorkflowContext};
 pub use crate::dag::{
-    DagBuildError, DagBuilder, DagDefinition, DagMapTaskRef, DagTask, DagTaskRef,
+    DagBuildError, DagBuilder, DagCondition, DagDefinition, DagDispatchDecision, DagMapTaskRef,
+    DagTask, DagTaskRef,
 };
 pub use crate::error::{HarvestError, HarvestResult, TimeoutType};
 pub use crate::event::{SideEffectKind, WorkflowEvent};

--- a/autumn-harvest/src/replay.rs
+++ b/autumn-harvest/src/replay.rs
@@ -2546,6 +2546,39 @@ impl HistoryMatcher {
         }
     }
 
+    /// Match a named `MarkerRecorded` event at the current cursor position.
+    ///
+    /// Used by `WorkflowContext::dag_skip_marker` to record the condition-skip
+    /// decision deterministically so replay always selects the identical branch.
+    ///
+    /// Returns:
+    /// - [`HistoryMatch::Matched`] — the event at cursor is `MarkerRecorded`
+    ///   with the exact `name`.
+    /// - [`HistoryMatch::Diverged`] — a different event (or a marker with a
+    ///   different name) is at the cursor; this indicates the condition predicate
+    ///   returned a different value than during the original run — a
+    ///   non-determinism violation.
+    /// - [`HistoryMatch::NoMatch`] — past end of history (live execution).
+    pub fn match_named_marker(&mut self, marker_name: &str) -> HistoryMatch {
+        if !self.prepare_match() {
+            return HistoryMatch::NoMatch;
+        }
+        match &self.events[self.cursor] {
+            WorkflowEvent::MarkerRecorded { name, .. } if name == marker_name => {
+                self.cursor += 1;
+                self.advance_to_next_unconsumed_event();
+                HistoryMatch::Matched {
+                    output: serde_json::Value::Null,
+                }
+            }
+            other => HistoryMatch::Diverged {
+                expected: format!("MarkerRecorded({marker_name})"),
+                actual: Self::actual_event_name(other),
+                event_index: i32::try_from(self.cursor).ok(),
+            },
+        }
+    }
+
     // ── Update primitive (issue #140) ─────────────────────────────────────
 
     /// Look up the recorded result for a specific update by `update_id`.

--- a/autumn-harvest/src/replay.rs
+++ b/autumn-harvest/src/replay.rs
@@ -2553,14 +2553,22 @@ impl HistoryMatcher {
     ///
     /// Returns:
     /// - [`HistoryMatch::Matched`] — the event at cursor is `MarkerRecorded`
-    ///   with the exact `name` and `expected_task` (in `details.task`).
+    ///   with the exact `name`, `expected_task` (in `details.task`), and
+    ///   matching `expected_upstreams` (in `details.upstreams`, when present).
     /// - [`HistoryMatch::Diverged`] — a different event, a marker with a
-    ///   different name, or the same marker index recording a different task
-    ///   name is at the cursor; this indicates the condition predicate
-    ///   returned a different value, or tasks were reordered/renamed across a
-    ///   deploy — a non-determinism violation.
+    ///   different name, a different task name, or (for new-format markers) a
+    ///   different upstream set is at the cursor — a non-determinism violation.
     /// - [`HistoryMatch::NoMatch`] — past end of history (live execution).
-    pub fn match_named_marker(&mut self, marker_name: &str, expected_task: &str) -> HistoryMatch {
+    ///
+    /// **Backward compatibility:** old markers without an `upstreams` field (written
+    /// before this field was introduced) pass the upstream check unconditionally,
+    /// so in-flight executions are not broken on upgrade.
+    pub fn match_named_marker(
+        &mut self,
+        marker_name: &str,
+        expected_task: &str,
+        expected_upstreams: &[usize],
+    ) -> HistoryMatch {
         if !self.prepare_match() {
             return HistoryMatch::NoMatch;
         }
@@ -2573,6 +2581,26 @@ impl HistoryMatcher {
                         actual: format!("MarkerRecorded({marker_name}, task={recorded_task})"),
                         event_index: i32::try_from(self.cursor).ok(),
                     };
+                }
+                // Validate upstream fingerprint only when the stored marker has the
+                // field (new-format markers); old markers without it pass through so
+                // in-flight executions survive an upgrade.
+                if let Some(arr) = details.get("upstreams").and_then(|v| v.as_array()) {
+                    let recorded_upstreams: Vec<usize> = arr
+                        .iter()
+                        .filter_map(|v| v.as_u64().and_then(|n| usize::try_from(n).ok()))
+                        .collect();
+                    if recorded_upstreams != expected_upstreams {
+                        return HistoryMatch::Diverged {
+                            expected: format!(
+                                "MarkerRecorded({marker_name}, task={expected_task}, upstreams={expected_upstreams:?})"
+                            ),
+                            actual: format!(
+                                "MarkerRecorded({marker_name}, task={recorded_task}, upstreams={recorded_upstreams:?})"
+                            ),
+                            event_index: i32::try_from(self.cursor).ok(),
+                        };
+                    }
                 }
                 self.cursor += 1;
                 self.advance_to_next_unconsumed_event();

--- a/autumn-harvest/src/replay.rs
+++ b/autumn-harvest/src/replay.rs
@@ -2553,18 +2553,27 @@ impl HistoryMatcher {
     ///
     /// Returns:
     /// - [`HistoryMatch::Matched`] — the event at cursor is `MarkerRecorded`
-    ///   with the exact `name`.
-    /// - [`HistoryMatch::Diverged`] — a different event (or a marker with a
-    ///   different name) is at the cursor; this indicates the condition predicate
-    ///   returned a different value than during the original run — a
-    ///   non-determinism violation.
+    ///   with the exact `name` and `expected_task` (in `details.task`).
+    /// - [`HistoryMatch::Diverged`] — a different event, a marker with a
+    ///   different name, or the same marker index recording a different task
+    ///   name is at the cursor; this indicates the condition predicate
+    ///   returned a different value, or tasks were reordered/renamed across a
+    ///   deploy — a non-determinism violation.
     /// - [`HistoryMatch::NoMatch`] — past end of history (live execution).
-    pub fn match_named_marker(&mut self, marker_name: &str) -> HistoryMatch {
+    pub fn match_named_marker(&mut self, marker_name: &str, expected_task: &str) -> HistoryMatch {
         if !self.prepare_match() {
             return HistoryMatch::NoMatch;
         }
         match &self.events[self.cursor] {
-            WorkflowEvent::MarkerRecorded { name, .. } if name == marker_name => {
+            WorkflowEvent::MarkerRecorded { name, details } if name == marker_name => {
+                let recorded_task = details.get("task").and_then(|v| v.as_str()).unwrap_or("");
+                if recorded_task != expected_task {
+                    return HistoryMatch::Diverged {
+                        expected: format!("MarkerRecorded({marker_name}, task={expected_task})"),
+                        actual: format!("MarkerRecorded({marker_name}, task={recorded_task})"),
+                        event_index: i32::try_from(self.cursor).ok(),
+                    };
+                }
                 self.cursor += 1;
                 self.advance_to_next_unconsumed_event();
                 HistoryMatch::Matched {

--- a/autumn-harvest/src/testing.rs
+++ b/autumn-harvest/src/testing.rs
@@ -2279,10 +2279,17 @@ impl WorkflowTestEnv {
                 Ok(false)
             }
 
+            // Markers (fan-out count guards, dag condition skips, etc.) must be
+            // persisted to history so the next replay iteration finds them in the
+            // same position as the real worker would.  Mirrors RecordSideEffect above.
+            WorkflowCommand::RecordMarker { name, details } => {
+                history.push(WorkflowEvent::MarkerRecorded { name, details });
+                Ok(false)
+            }
+
             // WaitForActivity: activity was scheduled in a previous iteration;
             // its terminal event is already in history and will be matched on replay.
             WorkflowCommand::WaitForActivity { .. }
-            | WorkflowCommand::RecordMarker { .. }
             | WorkflowCommand::RecordUpdateResult { .. }
             | WorkflowCommand::UpsertSearchAttributes { .. }
             | WorkflowCommand::SetCurrentDetails { .. }

--- a/autumn-harvest/tests/dag_unified_tests.rs
+++ b/autumn-harvest/tests/dag_unified_tests.rs
@@ -14,6 +14,7 @@ use autumn_harvest::event::WorkflowEvent;
 use autumn_harvest::executor::{WorkflowOutcome, run_workflow};
 use autumn_harvest::info::WorkflowHandlerFn;
 use autumn_harvest::prelude::*;
+#[cfg(feature = "db")]
 use autumn_harvest::scheduler::compile_dag_catalog;
 use autumn_harvest::testing::{NonDeterminismKind, ReplayStatus, WorkflowReplayer};
 use autumn_harvest::types::ActivityExecId;
@@ -646,6 +647,7 @@ fn builder_rejects_local_activities_in_dag_definitions() {
     );
 }
 
+#[cfg(feature = "db")]
 #[test]
 fn compile_dag_catalog_keeps_unified_dag_metadata() {
     let catalog = compile_dag_catalog(vec![__autumn_dag_info_linear_dag()])
@@ -658,6 +660,7 @@ fn compile_dag_catalog_keeps_unified_dag_metadata() {
     assert!(registered.schedule.is_none());
 }
 
+#[cfg(feature = "db")]
 #[test]
 fn compile_dag_catalog_rejects_duplicate_unified_dag_names() {
     let result = compile_dag_catalog(vec![
@@ -686,6 +689,7 @@ fn compile_dag_catalog_rejects_duplicate_unified_dag_names() {
 ///
 /// This test constructs a minimal `HandlerRegistry` that mirrors what
 /// `HarvestBuilder::dags()` produces and asserts the worker handler is present.
+#[cfg(feature = "db")]
 #[test]
 fn unified_dag_registers_workflow_handler_for_worker_execution() {
     use autumn_harvest::worker::HandlerRegistry;
@@ -792,5 +796,645 @@ async fn lowered_handler_leaves_queue_empty_when_dag_task_has_no_queue() {
     assert_eq!(
         queue, "",
         "DAG tasks with no DAG default_queue and no per-task queue must leave queue empty so the activity default queue can apply"
+    );
+}
+
+// ============================================================================
+// Issue #482 — Data-dependent DAG branching
+// ============================================================================
+
+// ---------------------------------------------------------------------------
+// Activity stubs for branching tests
+// ---------------------------------------------------------------------------
+
+#[activity]
+async fn score_payment(_ctx: &ActivityContext) -> Result<Value, String> {
+    Ok(json!({"fraud_score": 0.0})) // overridden per-test via mock
+}
+
+#[activity]
+async fn manual_review(_ctx: &ActivityContext) -> Result<Value, String> {
+    Ok(json!("reviewed"))
+}
+
+#[activity]
+async fn auto_approve(_ctx: &ActivityContext) -> Result<Value, String> {
+    Ok(json!("approved"))
+}
+
+#[activity]
+async fn notify_result(_ctx: &ActivityContext) -> Result<Value, String> {
+    Ok(json!("notified"))
+}
+
+#[activity]
+async fn low_risk_path(_ctx: &ActivityContext) -> Result<Value, String> {
+    Ok(json!("low"))
+}
+
+#[activity]
+async fn medium_risk_path(_ctx: &ActivityContext) -> Result<Value, String> {
+    Ok(json!("medium"))
+}
+
+#[activity]
+async fn high_risk_path(_ctx: &ActivityContext) -> Result<Value, String> {
+    Ok(json!("high"))
+}
+
+// ---------------------------------------------------------------------------
+// DAG fixtures for branching tests
+// ---------------------------------------------------------------------------
+
+/// Fraud-routing DAG: score_payment → (manual_review | auto_approve) → notify_result (AllDone)
+#[dag(default_queue = "risk-workers")]
+fn fraud_routing_dag(dag: &mut DagBuilder) {
+    let score = dag.activity(score_payment);
+    let review = dag
+        .activity(manual_review)
+        .upstream(&score)
+        .condition(|ups| ups[0]["fraud_score"].as_f64().is_some_and(|s| s > 0.8));
+    let auto = dag
+        .activity(auto_approve)
+        .upstream(&score)
+        .condition(|ups| ups[0]["fraud_score"].as_f64().is_some_and(|s| s <= 0.8));
+    // AllDone join fires regardless of which branch ran
+    let _notify = dag
+        .activity(notify_result)
+        .upstream(&review)
+        .upstream(&auto)
+        .trigger_rule(TriggerRule::AllDone);
+}
+
+/// Three-way switch: low / medium / high
+#[dag(default_queue = "risk-workers")]
+fn three_way_switch_dag(dag: &mut DagBuilder) {
+    let score = dag.activity(score_payment);
+    let _low = dag
+        .activity(low_risk_path)
+        .upstream(&score)
+        .condition(|ups| ups[0]["level"].as_str() == Some("low"));
+    let _medium = dag
+        .activity(medium_risk_path)
+        .upstream(&score)
+        .condition(|ups| ups[0]["level"].as_str() == Some("medium"));
+    let _high = dag
+        .activity(high_risk_path)
+        .upstream(&score)
+        .condition(|ups| ups[0]["level"].as_str() == Some("high"));
+}
+
+fn risk_input(task: &str) -> Value {
+    json!({ "conf": Value::Null, "dag_task": task })
+}
+
+// ---------------------------------------------------------------------------
+// Test 1 — condition-false branch replays with a dag_skip marker
+// ---------------------------------------------------------------------------
+
+/// Low fraud score: manual_review is skipped (condition false), auto_approve runs.
+/// History contains a `MarkerRecorded(dag_skip:1)` before auto_approve's events.
+#[tokio::test]
+async fn condition_false_branch_replays_with_skip_marker() {
+    let id_score = ActivityExecId::new();
+    let id_auto = ActivityExecId::new();
+    let id_notify = ActivityExecId::new();
+
+    // Task indices: 0=score_payment, 1=manual_review, 2=auto_approve, 3=notify_result
+    let history = vec![
+        WorkflowEvent::WorkflowStarted {
+            input: Value::Null,
+            timestamp: Utc::now(),
+        },
+        // Level 0: score_payment runs
+        WorkflowEvent::ActivityScheduled {
+            activity_id: id_score,
+            name: "score_payment".into(),
+            input: risk_input("score_payment"),
+            queue: "risk-workers".into(),
+        },
+        WorkflowEvent::ActivityCompleted {
+            activity_id: id_score,
+            output: json!({"fraud_score": 0.2}), // low → auto_approve wins
+        },
+        // Level 1: manual_review condition false → dag_skip:1 marker
+        WorkflowEvent::MarkerRecorded {
+            name: "dag_skip:1".into(),
+            details: json!({"task": "manual_review", "reason": "condition_false"}),
+        },
+        // Level 1: auto_approve condition true → runs
+        WorkflowEvent::ActivityScheduled {
+            activity_id: id_auto,
+            name: "auto_approve".into(),
+            input: risk_input("auto_approve"),
+            queue: "risk-workers".into(),
+        },
+        WorkflowEvent::ActivityCompleted {
+            activity_id: id_auto,
+            output: json!("approved"),
+        },
+        // Level 2: notify_result (AllDone join) runs
+        WorkflowEvent::ActivityScheduled {
+            activity_id: id_notify,
+            name: "notify_result".into(),
+            input: risk_input("notify_result"),
+            queue: "risk-workers".into(),
+        },
+        WorkflowEvent::ActivityCompleted {
+            activity_id: id_notify,
+            output: json!("notified"),
+        },
+    ];
+
+    let expected_events = history.len();
+    let report = WorkflowReplayer::new()
+        .register_fn(
+            "fraud_routing_dag",
+            __autumn_workflow_info_fraud_routing_dag().handler,
+        )
+        .replay_from_events(history)
+        .await;
+
+    assert_eq!(
+        report.events_replayed, expected_events,
+        "all events should be consumed; got: {report}"
+    );
+    assert!(
+        matches!(report.status, ReplayStatus::ReplaySucceeded),
+        "condition-false branch (auto_approve path) should replay successfully, got: {report}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 2 — condition-true branch schedules the activity
+// ---------------------------------------------------------------------------
+
+/// High fraud score: manual_review runs, auto_approve is skipped (condition false).
+#[tokio::test]
+async fn condition_true_branch_schedules_activity() {
+    let id_score = ActivityExecId::new();
+    let id_review = ActivityExecId::new();
+    let id_notify = ActivityExecId::new();
+
+    // Task indices: 0=score_payment, 1=manual_review, 2=auto_approve, 3=notify_result
+    let history = vec![
+        WorkflowEvent::WorkflowStarted {
+            input: Value::Null,
+            timestamp: Utc::now(),
+        },
+        WorkflowEvent::ActivityScheduled {
+            activity_id: id_score,
+            name: "score_payment".into(),
+            input: risk_input("score_payment"),
+            queue: "risk-workers".into(),
+        },
+        WorkflowEvent::ActivityCompleted {
+            activity_id: id_score,
+            output: json!({"fraud_score": 0.95}), // high → manual_review wins
+        },
+        // Level 1 task-index order: idx 1 (manual_review) → Run (pushed to futures),
+        // then idx 2 (auto_approve) → SkipByCondition → dag_skip:2 marker emitted
+        // synchronously before join_all awaits the futures.
+        // So the marker comes BEFORE manual_review's ActivityScheduled in history.
+        WorkflowEvent::MarkerRecorded {
+            name: "dag_skip:2".into(),
+            details: json!({"task": "auto_approve", "reason": "condition_false"}),
+        },
+        // manual_review condition true → runs (emitted by join_all after the marker)
+        WorkflowEvent::ActivityScheduled {
+            activity_id: id_review,
+            name: "manual_review".into(),
+            input: risk_input("manual_review"),
+            queue: "risk-workers".into(),
+        },
+        WorkflowEvent::ActivityCompleted {
+            activity_id: id_review,
+            output: json!("reviewed"),
+        },
+        // notify_result (AllDone join) runs
+        WorkflowEvent::ActivityScheduled {
+            activity_id: id_notify,
+            name: "notify_result".into(),
+            input: risk_input("notify_result"),
+            queue: "risk-workers".into(),
+        },
+        WorkflowEvent::ActivityCompleted {
+            activity_id: id_notify,
+            output: json!("notified"),
+        },
+    ];
+
+    let expected_events = history.len();
+    let report = WorkflowReplayer::new()
+        .register_fn(
+            "fraud_routing_dag",
+            __autumn_workflow_info_fraud_routing_dag().handler,
+        )
+        .replay_from_events(history)
+        .await;
+
+    assert_eq!(
+        report.events_replayed, expected_events,
+        "all events consumed; got: {report}"
+    );
+    assert!(
+        matches!(report.status, ReplayStatus::ReplaySucceeded),
+        "condition-true (manual_review) path should replay successfully, got: {report}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 3 — condition skip propagates downstream via trigger rules (no second marker)
+// ---------------------------------------------------------------------------
+
+/// When both branches are skipped by condition, the AllDone join still fires.
+/// A trigger-rule skip (AllSuccess on downstream of a skipped node) must NOT
+/// emit a dag_skip marker — only condition-skips emit markers.
+///
+/// This DAG: score → [review (cond false), auto (cond false)] → notify (AllDone)
+/// Because both branches are condition-skipped the notify still fires (AllDone).
+/// notify's Skipped propagation of downstream (none here) is trigger-rule-based.
+#[tokio::test]
+async fn condition_skip_propagates_and_alldone_join_still_fires() {
+    use autumn_harvest::testing::WorkflowTestEnv;
+
+    // Both conditions always false (score 0.5 — neither > 0.8 nor actually
+    // we need a DAG where both conditions can be false simultaneously).
+    // Use three_way_switch_dag with level="unknown" → all three branches skip.
+    let outcome = WorkflowTestEnv::new()
+        .mock_activity("score_payment", |_| Ok(json!({"level": "unknown"})))
+        .run(
+            __autumn_workflow_info_three_way_switch_dag().handler,
+            Value::Null,
+        )
+        .await;
+
+    // All three branches skipped by condition; DAG succeeds (no failed tasks)
+    assert!(
+        outcome.result.is_ok(),
+        "three-way-switch with all branches skipped should succeed (no failed tasks), got: {:?}",
+        outcome.result
+    );
+
+    // Verify exactly three dag_skip markers in the event history
+    let skip_markers: Vec<_> = outcome.events().iter().filter(|e| {
+        matches!(e, WorkflowEvent::MarkerRecorded { name, .. } if name.starts_with("dag_skip:"))
+    }).collect();
+    assert_eq!(
+        skip_markers.len(),
+        3,
+        "all three branches should emit dag_skip markers"
+    );
+
+    // Verify no trigger-rule-skipped nodes emit markers (there are none in this DAG beyond the 3 condition nodes)
+    let trigger_rule_skip_markers: Vec<_> = outcome
+        .events()
+        .iter()
+        .filter(|e| {
+            if let WorkflowEvent::MarkerRecorded { name, details } = e {
+                name.starts_with("dag_skip:")
+                    && details.get("reason").and_then(|r| r.as_str()) != Some("condition_false")
+            } else {
+                false
+            }
+        })
+        .collect();
+    assert!(
+        trigger_rule_skip_markers.is_empty(),
+        "trigger-rule skips must not emit markers"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 4 — flipping the condition is reported as non-determinism
+// ---------------------------------------------------------------------------
+
+/// If history contains a dag_skip marker but the condition now returns true
+/// (or vice versa), the replayer must report NonDeterministic.
+#[tokio::test]
+async fn condition_flip_is_reported_as_nondeterminism() {
+    let id_score = ActivityExecId::new();
+
+    // History: score succeeded, then dag_skip:1 (manual_review was condition-false)
+    let history = vec![
+        WorkflowEvent::WorkflowStarted {
+            input: Value::Null,
+            timestamp: Utc::now(),
+        },
+        WorkflowEvent::ActivityScheduled {
+            activity_id: id_score,
+            name: "score_payment".into(),
+            input: risk_input("score_payment"),
+            queue: "risk-workers".into(),
+        },
+        WorkflowEvent::ActivityCompleted {
+            activity_id: id_score,
+            output: json!({"fraud_score": 0.95}), // high score → manual_review condition TRUE
+                                                  // But history has dag_skip:1 → history says it was condition-false.
+                                                  // Replaying with the same code will NOT skip (condition is true for 0.95),
+                                                  // so the replayer will try to schedule manual_review but find dag_skip:1
+                                                  // marker at cursor → Diverged → NonDeterministic.
+        },
+        // Marker says manual_review was skipped — but our condition says it should run.
+        WorkflowEvent::MarkerRecorded {
+            name: "dag_skip:1".into(),
+            details: json!({"task": "manual_review", "reason": "condition_false"}),
+        },
+    ];
+
+    let report = WorkflowReplayer::new()
+        .register_fn(
+            "fraud_routing_dag",
+            __autumn_workflow_info_fraud_routing_dag().handler,
+        )
+        .replay_from_events(history)
+        .await;
+
+    assert!(
+        matches!(report.status, ReplayStatus::NonDeterminismDetected { .. }),
+        "flipped condition should report NonDeterminismDetected, got: {report}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 5 — run live with WorkflowTestEnv then replay identically (AC4)
+// ---------------------------------------------------------------------------
+
+/// Run the fraud DAG live via WorkflowTestEnv (score=0.2 → auto_approve),
+/// capture the produced event history, then replay it with WorkflowReplayer.
+/// The replay must succeed, verifying the branch decision is deterministic.
+#[tokio::test]
+async fn condition_dag_runs_live_then_replays_identically() {
+    use autumn_harvest::testing::WorkflowTestEnv;
+
+    // Live run: low fraud score → auto_approve branch
+    let outcome = WorkflowTestEnv::new()
+        .mock_activity("score_payment", |_| Ok(json!({"fraud_score": 0.2})))
+        .mock_activity("auto_approve", |_| Ok(json!("approved")))
+        .mock_activity("notify_result", |_| Ok(json!("notified")))
+        .run(
+            __autumn_workflow_info_fraud_routing_dag().handler,
+            Value::Null,
+        )
+        .await;
+
+    assert!(
+        outcome.result.is_ok(),
+        "live DAG run should succeed, got: {:?}",
+        outcome.result
+    );
+
+    let events = outcome.events();
+
+    // Exactly one dag_skip marker for manual_review (task idx 1)
+    let skip_markers: Vec<_> = events.iter().filter(|e| {
+        matches!(e, WorkflowEvent::MarkerRecorded { name, .. } if name.starts_with("dag_skip:"))
+    }).collect();
+    assert_eq!(
+        skip_markers.len(),
+        1,
+        "exactly one skip marker expected (manual_review), got {skip_markers:?}"
+    );
+
+    // No ActivityScheduled for manual_review
+    let manual_review_scheduled = events.iter().any(
+        |e| matches!(e, WorkflowEvent::ActivityScheduled { name, .. } if name == "manual_review"),
+    );
+    assert!(
+        !manual_review_scheduled,
+        "manual_review must not be scheduled when condition is false"
+    );
+
+    // Now replay: must reproduce the identical branch
+    let report = WorkflowReplayer::new()
+        .register_fn(
+            "fraud_routing_dag",
+            __autumn_workflow_info_fraud_routing_dag().handler,
+        )
+        .replay_from_events(events.to_vec())
+        .await;
+
+    assert!(
+        matches!(report.status, ReplayStatus::ReplaySucceeded),
+        "replay of live run should succeed (deterministic branch decision), got: {report}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 6 — 1000-replay sweep (success metric)
+// ---------------------------------------------------------------------------
+
+/// Alternate high-score / low-score fixtures across 1,000 replays.
+/// Every replay must reproduce the identical branch (ReplaySucceeded).
+#[tokio::test]
+async fn condition_branch_replay_sweep_1000() {
+    let handler = __autumn_workflow_info_fraud_routing_dag().handler;
+
+    for i in 0u32..1_000 {
+        // Alternate: even → low score (auto_approve), odd → high score (manual_review)
+        let (score, skip_task_idx, skip_task_name, run_task_name) = if i % 2 == 0 {
+            (0.2f64, 1usize, "manual_review", "auto_approve")
+        } else {
+            (0.95f64, 2usize, "auto_approve", "manual_review")
+        };
+
+        let id_score = ActivityExecId::new();
+        let id_run = ActivityExecId::new();
+        let id_notify = ActivityExecId::new();
+
+        let history = vec![
+            WorkflowEvent::WorkflowStarted {
+                input: Value::Null,
+                timestamp: Utc::now(),
+            },
+            WorkflowEvent::ActivityScheduled {
+                activity_id: id_score,
+                name: "score_payment".into(),
+                input: risk_input("score_payment"),
+                queue: "risk-workers".into(),
+            },
+            WorkflowEvent::ActivityCompleted {
+                activity_id: id_score,
+                output: json!({"fraud_score": score}),
+            },
+            // Which branch gets the skip marker depends on the score
+            // For low score: marker for manual_review (idx 1) before auto_approve
+            // For high score: manual_review runs first, then marker for auto_approve (idx 2)
+            // Build in the same order as the macro generates (task index order within a level)
+            // Level 1 has tasks [1=manual_review, 2=auto_approve] in order
+        ];
+
+        // Append level-1 events in task-index order (1 then 2)
+        let mut h = history;
+        if i % 2 == 0 {
+            // low score: skip manual_review (idx 1), run auto_approve (idx 2)
+            h.push(WorkflowEvent::MarkerRecorded {
+                name: format!("dag_skip:{skip_task_idx}"),
+                details: json!({"task": skip_task_name, "reason": "condition_false"}),
+            });
+            h.push(WorkflowEvent::ActivityScheduled {
+                activity_id: id_run,
+                name: run_task_name.into(),
+                input: risk_input(run_task_name),
+                queue: "risk-workers".into(),
+            });
+            h.push(WorkflowEvent::ActivityCompleted {
+                activity_id: id_run,
+                output: json!("approved"),
+            });
+        } else {
+            // high score: skip auto_approve (idx 2) marker first (sync during level loop),
+            // then manual_review (idx 1) runs via join_all.
+            // Level loop order: idx 1 (manual_review) → Run (pushed to futures),
+            // idx 2 (auto_approve) → SkipByCondition → marker emitted sync.
+            // Then join_all emits the activity events.
+            h.push(WorkflowEvent::MarkerRecorded {
+                name: format!("dag_skip:{skip_task_idx}"),
+                details: json!({"task": skip_task_name, "reason": "condition_false"}),
+            });
+            h.push(WorkflowEvent::ActivityScheduled {
+                activity_id: id_run,
+                name: run_task_name.into(),
+                input: risk_input(run_task_name),
+                queue: "risk-workers".into(),
+            });
+            h.push(WorkflowEvent::ActivityCompleted {
+                activity_id: id_run,
+                output: json!("reviewed"),
+            });
+        }
+        // Level 2: notify_result (AllDone join)
+        h.push(WorkflowEvent::ActivityScheduled {
+            activity_id: id_notify,
+            name: "notify_result".into(),
+            input: risk_input("notify_result"),
+            queue: "risk-workers".into(),
+        });
+        h.push(WorkflowEvent::ActivityCompleted {
+            activity_id: id_notify,
+            output: json!("notified"),
+        });
+
+        let report = WorkflowReplayer::new()
+            .register_fn("fraud_routing_dag", handler)
+            .replay_from_events(h)
+            .await;
+
+        assert!(
+            matches!(report.status, ReplayStatus::ReplaySucceeded),
+            "sweep iteration {i} (score={score}) failed: {report}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 7 — three-way switch: exactly one branch runs (AC5)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn three_way_switch_runs_exactly_one_branch() {
+    use autumn_harvest::testing::WorkflowTestEnv;
+
+    for level in ["low", "medium", "high"] {
+        let level_val = json!({"level": level});
+        let level_clone = level_val.clone();
+        let outcome = WorkflowTestEnv::new()
+            .mock_activity("score_payment", move |_| Ok(level_clone.clone()))
+            .mock_activity("low_risk_path", |_| Ok(json!("low")))
+            .mock_activity("medium_risk_path", |_| Ok(json!("medium")))
+            .mock_activity("high_risk_path", |_| Ok(json!("high")))
+            .run(
+                __autumn_workflow_info_three_way_switch_dag().handler,
+                Value::Null,
+            )
+            .await;
+
+        assert!(
+            outcome.result.is_ok(),
+            "three_way_switch level={level} should succeed, got: {:?}",
+            outcome.result
+        );
+
+        let events = outcome.events();
+        // Exactly one branch scheduled
+        let scheduled: Vec<_> = events
+            .iter()
+            .filter(|e| {
+                matches!(e, WorkflowEvent::ActivityScheduled { name, .. }
+                if matches!(name.as_str(), "low_risk_path" | "medium_risk_path" | "high_risk_path"))
+            })
+            .collect();
+        assert_eq!(
+            scheduled.len(),
+            1,
+            "exactly one branch should run for level={level}, got: {scheduled:?}"
+        );
+
+        // Exactly two dag_skip markers (the other two branches)
+        let skip_markers: Vec<_> = events.iter().filter(|e| {
+            matches!(e, WorkflowEvent::MarkerRecorded { name, .. } if name.starts_with("dag_skip:"))
+        }).collect();
+        assert_eq!(
+            skip_markers.len(),
+            2,
+            "exactly two branches skipped for level={level}, got: {skip_markers:?}"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test 8 — mapped task with condition skips whole map
+// ---------------------------------------------------------------------------
+
+#[activity]
+async fn process_item(_ctx: &ActivityContext) -> Result<Value, String> {
+    Ok(json!("processed"))
+}
+
+#[dag(default_queue = "workers")]
+fn conditional_map_dag(dag: &mut DagBuilder) {
+    let source = dag.activity(score_payment);
+    let _mapped = dag
+        .map_activity(process_item)
+        .over(&source)
+        .condition(|_ups| false); // always skip
+}
+
+#[tokio::test]
+async fn mapped_task_condition_skips_whole_map() {
+    use autumn_harvest::testing::WorkflowTestEnv;
+
+    let outcome = WorkflowTestEnv::new()
+        .mock_activity("score_payment", |_| Ok(json!([1, 2, 3])))
+        .run(
+            __autumn_workflow_info_conditional_map_dag().handler,
+            Value::Null,
+        )
+        .await;
+
+    assert!(
+        outcome.result.is_ok(),
+        "condition-skipped mapped task should not fail the DAG, got: {:?}",
+        outcome.result
+    );
+
+    let events = outcome.events();
+    // No process_item scheduled (map skipped entirely)
+    let any_mapped = events.iter().any(
+        |e| matches!(e, WorkflowEvent::ActivityScheduled { name, .. } if name == "process_item"),
+    );
+    assert!(
+        !any_mapped,
+        "no process_item instances should be scheduled when condition is false"
+    );
+
+    // Exactly one dag_skip marker
+    let skip_markers: Vec<_> = events.iter().filter(|e| {
+        matches!(e, WorkflowEvent::MarkerRecorded { name, .. } if name.starts_with("dag_skip:"))
+    }).collect();
+    assert_eq!(
+        skip_markers.len(),
+        1,
+        "exactly one dag_skip marker for the mapped task"
     );
 }

--- a/autumn-harvest/tests/dag_unified_tests.rs
+++ b/autumn-harvest/tests/dag_unified_tests.rs
@@ -846,7 +846,7 @@ async fn high_risk_path(_ctx: &ActivityContext) -> Result<Value, String> {
 // DAG fixtures for branching tests
 // ---------------------------------------------------------------------------
 
-/// Fraud-routing DAG: score_payment → (manual_review | auto_approve) → notify_result (AllDone)
+/// Fraud-routing DAG: `score_payment` → (`manual_review` | `auto_approve`) → `notify_result` (`AllDone`)
 #[dag(default_queue = "risk-workers")]
 fn fraud_routing_dag(dag: &mut DagBuilder) {
     let score = dag.activity(score_payment);
@@ -892,8 +892,8 @@ fn risk_input(task: &str) -> Value {
 // Test 1 — condition-false branch replays with a dag_skip marker
 // ---------------------------------------------------------------------------
 
-/// Low fraud score: manual_review is skipped (condition false), auto_approve runs.
-/// History contains a `MarkerRecorded(dag_skip:1)` before auto_approve's events.
+/// Low fraud score: `manual_review` is skipped (condition false), `auto_approve` runs.
+/// History contains a `MarkerRecorded(dag_skip:1)` before `auto_approve`'s events.
 #[tokio::test]
 async fn condition_false_branch_replays_with_skip_marker() {
     let id_score = ActivityExecId::new();
@@ -969,7 +969,7 @@ async fn condition_false_branch_replays_with_skip_marker() {
 // Test 2 — condition-true branch schedules the activity
 // ---------------------------------------------------------------------------
 
-/// High fraud score: manual_review runs, auto_approve is skipped (condition false).
+/// High fraud score: `manual_review` runs, `auto_approve` is skipped (condition false).
 #[tokio::test]
 async fn condition_true_branch_schedules_activity() {
     let id_score = ActivityExecId::new();
@@ -1047,12 +1047,12 @@ async fn condition_true_branch_schedules_activity() {
 // Test 3 — condition skip propagates downstream via trigger rules (no second marker)
 // ---------------------------------------------------------------------------
 
-/// When both branches are skipped by condition, the AllDone join still fires.
-/// A trigger-rule skip (AllSuccess on downstream of a skipped node) must NOT
-/// emit a dag_skip marker — only condition-skips emit markers.
+/// When both branches are skipped by condition, the `AllDone` join still fires.
+/// A trigger-rule skip (`AllSuccess` on downstream of a skipped node) must NOT
+/// emit a `dag_skip` marker — only condition-skips emit markers.
 ///
-/// This DAG: score → [review (cond false), auto (cond false)] → notify (AllDone)
-/// Because both branches are condition-skipped the notify still fires (AllDone).
+/// This DAG: score → [review (cond false), auto (cond false)] → notify (`AllDone`)
+/// Because both branches are condition-skipped the notify still fires (`AllDone`).
 /// notify's Skipped propagation of downstream (none here) is trigger-rule-based.
 #[tokio::test]
 async fn condition_skip_propagates_and_alldone_join_still_fires() {
@@ -1077,30 +1077,25 @@ async fn condition_skip_propagates_and_alldone_join_still_fires() {
     );
 
     // Verify exactly three dag_skip markers in the event history
-    let skip_markers: Vec<_> = outcome.events().iter().filter(|e| {
+    let skip_marker_count = outcome.events().iter().filter(|e| {
         matches!(e, WorkflowEvent::MarkerRecorded { name, .. } if name.starts_with("dag_skip:"))
-    }).collect();
+    }).count();
     assert_eq!(
-        skip_markers.len(),
-        3,
+        skip_marker_count, 3,
         "all three branches should emit dag_skip markers"
     );
 
     // Verify no trigger-rule-skipped nodes emit markers (there are none in this DAG beyond the 3 condition nodes)
-    let trigger_rule_skip_markers: Vec<_> = outcome
-        .events()
-        .iter()
-        .filter(|e| {
-            if let WorkflowEvent::MarkerRecorded { name, details } = e {
-                name.starts_with("dag_skip:")
-                    && details.get("reason").and_then(|r| r.as_str()) != Some("condition_false")
-            } else {
-                false
-            }
-        })
-        .collect();
+    let has_trigger_rule_skip_marker = outcome.events().iter().any(|e| {
+        if let WorkflowEvent::MarkerRecorded { name, details } = e {
+            name.starts_with("dag_skip:")
+                && details.get("reason").and_then(|r| r.as_str()) != Some("condition_false")
+        } else {
+            false
+        }
+    });
     assert!(
-        trigger_rule_skip_markers.is_empty(),
+        !has_trigger_rule_skip_marker,
         "trigger-rule skips must not emit markers"
     );
 }
@@ -1109,8 +1104,8 @@ async fn condition_skip_propagates_and_alldone_join_still_fires() {
 // Test 4 — flipping the condition is reported as non-determinism
 // ---------------------------------------------------------------------------
 
-/// If history contains a dag_skip marker but the condition now returns true
-/// (or vice versa), the replayer must report NonDeterministic.
+/// If history contains a `dag_skip` marker but the condition now returns true
+/// (or vice versa), the replayer must report `NonDeterministic`.
 #[tokio::test]
 async fn condition_flip_is_reported_as_nondeterminism() {
     let id_score = ActivityExecId::new();
@@ -1160,8 +1155,8 @@ async fn condition_flip_is_reported_as_nondeterminism() {
 // Test 5 — run live with WorkflowTestEnv then replay identically (AC4)
 // ---------------------------------------------------------------------------
 
-/// Run the fraud DAG live via WorkflowTestEnv (score=0.2 → auto_approve),
-/// capture the produced event history, then replay it with WorkflowReplayer.
+/// Run the fraud DAG live via `WorkflowTestEnv` (score=0.2 → `auto_approve`),
+/// capture the produced event history, then replay it with `WorkflowReplayer`.
 /// The replay must succeed, verifying the branch decision is deterministic.
 #[tokio::test]
 async fn condition_dag_runs_live_then_replays_identically() {
@@ -1225,7 +1220,7 @@ async fn condition_dag_runs_live_then_replays_identically() {
 // ---------------------------------------------------------------------------
 
 /// Alternate high-score / low-score fixtures across 1,000 replays.
-/// Every replay must reproduce the identical branch (ReplaySucceeded).
+/// Every replay must reproduce the identical branch (`ReplaySucceeded`).
 #[tokio::test]
 async fn condition_branch_replay_sweep_1000() {
     let handler = __autumn_workflow_info_fraud_routing_dag().handler;
@@ -1264,45 +1259,31 @@ async fn condition_branch_replay_sweep_1000() {
             // Level 1 has tasks [1=manual_review, 2=auto_approve] in order
         ];
 
-        // Append level-1 events in task-index order (1 then 2)
+        // Append level-1 events in task-index order (1 then 2).
+        // The marker and ActivityScheduled are the same for both branches; only the
+        // completed output differs (auto_approve → "approved", manual_review → "reviewed").
         let mut h = history;
-        if i % 2 == 0 {
-            // low score: skip manual_review (idx 1), run auto_approve (idx 2)
-            h.push(WorkflowEvent::MarkerRecorded {
-                name: format!("dag_skip:{skip_task_idx}"),
-                details: json!({"task": skip_task_name, "reason": "condition_false"}),
-            });
-            h.push(WorkflowEvent::ActivityScheduled {
-                activity_id: id_run,
-                name: run_task_name.into(),
-                input: risk_input(run_task_name),
-                queue: "risk-workers".into(),
-            });
-            h.push(WorkflowEvent::ActivityCompleted {
-                activity_id: id_run,
-                output: json!("approved"),
-            });
+        h.push(WorkflowEvent::MarkerRecorded {
+            name: format!("dag_skip:{skip_task_idx}"),
+            details: json!({"task": skip_task_name, "reason": "condition_false"}),
+        });
+        h.push(WorkflowEvent::ActivityScheduled {
+            activity_id: id_run,
+            name: run_task_name.into(),
+            input: risk_input(run_task_name),
+            queue: "risk-workers".into(),
+        });
+        // low score (even i): auto_approve outputs "approved"
+        // high score (odd i):  manual_review outputs "reviewed"
+        let run_output = if i % 2 == 0 {
+            json!("approved")
         } else {
-            // high score: skip auto_approve (idx 2) marker first (sync during level loop),
-            // then manual_review (idx 1) runs via join_all.
-            // Level loop order: idx 1 (manual_review) → Run (pushed to futures),
-            // idx 2 (auto_approve) → SkipByCondition → marker emitted sync.
-            // Then join_all emits the activity events.
-            h.push(WorkflowEvent::MarkerRecorded {
-                name: format!("dag_skip:{skip_task_idx}"),
-                details: json!({"task": skip_task_name, "reason": "condition_false"}),
-            });
-            h.push(WorkflowEvent::ActivityScheduled {
-                activity_id: id_run,
-                name: run_task_name.into(),
-                input: risk_input(run_task_name),
-                queue: "risk-workers".into(),
-            });
-            h.push(WorkflowEvent::ActivityCompleted {
-                activity_id: id_run,
-                output: json!("reviewed"),
-            });
-        }
+            json!("reviewed")
+        };
+        h.push(WorkflowEvent::ActivityCompleted {
+            activity_id: id_run,
+            output: run_output,
+        });
         // Level 2: notify_result (AllDone join)
         h.push(WorkflowEvent::ActivityScheduled {
             activity_id: id_notify,
@@ -1429,12 +1410,11 @@ async fn mapped_task_condition_skips_whole_map() {
     );
 
     // Exactly one dag_skip marker
-    let skip_markers: Vec<_> = events.iter().filter(|e| {
+    let skip_marker_count = events.iter().filter(|e| {
         matches!(e, WorkflowEvent::MarkerRecorded { name, .. } if name.starts_with("dag_skip:"))
-    }).collect();
+    }).count();
     assert_eq!(
-        skip_markers.len(),
-        1,
+        skip_marker_count, 1,
         "exactly one dag_skip marker for the mapped task"
     );
 }

--- a/autumn-harvest/tests/macros_dag.rs
+++ b/autumn-harvest/tests/macros_dag.rs
@@ -110,3 +110,47 @@ fn dag_metadata_attributes() {
     assert_eq!(info.runbook_url, Some("https://wiki.acme.com/etl-runbook"));
     assert_eq!(info.severity, Some("sev3"));
 }
+
+// ── Issue #482 — condition macro + builder parity (AC2) ──────────────────────
+
+#[activity]
+async fn score_payment(_ctx: &ActivityContext) -> Result<serde_json::Value, String> {
+    Ok(serde_json::json!({"fraud_score": 0.0}))
+}
+
+#[activity]
+async fn manual_review(_ctx: &ActivityContext) -> Result<serde_json::Value, String> {
+    Ok(serde_json::json!("reviewed"))
+}
+
+/// DAG using `.condition(...)` via the `#[dag]` macro — same DagTaskRef builder
+/// method as a hand-written DagBuilder call, so macro and builder produce
+/// identical DagDefinitions (AC2).
+#[cfg(feature = "unified-dag-execution")]
+#[dag(default_queue = "risk-workers")]
+fn conditional_dag_macro(dag: &mut DagBuilder) {
+    let score = dag.activity(score_payment);
+    let _review = dag
+        .activity(manual_review)
+        .upstream(&score)
+        .condition(|ups| ups[0]["fraud_score"].as_f64().is_some_and(|s| s > 0.8));
+}
+
+/// Verify that a `#[dag]` using `.condition(...)` compiles and produces a
+/// `DagDefinition` where the conditioned task has `condition.is_some()`.
+#[cfg(feature = "unified-dag-execution")]
+#[test]
+fn dag_macro_condition_compiles_and_is_stored_on_task() {
+    let info = __autumn_dag_info_conditional_dag_macro();
+    let definition = info.build_definition().expect("definition should build");
+    let tasks = definition.tasks();
+    assert_eq!(tasks.len(), 2, "two tasks expected");
+    assert!(
+        tasks[0].condition.is_none(),
+        "root task should have no condition"
+    );
+    assert!(
+        tasks[1].condition.is_some(),
+        "conditioned task should have condition set (AC2: macro parity with builder)"
+    );
+}

--- a/autumn-harvest/tests/macros_dag.rs
+++ b/autumn-harvest/tests/macros_dag.rs
@@ -123,9 +123,9 @@ async fn manual_review(_ctx: &ActivityContext) -> Result<serde_json::Value, Stri
     Ok(serde_json::json!("reviewed"))
 }
 
-/// DAG using `.condition(...)` via the `#[dag]` macro — same DagTaskRef builder
-/// method as a hand-written DagBuilder call, so macro and builder produce
-/// identical DagDefinitions (AC2).
+/// DAG using `.condition(...)` via the `#[dag]` macro — same `DagTaskRef` builder
+/// method as a hand-written `DagBuilder` call, so macro and builder produce
+/// identical `DagDefinitions` (AC2).
 #[cfg(feature = "unified-dag-execution")]
 #[dag(default_queue = "risk-workers")]
 fn conditional_dag_macro(dag: &mut DagBuilder) {

--- a/docs/getting-started/08-dags-and-schedules.md
+++ b/docs/getting-started/08-dags-and-schedules.md
@@ -185,6 +185,148 @@ states of its upstream tasks:
 tasks. `OneSuccess` is the "fan-in for any successful branch" shape.
 `OneFailed` is the "alert on first failure" shape.
 
+## Data-dependent branching
+
+Trigger rules gate a node on the *state* of its upstreams (succeeded,
+failed, skipped). Sometimes you need to route on the upstream's *output
+value* — "if `fraud_score > 0.8`, run manual review; otherwise
+auto-approve." That's what **condition predicates** do.
+
+Call `.condition(|outputs| …)` on a `DagTaskRef`. The closure receives a
+slice of `serde_json::Value` — one element per upstream output, in the
+order the upstreams were declared. If it returns `false`, the node is
+skipped; the skip propagates downstream through the normal trigger-rule
+inference (so an `AllSuccess` child of a skipped node is also skipped, and
+an `AllDone` join that receives all skips still fires).
+
+### Fraud-routing example
+
+```rust
+use serde_json::Value;
+use autumn_harvest::prelude::*;
+
+#[activity(start_to_close = "30s")]
+async fn score_payment(ctx: &ActivityContext, input: Value) -> HarvestResult<Value> {
+    // Returns {"score": 0.0–1.0}
+    Ok(serde_json::json!({ "score": 0.92 }))
+}
+
+#[activity(start_to_close = "5m")]
+async fn manual_review(ctx: &ActivityContext, input: Value) -> HarvestResult<Value> {
+    Ok(Value::Null)
+}
+
+#[activity(start_to_close = "5s")]
+async fn auto_approve(ctx: &ActivityContext, input: Value) -> HarvestResult<Value> {
+    Ok(Value::Null)
+}
+
+#[activity(start_to_close = "30s")]
+async fn notify_result(ctx: &ActivityContext, input: Value) -> HarvestResult<Value> {
+    Ok(Value::Null)
+}
+
+#[dag(schedule = "*/5 * * * *")]
+pub fn fraud_routing(dag: &mut DagBuilder) {
+    // Step 1: score the payment.
+    let score = dag.activity(score_payment);
+
+    // Step 2a: manual review only when score is high.
+    let review = dag
+        .activity(manual_review)
+        .upstream(&score)
+        .condition(|outputs| {
+            outputs[0]["score"].as_f64().unwrap_or(0.0) > 0.8
+        });
+
+    // Step 2b: auto-approve only when score is low.
+    let approve = dag
+        .activity(auto_approve)
+        .upstream(&score)
+        .condition(|outputs| {
+            outputs[0]["score"].as_f64().unwrap_or(0.0) <= 0.8
+        });
+
+    // Step 3: join — AllDone so it fires regardless of which branch ran.
+    let _notify = dag
+        .activity(notify_result)
+        .upstream(&review)
+        .upstream(&approve)
+        .trigger_rule(TriggerRule::AllDone);
+}
+```
+
+At each run exactly one of `manual_review` / `auto_approve` executes; the
+other is skipped. `notify_result` sees two upstreams — one succeeded, one
+skipped — so `AllDone` fires. If you use `AllSuccess` there instead,
+`notify_result` would also be skipped (skipped is not succeeded).
+
+### N-way switch
+
+Conditions are plain Rust closures, so multi-way routing is just multiple
+tasks with mutually-exclusive predicates:
+
+```rust
+#[dag]
+pub fn risk_triage(dag: &mut DagBuilder) {
+    let score = dag.activity(score_payment);
+
+    let _low = dag.activity(low_risk_path).upstream(&score)
+        .condition(|o| o[0]["score"].as_f64().unwrap_or(0.0) < 0.3);
+
+    let _medium = dag.activity(medium_risk_path).upstream(&score)
+        .condition(|o| {
+            let s = o[0]["score"].as_f64().unwrap_or(0.0);
+            (0.3..0.8).contains(&s)
+        });
+
+    let _high = dag.activity(high_risk_path).upstream(&score)
+        .condition(|o| o[0]["score"].as_f64().unwrap_or(0.0) >= 0.8);
+}
+```
+
+Exactly one branch runs per execution. The engine evaluates each condition
+independently — a task is skipped when *its* condition returns `false`,
+regardless of what any sibling condition returned.
+
+### Conditions on mapped tasks
+
+`.condition(…)` is available on `DagMapTaskRef` (returned by
+`dag.map_activity(…).over(&upstream)`) and works the same way: if the
+condition is false, the entire mapped fan-out is skipped as a unit.
+
+### Determinism rule
+
+The predicate is a **pure function of upstream outputs**. Those outputs are
+already frozen in `harvest_events` when the condition runs, so the same
+closure call produces the same result on every replay — as long as the
+closure only reads the `outputs` slice and nothing else. Do not read
+process state, the system clock, or random values inside a condition
+closure; use [`ctx.side_effect`](07-reliability-knobs.md) in an upstream
+activity instead and read the recorded value through its output.
+
+### Vantage UI and observability
+
+The Vantage DAG detail page distinguishes two skip reasons:
+
+| Display text | Meaning |
+|---|---|
+| *Skipped (upstream)* | Node skipped because a trigger rule was not satisfied. |
+| *Skipped (condition)* | Node skipped because its condition predicate returned `false`. |
+
+A `MarkerRecorded` event named `dag_skip:{N}` (where *N* is the zero-based
+task index) is appended to the execution history for every condition-skip.
+This event appears on the execution timeline page and can be queried
+directly from `harvest_events`. Trigger-rule skips emit no marker, so
+pre-existing DAG histories replay unchanged.
+
+### Simulator note
+
+The offline DAG simulator (`autumn_harvest::dag_simulator`) treats all
+nodes as runnable for the purpose of structure validation — it does not
+evaluate condition closures. Use `WorkflowTestEnv` or a real run to verify
+routing behaviour.
+
 ## Registering DAGs with the plugin
 
 ```rust

--- a/examples/billing-autumn-web/src/activities.rs
+++ b/examples/billing-autumn-web/src/activities.rs
@@ -23,6 +23,10 @@ pub fn activities() -> Vec<ActivityInfo> {
         export_billing_events,
         reconcile_gateway,
         notify_finance,
+        scan_discrepancies,
+        flag_for_audit,
+        auto_close_run,
+        send_reconciliation_summary,
     ]
 }
 
@@ -180,4 +184,35 @@ pub async fn reconcile_gateway(_ctx: &ActivityContext, input: Value) -> HarvestR
 #[activity(start_to_close = "30s", queue = "ops")]
 pub async fn notify_finance(_ctx: &ActivityContext, input: Value) -> HarvestResult<Value> {
     Ok(json!({ "notified": input }))
+}
+
+// Activities for the data-dependent branching example (anomaly_routing DAG).
+
+#[activity(start_to_close = "2m", queue = "ops")]
+pub async fn scan_discrepancies(_ctx: &ActivityContext, input: Value) -> HarvestResult<Value> {
+    // Returns the count of billing discrepancies found in the reconciliation window.
+    Ok(json!({ "discrepancy_count": 0, "window": input }))
+}
+
+// Runs only when scan_discrepancies reported at least one discrepancy.
+#[activity(start_to_close = "5m", queue = "ops")]
+pub async fn flag_for_audit(_ctx: &ActivityContext, input: Value) -> HarvestResult<Value> {
+    tracing::warn!(report = ?input, "discrepancies detected — flagging for finance audit");
+    Ok(json!({ "flagged": true }))
+}
+
+// Runs only when scan_discrepancies reported zero discrepancies.
+#[activity(start_to_close = "30s", queue = "ops")]
+pub async fn auto_close_run(_ctx: &ActivityContext, input: Value) -> HarvestResult<Value> {
+    tracing::info!(report = ?input, "reconciliation clean — auto-closing run");
+    Ok(json!({ "closed": true }))
+}
+
+#[activity(start_to_close = "30s", queue = "ops")]
+pub async fn send_reconciliation_summary(
+    _ctx: &ActivityContext,
+    input: Value,
+) -> HarvestResult<Value> {
+    tracing::info!(summary = ?input, "sent reconciliation summary");
+    Ok(json!({ "sent": true }))
 }

--- a/examples/billing-autumn-web/src/dags.rs
+++ b/examples/billing-autumn-web/src/dags.rs
@@ -2,10 +2,13 @@ use std::time::Duration;
 
 use autumn_harvest::prelude::*;
 
-use crate::activities::{export_billing_events, notify_finance, reconcile_gateway};
+use crate::activities::{
+    auto_close_run, export_billing_events, flag_for_audit, notify_finance, reconcile_gateway,
+    scan_discrepancies, send_reconciliation_summary,
+};
 
 pub fn dags() -> Vec<DagInfo> {
-    dags![billing_reconciliation]
+    dags![billing_reconciliation, anomaly_routing]
 }
 
 #[dag(
@@ -26,5 +29,42 @@ pub fn billing_reconciliation(dag: &mut DagBuilder) {
     let _notify = dag
         .activity(notify_finance)
         .upstream(&reconcile)
+        .trigger_rule(TriggerRule::AllDone);
+}
+
+/// Data-dependent branching example (issue #482).
+///
+/// `scan_discrepancies` returns `{"discrepancy_count": N}`.
+/// Only one of `flag_for_audit` / `auto_close_run` runs on each execution,
+/// depending on whether discrepancies were found.  The join node
+/// (`send_reconciliation_summary`) uses `AllDone` so it fires regardless
+/// of which branch was active.
+#[dag(
+    schedule = "0 7 * * *",
+    catchup = false,
+    max_active_runs = 1,
+    default_queue = "ops"
+)]
+pub fn anomaly_routing(dag: &mut DagBuilder) {
+    // Step 1: scan for discrepancies.
+    let scan = dag.activity(scan_discrepancies);
+
+    // Step 2a: flag for audit when at least one discrepancy was found.
+    let flag = dag
+        .activity(flag_for_audit)
+        .upstream(&scan)
+        .condition(|outputs| outputs[0]["discrepancy_count"].as_u64().unwrap_or(0) > 0);
+
+    // Step 2b: auto-close when the run is clean.
+    let close = dag
+        .activity(auto_close_run)
+        .upstream(&scan)
+        .condition(|outputs| outputs[0]["discrepancy_count"].as_u64().unwrap_or(0) == 0);
+
+    // Step 3: join — fires once whichever branch ran (or was skipped).
+    let _summary = dag
+        .activity(send_reconciliation_summary)
+        .upstream(&flag)
+        .upstream(&close)
         .trigger_rule(TriggerRule::AllDone);
 }


### PR DESCRIPTION
## Summary

Implements data-dependent branching for unified DAGs via condition predicates (issue #482). Tasks can now evaluate a closure over upstream outputs to decide whether to execute or skip, enabling workflows like "if fraud_score > 0.8, run manual review; else auto-approve."

## Key Changes

### Core DAG Condition Support
- **`DagCondition` type** (`dag.rs`): New `Arc`-wrapped closure type for pure predicates over `&[Value]` (upstream outputs in declaration order). Implements `Clone` and `Debug`.
- **`DagDispatchDecision` enum** (`dag.rs`): Three-way dispatch decision:
  - `Run`: task executes
  - `SkipByTriggerRule`: upstream state blocked execution (no marker recorded)
  - `SkipByCondition`: condition predicate returned false (marker recorded for determinism)
- **`DagTask::dispatch_decision()`** (`dag.rs`): Computes dispatch decision by first checking trigger rule, then evaluating condition if present. Upstream outputs for failed/skipped nodes are `Value::Null`.
- **`DagTaskRef::condition()`** (`dag.rs`): Builder method to attach a condition closure to a task.

### Determinism & Replay
- **`WorkflowContext::dag_skip_marker()`** (`context.rs`): Records or verifies `dag_skip:{task_index}` markers in event history. On live execution, pushes a `RecordMarker` command; on replay, matches the existing marker or returns `NonDeterministic` if the condition predicate returned a different value.
- **`HistoryMatcher::match_named_marker()`** (`replay.rs`): Matches a named `MarkerRecorded` event at cursor position, returning `Diverged` if a different event is found (condition flip detected).
- **Macro lowering** (`dag.rs` macro expansion): Updated dispatch loop to call `dispatch_decision()` and handle `SkipByCondition` by calling `ctx.dag_skip_marker()` before continuing to the next task.

### Testing
- **Comprehensive test suite** (`dag_unified_tests.rs`):
  - `condition_false_branch_replays_with_skip_marker`: Low fraud score → auto_approve runs, manual_review skipped with marker
  - `condition_true_branch_schedules_activity`: High fraud score → manual_review runs, auto_approve skipped
  - `condition_skip_propagates_and_alldone_join_still_fires`: All branches skipped by condition; `AllDone` join still fires
  - `condition_flip_is_reported_as_nondeterminism`: Condition returning different value on replay → `NonDeterministic`
  - `condition_dag_runs_live_then_replays_identically`: Live run + replay determinism verification
  - `condition_branch_replay_sweep_1000`: 1,000-replay alternating high/low score sweep
- **Macro integration test** (`macros_dag.rs`): Verifies `#[dag]` macro with `.condition()` compiles and stores condition on task.

### Documentation & Examples
- **Getting Started guide** (`08-dags-and-schedules.md`): New "Data-dependent branching" section with fraud-routing and N-way switch examples, determinism rule, and observability notes.
- **Example DAG** (`examples/billing-autumn-web/src/dags.rs`): `anomaly_routing` DAG demonstrating condition-based branching (scan discrepancies → flag for audit or auto-close).

### UI & Observability
- **Vantage UI** (`autumn-harvest-plugin/src/ui.rs`):
  - Load `dag_skip:` markers from event history to distinguish condition-skipped nodes
  - New `DagNodeState::SkippedByCondition` variant (distinct from `Skipped` for trigger-rule skips)
  - `dag_node_state_label()` helper: renders "Skipped (condition)" vs "Skipped (upstream)"
  - `parse_

https://claude.ai/code/session_01Svxq4mhDPvAyqXD3bM7DcD