### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -971,6 +971,9 @@ impl WorkflowContext {
         start_time: chrono::DateTime<chrono::Utc>,
         cancellation_reason: Option<String>,
         state: SharedState,
+        workflow_id: String,
+        workflow_name: String,
+        context_headers: std::sync::Arc<HashMap<String, String>>,
     ) -> std::sync::Arc<Self> {
         std::sync::Arc::new(Self {
             exec_id,
@@ -988,8 +991,8 @@ impl WorkflowContext {
             declarative_updates: Mutex::new(std::collections::HashMap::new()),
             cancellation_reason,
             strict_replay: false,
-            workflow_name: String::new(),
-            workflow_id: String::new(),
+            workflow_name,
+            workflow_id,
             build_id: None,
             nd_details: Mutex::new(None),
             payload_max_activity_input: DEFAULT_MAX_ACTIVITY_INPUT_BYTES,
@@ -999,7 +1002,7 @@ impl WorkflowContext {
             activity_input_cap_overrides: HashMap::new(),
             deferred_nd_error: Mutex::new(None),
             current_details_cap: DEFAULT_CURRENT_DETAILS_CAP_BYTES,
-            context_headers: std::sync::Arc::new(HashMap::new()),
+            context_headers,
         })
     }
 
@@ -4115,20 +4118,15 @@ impl WorkflowContext {
         let context_headers = std::sync::Arc::clone(&self.context_headers);
 
         let boxed_handler: crate::update::BoxUpdateHandler = std::sync::Arc::new(move |input| {
-            let mut ctx = Self::new_for_handler(
+            let ctx = Self::new_for_handler(
                 exec_id,
                 start_time,
                 cancellation_reason.clone(),
                 std::sync::Arc::clone(&state),
+                workflow_id.clone(),
+                workflow_name.clone(),
+                std::sync::Arc::clone(&context_headers),
             );
-            // Propagate correlation fields for logger. Arc was just created;
-            // no other reference exists yet so get_mut always succeeds.
-            {
-                let inner = std::sync::Arc::get_mut(&mut ctx).unwrap();
-                inner.workflow_id.clone_from(&workflow_id);
-                inner.workflow_name.clone_from(&workflow_name);
-                inner.context_headers = std::sync::Arc::clone(&context_headers);
-            }
             handler_fn(ctx, input)
         });
 
@@ -4179,18 +4177,15 @@ impl WorkflowContext {
             .get(name)
             .copied();
         handler.map(|h| {
-            let mut ctx = Self::new_for_handler(
+            let ctx = Self::new_for_handler(
                 self.exec_id,
                 self.start_time,
                 self.cancellation_reason.clone(),
                 std::sync::Arc::clone(&self.state),
+                self.workflow_id.clone(),
+                self.workflow_name.clone(),
+                std::sync::Arc::clone(&self.context_headers),
             );
-            {
-                let inner = std::sync::Arc::get_mut(&mut ctx).unwrap();
-                inner.workflow_id.clone_from(&self.workflow_id);
-                inner.workflow_name.clone_from(&self.workflow_name);
-                inner.context_headers = std::sync::Arc::clone(&self.context_headers);
-            }
             h(ctx, input)
         })
     }

--- a/autumn-harvest/tests/macros_query_handlers.rs
+++ b/autumn-harvest/tests/macros_query_handlers.rs
@@ -256,7 +256,7 @@ async fn update_handler_dispatches_without_validator() {
         ExecutionId::new(),
         chrono::Utc::now(),
         None,
-        empty_shared_state(),
+        empty_shared_state(), String::new(), String::new(), std::sync::Arc::new(std::collections::HashMap::new()),
     );
     let result = (info.handler)(ctx, serde_json::json!({"approved": true}))
         .await
@@ -278,7 +278,7 @@ async fn update_handler_with_validator_accept() {
         ExecutionId::new(),
         chrono::Utc::now(),
         None,
-        empty_shared_state(),
+        empty_shared_state(), String::new(), String::new(), std::sync::Arc::new(std::collections::HashMap::new()),
     );
     let result = (info.handler)(ctx, serde_json::json!({"approved": true}))
         .await
@@ -380,7 +380,7 @@ fn query_ctx_can_access_shared_state() {
     let state = std::sync::Arc::new(map);
 
     let info = __autumn_query_handler_info_read_counter();
-    let ctx = WorkflowContext::new_for_handler(ExecutionId::new(), chrono::Utc::now(), None, state);
+    let ctx = WorkflowContext::new_for_handler(ExecutionId::new(), chrono::Utc::now(), None, state, String::new(), String::new(), std::sync::Arc::new(std::collections::HashMap::new()));
     let result = (info.handler)(ctx.as_ref(), serde_json::Value::Null).unwrap();
     assert_eq!(result, serde_json::json!(77));
 }

--- a/autumn-harvest/tests/macros_query_handlers.rs
+++ b/autumn-harvest/tests/macros_query_handlers.rs
@@ -256,7 +256,10 @@ async fn update_handler_dispatches_without_validator() {
         ExecutionId::new(),
         chrono::Utc::now(),
         None,
-        empty_shared_state(), String::new(), String::new(), std::sync::Arc::new(std::collections::HashMap::new()),
+        empty_shared_state(),
+        String::new(),
+        String::new(),
+        std::sync::Arc::new(std::collections::HashMap::new()),
     );
     let result = (info.handler)(ctx, serde_json::json!({"approved": true}))
         .await
@@ -278,7 +281,10 @@ async fn update_handler_with_validator_accept() {
         ExecutionId::new(),
         chrono::Utc::now(),
         None,
-        empty_shared_state(), String::new(), String::new(), std::sync::Arc::new(std::collections::HashMap::new()),
+        empty_shared_state(),
+        String::new(),
+        String::new(),
+        std::sync::Arc::new(std::collections::HashMap::new()),
     );
     let result = (info.handler)(ctx, serde_json::json!({"approved": true}))
         .await
@@ -380,7 +386,15 @@ fn query_ctx_can_access_shared_state() {
     let state = std::sync::Arc::new(map);
 
     let info = __autumn_query_handler_info_read_counter();
-    let ctx = WorkflowContext::new_for_handler(ExecutionId::new(), chrono::Utc::now(), None, state, String::new(), String::new(), std::sync::Arc::new(std::collections::HashMap::new()));
+    let ctx = WorkflowContext::new_for_handler(
+        ExecutionId::new(),
+        chrono::Utc::now(),
+        None,
+        state,
+        String::new(),
+        String::new(),
+        std::sync::Arc::new(std::collections::HashMap::new()),
+    );
     let result = (info.handler)(ctx.as_ref(), serde_json::Value::Null).unwrap();
     assert_eq!(result, serde_json::json!(77));
 }


### PR DESCRIPTION
🎯 Target:
autumn-harvest/src/context.rs - WorkflowContext::new_for_handler, register_declarative_update_handler, and invoke_update

💣 Risk:
Calling Arc::get_mut(&mut ctx).unwrap() immediately after an Arc initialization assumes that the Arc instance is uniquely owned. While true right after creation, maintaining this assumption across codebase evolutions is a structural panic risk (unwrap on Option). If the creation and mutation flow is refactored, the assumption might fail causing fatal thread panics.

🧪 Strategy:
Refactored WorkflowContext::new_for_handler to accept the workflow_id, workflow_name, and context_headers fields as required parameters instead of depending on post-initialization mutation of the returned Arc<Self>. Update handlers using this function in register_declarative_update_handler and invoke_update pass these properties into the constructor instead of assigning them to the .unwrap() value of Arc::get_mut.

🔬 Verification:
Run cargo test -p autumn-harvest context:: or cargo test -p autumn-harvest --lib to verify the workflow contexts spawn securely without regressions.

---
*PR created automatically by Jules for task [18164398324820002120](https://jules.google.com/task/18164398324820002120) started by @madmax983*