### PR TITLE
⚡ Bolt: [performance improvement] Pre-allocate vectors in worker command extractors

### DIFF
--- a/autumn-harvest-plugin/tests/stalled_workflow_tests.rs
+++ b/autumn-harvest-plugin/tests/stalled_workflow_tests.rs
@@ -194,6 +194,7 @@ async fn seed_stalled_workflow(
             owner: None,
             runbook_url: None,
             severity: None,
+            context_headers: None,
         },
     )
     .await

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -740,7 +740,8 @@ fn extract_single_command<T>(
 fn extract_all_scheduled_activities(
     commands: &[WorkflowCommand],
 ) -> Option<Vec<ScheduledActivityCommand>> {
-    let mut scheduled = Vec::new();
+    // ⚡ Bolt: Pre-allocate vector capacity to avoid intermediate allocations
+    let mut scheduled = Vec::with_capacity(commands.len());
 
     for cmd in commands {
         match cmd {
@@ -780,7 +781,8 @@ fn extract_all_scheduled_activities(
 }
 
 fn extract_all_activity_waits(commands: &[WorkflowCommand]) -> Option<Vec<ActivityExecId>> {
-    let mut activity_ids = Vec::new();
+    // ⚡ Bolt: Pre-allocate vector capacity to avoid intermediate allocations
+    let mut activity_ids = Vec::with_capacity(commands.len());
 
     for cmd in commands {
         match cmd {
@@ -1139,8 +1141,9 @@ fn extract_signal_external_workflow(commands: Vec<WorkflowCommand>) -> Vec<Signa
 fn split_mixed_signal_batch(
     commands: Vec<WorkflowCommand>,
 ) -> (Vec<SignalBatchItem>, Vec<WorkflowCommand>) {
-    let mut signal_items = Vec::new();
-    let mut remaining = Vec::new();
+    // ⚡ Bolt: Pre-allocate vector capacity to avoid intermediate allocations
+    let mut signal_items = Vec::with_capacity(commands.len());
+    let mut remaining = Vec::with_capacity(commands.len());
     for cmd in commands {
         match cmd {
             WorkflowCommand::SignalExternalWorkflow {


### PR DESCRIPTION
💡 What: Switched `Vec::new()` to `Vec::with_capacity()` for extracting commands from the command list.
🎯 Why: Using `Vec::new()` requires multiple allocations when pushing dynamically, pre-allocating avoids this.
📊 Impact: Eliminates multiple vector reallocations per extracted batch. Minor memory over-allocation tradeoff (2 * N space for partitioned lists like signal_items and remaining) but saves CPU time.
🔬 Measurement: Run cargo test to verify logic preservation.

---
*PR created automatically by Jules for task [7821361367632322387](https://jules.google.com/task/7821361367632322387) started by @madmax983*