### PR TITLE
👺 Havoc: Fix parsing requirement char boundary panic

### DIFF
--- a/autumn-harvest/src/eligibility.rs
+++ b/autumn-harvest/src/eligibility.rs
@@ -92,8 +92,7 @@ fn find_operator_indices(token: &str) -> (Option<usize>, Option<usize>) {
     let mut in_idx = None;
     let mut in_quotes = None;
 
-    let mut iter = token.char_indices();
-    while let Some((i, c)) = iter.next() {
+    for (i, c) in token.char_indices() {
         match c {
             '\'' | '"' => {
                 if in_quotes == Some(c) {

--- a/autumn-harvest/src/eligibility.rs
+++ b/autumn-harvest/src/eligibility.rs
@@ -91,13 +91,9 @@ fn find_operator_indices(token: &str) -> (Option<usize>, Option<usize>) {
     let mut eq_idx = None;
     let mut in_idx = None;
     let mut in_quotes = None;
-    let token_chars: Vec<char> = token.chars().collect();
-    let token_lower = token.to_lowercase();
-    let token_lower_chars: Vec<char> = token_lower.chars().collect();
 
-    let mut i = 0;
-    while i < token_chars.len() {
-        let c = token_chars[i];
+    let mut iter = token.char_indices();
+    while let Some((i, c)) = iter.next() {
         match c {
             '\'' | '"' => {
                 if in_quotes == Some(c) {
@@ -110,19 +106,18 @@ fn find_operator_indices(token: &str) -> (Option<usize>, Option<usize>) {
                 eq_idx = Some(i);
             }
             _ => {
-                if in_quotes.is_none()
-                    && in_idx.is_none()
-                    && i + 3 < token_chars.len()
-                    && token_lower_chars[i] == ' '
-                    && token_lower_chars[i + 1] == 'i'
-                    && token_lower_chars[i + 2] == 'n'
-                    && token_lower_chars[i + 3] == ' '
-                {
-                    in_idx = Some(i);
+                if in_quotes.is_none() && in_idx.is_none() {
+                    let rem = &token[i..];
+                    if rem.starts_with(" in ")
+                        || rem.starts_with(" IN ")
+                        || rem.starts_with(" In ")
+                        || rem.starts_with(" iN ")
+                    {
+                        in_idx = Some(i);
+                    }
                 }
             }
         }
-        i += 1;
     }
     (eq_idx, in_idx)
 }
@@ -381,5 +376,18 @@ mod tests {
 
         // Empty requirements always match
         assert!(matches_requirements(&[], &labels));
+    }
+}
+
+#[cfg(test)]
+mod test_fuzz_parse_req {
+    use super::parse_requirements;
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn doesn_crash(s in "\\PC*") {
+            let _ = parse_requirements(&s);
+        }
     }
 }

--- a/autumn-harvest/tests/cross_workflow_cancel_tests.rs
+++ b/autumn-harvest/tests/cross_workflow_cancel_tests.rs
@@ -200,7 +200,8 @@ fn default_start_params(
     workflow_id: &'static str,
     input: serde_json::Value,
 ) -> StartWorkflowParams<'static> {
-    StartWorkflowParams { sla: None,
+    StartWorkflowParams {
+        sla: None,
         exec_id,
         workflow_name,
         workflow_id,
@@ -251,7 +252,8 @@ async fn test_same_shard_live_cancel() {
     let target_exec_id = ExecutionId::new_for_shard(ShardId::new(0));
     let caller_exec_id = ExecutionId::new_for_shard(ShardId::new(0));
 
-    let canceller_info = WorkflowInfo { sla: None,
+    let canceller_info = WorkflowInfo {
+        sla: None,
         name: "canceller_workflow",
         module: "cross_workflow_cancel_tests",
         handler: canceller_workflow,
@@ -266,7 +268,8 @@ async fn test_same_shard_live_cancel() {
         output_schema: None,
         error_schema: None,
     };
-    let target_info = WorkflowInfo { sla: None,
+    let target_info = WorkflowInfo {
+        sla: None,
         name: "long_running_target_workflow",
         module: "cross_workflow_cancel_tests",
         handler: long_running_target_workflow,
@@ -380,7 +383,8 @@ async fn test_already_terminal_target_is_no_op_success() {
 
     let built = HarvestBuilder::new()
         .workflows(vec![
-            WorkflowInfo { sla: None,
+            WorkflowInfo {
+                sla: None,
                 name: "canceller_workflow",
                 module: "cross_workflow_cancel_tests",
                 handler: canceller_workflow,
@@ -395,7 +399,8 @@ async fn test_already_terminal_target_is_no_op_success() {
                 output_schema: None,
                 error_schema: None,
             },
-            WorkflowInfo { sla: None,
+            WorkflowInfo {
+                sla: None,
                 name: "instant_complete_workflow",
                 module: "cross_workflow_cancel_tests",
                 handler: instant_complete_workflow,
@@ -520,7 +525,8 @@ async fn test_grace_window_expiry_unknown_target() {
     let caller_exec_id = ExecutionId::new_for_shard(ShardId::new(0));
 
     let built = HarvestBuilder::new()
-        .workflows(vec![WorkflowInfo { sla: None,
+        .workflows(vec![WorkflowInfo {
+            sla: None,
             name: "canceller_expecting_failure",
             module: "cross_workflow_cancel_tests",
             handler: canceller_expecting_failure,
@@ -626,7 +632,8 @@ async fn test_cross_shard_cancel_via_outbox() {
 
     let built = HarvestBuilder::new()
         .workflows(vec![
-            WorkflowInfo { sla: None,
+            WorkflowInfo {
+                sla: None,
                 name: "canceller_workflow",
                 module: "cross_workflow_cancel_tests",
                 handler: canceller_workflow,
@@ -641,7 +648,8 @@ async fn test_cross_shard_cancel_via_outbox() {
                 output_schema: None,
                 error_schema: None,
             },
-            WorkflowInfo { sla: None,
+            WorkflowInfo {
+                sla: None,
                 name: "long_running_target_workflow",
                 module: "cross_workflow_cancel_tests",
                 handler: long_running_target_workflow,

--- a/autumn-harvest/tests/cross_workflow_cancel_tests.rs
+++ b/autumn-harvest/tests/cross_workflow_cancel_tests.rs
@@ -200,7 +200,7 @@ fn default_start_params(
     workflow_id: &'static str,
     input: serde_json::Value,
 ) -> StartWorkflowParams<'static> {
-    StartWorkflowParams {
+    StartWorkflowParams { sla: None,
         exec_id,
         workflow_name,
         workflow_id,
@@ -251,7 +251,7 @@ async fn test_same_shard_live_cancel() {
     let target_exec_id = ExecutionId::new_for_shard(ShardId::new(0));
     let caller_exec_id = ExecutionId::new_for_shard(ShardId::new(0));
 
-    let canceller_info = WorkflowInfo {
+    let canceller_info = WorkflowInfo { sla: None,
         name: "canceller_workflow",
         module: "cross_workflow_cancel_tests",
         handler: canceller_workflow,
@@ -266,7 +266,7 @@ async fn test_same_shard_live_cancel() {
         output_schema: None,
         error_schema: None,
     };
-    let target_info = WorkflowInfo {
+    let target_info = WorkflowInfo { sla: None,
         name: "long_running_target_workflow",
         module: "cross_workflow_cancel_tests",
         handler: long_running_target_workflow,
@@ -380,7 +380,7 @@ async fn test_already_terminal_target_is_no_op_success() {
 
     let built = HarvestBuilder::new()
         .workflows(vec![
-            WorkflowInfo {
+            WorkflowInfo { sla: None,
                 name: "canceller_workflow",
                 module: "cross_workflow_cancel_tests",
                 handler: canceller_workflow,
@@ -395,7 +395,7 @@ async fn test_already_terminal_target_is_no_op_success() {
                 output_schema: None,
                 error_schema: None,
             },
-            WorkflowInfo {
+            WorkflowInfo { sla: None,
                 name: "instant_complete_workflow",
                 module: "cross_workflow_cancel_tests",
                 handler: instant_complete_workflow,
@@ -520,7 +520,7 @@ async fn test_grace_window_expiry_unknown_target() {
     let caller_exec_id = ExecutionId::new_for_shard(ShardId::new(0));
 
     let built = HarvestBuilder::new()
-        .workflows(vec![WorkflowInfo {
+        .workflows(vec![WorkflowInfo { sla: None,
             name: "canceller_expecting_failure",
             module: "cross_workflow_cancel_tests",
             handler: canceller_expecting_failure,
@@ -626,7 +626,7 @@ async fn test_cross_shard_cancel_via_outbox() {
 
     let built = HarvestBuilder::new()
         .workflows(vec![
-            WorkflowInfo {
+            WorkflowInfo { sla: None,
                 name: "canceller_workflow",
                 module: "cross_workflow_cancel_tests",
                 handler: canceller_workflow,
@@ -641,7 +641,7 @@ async fn test_cross_shard_cancel_via_outbox() {
                 output_schema: None,
                 error_schema: None,
             },
-            WorkflowInfo {
+            WorkflowInfo { sla: None,
                 name: "long_running_target_workflow",
                 module: "cross_workflow_cancel_tests",
                 handler: long_running_target_workflow,


### PR DESCRIPTION
🧨 The Trigger:
Fuzzing `parse_requirements` with input strings containing non-ASCII characters, like `①᯼￼=`, panics at byte slice boundaries.

📉 The Stack Trace:
thread 'eligibility::test_fuzz_parse_req::doesn_crash' panicked at autumn-harvest/src/eligibility.rs:392:5:
Test failed: byte index 4 is not a char boundary; it is inside '᯼' (bytes 3..6) of `①᯼￼=`.

🧪 Reproduction:
Run `cargo test --lib -p autumn-harvest test_fuzz_parse_req` which feeds non-ascii strings into the `parse_requirements` parser.

😈 Comment:
You assumed index means byte size and iterated over chars while yielding array indexing. But char size is not 1 byte. Welcome to the real world.

---
*PR created automatically by Jules for task [2535301412213417923](https://jules.google.com/task/2535301412213417923) started by @madmax983*