### PR TITLE
🌟 Nova: Export Chrome Trace from DagProfile

### DIFF
--- a/autumn-harvest/src/dag_profiler.rs
+++ b/autumn-harvest/src/dag_profiler.rs
@@ -167,6 +167,91 @@ impl DagProfiler {
     }
 }
 
+/// Exports a `DagProfile` to the Chrome Trace Event Format (JSON).
+///
+/// This generates a JSON array of events that can be loaded into profiling
+/// tools like `chrome://tracing` or Perfetto.
+///
+/// # Examples
+///
+/// ```rust
+/// use autumn_harvest::dag::DagBuilder;
+/// use autumn_harvest::dag_profiler::{DagProfiler, export_chrome_trace};
+/// use std::time::Duration;
+///
+/// fn my_activity() {}
+/// fn my_other_activity() {}
+///
+/// let mut builder = DagBuilder::new();
+/// let a = builder.activity(my_activity);
+/// let b = builder.activity(my_other_activity).upstream(&a);
+/// let dag = builder.build().unwrap();
+///
+/// let profiler = DagProfiler::new(dag).mock_duration("my_activity", Duration::from_secs(1));
+/// let profile = profiler.profile();
+///
+/// let trace = export_chrome_trace(&profile).unwrap();
+/// assert!(trace.contains("my_activity"));
+/// assert!(trace.contains("my_other_activity"));
+/// ```
+///
+/// # Errors
+/// Returns `std::fmt::Error` if string formatting fails.
+#[allow(clippy::cast_possible_truncation)]
+pub fn export_chrome_trace(profile: &DagProfile) -> Result<String, std::fmt::Error> {
+    use std::fmt::Write;
+
+    let mut out = String::new();
+    writeln!(out, "[")?;
+
+    let mut active_tasks = HashMap::new();
+    let mut free_tids = Vec::new();
+    let mut next_tid = 1;
+
+    let mut first = true;
+
+    for event in &profile.timeline {
+        let ts_micros = event.time.as_micros() as u64;
+
+        if first {
+            first = false;
+        } else {
+            writeln!(out, ",")?;
+        }
+
+        match &event.kind {
+            ProfilerEventKind::TaskStarted(idx, name) => {
+                let tid = free_tids.pop().unwrap_or_else(|| {
+                    let t = next_tid;
+                    next_tid += 1;
+                    t
+                });
+                active_tasks.insert(*idx, tid);
+
+                write!(
+                    out,
+                    r#"  {{"name":"{name}","ph":"B","ts":{ts_micros},"pid":1,"tid":{tid}}}"#
+                )?;
+            }
+            ProfilerEventKind::TaskCompleted(idx, name) => {
+                if let Some(tid) = active_tasks.remove(idx) {
+                    write!(
+                        out,
+                        r#"  {{"name":"{name}","ph":"E","ts":{ts_micros},"pid":1,"tid":{tid}}}"#
+                    )?;
+                    free_tids.push(tid);
+                    free_tids.sort_unstable_by(|a, b| b.cmp(a));
+                }
+            }
+        }
+    }
+
+    writeln!(out)?;
+    writeln!(out, "]")?;
+
+    Ok(out)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -235,5 +320,43 @@ mod tests {
         assert_eq!(profile.total_duration, Duration::from_secs(6));
         // max concurrency is 2 because B and C run at the same time.
         assert_eq!(profile.peak_concurrency, 2);
+    }
+
+    #[test]
+    fn test_export_chrome_trace_empty() {
+        let profile = DagProfile {
+            total_duration: Duration::ZERO,
+            peak_concurrency: 0,
+            timeline: vec![],
+        };
+        let trace = export_chrome_trace(&profile).unwrap();
+        assert_eq!(trace, "[\n\n]\n");
+    }
+
+    #[test]
+    fn test_export_chrome_trace_valid_json() {
+        let profile = DagProfile {
+            total_duration: Duration::from_secs(2),
+            peak_concurrency: 1,
+            timeline: vec![
+                ProfilerEvent {
+                    time: Duration::from_secs(0),
+                    kind: ProfilerEventKind::TaskStarted(0, "task_a".to_string()),
+                },
+                ProfilerEvent {
+                    time: Duration::from_secs(2),
+                    kind: ProfilerEventKind::TaskCompleted(0, "task_a".to_string()),
+                },
+            ],
+        };
+        let trace = export_chrome_trace(&profile).unwrap();
+
+        let parsed: Vec<serde_json::Value> = serde_json::from_str(&trace).unwrap();
+        assert_eq!(parsed.len(), 2);
+        assert_eq!(parsed[0]["name"], "task_a");
+        assert_eq!(parsed[0]["ph"], "B");
+        assert_eq!(parsed[1]["name"], "task_a");
+        assert_eq!(parsed[1]["ph"], "E");
+        assert_eq!(parsed[0]["tid"], parsed[1]["tid"]);
     }
 }

