### PR TITLE
⚡ Bolt: Pre-allocate Vecs and optimize HashMap entry lookups

### DIFF
--- a/autumn-harvest/src/dlq.rs
+++ b/autumn-harvest/src/dlq.rs
@@ -1080,9 +1080,9 @@ pub fn merge_dlq_aggregates(
         filtered_total += partial.filtered_total;
         for group in partial.groups {
             let entry = merged
-                .entry(group.key.clone())
-                .or_insert_with(|| DlqRawGroup {
-                    key: group.key.clone(),
+                .entry(group.key)
+                .or_insert_with_key(|key| DlqRawGroup {
+                    key: key.clone(),
                     count: 0,
                     first_seen: None,
                     last_seen: None,
@@ -1256,8 +1256,8 @@ pub async fn aggregate_dead_letters(
             })
             .collect();
 
-        let entry = groups.entry(key.clone()).or_insert_with(|| DlqRawGroup {
-            key,
+        let entry = groups.entry(key).or_insert_with_key(|key| DlqRawGroup {
+            key: key.clone(),
             count: 0,
             first_seen: None,
             last_seen: None,

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -740,7 +740,7 @@ fn extract_single_command<T>(
 fn extract_all_scheduled_activities(
     commands: &[WorkflowCommand],
 ) -> Option<Vec<ScheduledActivityCommand>> {
-    let mut scheduled = Vec::new();
+    let mut scheduled = Vec::with_capacity(commands.len());
 
     for cmd in commands {
         match cmd {
@@ -780,7 +780,7 @@ fn extract_all_scheduled_activities(
 }
 
 fn extract_all_activity_waits(commands: &[WorkflowCommand]) -> Option<Vec<ActivityExecId>> {
-    let mut activity_ids = Vec::new();
+    let mut activity_ids = Vec::with_capacity(commands.len());
 
     for cmd in commands {
         match cmd {
@@ -1139,8 +1139,8 @@ fn extract_signal_external_workflow(commands: Vec<WorkflowCommand>) -> Vec<Signa
 fn split_mixed_signal_batch(
     commands: Vec<WorkflowCommand>,
 ) -> (Vec<SignalBatchItem>, Vec<WorkflowCommand>) {
-    let mut signal_items = Vec::new();
-    let mut remaining = Vec::new();
+    let mut signal_items = Vec::with_capacity(commands.len());
+    let mut remaining = Vec::with_capacity(commands.len());
     for cmd in commands {
         match cmd {
             WorkflowCommand::SignalExternalWorkflow {


### PR DESCRIPTION
💡 What: Changed `Vec::new()` to `Vec::with_capacity(commands.len())` in `extract_all_scheduled_activities`, `extract_all_activity_waits`, and `split_mixed_signal_batch`. Switched `entry(key.clone()).or_insert_with(...)` to `.entry(key).or_insert_with_key(...)` in `merge_dlq_aggregates` and `load_dlq_groups`.
🎯 Why: Creating unbounded vectors requires intermediate heap allocations as the vectors grow. Pre-allocating bounds them perfectly. Calling `.clone()` on a `HashMap` key before `entry` causes an allocation even on cache hits. Using `or_insert_with_key` defers the clone until an insertion actually occurs.
📊 Impact: Removes unnecessary heap allocations per workflow task batch and DLQ aggregation request. Minor memory over-allocation tradeoff when vectors split commands but is deemed acceptable for batch performance.
🔬 Measurement: Verify using `cargo bench` or run integration tests `cargo test -p autumn-harvest --lib`.

---
*PR created automatically by Jules for task [11993644611797962171](https://jules.google.com/task/11993644611797962171) started by @madmax983*