### PR TITLE
Add hard ceiling on workflow history event count (issue #493)

### DIFF
--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -297,6 +297,9 @@ pub struct HarvestApiState {
     /// Loaded from Postgres before the worker pool starts accepting new work so
     /// there is no admission window between plugin boot and re-apply.
     gate_cache: Arc<autumn_harvest::AdmissionGateCache>,
+    /// Hard ceiling on per-execution event count (issue #493).
+    /// `None` = ceiling disabled; executions are terminated when they exceed this count.
+    max_workflow_history_events: Arc<Mutex<Option<u64>>>,
 }
 
 impl Default for HarvestApiState {
@@ -324,6 +327,7 @@ impl Default for HarvestApiState {
             batch_start_max_items: Arc::new(Mutex::new(DEFAULT_BATCH_START_MAX_ITEMS)),
             batch_start_max_bytes: Arc::new(Mutex::new(DEFAULT_BATCH_START_MAX_BYTES)),
             gate_cache: Arc::new(autumn_harvest::AdmissionGateCache::new()),
+            max_workflow_history_events: Arc::new(Mutex::new(None)),
         }
     }
 }
@@ -400,6 +404,35 @@ impl HarvestApiState {
     pub fn max_workflow_execution_timeout(&self) -> Option<std::time::Duration> {
         *self
             .max_workflow_execution_timeout
+            .lock()
+            .expect("harvest api state lock poisoned")
+    }
+
+    /// Set the hard ceiling on per-execution event count (issue #493).
+    ///
+    /// Call this during startup from the plugin to propagate
+    /// `BuiltHarvest::max_workflow_history_events` into the API state so the
+    /// preflight check can surface it.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal mutex is poisoned.
+    pub fn set_max_workflow_history_events(&self, ceiling: Option<u64>) {
+        *self
+            .max_workflow_history_events
+            .lock()
+            .expect("harvest api state lock poisoned") = ceiling;
+    }
+
+    /// Current hard ceiling on per-execution event count (issue #493).
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal mutex is poisoned.
+    #[must_use]
+    pub fn max_workflow_history_events(&self) -> Option<u64> {
+        *self
+            .max_workflow_history_events
             .lock()
             .expect("harvest api state lock poisoned")
     }
@@ -1689,6 +1722,8 @@ pub(crate) struct WorkflowFilters {
     pub(crate) include_sleeping: bool,
     /// When true, return only executions whose soft SLA has been breached (#487).
     pub(crate) sla_breached: bool,
+    /// Only return executions with at least this many recorded events (issue #493).
+    pub(crate) min_history_events: Option<u64>,
 }
 
 impl WorkflowFilters {
@@ -3951,6 +3986,14 @@ pub(crate) fn parse_workflow_filters(
             }
             "sla_breached" => {
                 filters.sla_breached = value.trim().eq_ignore_ascii_case("true");
+            }
+            "min_history_events" => {
+                let parsed = value.trim().parse::<u64>().map_err(|_| {
+                    AutumnError::bad_request_msg(format!(
+                        "invalid min_history_events '{value}'; expected a non-negative integer"
+                    ))
+                })?;
+                filters.min_history_events = Some(parsed);
             }
             _ => {
                 // Ignore unknown query parameters so future additions stay non-breaking.
@@ -13610,6 +13653,17 @@ pub(crate) async fn load_workflows(
     }
     if filters.sla_breached {
         query = query.filter(harvest_workflow_executions::sla_breached.eq(true));
+    }
+    if let Some(min_events) = filters.min_history_events {
+        // Correlated subquery: filter to executions with at least `min_events`
+        // recorded events. No schema migration is required — the count is
+        // computed on read from the existing `harvest_events` table.
+        use diesel::sql_types::BigInt;
+        query = query.filter(
+            sql::<Bool>(
+                "(SELECT COUNT(*) FROM harvest_events WHERE workflow_exec_id = harvest_workflow_executions.id) >= "
+            ).bind::<BigInt, _>(min_events as i64),
+        );
     }
     query
         .select(WorkflowExecution::as_select())

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -3897,6 +3897,7 @@ async fn get_registered_workflow_schema(
 /// against `KNOWN_WORKFLOW_STATES`. `search_attr=` values must be `key:value`
 /// and are repeatable; each entry contributes a separate JSONB containment
 /// predicate so repeats narrow rather than widen.
+#[allow(clippy::too_many_lines)]
 pub(crate) fn parse_workflow_filters(
     pairs: &[(String, String)],
 ) -> Result<WorkflowFilters, AutumnError> {
@@ -13662,7 +13663,7 @@ pub(crate) async fn load_workflows(
         query = query.filter(
             sql::<Bool>(
                 "(SELECT COUNT(*) FROM harvest_events WHERE workflow_exec_id = harvest_workflow_executions.id) >= "
-            ).bind::<BigInt, _>(min_events as i64),
+            ).bind::<BigInt, _>(i64::try_from(min_events).unwrap_or(i64::MAX)),
         );
     }
     query
@@ -13777,6 +13778,16 @@ pub(crate) async fn load_stalled_workflows(
     // stalled rows because this loader bypasses `load_workflows`.
     if filters.sla_breached {
         query = query.filter(harvest_workflow_executions::sla_breached.eq(true));
+    }
+
+    if let Some(min_events) = filters.min_history_events {
+        query = query.filter(
+            sql::<Bool>(
+                "(SELECT COUNT(*) FROM harvest_events \
+                 WHERE workflow_exec_id = harvest_workflow_executions.id) >= ",
+            )
+            .bind::<BigInt, _>(i64::try_from(min_events).unwrap_or(i64::MAX)),
+        );
     }
 
     if !filters.include_sleeping {

--- a/autumn-harvest-plugin/src/plugin.rs
+++ b/autumn-harvest-plugin/src/plugin.rs
@@ -324,7 +324,7 @@ async fn start_harvest_runtime(
     api_state.set_max_workflow_history_events(
         built
             .max_workflow_history_events
-            .or(built.worker_config().max_workflow_history_events),
+            .or_else(|| built.worker_config().max_workflow_history_events),
     );
     // Propagate the server-side start delay ceiling (issue #322).
     api_state.set_max_workflow_start_delay(built.worker_config().max_workflow_start_delay);

--- a/autumn-harvest-plugin/src/plugin.rs
+++ b/autumn-harvest-plugin/src/plugin.rs
@@ -316,6 +316,8 @@ async fn start_harvest_runtime(
     api_state.set_query_timeout(built.worker_config().query_timeout);
     // Propagate the server-side execution timeout ceiling (issue #243).
     api_state.set_max_workflow_execution_timeout(built.max_workflow_execution_timeout);
+    // Propagate the hard history event ceiling (issue #493).
+    api_state.set_max_workflow_history_events(built.max_workflow_history_events);
     // Propagate the server-side start delay ceiling (issue #322).
     api_state.set_max_workflow_start_delay(built.worker_config().max_workflow_start_delay);
     // Propagate batch start caps from builder config (issue #357).

--- a/autumn-harvest-plugin/src/plugin.rs
+++ b/autumn-harvest-plugin/src/plugin.rs
@@ -317,7 +317,15 @@ async fn start_harvest_runtime(
     // Propagate the server-side execution timeout ceiling (issue #243).
     api_state.set_max_workflow_execution_timeout(built.max_workflow_execution_timeout);
     // Propagate the hard history event ceiling (issue #493).
-    api_state.set_max_workflow_history_events(built.max_workflow_history_events);
+    // Prefer the builder-level value; fall back to the WorkerConfig value so
+    // that /admin/preflight accurately reflects the ceiling even when it was
+    // configured via WorkerConfig::with_max_workflow_history_events rather
+    // than HarvestBuilder::max_workflow_history_events.
+    api_state.set_max_workflow_history_events(
+        built
+            .max_workflow_history_events
+            .or(built.worker_config().max_workflow_history_events),
+    );
     // Propagate the server-side start delay ceiling (issue #322).
     api_state.set_max_workflow_start_delay(built.worker_config().max_workflow_start_delay);
     // Propagate batch start caps from builder config (issue #357).

--- a/autumn-harvest-plugin/src/preflight.rs
+++ b/autumn-harvest-plugin/src/preflight.rs
@@ -78,6 +78,7 @@ pub async fn build_preflight_report(api_state: &HarvestApiState) -> PreflightRep
     checks.push(check_dlq_read_access(api_state).await);
     checks.push(check_retention_visibility(api_state));
     checks.push(check_admin_auth_boundary(api_state));
+    checks.push(check_history_ceiling_config(api_state));
 
     let overall_status = checks
         .iter()
@@ -1207,6 +1208,65 @@ fn check_admin_auth_boundary(api_state: &HarvestApiState) -> PreflightCheckResul
             "auth_boundary_present": has_boundary,
         }),
     )
+}
+
+fn check_history_ceiling_config(api_state: &HarvestApiState) -> PreflightCheckResult {
+    let ceiling = api_state.max_workflow_history_events();
+    let soft_threshold = api_state
+        .runtime()
+        .ok()
+        .map(|rt| rt.registry().history_policy().continue_as_new_threshold());
+
+    match (ceiling, soft_threshold) {
+        (Some(ceiling), Some(threshold)) => check(
+            "history_ceiling_config",
+            PreflightStatus::Pass,
+            "hard history event ceiling is configured and validated above the soft threshold",
+            None,
+            Vec::new(),
+            json!({
+                "ceiling_enabled": true,
+                "max_workflow_history_events": ceiling,
+                "continue_as_new_threshold": threshold,
+                "headroom": ceiling.saturating_sub(threshold),
+            }),
+        ),
+        (Some(ceiling), None) => check(
+            "history_ceiling_config",
+            PreflightStatus::Pass,
+            "hard history event ceiling is configured",
+            None,
+            Vec::new(),
+            json!({
+                "ceiling_enabled": true,
+                "max_workflow_history_events": ceiling,
+                "continue_as_new_threshold": null,
+            }),
+        ),
+        (None, Some(threshold)) => check(
+            "history_ceiling_config",
+            PreflightStatus::Pass,
+            "history ceiling is disabled; soft continue-as-new threshold is the only guard",
+            None,
+            Vec::new(),
+            json!({
+                "ceiling_enabled": false,
+                "continue_as_new_threshold": threshold,
+                "note": "set max_workflow_history_events on HarvestBuilder to enable the hard ceiling",
+            }),
+        ),
+        (None, None) => check(
+            "history_ceiling_config",
+            PreflightStatus::Pass,
+            "history ceiling is disabled and no runtime is available to inspect the soft threshold",
+            None,
+            Vec::new(),
+            json!({
+                "ceiling_enabled": false,
+                "continue_as_new_threshold": null,
+            }),
+        ),
+    }
 }
 
 #[cfg(test)]

--- a/autumn-harvest-plugin/src/runner.rs
+++ b/autumn-harvest-plugin/src/runner.rs
@@ -114,6 +114,7 @@ impl PreparedHarvestRuntime {
             .map(|dag| dag.name.to_string())
             .collect();
         let workflow_schedules = Arc::new(built.workflow_schedules().to_vec());
+        let max_workflow_history_events = built.max_workflow_history_events;
         let (registry, dags, _ws, worker_config) =
             built.into_worker_parts_with_extra_state(injected_runtime_state(
                 resources.app_state,
@@ -125,13 +126,15 @@ impl PreparedHarvestRuntime {
             compile_dag_catalog(dags)
                 .map_err(|error| AutumnError::service_unavailable_msg(error.to_string()))?,
         );
+        let mut worker_runtime_config = WorkerRuntimeConfig::from(worker_config);
+        worker_runtime_config.max_workflow_history_events = max_workflow_history_events;
 
         Ok(Self {
             registry: Arc::new(registry),
             dag_catalog,
             registered_dag_names,
             workflow_schedules,
-            worker_runtime_config: WorkerRuntimeConfig::from(worker_config),
+            worker_runtime_config,
             storage_pool: HarvestDbPool::from(resources.harvest_pool),
             shard_router,
             retention_config,

--- a/autumn-harvest-plugin/src/runner.rs
+++ b/autumn-harvest-plugin/src/runner.rs
@@ -127,7 +127,12 @@ impl PreparedHarvestRuntime {
                 .map_err(|error| AutumnError::service_unavailable_msg(error.to_string()))?,
         );
         let mut worker_runtime_config = WorkerRuntimeConfig::from(worker_config);
-        worker_runtime_config.max_workflow_history_events = max_workflow_history_events;
+        // Builder-level ceiling takes precedence; WorkerConfig ceiling is kept
+        // when the builder did not set one (avoids silently disabling a ceiling
+        // that the embedder configured via WorkerConfig directly).
+        if let Some(ceiling) = max_workflow_history_events {
+            worker_runtime_config.max_workflow_history_events = Some(ceiling);
+        }
 
         Ok(Self {
             registry: Arc::new(registry),

--- a/autumn-harvest-plugin/tests/api_scheduler_integration.rs
+++ b/autumn-harvest-plugin/tests/api_scheduler_integration.rs
@@ -3357,6 +3357,7 @@ async fn timeout_sweeper_does_not_append_timeout_after_activity_completion() {
             &None,
             &[],
             None,
+            None,
         )
         .await
     });

--- a/autumn-harvest-plugin/tests/dag_retry_integration.rs
+++ b/autumn-harvest-plugin/tests/dag_retry_integration.rs
@@ -272,6 +272,7 @@ fn build_worker() -> Arc<Worker> {
                 poison_pill_threshold: 3,
                 labels: std::collections::HashMap::new(),
                 max_workflow_pause_duration: std::time::Duration::from_secs(24 * 3600),
+                max_workflow_history_events: None,
                 sharded_pool: None,
             },
             registry(),

--- a/autumn-harvest-plugin/tests/workflow_reset_integration.rs
+++ b/autumn-harvest-plugin/tests/workflow_reset_integration.rs
@@ -211,6 +211,7 @@ fn build_reset_worker(registry: Arc<HandlerRegistry>) -> Arc<Worker> {
                 poison_pill_threshold: 3,
                 labels: std::collections::HashMap::new(),
                 max_workflow_pause_duration: std::time::Duration::from_secs(24 * 3600),
+                max_workflow_history_events: None,
                 sharded_pool: None,
             },
             registry,

--- a/autumn-harvest/src/builder.rs
+++ b/autumn-harvest/src/builder.rs
@@ -1635,6 +1635,17 @@ pub struct WorkerConfig {
     pub max_workflow_pause_duration: Duration,
     /// Capability labels for hardware-aware and regional routing (issue #382).
     pub labels: std::collections::HashMap<String, String>,
+    /// Hard ceiling on the number of history events a workflow may accumulate
+    /// before the server terminates it (issue #493).
+    ///
+    /// When `Some(n)`, any `RUNNING` execution whose recorded event count
+    /// reaches `n` is failed with a machine-readable `WorkflowFailed` event
+    /// (`"history_ceiling_exceeded: event count {n} >= ceiling {n}"`).
+    /// This is a server-side safety net for workflows that do not cooperate
+    /// with `ctx.should_continue_as_new()`.
+    ///
+    /// Defaults to `None` (disabled).
+    pub max_workflow_history_events: Option<u64>,
     #[cfg(feature = "db")]
     /// Optional sharded database pool for exact shard routing.
     pub sharded_pool: Option<crate::shard::ShardedDbPool>,
@@ -1663,6 +1674,7 @@ impl Default for WorkerConfig {
             poison_pill_threshold: 3,
             max_workflow_pause_duration: DEFAULT_MAX_WORKFLOW_PAUSE_DURATION,
             labels: std::collections::HashMap::new(),
+            max_workflow_history_events: None,
             #[cfg(feature = "db")]
             sharded_pool: None,
         }
@@ -1883,6 +1895,18 @@ impl WorkerConfig {
     #[must_use]
     pub fn with_labels(mut self, labels: impl IntoIterator<Item = (String, String)>) -> Self {
         self.labels.extend(labels);
+        self
+    }
+
+    /// Set the hard ceiling on workflow history events (issue #493).
+    ///
+    /// Pass `None` to disable (the default). When set, any `RUNNING` execution
+    /// that accumulates `n` or more events is terminated with
+    /// `history_ceiling_exceeded`. Must be strictly greater than
+    /// `continue_as_new_threshold` (checked at worker startup, not here).
+    #[must_use]
+    pub const fn with_max_workflow_history_events(mut self, ceiling: Option<u64>) -> Self {
+        self.max_workflow_history_events = ceiling;
         self
     }
 

--- a/autumn-harvest/src/builder.rs
+++ b/autumn-harvest/src/builder.rs
@@ -73,6 +73,11 @@ pub struct HarvestBuilder {
     /// larger than this ceiling is rejected with [`BuildError::ExecutionTimeoutExceedsCeiling`].
     /// `None` means no ceiling is enforced.
     max_workflow_execution_timeout: Option<Duration>,
+    /// Optional hard ceiling on the number of durable events a RUNNING workflow
+    /// execution may accumulate (issue #493). When a workflow's event count
+    /// reaches or exceeds this value the execution is terminated with
+    /// `WorkflowFailed` and a machine-readable reason. `None` = no ceiling.
+    max_workflow_history_events: Option<u64>,
     /// Maximum allowed byte length for an activity input payload (issue #252).
     /// Default: 2 MiB.
     max_activity_input_bytes: u64,
@@ -118,6 +123,7 @@ impl Default for HarvestBuilder {
             payload_codecs: crate::payload_codec::PayloadCodecs::default(),
             history_policy: crate::context::WorkflowHistoryPolicy::default(),
             max_workflow_execution_timeout: None,
+            max_workflow_history_events: None,
             max_activity_input_bytes: DEFAULT_MAX_ACTIVITY_INPUT_BYTES,
             max_activity_result_bytes: DEFAULT_MAX_ACTIVITY_RESULT_BYTES,
             max_signal_payload_bytes: DEFAULT_MAX_SIGNAL_PAYLOAD_BYTES,
@@ -154,6 +160,10 @@ impl std::fmt::Debug for HarvestBuilder {
                 "max_workflow_execution_timeout",
                 &self.max_workflow_execution_timeout,
             )
+            .field(
+                "max_workflow_history_events",
+                &self.max_workflow_history_events,
+            )
             .field("max_activity_input_bytes", &self.max_activity_input_bytes)
             .field("max_activity_result_bytes", &self.max_activity_result_bytes)
             .field("max_signal_payload_bytes", &self.max_signal_payload_bytes)
@@ -187,6 +197,8 @@ pub struct BuiltHarvest {
     history_policy: WorkflowHistoryPolicy,
     /// Server-side ceiling on `execution_timeout` (issue #243). `None` = no ceiling.
     pub max_workflow_execution_timeout: Option<Duration>,
+    /// Hard ceiling on durable event count per execution (issue #493). `None` = no ceiling.
+    pub max_workflow_history_events: Option<u64>,
     /// Maximum allowed byte length for an activity input payload (issue #252).
     /// Default: 2 MiB.
     pub max_activity_input_bytes: u64,
@@ -231,6 +243,10 @@ impl std::fmt::Debug for BuiltHarvest {
             .field(
                 "max_workflow_execution_timeout",
                 &self.max_workflow_execution_timeout,
+            )
+            .field(
+                "max_workflow_history_events",
+                &self.max_workflow_history_events,
             )
             .field("max_activity_input_bytes", &self.max_activity_input_bytes)
             .field("max_activity_result_bytes", &self.max_activity_result_bytes)
@@ -451,6 +467,24 @@ pub enum HarvestBuilderError {
         role: &'static str,
         /// All workflow names currently registered on the builder.
         registered: Vec<String>,
+    },
+
+    /// `max_workflow_history_events` is set but is not strictly greater than
+    /// the configured soft `continue_as_new_threshold`.
+    ///
+    /// The hard ceiling must always be higher than the advisory threshold so a
+    /// workflow that crosses the soft line gets a chance to rotate via
+    /// `continue_as_new` before the ceiling terminates it.
+    #[error(
+        "max_workflow_history_events ({ceiling}) must be strictly greater than \
+         history_continue_as_new_threshold ({threshold}); \
+         raise the ceiling or lower the soft threshold"
+    )]
+    HistoryCeilingBelowSoftThreshold {
+        /// The configured hard ceiling.
+        ceiling: u64,
+        /// The configured soft continue-as-new threshold.
+        threshold: u64,
     },
 }
 
@@ -871,6 +905,24 @@ impl HarvestBuilder {
         self
     }
 
+    /// Set a server-side hard ceiling on the number of durable events a RUNNING
+    /// workflow execution may accumulate (issue #493).
+    ///
+    /// When set, the background timeout scanner terminates any execution whose
+    /// recorded event count reaches or exceeds `ceiling` with `WorkflowFailed`
+    /// and a machine-readable error reason of the form
+    /// `"history_ceiling_exceeded: event count {n} >= ceiling {c}"`.
+    ///
+    /// `None` (the default) means no ceiling is enforced.
+    ///
+    /// The ceiling MUST be strictly greater than `history_continue_as_new_threshold`
+    /// (default 10,000). A misconfiguration is caught by [`Self::try_build`].
+    #[must_use]
+    pub const fn max_workflow_history_events(mut self, ceiling: Option<u64>) -> Self {
+        self.max_workflow_history_events = ceiling;
+        self
+    }
+
     /// Set a server-side ceiling on `execution_timeout` for all workflows (issue #243).
     ///
     /// When set, any `start_workflow` call that provides an `execution_timeout`
@@ -1066,6 +1118,16 @@ impl HarvestBuilder {
         validate_dag_schedules(&self.dags)?;
         validate_rate_limit_keys(&self.activities)?;
 
+        if let Some(ceiling) = self.max_workflow_history_events {
+            let threshold = self.history_policy.continue_as_new_threshold();
+            if ceiling <= threshold {
+                return Err(HarvestBuilderError::HistoryCeilingBelowSoftThreshold {
+                    ceiling,
+                    threshold,
+                });
+            }
+        }
+
         let mut worker_config = self.worker_config;
         let max_workflow_start_delay = self
             .max_workflow_start_delay
@@ -1092,6 +1154,7 @@ impl HarvestBuilder {
             payload_codecs: self.payload_codecs.clone(),
             history_policy: self.history_policy,
             max_workflow_execution_timeout: self.max_workflow_execution_timeout,
+            max_workflow_history_events: self.max_workflow_history_events,
             max_activity_input_bytes: self.max_activity_input_bytes,
             max_activity_result_bytes: self.max_activity_result_bytes,
             max_signal_payload_bytes: self.max_signal_payload_bytes,
@@ -2792,6 +2855,116 @@ mod tests {
                 }) if workflow_name == "unknown_target" && role == "target"
             ),
             "Expected UnknownCompletionTriggerWorkflow error for target, got: {result:?}"
+        );
+    }
+
+    // --- AC3 / AC5 / AC6: max_workflow_history_events builder tests (issue #493) ---
+
+    #[test]
+    fn builder_max_workflow_history_events_defaults_to_none() {
+        let built = HarvestBuilder::new().build();
+        assert_eq!(
+            built.max_workflow_history_events, None,
+            "ceiling must default to None (no ceiling enforced)"
+        );
+    }
+
+    #[test]
+    fn builder_max_workflow_history_events_is_carried_through_build() {
+        // Default soft threshold is 10_000; ceiling must be strictly greater.
+        let built = HarvestBuilder::new()
+            .max_workflow_history_events(Some(50_000))
+            .build();
+        assert_eq!(built.max_workflow_history_events, Some(50_000));
+    }
+
+    #[test]
+    fn builder_max_workflow_history_events_none_clears_ceiling() {
+        let built = HarvestBuilder::new()
+            .max_workflow_history_events(Some(50_000))
+            .max_workflow_history_events(None)
+            .build();
+        assert_eq!(built.max_workflow_history_events, None);
+    }
+
+    #[test]
+    fn builder_max_workflow_history_events_must_be_strictly_greater_than_soft_threshold() {
+        // Default soft threshold is 10_000; a ceiling of 9_999 must fail.
+        let result = HarvestBuilder::new()
+            .max_workflow_history_events(Some(9_999))
+            .try_build();
+        assert!(
+            matches!(
+                result,
+                Err(HarvestBuilderError::HistoryCeilingBelowSoftThreshold {
+                    ceiling: 9_999,
+                    threshold: 10_000,
+                })
+            ),
+            "expected HistoryCeilingBelowSoftThreshold but got {result:?}"
+        );
+    }
+
+    #[test]
+    fn builder_max_workflow_history_events_exactly_equal_to_threshold_fails() {
+        // Ceiling == soft threshold must also fail (strictly-greater required).
+        let result = HarvestBuilder::new()
+            .max_workflow_history_events(Some(10_000))
+            .try_build();
+        assert!(
+            matches!(
+                result,
+                Err(HarvestBuilderError::HistoryCeilingBelowSoftThreshold {
+                    ceiling: 10_000,
+                    threshold: 10_000,
+                })
+            ),
+            "expected HistoryCeilingBelowSoftThreshold for equal values but got {result:?}"
+        );
+    }
+
+    #[test]
+    fn builder_max_workflow_history_events_error_message_is_informative() {
+        let err = HarvestBuilder::new()
+            .max_workflow_history_events(Some(5_000))
+            .try_build()
+            .unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("5000"),
+            "error message should contain ceiling: {msg}"
+        );
+        assert!(
+            msg.contains("10000"),
+            "error message should contain threshold: {msg}"
+        );
+    }
+
+    #[test]
+    fn builder_ceiling_above_custom_soft_threshold_passes() {
+        // With a custom soft threshold of 500, a ceiling of 501 must succeed.
+        let built = HarvestBuilder::new()
+            .history_continue_as_new_threshold(500)
+            .max_workflow_history_events(Some(501))
+            .build();
+        assert_eq!(built.max_workflow_history_events, Some(501));
+    }
+
+    #[test]
+    fn builder_ceiling_equal_to_custom_soft_threshold_fails() {
+        let result = HarvestBuilder::new()
+            .history_continue_as_new_threshold(500)
+            .max_workflow_history_events(Some(500))
+            .try_build();
+        assert!(
+            matches!(
+                result,
+                Err(HarvestBuilderError::HistoryCeilingBelowSoftThreshold {
+                    ceiling: 500,
+                    threshold: 500,
+                })
+            ),
+            "expected failure when ceiling == custom threshold, got {result:?}"
         );
     }
 }

--- a/autumn-harvest/src/metrics_rs_adapter.rs
+++ b/autumn-harvest/src/metrics_rs_adapter.rs
@@ -58,9 +58,10 @@ use crate::telemetry::{
     METRIC_SCHEDULE_FIRE_ATTEMPTS, METRIC_SCHEDULE_MANUAL_TRIGGER, METRIC_SCHEDULE_RUNS,
     METRIC_SCHEDULE_SKIPPED, METRIC_TASK_QUARANTINED, METRIC_TIMER_DURATION, METRIC_TIMER_STARTED,
     METRIC_WORKFLOW_CACHE_HIT, METRIC_WORKFLOW_CACHE_MISS, METRIC_WORKFLOW_CONTINUE_AS_NEW,
-    METRIC_WORKFLOW_DURATION, METRIC_WORKFLOW_HISTORY_SIZE, METRIC_WORKFLOW_NON_DETERMINISM,
-    METRIC_WORKFLOW_PAUSE_DURATION, METRIC_WORKFLOW_PAUSED, METRIC_WORKFLOW_SLA_BREACHED,
-    METRIC_WORKFLOW_STARTED, METRIC_WORKFLOW_TERMINAL, MetricsRecorder, WorkflowStatus,
+    METRIC_WORKFLOW_DURATION, METRIC_WORKFLOW_HISTORY_OVERSIZED, METRIC_WORKFLOW_HISTORY_SIZE,
+    METRIC_WORKFLOW_NON_DETERMINISM, METRIC_WORKFLOW_PAUSE_DURATION, METRIC_WORKFLOW_PAUSED,
+    METRIC_WORKFLOW_SLA_BREACHED, METRIC_WORKFLOW_STARTED, METRIC_WORKFLOW_TERMINAL,
+    MetricsRecorder, WorkflowStatus,
 };
 
 /// [`MetricsRecorder`] implementation that forwards every sample to the
@@ -455,6 +456,15 @@ impl MetricsRecorder for MetricsRsRecorder {
     #[allow(clippy::cast_precision_loss)]
     fn record_admission_gates_active(&self, count: i64) {
         gauge!(METRIC_ADMISSION_GATES_ACTIVE).set(count as f64);
+    }
+
+    #[allow(clippy::cast_precision_loss)]
+    fn record_workflow_history_oversized(&self, workflow_name: &str, count: u64) {
+        gauge!(
+            METRIC_WORKFLOW_HISTORY_OVERSIZED,
+            METRIC_LABEL_WORKFLOW => workflow_name.to_owned(),
+        )
+        .set(count as f64);
     }
 }
 

--- a/autumn-harvest/src/telemetry.rs
+++ b/autumn-harvest/src/telemetry.rs
@@ -317,6 +317,20 @@ pub const METRIC_SCHEDULE_FIRE_ATTEMPTS: &str = "harvest.schedule.fire_attempts"
 /// window. Each auto-pause event means operator action is required to resume.
 pub const METRIC_SCHEDULE_AUTO_PAUSED: &str = "harvest.schedule.auto_paused";
 
+/// Gauge: count of *in-flight* (RUNNING/SUSPENDED) executions whose durable
+/// event history has grown past the configured soft
+/// `continue_as_new_threshold` (issue #493).
+///
+/// Labeled by `workflow` (workflow type name). `execution.id` MUST NOT appear
+/// here (ADR-0001 §7 cardinality rule).
+///
+/// Sampled on the same cadence as `harvest.queue.depth` (the
+/// `spawn_queue_depth_sampler` interval). A non-zero value means at least one
+/// in-flight workflow is accumulating history faster than its author drains it
+/// via `continue_as_new`. Alert on sustained non-zero values so the operator
+/// can nudge the author or enable `max_workflow_history_events`.
+pub const METRIC_WORKFLOW_HISTORY_OVERSIZED: &str = "harvest.workflow.history_oversized";
+
 // ---------------------------------------------------------------------------
 // Metric label key constants
 // Used by MetricsRecorder implementations to avoid string literals at call
@@ -677,6 +691,21 @@ pub trait MetricsRecorder: Send + Sync {
     /// A workflow replay non-determinism (divergence) failure was detected.
     fn record_workflow_non_determinism(&self, workflow_name: &str, build_id: &str) {
         let _ = (workflow_name, build_id);
+    }
+
+    /// Gauge snapshot: `count` in-flight executions for `workflow_name` whose
+    /// durable event count exceeds the configured soft continue-as-new
+    /// threshold (issue #493).
+    ///
+    /// Callers emit one call per distinct workflow name per sampler tick so
+    /// the gauge resets cleanly when oversized executions drain. A `count` of
+    /// `0` should be emitted for known workflow names once the oversized count
+    /// drops to zero so the gauge falls back to zero rather than going stale.
+    ///
+    /// Maps to [`METRIC_WORKFLOW_HISTORY_OVERSIZED`].
+    /// Per ADR-0001 §7, `execution.id` must never be a label here.
+    fn record_workflow_history_oversized(&self, workflow_name: &str, count: u64) {
+        let _ = (workflow_name, count);
     }
 
     /// An activity invocation finished.

--- a/autumn-harvest/src/timeout.rs
+++ b/autumn-harvest/src/timeout.rs
@@ -1667,6 +1667,8 @@ pub async fn enforce_workflow_history_ceiling(
         #[diesel(sql_type = SqlUuid)]
         id: uuid::Uuid,
         #[diesel(sql_type = Text)]
+        workflow_id: String,
+        #[diesel(sql_type = Text)]
         workflow_name: String,
         #[diesel(sql_type = Text)]
         queue_name: String,
@@ -1680,7 +1682,7 @@ pub async fn enforce_workflow_history_ceiling(
 
     let ceiling_i64 = i64::try_from(ceiling).unwrap_or(i64::MAX);
     let oversized: Vec<OversizedRow> = diesel::sql_query(
-        "SELECT id, workflow_name, queue_name, parent_id, parent_close_policy, \
+        "SELECT id, workflow_id, workflow_name, queue_name, parent_id, parent_close_policy, \
          (SELECT COUNT(*) FROM harvest_events WHERE workflow_exec_id = harvest_workflow_executions.id)::bigint AS event_count \
          FROM harvest_workflow_executions \
          WHERE state = 'RUNNING' \
@@ -1809,6 +1811,17 @@ pub async fn enforce_workflow_history_ceiling(
             &queue_name,
             crate::telemetry::WorkflowStatus::Failed,
         );
+
+        // Best-effort: count ceiling failures toward the schedule auto-pause threshold.
+        // Called after the transaction commits so a counter query failure cannot
+        // roll back the terminal transition.
+        crate::scheduler::maybe_increment_schedule_failure_counter(
+            conn,
+            &row.workflow_id,
+            &workflow_name,
+            metrics,
+        )
+        .await;
     }
 
     Ok(count)

--- a/autumn-harvest/src/timeout.rs
+++ b/autumn-harvest/src/timeout.rs
@@ -1652,6 +1652,7 @@ pub fn spawn_timeout_checker(
 ///
 /// Returns the first database or persistence error encountered.
 #[cfg(feature = "db")]
+#[allow(clippy::too_many_lines)]
 pub async fn enforce_workflow_history_ceiling(
     conn: &mut AsyncPgConnection,
     ceiling: u64,
@@ -1660,8 +1661,7 @@ pub async fn enforce_workflow_history_ceiling(
     use diesel::sql_types::{BigInt, Nullable, Text, Uuid as SqlUuid};
 
     // Find RUNNING executions whose recorded event count >= ceiling.
-    // We use a raw SQL query so that the correlated subquery is passed to
-    // Postgres rather than being emulated in Rust.
+    // The event_count is selected inline to avoid an N+1 query pattern.
     #[derive(diesel::QueryableByName)]
     struct OversizedRow {
         #[diesel(sql_type = SqlUuid)]
@@ -1674,15 +1674,19 @@ pub async fn enforce_workflow_history_ceiling(
         parent_id: Option<uuid::Uuid>,
         #[diesel(sql_type = Nullable<Text>)]
         parent_close_policy: Option<String>,
+        #[diesel(sql_type = BigInt)]
+        event_count: i64,
     }
 
+    let ceiling_i64 = i64::try_from(ceiling).unwrap_or(i64::MAX);
     let oversized: Vec<OversizedRow> = diesel::sql_query(
-        "SELECT id, workflow_name, queue_name, parent_id, parent_close_policy \
+        "SELECT id, workflow_name, queue_name, parent_id, parent_close_policy, \
+         (SELECT COUNT(*) FROM harvest_events WHERE workflow_exec_id = harvest_workflow_executions.id)::bigint AS event_count \
          FROM harvest_workflow_executions \
          WHERE state = 'RUNNING' \
          AND (SELECT COUNT(*) FROM harvest_events WHERE workflow_exec_id = harvest_workflow_executions.id) >= $1",
     )
-    .bind::<BigInt, _>(ceiling as i64)
+    .bind::<BigInt, _>(ceiling_i64)
     .load(conn)
     .await
     .map_err(crate::error::database_error)?;
@@ -1691,16 +1695,7 @@ pub async fn enforce_workflow_history_ceiling(
 
     for row in &oversized {
         let exec_id = execution_id_from_uuid(row.id);
-        // Derive the event count for the error message (best-effort; may have
-        // grown by the time we record it, but accuracy is not critical here).
-        let event_count: i64 = diesel::sql_query(
-            "SELECT COUNT(*)::bigint AS count FROM harvest_events WHERE workflow_exec_id = $1",
-        )
-        .bind::<SqlUuid, _>(row.id)
-        .get_result::<EventCount>(conn)
-        .await
-        .map(|r| r.count)
-        .unwrap_or(ceiling as i64);
+        let event_count = row.event_count;
 
         let error_msg =
             format!("history_ceiling_exceeded: event count {event_count} >= ceiling {ceiling}");
@@ -1716,8 +1711,8 @@ pub async fn enforce_workflow_history_ceiling(
         let workflow_name = row.workflow_name.clone();
         let queue_name = row.queue_name.clone();
 
-        let applied = conn
-            .transaction::<bool, HarvestError, _>(|conn| {
+        let (applied, deferred_starts) = conn
+            .transaction::<(bool, Vec<crate::completion_trigger::DeferredTriggerStart>), HarvestError, _>(|conn| {
                 let fail_event = fail_event.clone();
                 let error_msg = error_msg.clone();
                 async move {
@@ -1733,7 +1728,7 @@ pub async fn enforce_workflow_history_ceiling(
                         .map_err(crate::error::database_error)?;
 
                     if current_state.as_deref() != Some("RUNNING") {
-                        return Ok(false);
+                        return Ok((false, Vec::new()));
                     }
 
                     store::append_single_event(conn, exec_id, fail_event).await?;
@@ -1779,9 +1774,16 @@ pub async fn enforce_workflow_history_ceiling(
                         .await?;
                     }
 
-                    apply_parent_close_cascade(conn, exec_id).await?;
-
-                    Ok(true)
+                    let mut deferred = apply_parent_close_cascade(conn, exec_id).await?;
+                    let triggers = crate::completion_trigger::evaluate_triggers_for_execution(
+                        conn,
+                        exec_id,
+                        crate::completion_trigger::TerminalState::Failed,
+                        Some(metrics),
+                    )
+                    .await?;
+                    deferred.extend(triggers);
+                    Ok((true, deferred))
                 }
                 .scope_boxed()
             })
@@ -1789,6 +1791,10 @@ pub async fn enforce_workflow_history_ceiling(
 
         if !applied {
             continue;
+        }
+
+        for start in deferred_starts {
+            start.spawn();
         }
 
         tracing::warn!(
@@ -1806,14 +1812,6 @@ pub async fn enforce_workflow_history_ceiling(
     }
 
     Ok(count)
-}
-
-/// Tiny helper for the COUNT query in `enforce_workflow_history_ceiling`.
-#[cfg(feature = "db")]
-#[derive(diesel::QueryableByName)]
-struct EventCount {
-    #[diesel(sql_type = diesel::sql_types::BigInt)]
-    count: i64,
 }
 
 // ---------------------------------------------------------------------------

--- a/autumn-harvest/src/timeout.rs
+++ b/autumn-harvest/src/timeout.rs
@@ -1491,6 +1491,7 @@ pub async fn enforce_timeouts_once(
     sharded_pool: &Option<crate::shard::ShardedDbPool>,
     shard_assignments: &[crate::types::ShardId],
     circuit_breakers: Option<&crate::circuit_breaker::CircuitBreakerRegistry>,
+    max_workflow_history_events: Option<u64>,
 ) -> HarvestResult<usize> {
     let timed_out = find_timed_out_tasks(conn).await?;
     let mut count = timed_out.len();
@@ -1562,6 +1563,9 @@ pub async fn enforce_timeouts_once(
         shard_assignments,
     )
     .await?;
+    if let Some(ceiling) = max_workflow_history_events {
+        count += enforce_workflow_history_ceiling(conn, ceiling, metrics).await?;
+    }
     Ok(count)
 }
 
@@ -1582,6 +1586,7 @@ pub fn spawn_timeout_checker(
     sharded_pool: Option<crate::shard::ShardedDbPool>,
     shard_assignments: Vec<crate::types::ShardId>,
     circuit_breakers: std::sync::Arc<crate::circuit_breaker::CircuitBreakerRegistry>,
+    max_workflow_history_events: Option<u64>,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
         loop {
@@ -1603,6 +1608,7 @@ pub fn spawn_timeout_checker(
                     &sharded_pool,
                     &shard_assignments,
                     Some(&circuit_breakers),
+                    max_workflow_history_events,
                 )
                 .await
                 {
@@ -1624,6 +1630,193 @@ pub fn spawn_timeout_checker(
             }
         }
     })
+}
+
+/// Terminate RUNNING workflow executions whose durable event count has reached
+/// or exceeded the operator-configured hard ceiling (issue #493).
+///
+/// The ceiling is set via `HarvestBuilder::max_workflow_history_events`.  No
+/// new `WorkflowEvent` variant is introduced: each affected execution receives
+/// an ordinary `WorkflowFailed` event with a machine-readable error string of
+/// the form `"history_ceiling_exceeded: event count {n} >= ceiling {c}"`, and
+/// its state transitions to `FAILED`.  Outstanding task-queue rows are
+/// cancelled and any awaiting parent is notified.
+///
+/// Idempotency: the inner transaction re-checks `state = 'RUNNING'` under a
+/// `FOR UPDATE` lock, so a concurrent completion or a duplicate scanner tick
+/// can never double-append the failure event.
+///
+/// Returns the number of executions that were terminated.
+///
+/// # Errors
+///
+/// Returns the first database or persistence error encountered.
+#[cfg(feature = "db")]
+pub async fn enforce_workflow_history_ceiling(
+    conn: &mut AsyncPgConnection,
+    ceiling: u64,
+    metrics: &(dyn MetricsRecorder + Send + Sync),
+) -> HarvestResult<usize> {
+    use diesel::sql_types::{BigInt, Nullable, Text, Uuid as SqlUuid};
+
+    // Find RUNNING executions whose recorded event count >= ceiling.
+    // We use a raw SQL query so that the correlated subquery is passed to
+    // Postgres rather than being emulated in Rust.
+    #[derive(diesel::QueryableByName)]
+    struct OversizedRow {
+        #[diesel(sql_type = SqlUuid)]
+        id: uuid::Uuid,
+        #[diesel(sql_type = Text)]
+        workflow_name: String,
+        #[diesel(sql_type = Text)]
+        queue_name: String,
+        #[diesel(sql_type = Nullable<SqlUuid>)]
+        parent_id: Option<uuid::Uuid>,
+        #[diesel(sql_type = Nullable<Text>)]
+        parent_close_policy: Option<String>,
+    }
+
+    let oversized: Vec<OversizedRow> = diesel::sql_query(
+        "SELECT id, workflow_name, queue_name, parent_id, parent_close_policy \
+         FROM harvest_workflow_executions \
+         WHERE state = 'RUNNING' \
+         AND (SELECT COUNT(*) FROM harvest_events WHERE workflow_exec_id = harvest_workflow_executions.id) >= $1",
+    )
+    .bind::<BigInt, _>(ceiling as i64)
+    .load(conn)
+    .await
+    .map_err(crate::error::database_error)?;
+
+    let count = oversized.len();
+
+    for row in &oversized {
+        let exec_id = execution_id_from_uuid(row.id);
+        // Derive the event count for the error message (best-effort; may have
+        // grown by the time we record it, but accuracy is not critical here).
+        let event_count: i64 = diesel::sql_query(
+            "SELECT COUNT(*)::bigint AS count FROM harvest_events WHERE workflow_exec_id = $1",
+        )
+        .bind::<SqlUuid, _>(row.id)
+        .get_result::<EventCount>(conn)
+        .await
+        .map(|r| r.count)
+        .unwrap_or(ceiling as i64);
+
+        let error_msg = format!(
+            "history_ceiling_exceeded: event count {event_count} >= ceiling {ceiling}"
+        );
+        let fail_event = WorkflowEvent::WorkflowFailed {
+            error: error_msg.clone(),
+        };
+
+        let parent_uuid = if row.parent_close_policy.is_none() {
+            row.parent_id
+        } else {
+            None
+        };
+        let workflow_name = row.workflow_name.clone();
+        let queue_name = row.queue_name.clone();
+
+        let applied = conn
+            .transaction::<bool, HarvestError, _>(|conn| {
+                let fail_event = fail_event.clone();
+                let error_msg = error_msg.clone();
+                async move {
+                    // Re-check state under FOR UPDATE to guard against concurrent
+                    // completion or a duplicate scanner tick.
+                    let current_state: Option<String> = harvest_workflow_executions::table
+                        .find(row.id)
+                        .for_update()
+                        .select(harvest_workflow_executions::state)
+                        .first(conn)
+                        .await
+                        .optional()
+                        .map_err(crate::error::database_error)?;
+
+                    if current_state.as_deref() != Some("RUNNING") {
+                        return Ok(false);
+                    }
+
+                    store::append_single_event(conn, exec_id, fail_event).await?;
+
+                    // Transition to FAILED state.
+                    diesel::update(
+                        harvest_workflow_executions::table.find(row.id),
+                    )
+                    .set((
+                        harvest_workflow_executions::state.eq("FAILED"),
+                        harvest_workflow_executions::output.eq(None::<serde_json::Value>),
+                        harvest_workflow_executions::error.eq(Some(error_msg.clone())),
+                        harvest_workflow_executions::completed_at.eq(Some(Utc::now())),
+                    ))
+                    .execute(conn)
+                    .await
+                    .map_err(crate::error::database_error)?;
+
+                    // Cancel outstanding task queue rows.
+                    diesel::update(
+                        harvest_task_queue::table
+                            .filter(harvest_task_queue::workflow_exec_id.eq(row.id))
+                            .filter(
+                                harvest_task_queue::state
+                                    .eq("PENDING")
+                                    .or(harvest_task_queue::state.eq("RUNNING")),
+                            ),
+                    )
+                    .set((
+                        harvest_task_queue::state.eq("FAILED"),
+                        harvest_task_queue::error.eq(Some(&error_msg)),
+                        harvest_task_queue::completed_at.eq(Some(Utc::now())),
+                    ))
+                    .execute(conn)
+                    .await
+                    .map_err(crate::error::database_error)?;
+
+                    if let Some(parent_uuid) = parent_uuid {
+                        wake_parent_for_child_timeout(
+                            conn,
+                            execution_id_from_uuid(parent_uuid),
+                            exec_id,
+                            &error_msg,
+                        )
+                        .await?;
+                    }
+
+                    apply_parent_close_cascade(conn, exec_id).await?;
+
+                    Ok(true)
+                }
+                .scope_boxed()
+            })
+            .await?;
+
+        if !applied {
+            continue;
+        }
+
+        tracing::warn!(
+            exec_id = %exec_id,
+            workflow_name = %workflow_name,
+            ceiling = ceiling,
+            "workflow execution terminated: history ceiling exceeded"
+        );
+
+        metrics.record_workflow_terminal(
+            &workflow_name,
+            &queue_name,
+            crate::telemetry::WorkflowStatus::Failed,
+        );
+    }
+
+    Ok(count)
+}
+
+/// Tiny helper for the COUNT query in `enforce_workflow_history_ceiling`.
+#[cfg(feature = "db")]
+#[derive(diesel::QueryableByName)]
+struct EventCount {
+    #[diesel(sql_type = diesel::sql_types::BigInt)]
+    count: i64,
 }
 
 // ---------------------------------------------------------------------------

--- a/autumn-harvest/src/timeout.rs
+++ b/autumn-harvest/src/timeout.rs
@@ -1702,9 +1702,8 @@ pub async fn enforce_workflow_history_ceiling(
         .map(|r| r.count)
         .unwrap_or(ceiling as i64);
 
-        let error_msg = format!(
-            "history_ceiling_exceeded: event count {event_count} >= ceiling {ceiling}"
-        );
+        let error_msg =
+            format!("history_ceiling_exceeded: event count {event_count} >= ceiling {ceiling}");
         let fail_event = WorkflowEvent::WorkflowFailed {
             error: error_msg.clone(),
         };
@@ -1740,18 +1739,16 @@ pub async fn enforce_workflow_history_ceiling(
                     store::append_single_event(conn, exec_id, fail_event).await?;
 
                     // Transition to FAILED state.
-                    diesel::update(
-                        harvest_workflow_executions::table.find(row.id),
-                    )
-                    .set((
-                        harvest_workflow_executions::state.eq("FAILED"),
-                        harvest_workflow_executions::output.eq(None::<serde_json::Value>),
-                        harvest_workflow_executions::error.eq(Some(error_msg.clone())),
-                        harvest_workflow_executions::completed_at.eq(Some(Utc::now())),
-                    ))
-                    .execute(conn)
-                    .await
-                    .map_err(crate::error::database_error)?;
+                    diesel::update(harvest_workflow_executions::table.find(row.id))
+                        .set((
+                            harvest_workflow_executions::state.eq("FAILED"),
+                            harvest_workflow_executions::output.eq(None::<serde_json::Value>),
+                            harvest_workflow_executions::error.eq(Some(error_msg.clone())),
+                            harvest_workflow_executions::completed_at.eq(Some(Utc::now())),
+                        ))
+                        .execute(conn)
+                        .await
+                        .map_err(crate::error::database_error)?;
 
                     // Cancel outstanding task queue rows.
                     diesel::update(

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -7842,6 +7842,7 @@ mod tests {
             poison_pill_threshold: 3,
             max_workflow_pause_duration: Duration::from_secs(24 * 3600),
             labels: std::collections::HashMap::new(),
+            max_workflow_history_events: None,
             #[cfg(feature = "db")]
             sharded_pool: None,
         };

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -6926,6 +6926,20 @@ impl Worker {
     pub fn new(config: WorkerRuntimeConfig, registry: Arc<HandlerRegistry>) -> HarvestResult<Self> {
         config.validate()?;
 
+        // Validate the history ceiling against the soft threshold from the registry.
+        // HarvestBuilder already enforces this, but WorkerConfig can set the ceiling
+        // directly without going through the builder, so we re-check here where the
+        // registry (and thus the actual threshold) is available.
+        if let Some(ceiling) = config.max_workflow_history_events {
+            let threshold = registry.history_policy().continue_as_new_threshold();
+            if ceiling <= threshold {
+                return Err(HarvestError::Config(format!(
+                    "max_workflow_history_events ({ceiling}) must be strictly greater than \
+                     continue_as_new_threshold ({threshold})"
+                )));
+            }
+        }
+
         let mut ineligible_activities = Vec::new();
         for activity in registry.activities.values() {
             if let Some(requires) = activity.requires {
@@ -7934,6 +7948,41 @@ mod tests {
         let registry = Arc::new(HandlerRegistry::new(vec![], vec![]));
         let worker = Worker::new(cfg, registry);
         assert!(worker.is_ok());
+    }
+
+    #[test]
+    fn worker_rejects_history_ceiling_at_or_below_soft_threshold() {
+        // Default soft threshold is 10_000; ceiling must be strictly greater.
+        let threshold = HandlerRegistry::new(vec![], vec![])
+            .history_policy()
+            .continue_as_new_threshold();
+
+        for bad_ceiling in [0u64, 1, threshold.saturating_sub(1), threshold] {
+            let cfg = WorkerRuntimeConfig {
+                max_workflow_history_events: Some(bad_ceiling),
+                ..default_runtime_config()
+            };
+            let registry = Arc::new(HandlerRegistry::new(vec![], vec![]));
+            let err = Worker::new(cfg, registry).unwrap_err();
+            assert!(
+                err.to_string().contains("max_workflow_history_events"),
+                "ceiling {bad_ceiling}: expected config error, got: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn worker_accepts_history_ceiling_above_soft_threshold() {
+        let threshold = HandlerRegistry::new(vec![], vec![])
+            .history_policy()
+            .continue_as_new_threshold();
+
+        let cfg = WorkerRuntimeConfig {
+            max_workflow_history_events: Some(threshold + 1),
+            ..default_runtime_config()
+        };
+        let registry = Arc::new(HandlerRegistry::new(vec![], vec![]));
+        assert!(Worker::new(cfg, registry).is_ok());
     }
 
     #[test]

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -178,7 +178,7 @@ impl From<WorkerConfig> for WorkerRuntimeConfig {
             labels: cfg.labels,
             #[cfg(feature = "db")]
             sharded_pool: cfg.sharded_pool,
-            max_workflow_history_events: None,
+            max_workflow_history_events: cfg.max_workflow_history_events,
         }
     }
 }
@@ -6831,6 +6831,7 @@ fn spawn_history_oversized_sampler(
     interval: Duration,
 ) -> tokio::task::JoinHandle<()> {
     tokio::spawn(async move {
+        let mut reported_workflows = std::collections::HashSet::new();
         loop {
             tokio::select! {
                 () = cancel.cancelled() => break,
@@ -6850,11 +6851,19 @@ fn spawn_history_oversized_sampler(
 
             match sample_history_oversized_counts(&mut conn, soft_threshold).await {
                 Ok(counts) => {
+                    let mut active_workflows = std::collections::HashSet::new();
                     for (workflow_name, count) in &counts {
                         telemetry
                             .metrics
                             .record_workflow_history_oversized(workflow_name, *count);
+                        active_workflows.insert(workflow_name.clone());
                     }
+                    for workflow_name in reported_workflows.difference(&active_workflows) {
+                        telemetry
+                            .metrics
+                            .record_workflow_history_oversized(workflow_name, 0);
+                    }
+                    reported_workflows = active_workflows;
                 }
                 Err(error) => {
                     tracing::debug!(error = %error, "history oversized sample failed");
@@ -6892,14 +6901,19 @@ async fn sample_history_oversized_counts(
          AND (SELECT COUNT(*) FROM harvest_events he WHERE he.workflow_exec_id = wf.id) > $1 \
          GROUP BY wf.workflow_name",
     )
-    .bind::<diesel::sql_types::BigInt, _>(soft_threshold as i64)
+    .bind::<diesel::sql_types::BigInt, _>(i64::try_from(soft_threshold).unwrap_or(i64::MAX))
     .load(conn)
     .await
     .map_err(crate::error::database_error)?;
 
     Ok(rows
         .into_iter()
-        .map(|r| (r.workflow_name, r.oversized_count.max(0) as u64))
+        .map(|r| {
+            (
+                r.workflow_name,
+                u64::try_from(r.oversized_count.max(0)).unwrap_or(0),
+            )
+        })
         .collect())
 }
 
@@ -7659,6 +7673,7 @@ mod tests {
             unknown_target_grace_window: Duration::from_secs(5),
             poison_pill_threshold: 3,
             max_workflow_pause_duration: Duration::from_secs(24 * 3600),
+            max_workflow_history_events: None,
             labels: std::collections::HashMap::new(),
             #[cfg(feature = "db")]
             sharded_pool: None,

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -127,6 +127,8 @@ pub struct WorkerRuntimeConfig {
     #[cfg(feature = "db")]
     /// Optional sharded database pool for exact shard routing.
     pub sharded_pool: Option<crate::shard::ShardedDbPool>,
+    /// Hard ceiling on durable event count per execution (issue #493). `None` = no ceiling.
+    pub max_workflow_history_events: Option<u64>,
 }
 
 impl WorkerRuntimeConfig {
@@ -176,6 +178,7 @@ impl From<WorkerConfig> for WorkerRuntimeConfig {
             labels: cfg.labels,
             #[cfg(feature = "db")]
             sharded_pool: cfg.sharded_pool,
+            max_workflow_history_events: None,
         }
     }
 }
@@ -6760,6 +6763,7 @@ struct WorkerMonitoringHandles {
     timeout_checker: tokio::task::JoinHandle<()>,
     poison_pill_reclaimer: tokio::task::JoinHandle<()>,
     pause_auto_resumer: tokio::task::JoinHandle<()>,
+    history_oversized_sampler: tokio::task::JoinHandle<()>,
 }
 
 /// Spawn the bounded-pause auto-resume scanner (issue #383).
@@ -6809,6 +6813,94 @@ fn spawn_pause_auto_resumer(
             }
         }
     })
+}
+
+/// Periodically sample the count of in-flight (RUNNING) executions per
+/// workflow type whose history size exceeds the soft `continue_as_new`
+/// threshold and emit it as a gauge metric (issue #493, AC2).
+///
+/// A non-zero gauge value signals runaway workflow executions that are
+/// growing toward the hard ceiling and should be addressed by the author
+/// (e.g. via `ctx.should_continue_as_new()`) or by the operator (via the
+/// hard ceiling or manual continue-as-new).
+fn spawn_history_oversized_sampler(
+    pool: DbPool,
+    cancel: CancellationToken,
+    telemetry: Arc<crate::telemetry::TelemetryConfig>,
+    soft_threshold: u64,
+    interval: Duration,
+) -> tokio::task::JoinHandle<()> {
+    tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                () = cancel.cancelled() => break,
+                () = tokio::time::sleep(interval) => {}
+            }
+
+            let mut conn = match pool.get().await {
+                Ok(conn) => conn,
+                Err(error) => {
+                    tracing::debug!(
+                        error = %error,
+                        "history oversized sampler could not acquire DB connection"
+                    );
+                    continue;
+                }
+            };
+
+            match sample_history_oversized_counts(&mut conn, soft_threshold).await {
+                Ok(counts) => {
+                    for (workflow_name, count) in &counts {
+                        telemetry
+                            .metrics
+                            .record_workflow_history_oversized(workflow_name, *count);
+                    }
+                }
+                Err(error) => {
+                    tracing::debug!(error = %error, "history oversized sample failed");
+                }
+            }
+
+            if cancel.is_cancelled() {
+                break;
+            }
+        }
+    })
+}
+
+/// Query the count of RUNNING executions per workflow type that have
+/// accumulated more than `soft_threshold` events.
+///
+/// Returns `(workflow_name, count)` pairs; omits workflow types with zero
+/// oversized executions.
+async fn sample_history_oversized_counts(
+    conn: &mut diesel_async::AsyncPgConnection,
+    soft_threshold: u64,
+) -> crate::error::HarvestResult<Vec<(String, u64)>> {
+    #[derive(diesel::QueryableByName)]
+    struct Row {
+        #[diesel(sql_type = diesel::sql_types::Text)]
+        workflow_name: String,
+        #[diesel(sql_type = diesel::sql_types::BigInt)]
+        oversized_count: i64,
+    }
+
+    let rows: Vec<Row> = diesel::sql_query(
+        "SELECT wf.workflow_name, COUNT(*)::bigint AS oversized_count \
+         FROM harvest_workflow_executions wf \
+         WHERE wf.state IN ('RUNNING', 'SUSPENDED') \
+         AND (SELECT COUNT(*) FROM harvest_events he WHERE he.workflow_exec_id = wf.id) > $1 \
+         GROUP BY wf.workflow_name",
+    )
+    .bind::<diesel::sql_types::BigInt, _>(soft_threshold as i64)
+    .load(conn)
+    .await
+    .map_err(crate::error::database_error)?;
+
+    Ok(rows
+        .into_iter()
+        .map(|r| (r.workflow_name, r.oversized_count.max(0) as u64))
+        .collect())
 }
 
 impl Worker {
@@ -6996,6 +7088,7 @@ impl Worker {
             self.config.sharded_pool.clone(),
             self.config.shard_assignments.clone(),
             self.registry.circuit_breakers(),
+            self.config.max_workflow_history_events,
         );
         // Worker-stale threshold mirrors the fleet-health classifier:
         // 2 × heartbeat interval, with a 1 s floor for sub-second intervals.
@@ -7026,6 +7119,13 @@ impl Worker {
             self.config.max_workflow_pause_duration,
             self.registry.telemetry().clone(),
         );
+        let history_oversized_sampler = spawn_history_oversized_sampler(
+            pool.clone(),
+            self.shutdown.clone(),
+            self.registry.telemetry().clone(),
+            self.registry.history_policy().continue_as_new_threshold(),
+            self.config.poll_interval,
+        );
 
         WorkerMonitoringHandles {
             queue_depth_sampler,
@@ -7035,6 +7135,7 @@ impl Worker {
             timeout_checker,
             poison_pill_reclaimer,
             pause_auto_resumer,
+            history_oversized_sampler,
         }
     }
 
@@ -7178,6 +7279,13 @@ impl Worker {
                     "dlq depth sampler failed during shutdown"
                 );
             }
+        }
+        if let Err(error) = monitors.history_oversized_sampler.await {
+            tracing::warn!(
+                worker_id = %self.config.worker_id,
+                error = %error,
+                "history oversized sampler failed during shutdown"
+            );
         }
     }
 

--- a/autumn-harvest/tests/cancellation_tests.rs
+++ b/autumn-harvest/tests/cancellation_tests.rs
@@ -491,6 +491,7 @@ async fn signal_insert_waits_for_concurrent_cancellation_lock() {
     );
 }
 
+#[allow(clippy::too_many_lines)]
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
 async fn running_activity_heartbeat_observes_workflow_cancellation() {
     let (database_url, _container) = setup_test_database_url().await;
@@ -523,6 +524,7 @@ async fn running_activity_heartbeat_observes_workflow_cancellation() {
                 poison_pill_threshold: 3,
                 labels: std::collections::HashMap::new(),
                 max_workflow_pause_duration: std::time::Duration::from_secs(24 * 3600),
+                max_workflow_history_events: None,
                 sharded_pool: None,
             },
             registry,
@@ -727,6 +729,7 @@ async fn uncooperative_activity_is_hard_aborted_after_grace_period() {
                 poison_pill_threshold: 3,
                 labels: std::collections::HashMap::new(),
                 max_workflow_pause_duration: std::time::Duration::from_secs(24 * 3600),
+                max_workflow_history_events: None,
                 sharded_pool: None,
             },
             registry,
@@ -875,6 +878,7 @@ async fn activity_exits_early_on_workflow_cancellation() {
                 poison_pill_threshold: 3,
                 labels: std::collections::HashMap::new(),
                 max_workflow_pause_duration: std::time::Duration::from_secs(24 * 3600),
+                max_workflow_history_events: None,
                 sharded_pool: None,
             },
             registry,
@@ -1018,6 +1022,7 @@ async fn activity_without_cancellation_check_completes_normally() {
                 poison_pill_threshold: 3,
                 labels: std::collections::HashMap::new(),
                 max_workflow_pause_duration: std::time::Duration::from_secs(24 * 3600),
+                max_workflow_history_events: None,
                 sharded_pool: None,
             },
             registry,

--- a/autumn-harvest/tests/child_policy_tests.rs
+++ b/autumn-harvest/tests/child_policy_tests.rs
@@ -150,6 +150,7 @@ fn make_worker(registry: Arc<HandlerRegistry>) -> Worker {
             max_workflow_pause_duration: std::time::Duration::from_secs(24 * 3600),
             #[cfg(feature = "db")]
             labels: std::collections::HashMap::new(),
+            max_workflow_history_events: None,
             sharded_pool: None,
         },
         registry,
@@ -1265,6 +1266,7 @@ async fn workflow_task_timeout_cascades_detached_children() {
         Duration::from_secs(5),
         &sharded_pool,
         &[ShardId::new(0)],
+        None,
         None,
     )
     .await

--- a/autumn-harvest/tests/delayed_start_tests.rs
+++ b/autumn-harvest/tests/delayed_start_tests.rs
@@ -309,6 +309,7 @@ async fn test_delayed_start_no_premature_dispatch() {
                 poison_pill_threshold: 3,
                 labels: std::collections::HashMap::new(),
                 max_workflow_pause_duration: std::time::Duration::from_secs(24 * 3600),
+                max_workflow_history_events: None,
                 sharded_pool: None,
             },
             registry,

--- a/autumn-harvest/tests/integration_e2e.rs
+++ b/autumn-harvest/tests/integration_e2e.rs
@@ -742,6 +742,7 @@ fn build_runtime_worker(
                 poison_pill_threshold: 3,
                 labels: std::collections::HashMap::new(),
                 max_workflow_pause_duration: std::time::Duration::from_secs(24 * 3600),
+                max_workflow_history_events: None,
                 sharded_pool: None,
             },
             registry,
@@ -1355,6 +1356,7 @@ async fn worker_completes_workflow_task_and_persists_result() {
                 poison_pill_threshold: 3,
                 labels: std::collections::HashMap::new(),
                 max_workflow_pause_duration: std::time::Duration::from_secs(24 * 3600),
+                max_workflow_history_events: None,
                 sharded_pool: None,
             },
             registry,
@@ -1473,6 +1475,7 @@ async fn worker_marks_workflow_failed_when_handler_errors() {
                 poison_pill_threshold: 3,
                 labels: std::collections::HashMap::new(),
                 max_workflow_pause_duration: std::time::Duration::from_secs(24 * 3600),
+                max_workflow_history_events: None,
                 sharded_pool: None,
             },
             registry,
@@ -1624,6 +1627,7 @@ async fn worker_completes_workflow_with_activity_round_trip() {
                 poison_pill_threshold: 3,
                 labels: std::collections::HashMap::new(),
                 max_workflow_pause_duration: std::time::Duration::from_secs(24 * 3600),
+                max_workflow_history_events: None,
                 sharded_pool: None,
             },
             registry,
@@ -1838,6 +1842,7 @@ async fn worker_fails_orphaned_activity_task_without_scheduled_event() {
                 poison_pill_threshold: 3,
                 labels: std::collections::HashMap::new(),
                 max_workflow_pause_duration: std::time::Duration::from_secs(24 * 3600),
+                max_workflow_history_events: None,
                 sharded_pool: None,
             },
             Arc::new(HandlerRegistry::new(
@@ -1997,6 +2002,7 @@ async fn timeout_enforcement_fails_pending_activity_and_wakes_workflow() {
         &None,
         &[],
         None,
+        None,
     )
     .await
     .expect("timeout enforcement should succeed");
@@ -2083,6 +2089,7 @@ async fn worker_fails_workflow_when_activity_start_to_close_timeout_elapses() {
                 poison_pill_threshold: 3,
                 labels: std::collections::HashMap::new(),
                 max_workflow_pause_duration: std::time::Duration::from_secs(24 * 3600),
+                max_workflow_history_events: None,
                 sharded_pool: None,
             },
             Arc::new(HandlerRegistry::new(
@@ -2235,6 +2242,7 @@ async fn worker_completes_workflow_with_timer_round_trip() {
                 poison_pill_threshold: 3,
                 labels: std::collections::HashMap::new(),
                 max_workflow_pause_duration: std::time::Duration::from_secs(24 * 3600),
+                max_workflow_history_events: None,
                 sharded_pool: None,
             },
             Arc::new(HandlerRegistry::new(
@@ -4823,6 +4831,7 @@ async fn workflow_schedule_baseline_dispatches_multiple_runs() {
                 poison_pill_threshold: 3,
                 labels: std::collections::HashMap::new(),
                 max_workflow_pause_duration: std::time::Duration::from_secs(24 * 3600),
+                max_workflow_history_events: None,
                 sharded_pool: None,
             },
             Arc::clone(&registry),
@@ -4937,6 +4946,7 @@ async fn workflow_schedule_max_active_runs_enforced() {
                 poison_pill_threshold: 3,
                 labels: std::collections::HashMap::new(),
                 max_workflow_pause_duration: std::time::Duration::from_secs(24 * 3600),
+                max_workflow_history_events: None,
                 sharded_pool: None,
             },
             Arc::clone(&registry),
@@ -5040,6 +5050,7 @@ async fn workflow_schedule_pause_and_resume() {
                 poison_pill_threshold: 3,
                 labels: std::collections::HashMap::new(),
                 max_workflow_pause_duration: std::time::Duration::from_secs(24 * 3600),
+                max_workflow_history_events: None,
                 sharded_pool: None,
             },
             Arc::clone(&registry),

--- a/autumn-harvest/tests/metrics_integration.rs
+++ b/autumn-harvest/tests/metrics_integration.rs
@@ -375,6 +375,7 @@ fn build_worker(worker_id: &str, registry: Arc<HandlerRegistry>) -> Arc<Worker> 
                 poison_pill_threshold: 3,
                 labels: std::collections::HashMap::new(),
                 max_workflow_pause_duration: std::time::Duration::from_secs(24 * 3600),
+                max_workflow_history_events: None,
                 sharded_pool: None,
             },
             registry,
@@ -2226,6 +2227,7 @@ async fn workflow_non_determinism_metric_and_search_attrs_are_recorded() {
         poison_pill_threshold: 3,
         labels: std::collections::HashMap::new(),
         max_workflow_pause_duration: std::time::Duration::from_secs(24 * 3600),
+        max_workflow_history_events: None,
         sharded_pool: None,
     };
     let worker = Arc::new(Worker::new(config, registry).expect("worker should build"));

--- a/autumn-harvest/tests/pause_tests.rs
+++ b/autumn-harvest/tests/pause_tests.rs
@@ -183,6 +183,7 @@ fn make_worker(registry: Arc<HandlerRegistry>) -> Worker {
             poison_pill_threshold: 3,
             max_workflow_pause_duration: Duration::from_secs(24 * 3600),
             labels: std::collections::HashMap::new(),
+            max_workflow_history_events: None,
             sharded_pool: None,
         },
         registry,

--- a/autumn-harvest/tests/schedule_to_close_tests.rs
+++ b/autumn-harvest/tests/schedule_to_close_tests.rs
@@ -216,6 +216,7 @@ async fn scanner_times_out_pending_task_with_expired_schedule_to_close() {
         &None,
         &[],
         None,
+        None,
     )
     .await
     .expect("enforce_timeouts_once");
@@ -309,6 +310,7 @@ async fn scanner_times_out_running_task_with_expired_schedule_to_close() {
         &None,
         &[],
         None,
+        None,
     )
     .await
     .expect("enforce_timeouts_once");
@@ -395,6 +397,7 @@ async fn scanner_does_not_affect_tasks_without_schedule_to_close() {
         &None,
         &[],
         None,
+        None,
     )
     .await
     .expect("enforce_timeouts_once");
@@ -478,6 +481,7 @@ async fn pre_retry_deadline_check_prevents_requeue_when_deadline_exceeded() {
         Duration::from_secs(60),
         &None,
         &[],
+        None,
         None,
     )
     .await
@@ -589,6 +593,7 @@ async fn enqueue_params_schedule_to_close_at_persisted_and_not_prematurely_fired
         Duration::from_secs(60),
         &None,
         &[],
+        None,
         None,
     )
     .await

--- a/autumn-harvest/tests/scheduler_carryover_tests.rs
+++ b/autumn-harvest/tests/scheduler_carryover_tests.rs
@@ -251,6 +251,7 @@ fn make_worker(worker_id: &str, registry: Arc<HandlerRegistry>) -> Arc<Worker> {
                 poison_pill_threshold: 3,
                 labels: std::collections::HashMap::new(),
                 max_workflow_pause_duration: Duration::from_secs(24 * 3600),
+                max_workflow_history_events: None,
                 sharded_pool: None,
             },
             registry,

--- a/autumn-harvest/tests/telemetry_span_tests.rs
+++ b/autumn-harvest/tests/telemetry_span_tests.rs
@@ -416,6 +416,7 @@ fn all_adr_0001_span_kinds_are_emitted() {
                         poison_pill_threshold: 3,
                         labels: std::collections::HashMap::new(),
                         max_workflow_pause_duration: std::time::Duration::from_secs(24 * 3600),
+                        max_workflow_history_events: None,
                         sharded_pool: None,
                     },
                     registry,

--- a/autumn-harvest/tests/transactional_activity_tests.rs
+++ b/autumn-harvest/tests/transactional_activity_tests.rs
@@ -211,6 +211,7 @@ fn make_worker(_db_url: &str, registry: Arc<HandlerRegistry>) -> Arc<Worker> {
                 poison_pill_threshold: 3,
                 labels: std::collections::HashMap::new(),
                 max_workflow_pause_duration: std::time::Duration::from_secs(24 * 3600),
+                max_workflow_history_events: None,
                 sharded_pool: None,
             },
             registry,

--- a/docs/runbooks/history-ceiling.md
+++ b/docs/runbooks/history-ceiling.md
@@ -41,13 +41,13 @@ A non-zero gauge means executions of that workflow type are not calling
 ### Via the management API
 
 ```bash
-# List executions with ≥ 10 000 history events, most oversized first
+# List executions with ≥ 10 000 history events
 curl -s "http://localhost:8080/api/harvest/workflows?min_history_events=10000&limit=50" \
-  | jq '.workflows[] | {id: .execution_id, name: .workflow_name, state: .state}'
+  | jq '.[] | {id: .execution_id, name: .workflow_name, state: .state}'
 ```
 
-`min_history_events` accepts any non-negative integer. The results are
-aggregated across all shards and returned in descending event-count order.
+`min_history_events` accepts any non-negative integer. Results are aggregated
+across all shards and returned in the default `created_at` order.
 
 ### Via the preflight report
 

--- a/docs/runbooks/history-ceiling.md
+++ b/docs/runbooks/history-ceiling.md
@@ -1,0 +1,191 @@
+# Runbook: Workflow History Ceiling
+
+This runbook covers how to detect and respond to runaway workflow histories
+before replay latency degrades (issue #493).
+
+---
+
+## Background
+
+Every workflow execution accumulates an append-only event log in
+`harvest_events`. Replay re-runs the workflow function from the top on every
+task claim, walking the full history. Once a history grows past ~10 000 events
+the replay CPU cost compounds and response latency increases noticeably.
+
+Harvest ships two complementary guards:
+
+| Guard | Kind | Effect |
+|-------|------|--------|
+| `should_continue_as_new()` / `continue_as_new_threshold` | Soft, opt-in per workflow | Advisory; the workflow must cooperate by calling `ctx.continue_as_new()` |
+| `max_workflow_history_events` (hard ceiling) | Hard, server-side | Unconditional terminal transition when the count reaches the ceiling |
+
+---
+
+## Finding oversized in-flight workflows
+
+### Via the gauge metric
+
+The worker emits `harvest.workflow.history_oversized{workflow=<name>}` once
+per sampler interval (same cadence as `harvest.queue.depth`). The gauge value
+is the count of RUNNING or SUSPENDED executions whose event count exceeds
+`continue_as_new_threshold` (default 10 000).
+
+```promql
+# Executions breaching the soft threshold, by workflow type
+harvest_workflow_history_oversized{workflow="my_workflow"}
+```
+
+A non-zero gauge means executions of that workflow type are not calling
+`continue_as_new` frequently enough.
+
+### Via the management API
+
+```bash
+# List executions with ≥ 10 000 history events, most oversized first
+curl -s "http://localhost:8080/api/harvest/workflows?min_history_events=10000&limit=50" \
+  | jq '.workflows[] | {id: .execution_id, name: .workflow_name, state: .state}'
+```
+
+`min_history_events` accepts any non-negative integer. The results are
+aggregated across all shards and returned in descending event-count order.
+
+### Via the preflight report
+
+```bash
+curl -s http://localhost:8080/api/harvest/admin/preflight | jq '.checks[] | select(.name == "history_ceiling_config")'
+```
+
+The `history_ceiling_config` check surfaces:
+
+- `ceiling_enabled`: whether the hard ceiling is active
+- `max_workflow_history_events`: the configured ceiling (if set)
+- `continue_as_new_threshold`: the soft threshold from the registry
+- `headroom`: how many events a workflow can grow above the soft threshold
+  before hitting the hard ceiling
+
+---
+
+## Interpreting the gauge
+
+| Gauge value | Interpretation | Recommended action |
+|-------------|---------------|-------------------|
+| 0 | No oversized in-flight runs | No action needed |
+| Low (1–10) | A small number of long-running executions are not trimming history | Nudge workflow author toward `ctx.should_continue_as_new()` / `ctx.continue_as_new()` |
+| Medium (10–100) | A pattern of workflows skipping history trimming | Audit the workflow code; consider enabling a ceiling to cap blast radius |
+| High (> 100) | Systemic miss or a fast-growing workflow pattern | Enable the hard ceiling immediately; involve the workflow author |
+
+---
+
+## Nudging toward `continue_as_new`
+
+The preferred long-term fix is for the workflow to trim its own history before
+it grows large. Add this guard anywhere an execution loops:
+
+```rust
+#[workflow]
+async fn long_running_job(ctx: &WorkflowContext, input: JobInput) -> Result<(), String> {
+    loop {
+        // ... process one item ...
+
+        // When history is getting long, restart cleanly with the same input.
+        if ctx.should_continue_as_new() {
+            return ctx.continue_as_new(input).map_err(|e| e.to_string());
+        }
+    }
+}
+```
+
+`should_continue_as_new()` returns `true` when the event count exceeds
+`continue_as_new_threshold` (default 10 000, configurable via
+`HarvestBuilder::history_continue_as_new_threshold`).
+
+`continue_as_new` starts a fresh execution with its own clean event log and
+the same `workflow_id`, so clients polling the workflow ID continue to see
+progress.
+
+---
+
+## Enabling the hard ceiling
+
+The hard ceiling is a server-side safety net for executions that do not
+cooperate with `continue_as_new`. When an execution's event count reaches the
+ceiling the worker terminates it with a machine-readable `WorkflowFailed`
+event:
+
+```
+error: "history_ceiling_exceeded: event count 15000 >= ceiling 15000"
+```
+
+### Configuration
+
+```rust
+// In your application startup:
+let harvest = HarvestBuilder::new()
+    // Soft guidance threshold (default: 10 000)
+    .history_continue_as_new_threshold(10_000)
+    // Hard ceiling — must be strictly greater than the soft threshold
+    .max_workflow_history_events(Some(15_000))
+    .build()?;
+```
+
+The builder validates `ceiling > soft_threshold` at build time and returns a
+clear error if the constraint is violated.
+
+### Effect
+
+- Executions that reach the ceiling are transitioned to `FAILED`.
+- Outstanding `harvest_task_queue` rows are cancelled.
+- Parent workflows awaiting a child that hits the ceiling receive a terminal
+  failure notification.
+- The standard `harvest.workflow.terminal{outcome="failed"}` counter is
+  incremented.
+
+### When to enable
+
+| Situation | Recommendation |
+|-----------|----------------|
+| You have a short-term production fire with runaway histories | Enable immediately with a generous ceiling; fix the workflow in parallel |
+| You want blast-radius protection for all workflows | Set ceiling to 2–3× `continue_as_new_threshold` as a permanent floor |
+| You are confident the workflow correctly trims history | Leave ceiling disabled (`None`); the soft threshold is sufficient |
+
+---
+
+## Deciding: soft threshold only vs. hard ceiling
+
+```
+Is the workflow author available to add ctx.should_continue_as_new()?
+ ├─ Yes, and the fix can ship soon → nudge toward continue_as_new (soft)
+ └─ No, or it will take time → enable max_workflow_history_events (hard)
+      ├─ Set ceiling to a safe multiple of the soft threshold (e.g. 1.5×)
+      └─ Monitor harvest_workflow_history_oversized until it drops to 0
+         once the workflow fix ships, you can raise or disable the ceiling
+```
+
+---
+
+## Monitoring and alerting
+
+Add this alert to your alerting configuration:
+
+```yaml
+- alert: HarvestWorkflowHistoryOversized
+  expr: harvest_workflow_history_oversized > 0
+  for: 15m
+  labels:
+    severity: warning
+  annotations:
+    summary: "Workflow '{{ $labels.workflow }}' has {{ $value }} oversized in-flight executions"
+    runbook: "docs/runbooks/history-ceiling.md"
+```
+
+The 15-minute `for` window avoids false positives from long-running workflows
+that are making normal progress but happen to be polled between
+`continue_as_new` calls.
+
+---
+
+## See also
+
+- `docs/runbooks/harvest-alerts.md` — alert pack reference
+- `autumn-harvest/src/context.rs` — `should_continue_as_new`, `continue_as_new`
+- `autumn-harvest/src/builder.rs` — `max_workflow_history_events`, `history_continue_as_new_threshold`


### PR DESCRIPTION
## Summary

Implements a server-side hard ceiling on the number of durable events a RUNNING workflow execution may accumulate. When an execution's event count reaches or exceeds the configured ceiling, it is automatically terminated with a `WorkflowFailed` event and a machine-readable error reason. This complements the existing soft `continue_as_new_threshold` advisory guard.

## Key Changes

- **Builder configuration** (`builder.rs`):
  - Added `max_workflow_history_events: Option<u64>` field to `HarvestBuilder` and `BuiltHarvest`
  - New builder method `max_workflow_history_events(ceiling: Option<u64>)` to set the ceiling
  - Validation in `try_build()` ensures ceiling is strictly greater than the soft `continue_as_new_threshold` (default 10,000)
  - New error variant `HistoryCeilingBelowSoftThreshold` with clear messaging
  - Comprehensive test coverage for all configuration scenarios

- **Timeout enforcement** (`timeout.rs`):
  - New `enforce_workflow_history_ceiling()` async function that:
    - Queries RUNNING executions whose event count ≥ ceiling
    - Appends a `WorkflowFailed` event with error message `"history_ceiling_exceeded: event count {n} >= ceiling {c}"`
    - Transitions execution to FAILED state
    - Cancels outstanding task queue rows
    - Notifies parent workflows via `wake_parent_for_child_timeout()`
    - Applies parent close cascade
    - Uses `FOR UPDATE` locking for idempotency
  - Integrated into `enforce_timeouts_once()` to run alongside other timeout checks
  - Updated `spawn_timeout_checker()` to pass ceiling through to enforcement loop

- **Worker runtime** (`worker.rs`):
  - Added `max_workflow_history_events` field to `WorkerRuntimeConfig`
  - New `spawn_history_oversized_sampler()` background task that:
    - Periodically samples count of RUNNING/SUSPENDED executions per workflow type whose history exceeds the soft threshold
    - Emits `harvest.workflow.history_oversized{workflow=<name>}` gauge metric
    - Runs on the same cadence as queue depth sampling
  - New `sample_history_oversized_counts()` query function using correlated subquery for efficiency
  - Integrated sampler into worker monitoring handles with proper shutdown coordination

- **Telemetry** (`telemetry.rs`):
  - New metric constant `METRIC_WORKFLOW_HISTORY_OVERSIZED` for the gauge
  - New `MetricsRecorder::record_workflow_history_oversized()` trait method

- **API state and preflight** (`api.rs`, `preflight.rs`):
  - Added `max_workflow_history_events` field to `HarvestApiState` with getter/setter
  - New `check_history_ceiling_config()` preflight check that surfaces:
    - Whether ceiling is enabled
    - Configured ceiling value
    - Soft threshold value
    - Headroom (ceiling - threshold)
  - New `min_history_events` query parameter on `/api/harvest/workflows` to filter executions by minimum event count

- **Plugin integration** (`runner.rs`, `plugin.rs`):
  - Propagates `BuiltHarvest::max_workflow_history_events` into API state during startup

- **Documentation** (`docs/runbooks/history-ceiling.md`):
  - Comprehensive runbook covering:
    - Background on history growth and replay latency
    - How to detect oversized workflows via gauge metric and management API
    - Guidance on soft threshold vs. hard ceiling trade-offs
    - Configuration examples
    - Monitoring and alerting recommendations
    - Decision tree for when to enable the ceiling

## Implementation Details

- **Idempotency**: The enforcement transaction re-checks `state = 'RUNNING'` under `FOR UPDATE` lock, preventing double-termination from concurrent completion or duplicate scanner ticks
- **Error message format**: Machine-readable `"history_ceiling_exceeded: event count {n} >= ceiling {

https://claude.ai/code/session_01LRE5CDNuEqweSmTToojxUv