--- a/autumn-harvest/src/lib.rs
+++ b/autumn-harvest/src/lib.rs
@@ -203,7 +203,9 @@ pub use dag_linter::{
     MissingTimeoutRule,
 };
 #[cfg(feature = "testing")]
-pub use dag_profiler::{DagProfile, DagProfiler, ProfilerEvent, ProfilerEventKind};
+pub use dag_profiler::{
+    DagProfile, DagProfiler, ProfilerEvent, ProfilerEventKind, export_chrome_trace,
+};
 #[cfg(any(test, feature = "testing"))]
 pub use dag_simulator::{DagSimulator, DagSimulatorResult};
 pub use det_check::{

--- a/autumn-harvest/tests/cross_workflow_cancel_tests.rs
+++ b/autumn-harvest/tests/cross_workflow_cancel_tests.rs
@@ -201,6 +201,7 @@ fn default_start_params(
     input: serde_json::Value,
 ) -> StartWorkflowParams<'static> {
     StartWorkflowParams {
+        sla: None,
         exec_id,
         workflow_name,
         workflow_id,
@@ -252,6 +253,7 @@ async fn test_same_shard_live_cancel() {
     let caller_exec_id = ExecutionId::new_for_shard(ShardId::new(0));
 
     let canceller_info = WorkflowInfo {
+        sla: None,
         name: "canceller_workflow",
         module: "cross_workflow_cancel_tests",
         handler: canceller_workflow,
@@ -267,6 +269,7 @@ async fn test_same_shard_live_cancel() {
         error_schema: None,
     };
     let target_info = WorkflowInfo {
+        sla: None,
         name: "long_running_target_workflow",
         module: "cross_workflow_cancel_tests",
         handler: long_running_target_workflow,
@@ -381,6 +384,7 @@ async fn test_already_terminal_target_is_no_op_success() {
     let built = HarvestBuilder::new()
         .workflows(vec![
             WorkflowInfo {
+                sla: None,
                 name: "canceller_workflow",
                 module: "cross_workflow_cancel_tests",
                 handler: canceller_workflow,
@@ -396,6 +400,7 @@ async fn test_already_terminal_target_is_no_op_success() {
                 error_schema: None,
             },
             WorkflowInfo {
+                sla: None,
                 name: "instant_complete_workflow",
                 module: "cross_workflow_cancel_tests",
                 handler: instant_complete_workflow,
@@ -521,6 +526,7 @@ async fn test_grace_window_expiry_unknown_target() {
 
     let built = HarvestBuilder::new()
         .workflows(vec![WorkflowInfo {
+            sla: None,
             name: "canceller_expecting_failure",
             module: "cross_workflow_cancel_tests",
             handler: canceller_expecting_failure,
@@ -627,6 +633,7 @@ async fn test_cross_shard_cancel_via_outbox() {
     let built = HarvestBuilder::new()
         .workflows(vec![
             WorkflowInfo {
+                sla: None,
                 name: "canceller_workflow",
                 module: "cross_workflow_cancel_tests",
                 handler: canceller_workflow,
@@ -642,6 +649,7 @@ async fn test_cross_shard_cancel_via_outbox() {
                 error_schema: None,
             },
             WorkflowInfo {
+                sla: None,
                 name: "long_running_target_workflow",
                 module: "cross_workflow_cancel_tests",
                 handler: long_running_target_workflow,


### PR DESCRIPTION
💡 The Spark: We have profiling tools for DAGs but no way to visualize them outside our simple structures.
🚀 The Feature: Implemented `export_chrome_trace` which generates Chrome Trace Event JSON arrays.
🔮 The Potential: This JSON output can be directly imported into `chrome://tracing` or Perfetto for advanced visual analysis of DAG executions.
⚠️ Risk: Low. Isolated pure function in `dag_profiler.rs`.

---
*PR created automatically by Jules for task [18124606175203613985](https://jules.google.com/task/18124606175203613985) started by @madmax983*