### PR TITLE
⚡ Bolt: Pre-allocate vectors in signal batching

### DIFF
--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -1168,8 +1168,9 @@ fn extract_signal_external_workflow(commands: Vec<WorkflowCommand>) -> Vec<Signa
 fn split_mixed_signal_batch(
     commands: Vec<WorkflowCommand>,
 ) -> (Vec<SignalBatchItem>, Vec<WorkflowCommand>) {
+    // ⚡ Bolt: Pre-allocate vector capacity to avoid intermediate allocations
     let mut signal_items = Vec::new();
-    let mut remaining = Vec::new();
+    let mut remaining = Vec::with_capacity(commands.len());
     for cmd in commands {
         match cmd {
             WorkflowCommand::SignalExternalWorkflow {
@@ -1262,7 +1263,8 @@ async fn persist_external_signal_inline(
     let (new_events, final_next, deferred_starts, cancel_metrics): InlinePersistResult = conn
         .transaction::<InlinePersistResult, HarvestError, _>(|conn| {
             async move {
-                let mut new_events: Vec<WorkflowEvent> = Vec::new();
+                // ⚡ Bolt: Pre-allocate vector capacity to avoid intermediate allocations
+                let mut new_events: Vec<WorkflowEvent> = Vec::with_capacity(items.len());
                 let mut next = start_next;
                 // Completion-trigger / cascade follow-up starts produced by
                 // same-shard cancellations. These must be spawned only *after*

--- a/autumn-harvest/tests/cross_workflow_cancel_tests.rs
+++ b/autumn-harvest/tests/cross_workflow_cancel_tests.rs
@@ -207,6 +207,7 @@ fn default_start_params(
         input,
         parent_id: None,
         queue_name: "default",
+        sla: None,
         execution_timeout: None,
         memo: None,
         search_attrs: None,
@@ -265,6 +266,7 @@ async fn test_same_shard_live_cancel() {
         input_schema: None,
         output_schema: None,
         error_schema: None,
+        sla: None,
     };
     let target_info = WorkflowInfo {
         name: "long_running_target_workflow",
@@ -280,6 +282,7 @@ async fn test_same_shard_live_cancel() {
         input_schema: None,
         output_schema: None,
         error_schema: None,
+        sla: None,
     };
 
     let built = HarvestBuilder::new()
@@ -394,6 +397,7 @@ async fn test_already_terminal_target_is_no_op_success() {
                 input_schema: None,
                 output_schema: None,
                 error_schema: None,
+                sla: None,
             },
             WorkflowInfo {
                 name: "instant_complete_workflow",
@@ -409,6 +413,7 @@ async fn test_already_terminal_target_is_no_op_success() {
                 input_schema: None,
                 output_schema: None,
                 error_schema: None,
+                sla: None,
             },
         ])
         .worker(WorkerConfig::default())
@@ -534,6 +539,7 @@ async fn test_grace_window_expiry_unknown_target() {
             input_schema: None,
             output_schema: None,
             error_schema: None,
+            sla: None,
         }])
         .worker(WorkerConfig::default().with_unknown_target_grace_window(Duration::from_secs(1)))
         .build();
@@ -640,6 +646,7 @@ async fn test_cross_shard_cancel_via_outbox() {
                 input_schema: None,
                 output_schema: None,
                 error_schema: None,
+                sla: None,
             },
             WorkflowInfo {
                 name: "long_running_target_workflow",
@@ -655,6 +662,7 @@ async fn test_cross_shard_cancel_via_outbox() {
                 input_schema: None,
                 output_schema: None,
                 error_schema: None,
+                sla: None,
             },
         ])
         .worker(WorkerConfig::default())


### PR DESCRIPTION
💡 What: Pre-allocate vectors with capacity in worker's signal batching logic.
🎯 Why: Avoid multiple intermediate heap reallocations on the hot path.
📊 Impact: Reduces heap reallocations for large command/signal batches.
🔬 Measurement: Run `cargo test` and verify CI passes.

---
*PR created automatically by Jules for task [14854316544015568304](https://jules.google.com/task/14854316544015568304) started by @madmax983*