### PR TITLE
⚒️ Forge: Extract validate_required helper

### DIFF
--- a/autumn-harvest/src/info.rs
+++ b/autumn-harvest/src/info.rs
@@ -398,23 +398,7 @@ fn validate_node(
     }
 
     // required fields
-    if let (Some(required), Some(obj)) = (
-        schema_obj.get("required").and_then(|v| v.as_array()),
-        value.as_object(),
-    ) {
-        for req in required {
-            if let Some(field) = req.as_str()
-                && !obj.contains_key(field)
-            {
-                // Escape field name per RFC 6901: ~ → ~0, / → ~1.
-                let escaped = field.replace('~', "~0").replace('/', "~1");
-                out.push(SchemaViolation {
-                    message: format!("missing required field '{field}'"),
-                    field_path: Some(format!("{ptr}/{escaped}")),
-                });
-            }
-        }
-    }
+    validate_required(schema_obj, value, ptr, out);
 
     // properties — recurse
     if let (Some(properties), Some(obj)) = (
@@ -571,6 +555,35 @@ fn validate_node(
                 ),
                 field_path: path(),
             });
+        }
+    }
+}
+
+fn validate_required(
+    schema_obj: &serde_json::Map<String, serde_json::Value>,
+    value: &serde_json::Value,
+    ptr: &str,
+    out: &mut Vec<SchemaViolation>,
+) {
+    if let (Some(required), Some(obj)) = (
+        schema_obj.get("required").and_then(|v| v.as_array()),
+        value.as_object(),
+    ) {
+        for req in required {
+            if let Some(field) = req.as_str()
+                && !obj.contains_key(field)
+            {
+                // Escape field name per RFC 6901: ~ → ~0, / → ~1.
+                let escaped = field.replace('~', "~0").replace('/', "~1");
+                out.push(SchemaViolation {
+                    message: format!("missing required field '{field}'"),
+                    field_path: if ptr.is_empty() {
+                        Some(format!("/{escaped}"))
+                    } else {
+                        Some(format!("{ptr}/{escaped}"))
+                    },
+                });
+            }
         }
     }
 }

--- a/autumn-harvest/tests/cross_workflow_cancel_tests.rs
+++ b/autumn-harvest/tests/cross_workflow_cancel_tests.rs
@@ -224,6 +224,7 @@ fn default_start_params(
         runbook_url: None,
         severity: None,
         context_headers: None,
+        sla: None,
     }
 }
 
@@ -265,6 +266,7 @@ async fn test_same_shard_live_cancel() {
         input_schema: None,
         output_schema: None,
         error_schema: None,
+        sla: None,
     };
     let target_info = WorkflowInfo {
         name: "long_running_target_workflow",
@@ -280,6 +282,7 @@ async fn test_same_shard_live_cancel() {
         input_schema: None,
         output_schema: None,
         error_schema: None,
+        sla: None,
     };
 
     let built = HarvestBuilder::new()
@@ -394,6 +397,7 @@ async fn test_already_terminal_target_is_no_op_success() {
                 input_schema: None,
                 output_schema: None,
                 error_schema: None,
+                sla: None,
             },
             WorkflowInfo {
                 name: "instant_complete_workflow",
@@ -409,6 +413,7 @@ async fn test_already_terminal_target_is_no_op_success() {
                 input_schema: None,
                 output_schema: None,
                 error_schema: None,
+                sla: None,
             },
         ])
         .worker(WorkerConfig::default())
@@ -534,6 +539,7 @@ async fn test_grace_window_expiry_unknown_target() {
             input_schema: None,
             output_schema: None,
             error_schema: None,
+            sla: None,
         }])
         .worker(WorkerConfig::default().with_unknown_target_grace_window(Duration::from_secs(1)))
         .build();
@@ -640,6 +646,7 @@ async fn test_cross_shard_cancel_via_outbox() {
                 input_schema: None,
                 output_schema: None,
                 error_schema: None,
+                sla: None,
             },
             WorkflowInfo {
                 name: "long_running_target_workflow",
@@ -655,6 +662,7 @@ async fn test_cross_shard_cancel_via_outbox() {
                 input_schema: None,
                 output_schema: None,
                 error_schema: None,
+                sla: None,
             },
         ])
         .worker(WorkerConfig::default())

--- a/examples/billing-autumn-web/src/tests.rs
+++ b/examples/billing-autumn-web/src/tests.rs
@@ -110,8 +110,8 @@ async fn billing_checkout_happy_path_uses_saga_child_signal_version_and_timer() 
     )));
     assert!(result.history.iter().any(|event| matches!(
         event,
-        WorkflowEvent::MarkerRecorded { name, .. }
-            if name == "side_effect:subscription-id"
+        WorkflowEvent::SideEffectRecorded { name: Some(name), .. }
+            if name == "subscription-id"
     )));
     assert!(result.history.iter().any(|event| matches!(
         event,


### PR DESCRIPTION
Extracted the `required` validation logic in `autumn-harvest/src/info.rs` into a new `validate_required` helper function. This reduces the cognitive complexity of the `validate_node` monolithic function, flattening nesting and separating concerns.

Additionally, this PR includes fixes for broken build states and test assertions:
- Initialized missing `sla` fields for `StartWorkflowParams` and `WorkflowInfo` in `autumn-harvest/tests/cross_workflow_cancel_tests.rs`.
- Fixed the `billing_checkout_happy_path_uses_saga_child_signal_version_and_timer` test in `examples/billing-autumn-web/src/tests.rs` by correctly asserting on `WorkflowEvent::SideEffectRecorded` instead of `WorkflowEvent::MarkerRecorded` to reflect the updated side-effect behavior.

All relevant unit tests pass locally (`cargo test -p autumn-harvest --lib`, `cargo test -p billing-autumn-web`). Integration tests that require local Docker containers (`audit_tests`) fail gracefully in the sandbox due to environment limitations, but this is a pre-existing condition and unrelated to the refactor.

---
*PR created automatically by Jules for task [9649966290887640152](https://jules.google.com/task/9649966290887640152) started by @madmax983*