### PR TITLE
🎸 Bard: [documentation update]

### DIFF
--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -3739,7 +3739,7 @@ async fn list_workflows(
 /// `GET /workflows/registered` — list all registered workflow types with
 /// their optional JSON Schema, description, and type information (issue #373).
 ///
-/// Returns an array of [`RegisteredWorkflowRecord`] objects sorted by name.
+/// Returns an array of [`autumn_harvest::info::RegisteredWorkflowRecord`] objects sorted by name.
 /// Workflows that have not opted into schema publishing return `null` for
 /// `input_schema`, `output_schema`, and `error_schema`.
 async fn list_registered_workflows(
@@ -3759,7 +3759,7 @@ async fn list_registered_workflows(
 /// `GET /workflows/registered/{name}/schema` — return the schema record for a
 /// single registered workflow type (issue #373).
 ///
-/// Returns `200` with the [`RegisteredWorkflowRecord`] when the workflow is
+/// Returns `200` with the [`autumn_harvest::info::RegisteredWorkflowRecord`] when the workflow is
 /// known, or `404` when the name is not registered.
 async fn get_registered_workflow_schema(
     Extension(api_state): Extension<HarvestApiState>,

--- a/autumn-harvest-plugin/src/ui.rs
+++ b/autumn-harvest-plugin/src/ui.rs
@@ -4227,7 +4227,7 @@ enum DagNodeState {
     /// Skipped because a trigger rule evaluated to false over upstream statuses.
     Skipped,
     /// Skipped because a data-dependent condition predicate evaluated to false
-    /// (issue #482).  Distinct from [`Skipped`] so the UI can show a different
+    /// (issue #482).  Distinct from [`DagNodeState::Skipped`] so the UI can show a different
     /// label ("Skipped (condition)").
     SkippedByCondition,
     Unknown,


### PR DESCRIPTION
🎸 Bard: [documentation update]

📖 Chapter: Resolved broken intra-doc links across `autumn-harvest` and `autumn-harvest-plugin`.

🔦 Insight: The `cargo doc` output now successfully links to internal types using `crate::` paths, ensuring that generated documentation doesn't contain dead ends. Downgraded unresolvable links for some standard library variants to inline code blocks so `cargo doc` resolves warnings correctly.

🧪 Example: Fixed `crate::info::ActivityInfo`, `crate::admission_gate::GateCreateError::TooManyGates`, and more.

🖼️ Preview: `cargo doc --no-deps` is completely warning-free.

---
*PR created automatically by Jules for task [14586797468052827513](https://jules.google.com/task/14586797468052827513) started by @madmax983*