### PR TITLE
Add workflow-task dispatch timeout with poison-pill escalation (issue #494)

### DIFF
--- a/autumn-harvest-plugin/tests/dag_retry_integration.rs
+++ b/autumn-harvest-plugin/tests/dag_retry_integration.rs
@@ -270,6 +270,7 @@ fn build_worker() -> Arc<Worker> {
                 priority_aging_secs: None,
                 unknown_target_grace_window: Duration::from_secs(5),
                 poison_pill_threshold: 3,
+                workflow_task_timeout: std::time::Duration::from_secs(10),
                 labels: std::collections::HashMap::new(),
                 max_workflow_pause_duration: std::time::Duration::from_secs(24 * 3600),
                 max_workflow_history_events: None,

--- a/autumn-harvest-plugin/tests/workflow_reset_integration.rs
+++ b/autumn-harvest-plugin/tests/workflow_reset_integration.rs
@@ -209,6 +209,7 @@ fn build_reset_worker(registry: Arc<HandlerRegistry>) -> Arc<Worker> {
                 priority_aging_secs: None,
                 unknown_target_grace_window: Duration::from_secs(5),
                 poison_pill_threshold: 3,
+                workflow_task_timeout: std::time::Duration::from_secs(10),
                 labels: std::collections::HashMap::new(),
                 max_workflow_pause_duration: std::time::Duration::from_secs(24 * 3600),
                 max_workflow_history_events: None,

--- a/autumn-harvest/src/builder.rs
+++ b/autumn-harvest/src/builder.rs
@@ -1626,6 +1626,23 @@ pub struct WorkerConfig {
     /// poison pills are re-queued indefinitely — the legacy retry-loop
     /// behaviour).
     pub poison_pill_threshold: i32,
+    /// Maximum wall-clock time a single workflow-task dispatch may run before
+    /// the worker reclaims the concurrency slot (issue #494).
+    ///
+    /// When a `#[workflow]` body does not reach a suspension point or complete
+    /// within this budget, the dispatch is abandoned: its semaphore permit is
+    /// released so other tasks can proceed and the task row is reset to
+    /// `PENDING` for a subsequent attempt. Deterministic replay means a
+    /// transient slow dispatch recovers safely on retry.
+    ///
+    /// After `poison_pill_threshold` consecutive timeouts for the same
+    /// execution the task is escalated to the dead-letter queue rather than
+    /// re-queued, so a permanently stuck workflow body never loops forever.
+    ///
+    /// Defaults to **10 seconds**. Set to [`Duration::ZERO`] to disable
+    /// (workflow tasks run without a wall-clock budget — the behaviour before
+    /// this field was added). Protection is **on by default**.
+    pub workflow_task_timeout: Duration,
     /// Maximum wall-clock time a workflow execution may stay paused before the
     /// bounded-pause auto-resume scanner force-resumes it with
     /// `actor = "auto-resume(timeout)"` (issue #383).
@@ -1672,6 +1689,7 @@ impl Default for WorkerConfig {
             max_workflow_start_delay: DEFAULT_MAX_WORKFLOW_START_DELAY,
             unknown_target_grace_window: Duration::from_secs(5),
             poison_pill_threshold: 3,
+            workflow_task_timeout: Duration::from_secs(10),
             max_workflow_pause_duration: DEFAULT_MAX_WORKFLOW_PAUSE_DURATION,
             labels: std::collections::HashMap::new(),
             max_workflow_history_events: None,
@@ -1819,6 +1837,42 @@ impl WorkerConfig {
     #[must_use]
     pub const fn with_poison_pill_threshold(mut self, threshold: i32) -> Self {
         self.poison_pill_threshold = threshold;
+        self
+    }
+
+    /// Override the per-workflow-task dispatch timeout (default 10 s, issue #494).
+    ///
+    /// A workflow-task dispatch that does not complete or suspend within this
+    /// budget has its concurrency permit reclaimed immediately, allowing other
+    /// tasks to proceed. The hung future is cancelled and the task row is reset
+    /// to `PENDING` so any worker can re-claim it on the next poll.
+    ///
+    /// After `poison_pill_threshold` consecutive timeouts for the same
+    /// execution the task is escalated to the DLQ rather than re-queued
+    /// indefinitely (see [`with_poison_pill_threshold`]).
+    ///
+    /// Set to [`Duration::ZERO`] to disable (no wall-clock budget on workflow
+    /// tasks — the behaviour before this setting was added).
+    ///
+    /// [`with_poison_pill_threshold`]: Self::with_poison_pill_threshold
+    ///
+    /// ## Example
+    ///
+    /// ```rust
+    /// use std::time::Duration;
+    /// use autumn_harvest::builder::WorkerConfig;
+    ///
+    /// // Tighten to 5 s for a latency-sensitive deployment.
+    /// let config = WorkerConfig::default().with_workflow_task_timeout(Duration::from_secs(5));
+    /// assert_eq!(config.workflow_task_timeout, Duration::from_secs(5));
+    ///
+    /// // Disable the guard entirely.
+    /// let config = WorkerConfig::default().with_workflow_task_timeout(Duration::ZERO);
+    /// assert!(config.workflow_task_timeout.is_zero());
+    /// ```
+    #[must_use]
+    pub const fn with_workflow_task_timeout(mut self, timeout: Duration) -> Self {
+        self.workflow_task_timeout = timeout;
         self
     }
 
@@ -2446,6 +2500,28 @@ mod tests {
             config.max_local_activity_start_to_close,
             Duration::from_secs(60)
         );
+    }
+
+    // ── Workflow-task timeout tests (issue #494) ──────────────────────────
+
+    #[test]
+    fn worker_config_workflow_task_timeout_defaults_to_10s() {
+        assert_eq!(
+            WorkerConfig::default().workflow_task_timeout,
+            Duration::from_secs(10)
+        );
+    }
+
+    #[test]
+    fn worker_config_with_workflow_task_timeout_overrides() {
+        let config = WorkerConfig::default().with_workflow_task_timeout(Duration::from_secs(30));
+        assert_eq!(config.workflow_task_timeout, Duration::from_secs(30));
+    }
+
+    #[test]
+    fn worker_config_workflow_task_timeout_zero_disables() {
+        let config = WorkerConfig::default().with_workflow_task_timeout(Duration::ZERO);
+        assert_eq!(config.workflow_task_timeout, Duration::ZERO);
     }
 
     #[test]

--- a/autumn-harvest/src/dlq.rs
+++ b/autumn-harvest/src/dlq.rs
@@ -118,6 +118,19 @@ pub enum DeadLetterReason {
         crash_strikes: i32,
         last_worker_id: Option<String>,
     },
+    /// A workflow-task dispatch did not complete or suspend within the
+    /// `workflow_task_timeout` budget `task_timeout_strikes` times in a row
+    /// (issue #494). The worker reclaimed the concurrency slot on each
+    /// occasion; after hitting the threshold the task was quarantined rather
+    /// than re-queued indefinitely.
+    ///
+    /// `timeout_secs` is the configured budget (whole seconds) at quarantine
+    /// time. `task_timeout_strikes` is the in-process consecutive-timeout
+    /// count that triggered escalation.
+    WorkflowTaskTimeout {
+        task_timeout_strikes: i32,
+        timeout_secs: u64,
+    },
 }
 
 impl std::fmt::Display for DeadLetterReason {
@@ -1390,6 +1403,23 @@ mod tests {
         assert!(json.contains("PoisonPill"));
         assert!(json.contains("crash_strikes"));
         assert!(json.contains("worker-7"));
+    }
+
+    #[test]
+    fn dead_letter_reason_workflow_task_timeout_is_typed_json() {
+        let reason = DeadLetterReason::WorkflowTaskTimeout {
+            task_timeout_strikes: 3,
+            timeout_secs: 10,
+        };
+
+        let json = reason.to_string();
+        let back: DeadLetterReason =
+            serde_json::from_str(&json).expect("typed reason should deserialize");
+
+        assert_eq!(back, reason);
+        assert!(json.contains("WorkflowTaskTimeout"));
+        assert!(json.contains("task_timeout_strikes"));
+        assert!(json.contains("timeout_secs"));
     }
 
     #[test]

--- a/autumn-harvest/src/metrics_rs_adapter.rs
+++ b/autumn-harvest/src/metrics_rs_adapter.rs
@@ -60,8 +60,8 @@ use crate::telemetry::{
     METRIC_WORKFLOW_CACHE_HIT, METRIC_WORKFLOW_CACHE_MISS, METRIC_WORKFLOW_CONTINUE_AS_NEW,
     METRIC_WORKFLOW_DURATION, METRIC_WORKFLOW_HISTORY_OVERSIZED, METRIC_WORKFLOW_HISTORY_SIZE,
     METRIC_WORKFLOW_NON_DETERMINISM, METRIC_WORKFLOW_PAUSE_DURATION, METRIC_WORKFLOW_PAUSED,
-    METRIC_WORKFLOW_SLA_BREACHED, METRIC_WORKFLOW_STARTED, METRIC_WORKFLOW_TERMINAL,
-    MetricsRecorder, WorkflowStatus,
+    METRIC_WORKFLOW_SLA_BREACHED, METRIC_WORKFLOW_STARTED, METRIC_WORKFLOW_TASK_TIMEOUT,
+    METRIC_WORKFLOW_TERMINAL, MetricsRecorder, WorkflowStatus,
 };
 
 /// [`MetricsRecorder`] implementation that forwards every sample to the
@@ -396,6 +396,15 @@ impl MetricsRecorder for MetricsRsRecorder {
     fn record_workflow_sla_breach(&self, workflow_name: &str, queue: &str) {
         counter!(
             METRIC_WORKFLOW_SLA_BREACHED,
+            METRIC_LABEL_WORKFLOW => workflow_name.to_owned(),
+            METRIC_LABEL_QUEUE => queue.to_owned(),
+        )
+        .increment(1);
+    }
+
+    fn record_workflow_task_timeout(&self, workflow_name: &str, queue: &str) {
+        counter!(
+            METRIC_WORKFLOW_TASK_TIMEOUT,
             METRIC_LABEL_WORKFLOW => workflow_name.to_owned(),
             METRIC_LABEL_QUEUE => queue.to_owned(),
         )

--- a/autumn-harvest/src/telemetry.rs
+++ b/autumn-harvest/src/telemetry.rs
@@ -198,6 +198,19 @@ pub const ATTR_SIGNAL_ID: &str = "harvest.signal.id";
 /// `execution.id` stays span-only per the cardinality rule (ADR-0001 §7).
 pub const METRIC_WORKFLOW_TIMEOUT: &str = "harvest.workflow.timeout";
 
+/// Counter: incremented each time a workflow-task dispatch is abandoned because
+/// it did not complete or suspend within `WorkerConfig::workflow_task_timeout`
+/// (issue #494).
+///
+/// Each increment signals one reclamation of a worker concurrency slot from a
+/// hung or blocking workflow body. After `poison_pill_threshold` consecutive
+/// increments for the same execution the task is quarantined to the DLQ with
+/// [`DeadLetterReason::WorkflowTaskTimeout`](crate::dlq::DeadLetterReason).
+///
+/// Labeled by `workflow` (workflow name) and `queue` (task queue name).
+/// `execution.id` stays span-only per the cardinality rule (ADR-0001 §7).
+pub const METRIC_WORKFLOW_TASK_TIMEOUT: &str = "harvest.workflow.task_timeout";
+
 /// Counter: incremented exactly once per run when a workflow execution exceeds its
 /// declared soft SLA budget (`sla_deadline_at`) while still RUNNING/SUSPENDED.
 ///
@@ -956,6 +969,18 @@ pub trait MetricsRecorder: Send + Sync {
         let _ = (workflow_name, queue);
     }
 
+    /// A workflow-task dispatch was abandoned because it did not complete or
+    /// suspend within `WorkerConfig::workflow_task_timeout` (issue #494).
+    ///
+    /// Each call represents one reclaimed worker concurrency slot. After
+    /// `poison_pill_threshold` consecutive calls for the same execution the
+    /// task is escalated to the DLQ.
+    ///
+    /// Maps to the counter `harvest.workflow.task_timeout{workflow, queue}`.
+    fn record_workflow_task_timeout(&self, workflow_name: &str, queue: &str) {
+        let _ = (workflow_name, queue);
+    }
+
     /// A workflow execution has exceeded its declared soft SLA budget while
     /// still RUNNING/SUSPENDED (issue #487).
     ///
@@ -1218,6 +1243,10 @@ mod tests {
             METRIC_WORKFLOW_NON_DETERMINISM,
             "harvest.workflow.non_determinism"
         );
+        assert_eq!(
+            METRIC_WORKFLOW_TASK_TIMEOUT,
+            "harvest.workflow.task_timeout"
+        );
     }
 
     #[test]
@@ -1331,6 +1360,23 @@ mod tests {
         rec.record_workflow_terminal("billing", "default", WorkflowStatus::Completed);
         // If execution.id were a parameter the call above would require an
         // extra UUID argument and this test would fail to compile.
+    }
+
+    // ── Workflow-task timeout metric tests (issue #494) ───────────────────
+
+    #[test]
+    fn record_workflow_task_timeout_has_noop_default() {
+        // MetricsRecorder::record_workflow_task_timeout must exist with a
+        // no-op default so existing implementations compile without changes.
+        let rec = NoOpMetrics;
+        rec.record_workflow_task_timeout("onboarding", "default");
+    }
+
+    #[test]
+    fn execution_id_is_not_a_parameter_of_record_workflow_task_timeout() {
+        // ADR-0001 §7 cardinality rule: execution.id is span-only.
+        let rec: Arc<dyn MetricsRecorder> = Arc::new(NoOpMetrics);
+        rec.record_workflow_task_timeout("billing", "default");
     }
 
     #[test]

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -7565,8 +7565,21 @@ impl Worker {
         let workflow_cache = Arc::clone(&self.workflow_cache);
 
         // Workflow-task timeout (issue #494): only apply to workflow tasks.
+        // Local activities execute inline inside the workflow task, so the
+        // effective budget must be at least as large as
+        // max_local_activity_start_to_close to avoid prematurely killing a
+        // workflow that is legitimately waiting for an in-progress local
+        // activity.  When workflow_task_timeout is 0 the feature is disabled.
         let workflow_task_timeout = match kind {
-            ClaimedTaskKind::Workflow => self.config.workflow_task_timeout,
+            ClaimedTaskKind::Workflow => {
+                if self.config.workflow_task_timeout.is_zero() {
+                    Duration::ZERO
+                } else {
+                    self.config
+                        .workflow_task_timeout
+                        .max(self.config.max_local_activity_start_to_close)
+                }
+            }
             ClaimedTaskKind::Activity => Duration::ZERO,
         };
         let poison_pill_threshold = self.config.poison_pill_threshold;
@@ -7576,7 +7589,7 @@ impl Worker {
 
         tokio::spawn(async move {
             // Acquire semaphore permit — blocks if at concurrency limit.
-            let Ok(_permit) = semaphore.acquire().await else {
+            let Ok(permit) = semaphore.acquire().await else {
                 tracing::error!(task_id = %task_id, "semaphore closed");
                 return;
             };
@@ -7636,10 +7649,14 @@ impl Worker {
                         );
                     }
                     Err(_elapsed) => {
-                        // The dispatch did not complete or suspend within the
-                        // budget. The permit is dropped automatically (the
-                        // task future was cancelled), freeing the concurrency
-                        // slot for new tasks.
+                        // Release the concurrency slot immediately so other
+                        // tasks can be dispatched while we do recovery I/O
+                        // (metric DB lookup + reset/quarantine).  The
+                        // `process_task` future was already cancelled by
+                        // tokio::time::timeout, but `permit` lives in this
+                        // outer scope and would otherwise be held until the
+                        // recovery awaits complete.
+                        drop(permit);
                         let timeout_secs = workflow_task_timeout.as_secs();
                         let new_strikes = exec_id_for_timeout.map_or(1, |exec_id| {
                             let mut guard = timeout_strikes
@@ -7911,26 +7928,35 @@ pub async fn quarantine_workflow_task_timeout(
         .flatten()
         .unwrap_or((serde_json::Value::Null, 1));
 
-    // Fetch owner/severity from the execution row for the DLQ entry.
-    // Also record whether the execution row exists so we can skip the
-    // event-append path inside the transaction when the row has been
-    // deleted or archived (FK violation would otherwise roll back the
-    // entire quarantine, leaving the task un-quarantined).
+    // Fetch owner/severity/parent_id from the execution row for the DLQ
+    // entry and parent notification.  Also record whether the execution row
+    // exists so we can skip the event-append path inside the transaction when
+    // the row has been deleted or archived (FK violation would otherwise roll
+    // back the entire quarantine, leaving the task un-quarantined).
     let mut exec_exists = false;
+    let mut parent_id_opt: Option<uuid::Uuid> = None;
     let (owner, severity) = match exec_id_opt {
         Some(exec_uuid) => {
             let res = exec_dsl::harvest_workflow_executions
                 .find(exec_uuid)
-                .select((exec_dsl::owner, exec_dsl::severity))
-                .first::<(Option<String>, Option<String>)>(&mut conn)
+                .select((
+                    exec_dsl::owner,
+                    exec_dsl::severity,
+                    exec_dsl::parent_id,
+                ))
+                .first::<(Option<String>, Option<String>, Option<uuid::Uuid>)>(&mut conn)
                 .await
                 .optional()
                 .ok()
                 .flatten();
-            if res.is_some() {
-                exec_exists = true;
+            match res {
+                Some((o, s, p)) => {
+                    exec_exists = true;
+                    parent_id_opt = p;
+                    (o, s)
+                }
+                None => (None, None),
             }
-            res.unwrap_or((None, None))
         }
         None => (None, None),
     };
@@ -7989,6 +8015,20 @@ pub async fn quarantine_workflow_task_timeout(
                         )
                         .await?;
                         deferred.extend(triggers);
+                        // Notify the parent workflow (if any) that this child
+                        // has failed.  Mirrors the path in persist_child_workflow_failure
+                        // so a parent waiting on this child is not left suspended
+                        // indefinitely after a timeout quarantine.
+                        if let Some(parent_uuid) = parent_id_opt {
+                            let parent_exec_id = execution_id_from_uuid(parent_uuid);
+                            let _ = wake_parent_for_child_failure(
+                                conn,
+                                parent_exec_id,
+                                exec_id,
+                                &error_msg,
+                            )
+                            .await;
+                        }
                         (deferred, Some(entry.queue_name.clone()))
                     } else {
                         (Vec::new(), None)
@@ -8036,14 +8076,42 @@ pub async fn quarantine_workflow_task_timeout(
 pub async fn reset_timed_out_workflow_task(pool: &DbPool, task_id: uuid::Uuid, worker_id: &str) {
     use crate::schema::harvest_task_queue::dsl;
 
-    let mut conn = match pool.get().await {
-        Ok(c) => c,
-        Err(e) => {
+    // Retry acquiring a pool connection: a transient pool saturation during
+    // timeout handling would otherwise leave the task stuck in RUNNING on a
+    // live worker (the orphan reclaimer skips tasks owned by live workers).
+    let mut conn = {
+        let mut last_err = None;
+        let backoff_ms: &[u64] = &[0, 200, 500, 2_000];
+        let mut result = None;
+        for &delay_ms in backoff_ms {
+            if delay_ms > 0 {
+                tokio::time::sleep(Duration::from_millis(delay_ms)).await;
+            }
+            match pool.get().await {
+                Ok(c) => {
+                    result = Some(c);
+                    break;
+                }
+                Err(e) => {
+                    tracing::warn!(
+                        task_id = %task_id,
+                        worker_id = %worker_id,
+                        error = %e,
+                        "workflow task timeout reset: pool unavailable, retrying"
+                    );
+                    last_err = Some(e);
+                }
+            }
+        }
+        if let Some(c) = result {
+            c
+        } else {
             tracing::error!(
                 task_id = %task_id,
                 worker_id = %worker_id,
-                error = %e,
-                "workflow task timeout reset: pool exhausted"
+                error = ?last_err,
+                "workflow task timeout reset: pool exhausted after retries; \
+                 task may be stuck RUNNING until worker stops"
             );
             return;
         }

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -8210,7 +8210,7 @@ mod tests {
             tokio::time::sleep(Duration::from_millis(5)).await;
             let _ = tx.send(());
         };
-        let (hung_result, _) = tokio::join!(
+        let (hung_result, ()) = tokio::join!(
             tokio::time::timeout(Duration::from_millis(30), hung),
             healthy,
         );

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -7912,16 +7912,26 @@ pub async fn quarantine_workflow_task_timeout(
         .unwrap_or((serde_json::Value::Null, 1));
 
     // Fetch owner/severity from the execution row for the DLQ entry.
+    // Also record whether the execution row exists so we can skip the
+    // event-append path inside the transaction when the row has been
+    // deleted or archived (FK violation would otherwise roll back the
+    // entire quarantine, leaving the task un-quarantined).
+    let mut exec_exists = false;
     let (owner, severity) = match exec_id_opt {
-        Some(exec_uuid) => exec_dsl::harvest_workflow_executions
-            .find(exec_uuid)
-            .select((exec_dsl::owner, exec_dsl::severity))
-            .first::<(Option<String>, Option<String>)>(&mut conn)
-            .await
-            .optional()
-            .ok()
-            .flatten()
-            .unwrap_or((None, None)),
+        Some(exec_uuid) => {
+            let res = exec_dsl::harvest_workflow_executions
+                .find(exec_uuid)
+                .select((exec_dsl::owner, exec_dsl::severity))
+                .first::<(Option<String>, Option<String>)>(&mut conn)
+                .await
+                .optional()
+                .ok()
+                .flatten();
+            if res.is_some() {
+                exec_exists = true;
+            }
+            res.unwrap_or((None, None))
+        }
         None => (None, None),
     };
 
@@ -7951,34 +7961,38 @@ pub async fn quarantine_workflow_task_timeout(
                 queue::fail_task(conn, task_id, &error_msg).await?;
 
                 let (deferred, queue_used) = if let Some(exec_uuid) = exec_id_opt {
-                    let exec_id = execution_id_from_uuid(exec_uuid);
-                    let history = crate::store::load_history(conn, exec_id).await?;
-                    crate::store::append_events(
-                        conn,
-                        exec_id,
-                        &[WorkflowEvent::WorkflowFailed {
-                            error: error_msg.clone(),
-                        }],
-                        history.next_event_id,
-                    )
-                    .await?;
-                    // update_workflow_execution_failed returns an error when the
-                    // execution is already terminal; ignore it — the DLQ entry
-                    // and event append are the durable record.
-                    let _ = update_workflow_execution_failed(
-                        conn, exec_id, &worker_id, &error_msg, None,
-                    )
-                    .await;
-                    let mut deferred = apply_parent_close_cascade(conn, exec_id).await?;
-                    let triggers = crate::completion_trigger::evaluate_triggers_for_execution(
-                        conn,
-                        exec_id,
-                        crate::completion_trigger::TerminalState::Failed,
-                        None,
-                    )
-                    .await?;
-                    deferred.extend(triggers);
-                    (deferred, Some(entry.queue_name.clone()))
+                    if exec_exists {
+                        let exec_id = execution_id_from_uuid(exec_uuid);
+                        let history = crate::store::load_history(conn, exec_id).await?;
+                        crate::store::append_events(
+                            conn,
+                            exec_id,
+                            &[WorkflowEvent::WorkflowFailed {
+                                error: error_msg.clone(),
+                            }],
+                            history.next_event_id,
+                        )
+                        .await?;
+                        // update_workflow_execution_failed returns an error when the
+                        // execution is already terminal; ignore it — the DLQ entry
+                        // and event append are the durable record.
+                        let _ = update_workflow_execution_failed(
+                            conn, exec_id, &worker_id, &error_msg, None,
+                        )
+                        .await;
+                        let mut deferred = apply_parent_close_cascade(conn, exec_id).await?;
+                        let triggers = crate::completion_trigger::evaluate_triggers_for_execution(
+                            conn,
+                            exec_id,
+                            crate::completion_trigger::TerminalState::Failed,
+                            None,
+                        )
+                        .await?;
+                        deferred.extend(triggers);
+                        (deferred, Some(entry.queue_name.clone()))
+                    } else {
+                        (Vec::new(), None)
+                    }
                 } else {
                     (Vec::new(), None)
                 };

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -7935,20 +7935,36 @@ pub async fn quarantine_workflow_task_timeout(
     // back the entire quarantine, leaving the task un-quarantined).
     let mut exec_exists = false;
     let mut parent_id_opt: Option<uuid::Uuid> = None;
+    let mut parent_close_policy_opt: Option<String> = None;
+    let mut workflow_id_str = String::new();
     let (owner, severity) = match exec_id_opt {
         Some(exec_uuid) => {
             let res = exec_dsl::harvest_workflow_executions
                 .find(exec_uuid)
-                .select((exec_dsl::owner, exec_dsl::severity, exec_dsl::parent_id))
-                .first::<(Option<String>, Option<String>, Option<uuid::Uuid>)>(&mut conn)
+                .select((
+                    exec_dsl::owner,
+                    exec_dsl::severity,
+                    exec_dsl::parent_id,
+                    exec_dsl::parent_close_policy,
+                    exec_dsl::workflow_id,
+                ))
+                .first::<(
+                    Option<String>,
+                    Option<String>,
+                    Option<uuid::Uuid>,
+                    Option<String>,
+                    String,
+                )>(&mut conn)
                 .await
                 .optional()
                 .ok()
                 .flatten();
             match res {
-                Some((o, s, p)) => {
+                Some((o, s, p, pcp, wid)) => {
                     exec_exists = true;
                     parent_id_opt = p;
+                    parent_close_policy_opt = pcp;
+                    workflow_id_str = wid;
                     (o, s)
                 }
                 None => (None, None),
@@ -7984,6 +8000,27 @@ pub async fn quarantine_workflow_task_timeout(
 
                 let (deferred, queue_used) = if let Some(exec_uuid) = exec_id_opt {
                     if exec_exists {
+                        // Drain sibling tasks (PENDING/RUNNING) so they are not
+                        // claimed and run after the workflow has been terminally
+                        // failed. Mirrors the poison-pill quarantine path.
+                        diesel::update(
+                            task_dsl::harvest_task_queue
+                                .filter(task_dsl::workflow_exec_id.eq(exec_uuid))
+                                .filter(
+                                    task_dsl::state
+                                        .eq("PENDING")
+                                        .or(task_dsl::state.eq("RUNNING")),
+                                ),
+                        )
+                        .set((
+                            task_dsl::state.eq("FAILED"),
+                            task_dsl::error.eq(Some(error_msg.clone())),
+                            task_dsl::completed_at.eq(Some(chrono::Utc::now())),
+                        ))
+                        .execute(conn)
+                        .await
+                        .map_err(crate::error::database_error)?;
+
                         let exec_id = execution_id_from_uuid(exec_uuid);
                         let history = crate::store::load_history(conn, exec_id).await?;
                         crate::store::append_events(
@@ -7995,12 +8032,27 @@ pub async fn quarantine_workflow_task_timeout(
                             history.next_event_id,
                         )
                         .await?;
-                        // update_workflow_execution_failed returns an error when the
-                        // execution is already terminal; ignore it — the DLQ entry
-                        // and event append are the durable record.
+                        // update_workflow_execution_failed only transitions RUNNING
+                        // rows; ignore errors — the DLQ entry and event append are
+                        // the durable record.
                         let _ = update_workflow_execution_failed(
                             conn, exec_id, &worker_id, &error_msg, None,
                         )
+                        .await;
+                        // Also handle the PAUSED → FAILED transition: an operator
+                        // may have paused the execution between dispatch and quarantine.
+                        let _ = diesel::update(
+                            exec_dsl::harvest_workflow_executions
+                                .find(exec_uuid)
+                                .filter(exec_dsl::state.eq("PAUSED")),
+                        )
+                        .set((
+                            exec_dsl::state.eq("FAILED"),
+                            exec_dsl::output.eq(None::<serde_json::Value>),
+                            exec_dsl::error.eq(Some(error_msg.clone())),
+                            exec_dsl::completed_at.eq(Some(chrono::Utc::now())),
+                        ))
+                        .execute(conn)
                         .await;
                         let mut deferred = apply_parent_close_cascade(conn, exec_id).await?;
                         let triggers = crate::completion_trigger::evaluate_triggers_for_execution(
@@ -8011,19 +8063,21 @@ pub async fn quarantine_workflow_task_timeout(
                         )
                         .await?;
                         deferred.extend(triggers);
-                        // Notify the parent workflow (if any) that this child
-                        // has failed.  Mirrors the path in persist_child_workflow_failure
-                        // so a parent waiting on this child is not left suspended
-                        // indefinitely after a timeout quarantine.
-                        if let Some(parent_uuid) = parent_id_opt {
-                            let parent_exec_id = execution_id_from_uuid(parent_uuid);
-                            let _ = wake_parent_for_child_failure(
-                                conn,
-                                parent_exec_id,
-                                exec_id,
-                                &error_msg,
-                            )
-                            .await;
+                        // Notify the parent only for awaited children (those without
+                        // a parent_close_policy). Detached children are managed by
+                        // apply_parent_close_cascade above, mirroring the poison-pill
+                        // and timeout paths.
+                        if parent_close_policy_opt.is_none() {
+                            if let Some(parent_uuid) = parent_id_opt {
+                                let parent_exec_id = execution_id_from_uuid(parent_uuid);
+                                let _ = wake_parent_for_child_failure(
+                                    conn,
+                                    parent_exec_id,
+                                    exec_id,
+                                    &error_msg,
+                                )
+                                .await;
+                            }
                         }
                         (deferred, Some(entry.queue_name.clone()))
                     } else {
@@ -8047,6 +8101,20 @@ pub async fn quarantine_workflow_task_timeout(
                     &q,
                     crate::telemetry::WorkflowStatus::Failed,
                 );
+            }
+            // Best-effort: count quarantine failures toward the schedule
+            // auto-pause threshold (mirrors execution-timeout and normal failure
+            // paths). Called after the transaction commits so a counter query
+            // failure cannot roll back the quarantine.
+            #[cfg(feature = "db")]
+            if !workflow_id_str.is_empty() {
+                crate::scheduler::maybe_increment_schedule_failure_counter(
+                    &mut conn,
+                    &workflow_id_str,
+                    workflow_name,
+                    metrics,
+                )
+                .await;
             }
             for start in deferred_starts {
                 start.spawn();
@@ -8123,6 +8191,10 @@ pub async fn reset_timed_out_workflow_task(pool: &DbPool, task_id: uuid::Uuid, w
         dsl::worker_id.eq(None::<String>),
         dsl::started_at.eq(None::<chrono::DateTime<chrono::Utc>>),
         dsl::last_heartbeat_at.eq(None::<chrono::DateTime<chrono::Utc>>),
+        // Clear sticky affinity so any worker can reclaim the task immediately
+        // rather than waiting for the expired lease of the hung worker.
+        dsl::sticky_worker_id.eq(None::<String>),
+        dsl::sticky_until.eq(None::<chrono::DateTime<chrono::Utc>>),
     ))
     .execute(&mut conn)
     .await

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -8064,17 +8064,17 @@ pub async fn quarantine_workflow_task_timeout(
                         // a parent_close_policy). Detached children are managed by
                         // apply_parent_close_cascade above, mirroring the poison-pill
                         // and timeout paths.
-                        if parent_close_policy_opt.is_none() {
-                            if let Some(parent_uuid) = parent_id_opt {
-                                let parent_exec_id = execution_id_from_uuid(parent_uuid);
-                                let _ = wake_parent_for_child_failure(
-                                    conn,
-                                    parent_exec_id,
-                                    exec_id,
-                                    &error_msg,
-                                )
-                                .await;
-                            }
+                        if parent_close_policy_opt.is_none()
+                            && let Some(parent_uuid) = parent_id_opt
+                        {
+                            let parent_exec_id = execution_id_from_uuid(parent_uuid);
+                            let _ = wake_parent_for_child_failure(
+                                conn,
+                                parent_exec_id,
+                                exec_id,
+                                &error_msg,
+                            )
+                            .await;
                         }
                         (deferred, Some(entry.queue_name.clone()))
                     } else {

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -119,6 +119,10 @@ pub struct WorkerRuntimeConfig {
     /// Consecutive worker crashes a task may cause before quarantine (issue #367).
     /// `0` disables quarantine (reclaimed poison pills are re-queued forever).
     pub poison_pill_threshold: i32,
+    /// Maximum wall-clock time a single workflow-task dispatch may run before
+    /// the worker reclaims the concurrency slot (issue #494).
+    /// `Duration::ZERO` disables the timeout (unbounded dispatch time).
+    pub workflow_task_timeout: Duration,
     /// Bounded-pause ceiling before the auto-resume scanner force-resumes a
     /// paused execution (issue #383). Default 24 hours.
     pub max_workflow_pause_duration: Duration,
@@ -174,6 +178,7 @@ impl From<WorkerConfig> for WorkerRuntimeConfig {
             priority_aging_secs: cfg.priority_aging_secs,
             unknown_target_grace_window: cfg.unknown_target_grace_window,
             poison_pill_threshold: cfg.poison_pill_threshold,
+            workflow_task_timeout: cfg.workflow_task_timeout,
             max_workflow_pause_duration: cfg.max_workflow_pause_duration,
             labels: cfg.labels,
             #[cfg(feature = "db")]
@@ -6762,6 +6767,19 @@ pub struct Worker {
     /// Wrapped in `Arc<tokio::sync::Mutex<_>>` so it can be shared across
     /// concurrently-running task handler futures without cloning the events.
     workflow_cache: Arc<tokio::sync::Mutex<crate::cache::WorkflowCache>>,
+    /// In-process consecutive-timeout strike counter per workflow execution
+    /// (issue #494).
+    ///
+    /// Each time a workflow-task dispatch exceeds `workflow_task_timeout` the
+    /// counter for that execution ID is incremented. Once it reaches
+    /// `poison_pill_threshold` the task is quarantined to the DLQ rather than
+    /// re-queued. The counter is cleared when a dispatch completes (either
+    /// successfully or with an error) so only **consecutive** timeouts count.
+    ///
+    /// Keyed by `workflow_exec_id` (not `task.id`) so re-queued tasks from
+    /// the same execution accumulate toward the same threshold.
+    workflow_task_timeout_strikes:
+        Arc<std::sync::Mutex<std::collections::HashMap<uuid::Uuid, i32>>>,
 }
 
 struct WorkerMonitoringHandles {
@@ -6979,6 +6997,9 @@ impl Worker {
             shutdown: CancellationToken::new(),
             remote_drain_deadline: Arc::new(Mutex::new(None)),
             workflow_cache,
+            workflow_task_timeout_strikes: Arc::new(std::sync::Mutex::new(
+                std::collections::HashMap::new(),
+            )),
         })
     }
 
@@ -7513,6 +7534,7 @@ impl Worker {
     }
 
     /// Spawn a bounded Tokio task for the claimed work item.
+    #[allow(clippy::too_many_lines)]
     fn dispatch_task(&self, task: TaskQueueItem, pool: &DbPool) {
         let kind = match ClaimedTaskKind::from_db(&task.task_type) {
             Ok(kind) => kind,
@@ -7542,6 +7564,16 @@ impl Worker {
         let max_local_activity_start_to_close = self.config.max_local_activity_start_to_close;
         let workflow_cache = Arc::clone(&self.workflow_cache);
 
+        // Workflow-task timeout (issue #494): only apply to workflow tasks.
+        let workflow_task_timeout = match kind {
+            ClaimedTaskKind::Workflow => self.config.workflow_task_timeout,
+            ClaimedTaskKind::Activity => Duration::ZERO,
+        };
+        let poison_pill_threshold = self.config.poison_pill_threshold;
+        let timeout_strikes = Arc::clone(&self.workflow_task_timeout_strikes);
+        let exec_id_for_timeout = task.workflow_exec_id;
+        let telemetry = Arc::clone(&self.registry);
+
         tokio::spawn(async move {
             // Acquire semaphore permit — blocks if at concurrency limit.
             let Ok(_permit) = semaphore.acquire().await else {
@@ -7556,26 +7588,162 @@ impl Worker {
                 "executing task"
             );
 
-            if let Err(error) = process_task(
-                &pool,
-                registry,
-                task,
-                &worker_id,
-                &build_id,
-                cancellation_grace_period,
-                sticky_timeout,
-                max_local_activity_start_to_close,
-                workflow_cache,
-            )
-            .await
-            {
-                tracing::error!(
-                    task_id = %task_id,
-                    task_type = %task_type,
-                    worker_id = %worker_id,
-                    error = %error,
-                    "task execution failed"
-                );
+            // Apply per-workflow-task wall-clock budget when configured and
+            // this is a workflow task with a non-zero timeout.
+            if !workflow_task_timeout.is_zero() && task_type == "workflow" {
+                match tokio::time::timeout(
+                    workflow_task_timeout,
+                    process_task(
+                        &pool,
+                        Arc::clone(&registry),
+                        task,
+                        &worker_id,
+                        &build_id,
+                        cancellation_grace_period,
+                        sticky_timeout,
+                        max_local_activity_start_to_close,
+                        workflow_cache,
+                    ),
+                )
+                .await
+                {
+                    Ok(Ok(())) => {
+                        // Success: clear the consecutive-timeout counter for
+                        // this execution so a later transient timeout doesn't
+                        // inherit previous strikes.
+                        if let Some(exec_id) = exec_id_for_timeout {
+                            timeout_strikes
+                                .lock()
+                                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                                .remove(&exec_id);
+                        }
+                    }
+                    Ok(Err(error)) => {
+                        // Task returned a clean error (not a timeout): clear
+                        // the strike counter and log the error normally.
+                        if let Some(exec_id) = exec_id_for_timeout {
+                            timeout_strikes
+                                .lock()
+                                .unwrap_or_else(std::sync::PoisonError::into_inner)
+                                .remove(&exec_id);
+                        }
+                        tracing::error!(
+                            task_id = %task_id,
+                            task_type = %task_type,
+                            worker_id = %worker_id,
+                            error = %error,
+                            "task execution failed"
+                        );
+                    }
+                    Err(_elapsed) => {
+                        // The dispatch did not complete or suspend within the
+                        // budget. The permit is dropped automatically (the
+                        // task future was cancelled), freeing the concurrency
+                        // slot for new tasks.
+                        let timeout_secs = workflow_task_timeout.as_secs();
+                        let new_strikes = exec_id_for_timeout.map_or(1, |exec_id| {
+                            let mut guard = timeout_strikes
+                                .lock()
+                                .unwrap_or_else(std::sync::PoisonError::into_inner);
+                            let count = guard.entry(exec_id).or_insert(0);
+                            *count += 1;
+                            let result = *count;
+                            drop(guard);
+                            result
+                        });
+
+                        // Emit metric tagged by workflow+queue. We attempt a
+                        // best-effort DB lookup for the workflow name; the
+                        // metric is still emitted with "unknown" on failure
+                        // rather than being dropped.
+                        #[cfg(feature = "db")]
+                        let (workflow_name_str, queue_name_str) = {
+                            workflow_task_timeout_metric_names(&pool, exec_id_for_timeout).await
+                        };
+                        #[cfg(not(feature = "db"))]
+                        let (workflow_name_str, queue_name_str) =
+                            ("unknown".to_string(), "default".to_string());
+
+                        telemetry
+                            .telemetry()
+                            .metrics
+                            .record_workflow_task_timeout(&workflow_name_str, &queue_name_str);
+
+                        tracing::warn!(
+                            task_id = %task_id,
+                            exec_id = ?exec_id_for_timeout,
+                            strikes = new_strikes,
+                            threshold = poison_pill_threshold,
+                            timeout_secs = timeout_secs,
+                            workflow = %workflow_name_str,
+                            queue = %queue_name_str,
+                            "workflow task timed out; concurrency slot reclaimed"
+                        );
+
+                        let decision = crate::poison_pill::quarantine_decision(
+                            new_strikes,
+                            poison_pill_threshold,
+                        );
+
+                        #[cfg(feature = "db")]
+                        match decision {
+                            crate::poison_pill::ReclaimAction::Quarantine => {
+                                // Clear the in-process counter before the
+                                // async DB call so a concurrent reclaim
+                                // doesn't double-quarantine.
+                                if let Some(exec_id) = exec_id_for_timeout {
+                                    timeout_strikes
+                                        .lock()
+                                        .unwrap_or_else(std::sync::PoisonError::into_inner)
+                                        .remove(&exec_id);
+                                }
+                                quarantine_workflow_task_timeout(
+                                    &pool,
+                                    task_id,
+                                    exec_id_for_timeout,
+                                    &worker_id,
+                                    new_strikes,
+                                    timeout_secs,
+                                    &workflow_name_str,
+                                    &queue_name_str,
+                                    &*telemetry.telemetry().metrics,
+                                )
+                                .await;
+                            }
+                            crate::poison_pill::ReclaimAction::Requeue => {
+                                // Reset the task to PENDING so any worker can
+                                // re-claim it on the next poll, without waiting
+                                // for the orphan-reclaim staleness window.
+                                reset_timed_out_workflow_task(&pool, task_id, &worker_id).await;
+                            }
+                        }
+                        #[cfg(not(feature = "db"))]
+                        let _ = decision;
+                    }
+                }
+            } else {
+                // No timeout configured, or not a workflow task: run unbounded.
+                if let Err(error) = process_task(
+                    &pool,
+                    registry,
+                    task,
+                    &worker_id,
+                    &build_id,
+                    cancellation_grace_period,
+                    sticky_timeout,
+                    max_local_activity_start_to_close,
+                    workflow_cache,
+                )
+                .await
+                {
+                    tracing::error!(
+                        task_id = %task_id,
+                        task_type = %task_type,
+                        worker_id = %worker_id,
+                        error = %error,
+                        "task execution failed"
+                    );
+                }
             }
         });
     }
@@ -7665,6 +7833,248 @@ impl Worker {
 }
 
 // ---------------------------------------------------------------------------
+// Workflow-task timeout helpers (issue #494)
+// ---------------------------------------------------------------------------
+
+/// Look up the workflow name and queue name for timeout metric labels.
+///
+/// Falls back to `("unknown", "default")` on any DB or pool failure so the
+/// metric is always emitted even when the execution row is gone.
+async fn workflow_task_timeout_metric_names(
+    pool: &DbPool,
+    exec_id: Option<uuid::Uuid>,
+) -> (String, String) {
+    use crate::schema::harvest_workflow_executions::dsl;
+
+    let Some(exec_uuid) = exec_id else {
+        return ("unknown".to_string(), "default".to_string());
+    };
+    let Ok(mut conn) = pool.get().await else {
+        return ("unknown".to_string(), "default".to_string());
+    };
+    dsl::harvest_workflow_executions
+        .find(exec_uuid)
+        .select((dsl::workflow_name, dsl::queue_name))
+        .first::<(String, String)>(&mut conn)
+        .await
+        .optional()
+        .ok()
+        .flatten()
+        .unwrap_or_else(|| ("unknown".to_string(), "default".to_string()))
+}
+
+/// Move a timed-out workflow task to the DLQ and fail the owning execution.
+///
+/// Called when the consecutive in-memory timeout counter reaches
+/// `poison_pill_threshold` (issue #494). Errors are logged and swallowed.
+#[allow(clippy::too_many_arguments, clippy::too_many_lines)]
+pub async fn quarantine_workflow_task_timeout(
+    pool: &DbPool,
+    task_id: uuid::Uuid,
+    exec_id_opt: Option<uuid::Uuid>,
+    worker_id: &str,
+    new_strikes: i32,
+    timeout_secs: u64,
+    workflow_name: &str,
+    queue_name: &str,
+    metrics: &dyn crate::telemetry::MetricsRecorder,
+) {
+    use crate::schema::harvest_task_queue::dsl as task_dsl;
+    use crate::schema::harvest_workflow_executions::dsl as exec_dsl;
+
+    let mut conn = match pool.get().await {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::error!(
+                task_id = %task_id,
+                error = %e,
+                "workflow task timeout quarantine: pool exhausted"
+            );
+            return;
+        }
+    };
+
+    let reason = crate::dlq::DeadLetterReason::WorkflowTaskTimeout {
+        task_timeout_strikes: new_strikes,
+        timeout_secs,
+    };
+    let error_msg = reason.to_string();
+
+    // Fetch the task row's input + attempt for the DLQ entry.
+    let (input, attempts) = task_dsl::harvest_task_queue
+        .find(task_id)
+        .select((task_dsl::input, task_dsl::attempt))
+        .first::<(serde_json::Value, i32)>(&mut conn)
+        .await
+        .optional()
+        .ok()
+        .flatten()
+        .unwrap_or((serde_json::Value::Null, 1));
+
+    // Fetch owner/severity from the execution row for the DLQ entry.
+    let (owner, severity) = match exec_id_opt {
+        Some(exec_uuid) => exec_dsl::harvest_workflow_executions
+            .find(exec_uuid)
+            .select((exec_dsl::owner, exec_dsl::severity))
+            .first::<(Option<String>, Option<String>)>(&mut conn)
+            .await
+            .optional()
+            .ok()
+            .flatten()
+            .unwrap_or((None, None)),
+        None => (None, None),
+    };
+
+    let entry = crate::dlq::NewDeadLetterEntry {
+        original_task_id: task_id,
+        queue_name: queue_name.to_string(),
+        task_type: "workflow".to_string(),
+        workflow_exec_id: exec_id_opt,
+        activity_name: None,
+        input,
+        error: error_msg.clone(),
+        attempts,
+        owner,
+        severity,
+    };
+
+    let result = conn
+        .transaction::<(
+            Vec<crate::completion_trigger::DeferredTriggerStart>,
+            Option<String>,
+        ), HarvestError, _>(|conn| {
+            let error_msg = error_msg.clone();
+            let entry = entry.clone();
+            let worker_id = worker_id.to_string();
+            async move {
+                dlq::dead_letter(conn, &entry).await?;
+                queue::fail_task(conn, task_id, &error_msg).await?;
+
+                let (deferred, queue_used) = if let Some(exec_uuid) = exec_id_opt {
+                    let exec_id = execution_id_from_uuid(exec_uuid);
+                    let history = crate::store::load_history(conn, exec_id).await?;
+                    crate::store::append_events(
+                        conn,
+                        exec_id,
+                        &[WorkflowEvent::WorkflowFailed {
+                            error: error_msg.clone(),
+                        }],
+                        history.next_event_id,
+                    )
+                    .await?;
+                    // update_workflow_execution_failed returns an error when the
+                    // execution is already terminal; ignore it — the DLQ entry
+                    // and event append are the durable record.
+                    let _ = update_workflow_execution_failed(
+                        conn, exec_id, &worker_id, &error_msg, None,
+                    )
+                    .await;
+                    let mut deferred = apply_parent_close_cascade(conn, exec_id).await?;
+                    let triggers = crate::completion_trigger::evaluate_triggers_for_execution(
+                        conn,
+                        exec_id,
+                        crate::completion_trigger::TerminalState::Failed,
+                        None,
+                    )
+                    .await?;
+                    deferred.extend(triggers);
+                    (deferred, Some(entry.queue_name.clone()))
+                } else {
+                    (Vec::new(), None)
+                };
+
+                Ok((deferred, queue_used))
+            }
+            .scope_boxed()
+        })
+        .await;
+
+    match result {
+        Ok((deferred_starts, queue_used)) => {
+            if let Some(q) = queue_used {
+                metrics.record_workflow_terminal(
+                    workflow_name,
+                    &q,
+                    crate::telemetry::WorkflowStatus::Failed,
+                );
+            }
+            for start in deferred_starts {
+                start.spawn();
+            }
+        }
+        Err(e) => {
+            tracing::error!(
+                task_id = %task_id,
+                error = %e,
+                "workflow task timeout quarantine: transaction failed"
+            );
+        }
+    }
+}
+
+/// Reset a timed-out RUNNING workflow task back to PENDING so any worker can
+/// re-claim it on the next poll cycle without waiting for the orphan-reclaim
+/// staleness window (issue #494).
+///
+/// Uses an optimistic `WHERE state = 'RUNNING' AND worker_id = …` guard so a
+/// concurrent reclaim or a different worker that somehow picked it up does not
+/// get its state overwritten.
+pub async fn reset_timed_out_workflow_task(pool: &DbPool, task_id: uuid::Uuid, worker_id: &str) {
+    use crate::schema::harvest_task_queue::dsl;
+
+    let mut conn = match pool.get().await {
+        Ok(c) => c,
+        Err(e) => {
+            tracing::error!(
+                task_id = %task_id,
+                worker_id = %worker_id,
+                error = %e,
+                "workflow task timeout reset: pool exhausted"
+            );
+            return;
+        }
+    };
+    match diesel::update(
+        dsl::harvest_task_queue
+            .find(task_id)
+            .filter(dsl::state.eq("RUNNING"))
+            .filter(dsl::worker_id.eq(worker_id)),
+    )
+    .set((
+        dsl::state.eq("PENDING"),
+        dsl::worker_id.eq(None::<String>),
+        dsl::started_at.eq(None::<chrono::DateTime<chrono::Utc>>),
+        dsl::last_heartbeat_at.eq(None::<chrono::DateTime<chrono::Utc>>),
+    ))
+    .execute(&mut conn)
+    .await
+    {
+        Ok(n) if n > 0 => {
+            tracing::debug!(
+                task_id = %task_id,
+                worker_id = %worker_id,
+                "reset timed-out workflow task to PENDING"
+            );
+        }
+        Ok(_) => {
+            tracing::debug!(
+                task_id = %task_id,
+                worker_id = %worker_id,
+                "timed-out workflow task already reclaimed or transitioned"
+            );
+        }
+        Err(e) => {
+            tracing::error!(
+                task_id = %task_id,
+                worker_id = %worker_id,
+                error = %e,
+                "failed to reset timed-out workflow task to PENDING"
+            );
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Tests (unit, no DB)
 // ---------------------------------------------------------------------------
 
@@ -7695,6 +8105,7 @@ mod tests {
             priority_aging_secs: None,
             unknown_target_grace_window: Duration::from_secs(5),
             poison_pill_threshold: 3,
+            workflow_task_timeout: Duration::from_secs(10),
             max_workflow_pause_duration: Duration::from_secs(24 * 3600),
             max_workflow_history_events: None,
             labels: std::collections::HashMap::new(),
@@ -7707,6 +8118,107 @@ mod tests {
     fn worker_config_validates() {
         let cfg = default_runtime_config();
         assert!(cfg.validate().is_ok());
+    }
+
+    // ── Workflow-task timeout tests (issue #494) ──────────────────────────
+
+    #[test]
+    fn runtime_config_workflow_task_timeout_propagated() {
+        // WorkerRuntimeConfig must expose workflow_task_timeout so dispatch_task
+        // can apply the bounded budget.
+        let cfg = default_runtime_config();
+        assert_eq!(cfg.workflow_task_timeout, Duration::from_secs(10));
+    }
+
+    #[test]
+    fn runtime_config_workflow_task_timeout_zero_disables() {
+        let mut cfg = default_runtime_config();
+        cfg.workflow_task_timeout = Duration::ZERO;
+        assert!(cfg.workflow_task_timeout.is_zero());
+    }
+
+    #[test]
+    fn workflow_task_timeout_threshold_decision_under_threshold() {
+        // A consecutive-timeout count strictly below the threshold → Requeue.
+        assert_eq!(
+            crate::poison_pill::quarantine_decision(1, 3),
+            crate::poison_pill::ReclaimAction::Requeue
+        );
+        assert_eq!(
+            crate::poison_pill::quarantine_decision(2, 3),
+            crate::poison_pill::ReclaimAction::Requeue
+        );
+    }
+
+    #[test]
+    fn workflow_task_timeout_threshold_decision_at_threshold() {
+        // Exactly at or above threshold → Quarantine.
+        assert_eq!(
+            crate::poison_pill::quarantine_decision(3, 3),
+            crate::poison_pill::ReclaimAction::Quarantine
+        );
+        assert_eq!(
+            crate::poison_pill::quarantine_decision(4, 3),
+            crate::poison_pill::ReclaimAction::Quarantine
+        );
+    }
+
+    #[test]
+    fn workflow_task_timeout_zero_threshold_always_requeues() {
+        // threshold = 0 disables quarantine (backward compat).
+        assert_eq!(
+            crate::poison_pill::quarantine_decision(100, 0),
+            crate::poison_pill::ReclaimAction::Requeue
+        );
+    }
+
+    /// AC #7a — a `tokio::time::timeout` on a dispatch releases the semaphore
+    /// permit when the budget expires, so the slot is not permanently consumed.
+    #[tokio::test]
+    async fn timeout_releases_semaphore_permit() {
+        use tokio::sync::Semaphore;
+        let sem = std::sync::Arc::new(Semaphore::new(1));
+        let sem2 = sem.clone();
+        let hung = async move {
+            let _permit = sem2.acquire().await.expect("acquire");
+            tokio::time::sleep(Duration::from_secs(60)).await;
+        };
+        let result = tokio::time::timeout(Duration::from_millis(20), hung).await;
+        assert!(result.is_err(), "timeout must fire");
+        assert_eq!(
+            sem.available_permits(),
+            1,
+            "permit must be released after dispatch timeout"
+        );
+    }
+
+    /// AC #7b — while one slot is stuck, a second concurrent dispatch still
+    /// makes progress (does not block on the wedged future).
+    #[tokio::test]
+    async fn healthy_dispatch_proceeds_while_slot_is_timed_out() {
+        use tokio::sync::{Semaphore, oneshot};
+        let sem = std::sync::Arc::new(Semaphore::new(2));
+        let (tx, rx) = oneshot::channel::<()>();
+        let sem_hung = sem.clone();
+        let hung = async move {
+            let _permit = sem_hung.acquire().await.expect("acquire");
+            tokio::time::sleep(Duration::from_secs(60)).await;
+        };
+        let sem_ok = sem.clone();
+        let healthy = async move {
+            let _permit = sem_ok.acquire().await.expect("acquire");
+            tokio::time::sleep(Duration::from_millis(5)).await;
+            let _ = tx.send(());
+        };
+        let (hung_result, _) = tokio::join!(
+            tokio::time::timeout(Duration::from_millis(30), hung),
+            healthy,
+        );
+        assert!(hung_result.is_err(), "hung dispatch must time out");
+        assert!(
+            rx.await.is_ok(),
+            "healthy dispatch must complete while hung dispatch is active"
+        );
     }
 
     // ── merge_wake_events (issue #476 review) ─────────────────────────────
@@ -7863,6 +8375,7 @@ mod tests {
             max_workflow_start_delay: Duration::from_secs(365 * 24 * 3600),
             unknown_target_grace_window: Duration::from_secs(5),
             poison_pill_threshold: 3,
+            workflow_task_timeout: Duration::from_secs(10),
             max_workflow_pause_duration: Duration::from_secs(24 * 3600),
             labels: std::collections::HashMap::new(),
             max_workflow_history_events: None,

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -7898,6 +7898,7 @@ pub async fn quarantine_workflow_task_timeout(
 ) {
     use crate::schema::harvest_task_queue::dsl as task_dsl;
     use crate::schema::harvest_workflow_executions::dsl as exec_dsl;
+    use diesel::BoolExpressionMethods;
 
     let mut conn = match pool.get().await {
         Ok(c) => c,
@@ -8006,8 +8007,11 @@ pub async fn quarantine_workflow_task_timeout(
                         diesel::update(
                             task_dsl::harvest_task_queue
                                 .filter(task_dsl::workflow_exec_id.eq(exec_uuid))
-                                .filter(task_dsl::state.eq("PENDING"))
-                                .or_filter(task_dsl::state.eq("RUNNING")),
+                                .filter(
+                                    task_dsl::state
+                                        .eq("PENDING")
+                                        .or(task_dsl::state.eq("RUNNING")),
+                                ),
                         )
                         .set((
                             task_dsl::state.eq("FAILED"),

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -8006,11 +8006,8 @@ pub async fn quarantine_workflow_task_timeout(
                         diesel::update(
                             task_dsl::harvest_task_queue
                                 .filter(task_dsl::workflow_exec_id.eq(exec_uuid))
-                                .filter(
-                                    task_dsl::state
-                                        .eq("PENDING")
-                                        .or(task_dsl::state.eq("RUNNING")),
-                                ),
+                                .filter(task_dsl::state.eq("PENDING"))
+                                .or_filter(task_dsl::state.eq("RUNNING")),
                         )
                         .set((
                             task_dsl::state.eq("FAILED"),

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -7939,11 +7939,7 @@ pub async fn quarantine_workflow_task_timeout(
         Some(exec_uuid) => {
             let res = exec_dsl::harvest_workflow_executions
                 .find(exec_uuid)
-                .select((
-                    exec_dsl::owner,
-                    exec_dsl::severity,
-                    exec_dsl::parent_id,
-                ))
+                .select((exec_dsl::owner, exec_dsl::severity, exec_dsl::parent_id))
                 .first::<(Option<String>, Option<String>, Option<uuid::Uuid>)>(&mut conn)
                 .await
                 .optional()

--- a/autumn-harvest/tests/cancellation_tests.rs
+++ b/autumn-harvest/tests/cancellation_tests.rs
@@ -522,6 +522,8 @@ async fn running_activity_heartbeat_observes_workflow_cancellation() {
                 priority_aging_secs: None,
                 unknown_target_grace_window: Duration::from_secs(5),
                 poison_pill_threshold: 3,
+
+                workflow_task_timeout: std::time::Duration::from_secs(10),
                 labels: std::collections::HashMap::new(),
                 max_workflow_pause_duration: std::time::Duration::from_secs(24 * 3600),
                 max_workflow_history_events: None,
@@ -727,6 +729,8 @@ async fn uncooperative_activity_is_hard_aborted_after_grace_period() {
                 priority_aging_secs: None,
                 unknown_target_grace_window: Duration::from_secs(5),
                 poison_pill_threshold: 3,
+
+                workflow_task_timeout: std::time::Duration::from_secs(10),
                 labels: std::collections::HashMap::new(),
                 max_workflow_pause_duration: std::time::Duration::from_secs(24 * 3600),
                 max_workflow_history_events: None,
@@ -876,6 +880,8 @@ async fn activity_exits_early_on_workflow_cancellation() {
                 priority_aging_secs: None,
                 unknown_target_grace_window: Duration::from_secs(5),
                 poison_pill_threshold: 3,
+
+                workflow_task_timeout: std::time::Duration::from_secs(10),
                 labels: std::collections::HashMap::new(),
                 max_workflow_pause_duration: std::time::Duration::from_secs(24 * 3600),
                 max_workflow_history_events: None,
@@ -1020,6 +1026,8 @@ async fn activity_without_cancellation_check_completes_normally() {
                 priority_aging_secs: None,
                 unknown_target_grace_window: Duration::from_secs(5),
                 poison_pill_threshold: 3,
+
+                workflow_task_timeout: std::time::Duration::from_secs(10),
                 labels: std::collections::HashMap::new(),
                 max_workflow_pause_duration: std::time::Duration::from_secs(24 * 3600),
                 max_workflow_history_events: None,

--- a/autumn-harvest/tests/child_policy_tests.rs
+++ b/autumn-harvest/tests/child_policy_tests.rs
@@ -147,6 +147,7 @@ fn make_worker(registry: Arc<HandlerRegistry>) -> Worker {
             priority_aging_secs: None,
             unknown_target_grace_window: Duration::from_secs(5),
             poison_pill_threshold: 3,
+            workflow_task_timeout: std::time::Duration::from_secs(10),
             max_workflow_pause_duration: std::time::Duration::from_secs(24 * 3600),
             #[cfg(feature = "db")]
             labels: std::collections::HashMap::new(),

--- a/autumn-harvest/tests/delayed_start_tests.rs
+++ b/autumn-harvest/tests/delayed_start_tests.rs
@@ -307,6 +307,8 @@ async fn test_delayed_start_no_premature_dispatch() {
                 priority_aging_secs: None,
                 unknown_target_grace_window: Duration::from_secs(5),
                 poison_pill_threshold: 3,
+
+                workflow_task_timeout: std::time::Duration::from_secs(10),
                 labels: std::collections::HashMap::new(),
                 max_workflow_pause_duration: std::time::Duration::from_secs(24 * 3600),
                 max_workflow_history_events: None,

--- a/autumn-harvest/tests/integration_e2e.rs
+++ b/autumn-harvest/tests/integration_e2e.rs
@@ -740,6 +740,8 @@ fn build_runtime_worker(
                 priority_aging_secs: None,
                 unknown_target_grace_window: Duration::from_secs(5),
                 poison_pill_threshold: 3,
+
+                workflow_task_timeout: std::time::Duration::from_secs(10),
                 labels: std::collections::HashMap::new(),
                 max_workflow_pause_duration: std::time::Duration::from_secs(24 * 3600),
                 max_workflow_history_events: None,
@@ -1354,6 +1356,8 @@ async fn worker_completes_workflow_task_and_persists_result() {
                 priority_aging_secs: None,
                 unknown_target_grace_window: Duration::from_secs(5),
                 poison_pill_threshold: 3,
+
+                workflow_task_timeout: std::time::Duration::from_secs(10),
                 labels: std::collections::HashMap::new(),
                 max_workflow_pause_duration: std::time::Duration::from_secs(24 * 3600),
                 max_workflow_history_events: None,
@@ -1473,6 +1477,8 @@ async fn worker_marks_workflow_failed_when_handler_errors() {
                 priority_aging_secs: None,
                 unknown_target_grace_window: Duration::from_secs(5),
                 poison_pill_threshold: 3,
+
+                workflow_task_timeout: std::time::Duration::from_secs(10),
                 labels: std::collections::HashMap::new(),
                 max_workflow_pause_duration: std::time::Duration::from_secs(24 * 3600),
                 max_workflow_history_events: None,
@@ -1625,6 +1631,8 @@ async fn worker_completes_workflow_with_activity_round_trip() {
                 priority_aging_secs: None,
                 unknown_target_grace_window: Duration::from_secs(5),
                 poison_pill_threshold: 3,
+
+                workflow_task_timeout: std::time::Duration::from_secs(10),
                 labels: std::collections::HashMap::new(),
                 max_workflow_pause_duration: std::time::Duration::from_secs(24 * 3600),
                 max_workflow_history_events: None,
@@ -1840,6 +1848,8 @@ async fn worker_fails_orphaned_activity_task_without_scheduled_event() {
                 priority_aging_secs: None,
                 unknown_target_grace_window: Duration::from_secs(5),
                 poison_pill_threshold: 3,
+
+                workflow_task_timeout: std::time::Duration::from_secs(10),
                 labels: std::collections::HashMap::new(),
                 max_workflow_pause_duration: std::time::Duration::from_secs(24 * 3600),
                 max_workflow_history_events: None,
@@ -2087,6 +2097,8 @@ async fn worker_fails_workflow_when_activity_start_to_close_timeout_elapses() {
                 priority_aging_secs: None,
                 unknown_target_grace_window: Duration::from_secs(5),
                 poison_pill_threshold: 3,
+
+                workflow_task_timeout: std::time::Duration::from_secs(10),
                 labels: std::collections::HashMap::new(),
                 max_workflow_pause_duration: std::time::Duration::from_secs(24 * 3600),
                 max_workflow_history_events: None,
@@ -2240,6 +2252,8 @@ async fn worker_completes_workflow_with_timer_round_trip() {
                 priority_aging_secs: None,
                 unknown_target_grace_window: Duration::from_secs(5),
                 poison_pill_threshold: 3,
+
+                workflow_task_timeout: std::time::Duration::from_secs(10),
                 labels: std::collections::HashMap::new(),
                 max_workflow_pause_duration: std::time::Duration::from_secs(24 * 3600),
                 max_workflow_history_events: None,
@@ -4829,6 +4843,8 @@ async fn workflow_schedule_baseline_dispatches_multiple_runs() {
                 priority_aging_secs: None,
                 unknown_target_grace_window: Duration::from_secs(5),
                 poison_pill_threshold: 3,
+
+                workflow_task_timeout: std::time::Duration::from_secs(10),
                 labels: std::collections::HashMap::new(),
                 max_workflow_pause_duration: std::time::Duration::from_secs(24 * 3600),
                 max_workflow_history_events: None,
@@ -4944,6 +4960,8 @@ async fn workflow_schedule_max_active_runs_enforced() {
                 priority_aging_secs: None,
                 unknown_target_grace_window: Duration::from_secs(5),
                 poison_pill_threshold: 3,
+
+                workflow_task_timeout: std::time::Duration::from_secs(10),
                 labels: std::collections::HashMap::new(),
                 max_workflow_pause_duration: std::time::Duration::from_secs(24 * 3600),
                 max_workflow_history_events: None,
@@ -5048,6 +5066,8 @@ async fn workflow_schedule_pause_and_resume() {
                 priority_aging_secs: None,
                 unknown_target_grace_window: Duration::from_secs(5),
                 poison_pill_threshold: 3,
+
+                workflow_task_timeout: std::time::Duration::from_secs(10),
                 labels: std::collections::HashMap::new(),
                 max_workflow_pause_duration: std::time::Duration::from_secs(24 * 3600),
                 max_workflow_history_events: None,

--- a/autumn-harvest/tests/integration_e2e.rs
+++ b/autumn-harvest/tests/integration_e2e.rs
@@ -1288,6 +1288,7 @@ async fn claim_task_returns_none_on_empty_queue() {
 }
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+#[allow(clippy::too_many_lines)]
 async fn worker_completes_workflow_task_and_persists_result() {
     let (database_url, _container) = setup_test_database_url().await;
     let mut conn = <AsyncPgConnection as diesel_async::AsyncConnection>::establish(&database_url)

--- a/autumn-harvest/tests/metrics_coverage.rs
+++ b/autumn-harvest/tests/metrics_coverage.rs
@@ -15,7 +15,7 @@ use autumn_harvest::telemetry::{
     METRIC_RETENTION_DELETED, METRIC_SCHEDULE_DECISION_WRITE_FAILED, METRIC_SCHEDULE_RUNS,
     METRIC_SCHEDULE_SKIPPED, METRIC_TIMER_STARTED, METRIC_WORKFLOW_CONTINUE_AS_NEW,
     METRIC_WORKFLOW_DURATION, METRIC_WORKFLOW_HISTORY_SIZE, METRIC_WORKFLOW_STARTED,
-    MetricsRecorder, NoOpMetrics, WorkflowStatus,
+    METRIC_WORKFLOW_TASK_TIMEOUT, MetricsRecorder, NoOpMetrics, WorkflowStatus,
 };
 
 // ---------------------------------------------------------------------------
@@ -171,6 +171,16 @@ impl MetricsRecorder for RecordingMetrics {
             ],
         });
     }
+
+    fn record_workflow_task_timeout(&self, workflow_name: &str, queue: &str) {
+        self.samples.lock().unwrap().push(MetricSample {
+            name: METRIC_WORKFLOW_TASK_TIMEOUT,
+            labels: vec![
+                ("workflow", workflow_name.to_owned()),
+                ("queue", queue.to_owned()),
+            ],
+        });
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -196,6 +206,7 @@ fn all_catalogue_metrics_are_reachable_via_trait() {
     rec.record_schedule_skipped("workflow", "nightly", "paused");
     rec.record_schedule_decision_write_failed();
     rec.record_retention_tick(0, 100, 50, 0.01);
+    rec.record_workflow_task_timeout("my_workflow", "default");
 
     let samples = rec.drain();
     let names: Vec<&str> = samples.iter().map(|s| s.name).collect();
@@ -262,6 +273,10 @@ fn all_catalogue_metrics_are_reachable_via_trait() {
         names.contains(&METRIC_RETENTION_DELETED),
         "harvest.retention.deleted not sampled"
     );
+    assert!(
+        names.contains(&METRIC_WORKFLOW_TASK_TIMEOUT),
+        "harvest.workflow.task_timeout not sampled"
+    );
 }
 
 #[test]
@@ -283,6 +298,7 @@ fn cardinality_no_execution_id_label_on_any_metric() {
     rec.record_schedule_skipped("dag", "my_dag", "max_active_runs_reached");
     rec.record_schedule_decision_write_failed();
     rec.record_retention_tick(0, 0, 0, 0.0);
+    rec.record_workflow_task_timeout("wf", "default");
 
     for sample in rec.drain() {
         for (key, _val) in &sample.labels {

--- a/autumn-harvest/tests/metrics_integration.rs
+++ b/autumn-harvest/tests/metrics_integration.rs
@@ -373,6 +373,8 @@ fn build_worker(worker_id: &str, registry: Arc<HandlerRegistry>) -> Arc<Worker> 
                 priority_aging_secs: None,
                 unknown_target_grace_window: Duration::from_secs(5),
                 poison_pill_threshold: 3,
+
+                workflow_task_timeout: std::time::Duration::from_secs(10),
                 labels: std::collections::HashMap::new(),
                 max_workflow_pause_duration: std::time::Duration::from_secs(24 * 3600),
                 max_workflow_history_events: None,
@@ -2225,6 +2227,8 @@ async fn workflow_non_determinism_metric_and_search_attrs_are_recorded() {
         priority_aging_secs: None,
         unknown_target_grace_window: Duration::from_secs(5),
         poison_pill_threshold: 3,
+
+        workflow_task_timeout: std::time::Duration::from_secs(10),
         labels: std::collections::HashMap::new(),
         max_workflow_pause_duration: std::time::Duration::from_secs(24 * 3600),
         max_workflow_history_events: None,

--- a/autumn-harvest/tests/pause_tests.rs
+++ b/autumn-harvest/tests/pause_tests.rs
@@ -181,6 +181,8 @@ fn make_worker(registry: Arc<HandlerRegistry>) -> Worker {
             priority_aging_secs: None,
             unknown_target_grace_window: Duration::from_secs(5),
             poison_pill_threshold: 3,
+
+            workflow_task_timeout: std::time::Duration::from_secs(10),
             max_workflow_pause_duration: Duration::from_secs(24 * 3600),
             labels: std::collections::HashMap::new(),
             max_workflow_history_events: None,

--- a/autumn-harvest/tests/poison_pill_tests.rs
+++ b/autumn-harvest/tests/poison_pill_tests.rs
@@ -353,6 +353,9 @@ async fn orphan_at_threshold_is_quarantined() {
         DeadLetterReason::HistoryCapExceeded { .. } => {
             panic!("expected PoisonPill reason, got HistoryCapExceeded")
         }
+        DeadLetterReason::WorkflowTaskTimeout { .. } => {
+            panic!("expected PoisonPill reason, got WorkflowTaskTimeout")
+        }
     }
 
     // Metric emitted with queue + reason labels (AC6).

--- a/autumn-harvest/tests/scheduler_carryover_tests.rs
+++ b/autumn-harvest/tests/scheduler_carryover_tests.rs
@@ -249,6 +249,8 @@ fn make_worker(worker_id: &str, registry: Arc<HandlerRegistry>) -> Arc<Worker> {
                 priority_aging_secs: None,
                 unknown_target_grace_window: Duration::from_secs(5),
                 poison_pill_threshold: 3,
+
+                workflow_task_timeout: std::time::Duration::from_secs(10),
                 labels: std::collections::HashMap::new(),
                 max_workflow_pause_duration: Duration::from_secs(24 * 3600),
                 max_workflow_history_events: None,

--- a/autumn-harvest/tests/telemetry_span_tests.rs
+++ b/autumn-harvest/tests/telemetry_span_tests.rs
@@ -414,6 +414,8 @@ fn all_adr_0001_span_kinds_are_emitted() {
                         priority_aging_secs: None,
                         unknown_target_grace_window: Duration::from_secs(5),
                         poison_pill_threshold: 3,
+
+                        workflow_task_timeout: std::time::Duration::from_secs(10),
                         labels: std::collections::HashMap::new(),
                         max_workflow_pause_duration: std::time::Duration::from_secs(24 * 3600),
                         max_workflow_history_events: None,

--- a/autumn-harvest/tests/transactional_activity_tests.rs
+++ b/autumn-harvest/tests/transactional_activity_tests.rs
@@ -209,6 +209,8 @@ fn make_worker(_db_url: &str, registry: Arc<HandlerRegistry>) -> Arc<Worker> {
                 priority_aging_secs: None,
                 unknown_target_grace_window: Duration::from_secs(5),
                 poison_pill_threshold: 3,
+
+                workflow_task_timeout: std::time::Duration::from_secs(10),
                 labels: std::collections::HashMap::new(),
                 max_workflow_pause_duration: std::time::Duration::from_secs(24 * 3600),
                 max_workflow_history_events: None,

--- a/autumn-harvest/tests/workflow_task_timeout_tests.rs
+++ b/autumn-harvest/tests/workflow_task_timeout_tests.rs
@@ -42,7 +42,7 @@ use uuid::Uuid;
 /// database so leftover databases are harmless.
 enum Keepalive {
     #[allow(dead_code)]
-    Container(ContainerAsync<Postgres>),
+    Container(Box<ContainerAsync<Postgres>>),
     /// No cleanup needed; the test database is abandoned (unique UUID name).
     LocalDb,
 }
@@ -120,6 +120,16 @@ const INIT_SQL: &str = concat!(
     "\n",
     include_str!("../migrations/20260615000001_harvest_context_headers/up.sql")
 );
+
+// ---------------------------------------------------------------------------
+// Diesel helper types
+// ---------------------------------------------------------------------------
+
+#[derive(QueryableByName)]
+struct ReasonRow {
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    error: String,
+}
 
 // ---------------------------------------------------------------------------
 // Recording metrics stub
@@ -211,7 +221,7 @@ async fn setup() -> (AsyncPgConnection, DbPool, Keepalive) {
         .build()
         .expect("pool build");
 
-    (conn, pool, Keepalive::Container(container))
+    (conn, pool, Keepalive::Container(Box::new(container)))
 }
 
 /// Insert a RUNNING workflow execution and return its UUID.
@@ -386,12 +396,15 @@ async fn quarantine_writes_dlq_and_fails_execution() {
     assert_eq!(dlq_count, 1, "exactly one DLQ entry expected");
 
     // Terminal metric emitted.
-    let terminal = metrics.terminal.lock().unwrap();
-    assert!(
+    let has_terminal = {
+        let terminal = metrics.terminal.lock().unwrap();
         terminal
             .iter()
-            .any(|(wf, q, _)| wf == "timeout_wf" && q == "default"),
-        "record_workflow_terminal should be called with (timeout_wf, default), got {terminal:?}"
+            .any(|(wf, q, _)| wf == "timeout_wf" && q == "default")
+    };
+    assert!(
+        has_terminal,
+        "record_workflow_terminal should be called with (timeout_wf, default)"
     );
 }
 
@@ -419,19 +432,14 @@ async fn quarantine_writes_typed_dlq_reason() {
     .await;
 
     // Inspect the raw reason JSON stored in harvest_dead_letters.
-    #[derive(QueryableByName)]
-    struct ReasonRow {
-        #[diesel(sql_type = diesel::sql_types::Text)]
-        error: String,
-    }
     let rows: Vec<ReasonRow> = diesel::sql_query("SELECT error FROM harvest_dead_letters LIMIT 1")
         .load(&mut conn)
         .await
         .expect("query dlq");
-    let reason_json = &rows.get(0).expect("dlq row").error;
+    let reason_json = rows.into_iter().next().expect("dlq row").error;
 
     let reason: DeadLetterReason =
-        serde_json::from_str(reason_json).expect("reason must deserialize");
+        serde_json::from_str(&reason_json).expect("reason must deserialize");
     assert!(
         matches!(
             reason,

--- a/autumn-harvest/tests/workflow_task_timeout_tests.rs
+++ b/autumn-harvest/tests/workflow_task_timeout_tests.rs
@@ -1,0 +1,475 @@
+#![cfg(feature = "db")]
+//! Workflow-task timeout quarantine integration tests — issue #494.
+//!
+//! The worker wraps each workflow-task dispatch in a bounded wall-clock budget
+//! (`WorkerConfig::workflow_task_timeout`, default 10 s). A hung body that
+//! exceeds the budget has its concurrency slot reclaimed and its execution's
+//! consecutive-timeout counter incremented. At or above
+//! `poison_pill_threshold` (default 3) the task is quarantined to the DLQ and
+//! the owning execution is failed terminally.
+//!
+//! These tests exercise the DB-layer helpers directly against a real Postgres
+//! container:
+//!
+//! - `reset_timed_out_workflow_task` reverts a RUNNING task to PENDING so it
+//!   can be re-claimed without waiting for the orphan-reclaim staleness window.
+//! - `quarantine_workflow_task_timeout` moves the task to the DLQ, fails the
+//!   execution, and emits `harvest.workflow.task_timeout` + terminal metrics.
+//! - `WorkerConfig::workflow_task_timeout` defaults to 10 s; zero disables.
+
+use std::sync::Mutex;
+
+use autumn_harvest::dlq::{DeadLetterReason, dead_letter_count};
+use autumn_harvest::telemetry::MetricsRecorder;
+use autumn_harvest::worker::{
+    DbPool, quarantine_workflow_task_timeout, reset_timed_out_workflow_task,
+};
+use diesel::prelude::*;
+use diesel_async::AsyncConnection;
+use diesel_async::AsyncPgConnection;
+use diesel_async::RunQueryDsl;
+use diesel_async::SimpleAsyncConnection;
+use diesel_async::pooled_connection::AsyncDieselConnectionManager;
+use testcontainers::ContainerAsync;
+use testcontainers::ImageExt;
+use testcontainers_modules::postgres::Postgres;
+use testcontainers_modules::testcontainers::runners::AsyncRunner;
+use uuid::Uuid;
+
+/// Keepalive handle for either a testcontainers container or a local
+/// per-test database. Dropping this stops the container (testcontainers path).
+/// For the local-PG path we keep `()` — each test uses a unique UUID-named
+/// database so leftover databases are harmless.
+enum Keepalive {
+    #[allow(dead_code)]
+    Container(ContainerAsync<Postgres>),
+    /// No cleanup needed; the test database is abandoned (unique UUID name).
+    LocalDb,
+}
+
+const INIT_SQL: &str = concat!(
+    include_str!("../migrations/20260409000000_harvest_initial/up.sql"),
+    "\n",
+    include_str!("../migrations/20260424000001_harvest_trace_context/up.sql"),
+    "\n",
+    include_str!("../migrations/20260505000000_harvest_heartbeat_details/up.sql"),
+    "\n",
+    include_str!("../migrations/20260427000000_harvest_continue_as_new/up.sql"),
+    "\n",
+    include_str!("../migrations/20260429000000_harvest_concurrency_key/up.sql"),
+    "\n",
+    include_str!("../migrations/20260430000000_harvest_workflow_schedules/up.sql"),
+    "\n",
+    include_str!("../migrations/20260430000001_harvest_external_tasks/up.sql"),
+    "\n",
+    include_str!("../migrations/20260508000000_harvest_external_task_updated_at/up.sql"),
+    "\n",
+    include_str!("../migrations/20260506000000_harvest_audit_log/up.sql"),
+    "\n",
+    include_str!("../migrations/20260501000000_harvest_workers/up.sql"),
+    "\n",
+    include_str!("../migrations/20260508010000_harvest_workers_drain_deadline/up.sql"),
+    "\n",
+    include_str!("../migrations/20260509000000_harvest_build_routing/up.sql"),
+    "\n",
+    include_str!("../migrations/20260513000000_harvest_schedule_pause_metadata/up.sql"),
+    "\n",
+    include_str!("../migrations/20260514020000_harvest_task_activity_id/up.sql"),
+    "\n",
+    include_str!("../migrations/20260518000000_harvest_signal_idempotency/up.sql"),
+    "\n",
+    include_str!("../migrations/20260517000000_harvest_schedule_jitter/up.sql"),
+    "\n",
+    include_str!("../migrations/20260517000001_harvest_schedule_overlap_policy/up.sql"),
+    "\n",
+    include_str!("../migrations/20260518000001_harvest_workflow_execution_timeout/up.sql"),
+    "\n",
+    include_str!("../migrations/20260613000000_harvest_workflow_sla/up.sql"),
+    "\n",
+    include_str!("../migrations/20260519000000_harvest_calendar_awareness/up.sql"),
+    "\n",
+    include_str!("../migrations/20260522000000_harvest_schedule_decisions/up.sql"),
+    "\n",
+    include_str!("../migrations/20260522000001_harvest_rate_limiting/up.sql"),
+    "\n",
+    include_str!("../migrations/20260526000001_harvest_parent_close_policy/up.sql"),
+    "\n",
+    include_str!("../migrations/20260530000000_harvest_schedule_ha_claim/up.sql"),
+    "\n",
+    include_str!("../migrations/20260601000000_harvest_schedule_auto_pause/up.sql"),
+    "\n",
+    include_str!("../migrations/20260601000001_harvest_poison_pill_strikes/up.sql"),
+    "\n",
+    include_str!("../migrations/20260601000002_harvest_ownership_metadata/up.sql"),
+    "\n",
+    include_str!("../migrations/20260603000000_harvest_completion_triggers/up.sql"),
+    include_str!("../migrations/20260605000000_harvest_admission_gates/up.sql"),
+    include_str!("../migrations/20260606000001_harvest_activity_schedule_to_close/up.sql"),
+    include_str!("../migrations/20260607000000_harvest_worker_capability_labels/up.sql"),
+    include_str!("../migrations/20260607000001_harvest_task_required_capabilities/up.sql"),
+    "\n",
+    include_str!("../migrations/20260607000002_harvest_workflow_pause/up.sql"),
+    "\n",
+    include_str!("../migrations/20260609000001_harvest_workflow_current_details/up.sql"),
+    "\n",
+    include_str!("../migrations/20260610000001_harvest_schedule_bounded_runs/up.sql"),
+    "\n",
+    include_str!("../migrations/20260613000001_harvest_schedule_catchup_window/up.sql"),
+    "\n",
+    include_str!("../migrations/20260616000001_harvest_workflow_schedule_id/up.sql"),
+    "\n",
+    include_str!("../migrations/20260615000001_harvest_context_headers/up.sql")
+);
+
+// ---------------------------------------------------------------------------
+// Recording metrics stub
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Default)]
+struct RecordingMetrics {
+    task_timeouts: Mutex<Vec<(String, String)>>,
+    terminal: Mutex<Vec<(String, String, String)>>,
+}
+
+impl MetricsRecorder for RecordingMetrics {
+    fn record_workflow_task_timeout(&self, workflow_name: &str, queue: &str) {
+        self.task_timeouts
+            .lock()
+            .unwrap()
+            .push((workflow_name.to_owned(), queue.to_owned()));
+    }
+
+    fn record_workflow_terminal(
+        &self,
+        workflow_name: &str,
+        queue: &str,
+        status: autumn_harvest::telemetry::WorkflowStatus,
+    ) {
+        self.terminal.lock().unwrap().push((
+            workflow_name.to_owned(),
+            queue.to_owned(),
+            format!("{status:?}"),
+        ));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+async fn setup() -> (AsyncPgConnection, DbPool, Keepalive) {
+    // When `TEST_DATABASE_URL` is set (e.g. in environments where Docker image
+    // pulls are blocked), create a fresh per-test database on the local
+    // Postgres instance instead of spinning up a container.
+    if let Ok(admin_url) = std::env::var("TEST_DATABASE_URL") {
+        let db_name = format!("harvest_test_{}", Uuid::new_v4().simple());
+        // Create the fresh test database.
+        let mut admin_conn = AsyncPgConnection::establish(&admin_url)
+            .await
+            .expect("connect to admin DB");
+        admin_conn
+            .batch_execute(&format!("CREATE DATABASE \"{db_name}\";"))
+            .await
+            .expect("create test database");
+
+        // Build a URL pointing at the new database.
+        // Strip trailing "/postgres" and replace with the new db name.
+        let test_url = {
+            let base = admin_url.trim_end_matches('/');
+            let without_db = base.rfind('/').map_or(base, |i| &base[..i]);
+            format!("{without_db}/{db_name}")
+        };
+
+        let mut conn = AsyncPgConnection::establish(&test_url)
+            .await
+            .expect("connect to test DB");
+        conn.batch_execute(INIT_SQL).await.expect("migration");
+
+        let mgr = AsyncDieselConnectionManager::<AsyncPgConnection>::new(test_url);
+        let pool = deadpool::managed::Pool::builder(mgr)
+            .max_size(4)
+            .build()
+            .expect("pool build");
+
+        return (conn, pool, Keepalive::LocalDb);
+    }
+
+    let container = Postgres::default()
+        .with_tag("16")
+        .start()
+        .await
+        .expect("postgres start");
+    let host = container.get_host().await.expect("host");
+    let port = container.get_host_port_ipv4(5432).await.expect("port");
+    let url = format!("postgresql://postgres:postgres@{host}:{port}/postgres");
+    let mut conn = AsyncPgConnection::establish(&url).await.expect("connect");
+    conn.batch_execute(INIT_SQL).await.expect("migration");
+
+    let mgr = AsyncDieselConnectionManager::<AsyncPgConnection>::new(url);
+    let pool = deadpool::managed::Pool::builder(mgr)
+        .max_size(4)
+        .build()
+        .expect("pool build");
+
+    (conn, pool, Keepalive::Container(container))
+}
+
+/// Insert a RUNNING workflow execution and return its UUID.
+async fn insert_running_workflow(conn: &mut AsyncPgConnection) -> Uuid {
+    let id = Uuid::new_v4();
+    diesel::sql_query(
+        "INSERT INTO harvest_workflow_executions \
+         (id, workflow_name, workflow_id, shard_id, state, input, queue_name) \
+         VALUES ($1, 'timeout_wf', 'wf-timeout-1', 0, 'RUNNING', '{}'::jsonb, 'default')",
+    )
+    .bind::<diesel::sql_types::Uuid, _>(id)
+    .execute(conn)
+    .await
+    .expect("insert execution");
+    id
+}
+
+/// Insert a RUNNING task claimed by `worker_id` linked to `workflow_exec_id`.
+async fn insert_running_workflow_task(
+    conn: &mut AsyncPgConnection,
+    workflow_exec_id: Uuid,
+    worker_id: &str,
+) -> Uuid {
+    let id = Uuid::new_v4();
+    diesel::sql_query(
+        "INSERT INTO harvest_task_queue \
+         (id, queue_name, task_type, workflow_exec_id, input, state, worker_id, \
+          attempt, max_attempts, started_at) \
+         VALUES ($1, 'default', 'workflow', $2, '{}'::jsonb, 'RUNNING', $3, \
+                 1, 3, NOW() - INTERVAL '30 seconds')",
+    )
+    .bind::<diesel::sql_types::Uuid, _>(id)
+    .bind::<diesel::sql_types::Uuid, _>(workflow_exec_id)
+    .bind::<diesel::sql_types::Text, _>(worker_id)
+    .execute(conn)
+    .await
+    .expect("insert task");
+    id
+}
+
+async fn task_state(conn: &mut AsyncPgConnection, task_id: Uuid) -> String {
+    diesel::sql_query("SELECT state FROM harvest_task_queue WHERE id = $1")
+        .bind::<diesel::sql_types::Uuid, _>(task_id)
+        .load::<TaskStateRow>(conn)
+        .await
+        .expect("query")
+        .into_iter()
+        .next()
+        .expect("row")
+        .state
+}
+
+async fn execution_state(conn: &mut AsyncPgConnection, exec_id: Uuid) -> String {
+    diesel::sql_query("SELECT state FROM harvest_workflow_executions WHERE id = $1")
+        .bind::<diesel::sql_types::Uuid, _>(exec_id)
+        .load::<ExecStateRow>(conn)
+        .await
+        .expect("query")
+        .into_iter()
+        .next()
+        .expect("row")
+        .state
+}
+
+#[derive(QueryableByName)]
+struct TaskStateRow {
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    state: String,
+}
+
+#[derive(QueryableByName)]
+struct ExecStateRow {
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    state: String,
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// `reset_timed_out_workflow_task` reverts a RUNNING task to PENDING so the
+/// next poll cycle can re-claim it without waiting for the orphan-reclaim
+/// staleness window.
+#[tokio::test]
+async fn reset_reverts_running_task_to_pending() {
+    let (mut conn, pool, _container) = setup().await;
+
+    let exec_id = insert_running_workflow(&mut conn).await;
+    let task_id = insert_running_workflow_task(&mut conn, exec_id, "worker-1").await;
+
+    assert_eq!(task_state(&mut conn, task_id).await, "RUNNING");
+
+    reset_timed_out_workflow_task(&pool, task_id, "worker-1").await;
+
+    assert_eq!(
+        task_state(&mut conn, task_id).await,
+        "PENDING",
+        "reset should move RUNNING → PENDING"
+    );
+    // Execution stays RUNNING (timeout below threshold doesn't fail it).
+    assert_eq!(execution_state(&mut conn, exec_id).await, "RUNNING");
+}
+
+/// `reset_timed_out_workflow_task` is a no-op when the task is already
+/// PENDING or was claimed by a different worker — the optimistic guard prevents
+/// a stale reset from clobbering a fresh claim.
+#[tokio::test]
+async fn reset_is_idempotent_on_wrong_state_or_worker() {
+    let (mut conn, pool, _container) = setup().await;
+
+    let exec_id = insert_running_workflow(&mut conn).await;
+    let task_id = insert_running_workflow_task(&mut conn, exec_id, "worker-1").await;
+
+    // Wrong worker_id — should not transition.
+    reset_timed_out_workflow_task(&pool, task_id, "worker-99").await;
+    assert_eq!(
+        task_state(&mut conn, task_id).await,
+        "RUNNING",
+        "wrong worker_id must not reset the task"
+    );
+
+    // Correct worker — transitions.
+    reset_timed_out_workflow_task(&pool, task_id, "worker-1").await;
+    assert_eq!(task_state(&mut conn, task_id).await, "PENDING");
+
+    // Second call on PENDING task — no crash, still PENDING.
+    reset_timed_out_workflow_task(&pool, task_id, "worker-1").await;
+    assert_eq!(task_state(&mut conn, task_id).await, "PENDING");
+}
+
+/// `quarantine_workflow_task_timeout` moves the task to the dead-letter queue,
+/// fails the owning execution, and emits the `workflow.task_timeout` +
+/// `workflow.terminal` metrics.
+#[tokio::test]
+async fn quarantine_writes_dlq_and_fails_execution() {
+    let (mut conn, pool, _container) = setup().await;
+
+    let exec_id = insert_running_workflow(&mut conn).await;
+    let task_id = insert_running_workflow_task(&mut conn, exec_id, "worker-1").await;
+
+    let metrics = std::sync::Arc::new(RecordingMetrics::default());
+
+    quarantine_workflow_task_timeout(
+        &pool,
+        task_id,
+        Some(exec_id),
+        "worker-1",
+        3,  // new_strikes (= threshold)
+        10, // timeout_secs
+        "timeout_wf",
+        "default",
+        &*metrics,
+    )
+    .await;
+
+    // Task row must be FAILED.
+    assert_eq!(
+        task_state(&mut conn, task_id).await,
+        "FAILED",
+        "timed-out task must be quarantined (FAILED)"
+    );
+
+    // Owning execution must be FAILED.
+    assert_eq!(
+        execution_state(&mut conn, exec_id).await,
+        "FAILED",
+        "owning execution must be failed after quarantine"
+    );
+
+    // DLQ must have one entry.
+    let dlq_count = dead_letter_count(&mut conn).await.expect("dlq count");
+    assert_eq!(dlq_count, 1, "exactly one DLQ entry expected");
+
+    // Terminal metric emitted.
+    let terminal = metrics.terminal.lock().unwrap();
+    assert!(
+        terminal
+            .iter()
+            .any(|(wf, q, _)| wf == "timeout_wf" && q == "default"),
+        "record_workflow_terminal should be called with (timeout_wf, default), got {terminal:?}"
+    );
+}
+
+/// The DLQ entry carries a `WorkflowTaskTimeout` typed reason so operators
+/// can distinguish this from poison-pill quarantines.
+#[tokio::test]
+async fn quarantine_writes_typed_dlq_reason() {
+    let (mut conn, pool, _container) = setup().await;
+
+    let exec_id = insert_running_workflow(&mut conn).await;
+    let task_id = insert_running_workflow_task(&mut conn, exec_id, "worker-1").await;
+
+    let metrics = RecordingMetrics::default();
+    quarantine_workflow_task_timeout(
+        &pool,
+        task_id,
+        Some(exec_id),
+        "worker-1",
+        3,
+        10,
+        "timeout_wf",
+        "default",
+        &metrics,
+    )
+    .await;
+
+    // Inspect the raw reason JSON stored in harvest_dead_letters.
+    #[derive(QueryableByName)]
+    struct ReasonRow {
+        #[diesel(sql_type = diesel::sql_types::Text)]
+        error: String,
+    }
+    let rows: Vec<ReasonRow> = diesel::sql_query("SELECT error FROM harvest_dead_letters LIMIT 1")
+        .load(&mut conn)
+        .await
+        .expect("query dlq");
+    let reason_json = &rows.get(0).expect("dlq row").error;
+
+    let reason: DeadLetterReason =
+        serde_json::from_str(reason_json).expect("reason must deserialize");
+    assert!(
+        matches!(
+            reason,
+            DeadLetterReason::WorkflowTaskTimeout {
+                task_timeout_strikes: 3,
+                timeout_secs: 10
+            }
+        ),
+        "DLQ reason must be WorkflowTaskTimeout, got {reason:?}"
+    );
+}
+
+/// `quarantine_workflow_task_timeout` with no `exec_id` still marks the task
+/// FAILED and writes a DLQ entry, but does not try to fail any execution.
+#[tokio::test]
+async fn quarantine_with_no_exec_id_only_fails_task() {
+    let (mut conn, pool, _container) = setup().await;
+
+    // Task with no execution association.
+    let task_id = Uuid::new_v4();
+    diesel::sql_query(
+        "INSERT INTO harvest_task_queue \
+         (id, queue_name, task_type, input, state, worker_id, attempt, max_attempts, started_at) \
+         VALUES ($1, 'default', 'workflow', '{}'::jsonb, 'RUNNING', 'worker-1', 1, 3, NOW())",
+    )
+    .bind::<diesel::sql_types::Uuid, _>(task_id)
+    .execute(&mut conn)
+    .await
+    .expect("insert orphan task");
+
+    let metrics = RecordingMetrics::default();
+    quarantine_workflow_task_timeout(
+        &pool, task_id, None, // no exec_id
+        "worker-1", 3, 10, "unknown", "default", &metrics,
+    )
+    .await;
+
+    assert_eq!(task_state(&mut conn, task_id).await, "FAILED");
+    let dlq_count = dead_letter_count(&mut conn).await.expect("dlq count");
+    assert_eq!(dlq_count, 1);
+}


### PR DESCRIPTION
## Summary

Implements per-workflow-task wall-clock timeout enforcement to prevent hung or blocking workflow bodies from monopolizing worker concurrency slots indefinitely. When a workflow-task dispatch exceeds the configured budget, the worker reclaims the slot immediately and resets the task to `PENDING` for retry. After `poison_pill_threshold` consecutive timeouts for the same execution, the task is escalated to the dead-letter queue rather than re-queued forever.

## Key Changes

- **New `WorkerConfig::workflow_task_timeout` field** (default 10 seconds, can be disabled with `Duration::ZERO`)
  - Applies only to workflow tasks, not activities
  - Wrapped in `tokio::time::timeout()` during dispatch
  - Deterministic replay ensures transient slow dispatches recover safely on retry

- **In-process consecutive-timeout strike counter** (`Worker::workflow_task_timeout_strikes`)
  - Keyed by `workflow_exec_id` so re-queued tasks from the same execution accumulate toward the same threshold
  - Cleared on successful completion or clean error (only consecutive timeouts count)
  - Incremented on timeout; when it reaches `poison_pill_threshold`, the task is quarantined

- **New helper functions** for timeout handling:
  - `reset_timed_out_workflow_task()`: Reverts a `RUNNING` task to `PENDING` with optimistic `WHERE state = 'RUNNING' AND worker_id = …` guard
  - `quarantine_workflow_task_timeout()`: Moves task to DLQ, fails the owning execution, appends `WorkflowFailed` event, and emits metrics
  - `workflow_task_timeout_metric_names()`: Best-effort DB lookup for workflow/queue names for metric labels

- **New `DeadLetterReason::WorkflowTaskTimeout` variant** with `task_timeout_strikes` and `timeout_secs` fields for operator visibility

- **New telemetry**:
  - `METRIC_WORKFLOW_TASK_TIMEOUT` counter (`harvest.workflow.task_timeout{workflow, queue}`) emitted on each timeout
  - `record_workflow_task_timeout()` method on `MetricsRecorder` trait
  - Metrics emitted even if execution row is gone (fallback to `"unknown"` / `"default"`)

- **Comprehensive integration tests** (`workflow_task_timeout_tests.rs`) covering:
  - Task reset to `PENDING` and idempotency
  - DLQ quarantine with typed reason and execution failure
  - Orphan task handling (no execution association)
  - Metric emission

## Implementation Details

- Timeout is applied at the `dispatch_task()` level, wrapping the entire `process_task()` future
- On timeout, the semaphore permit is dropped automatically (future is cancelled), freeing the concurrency slot
- The in-memory strike counter is protected by `Arc<std::sync::Mutex<HashMap<Uuid, i32>>>` for thread-safe concurrent access
- Quarantine decision reuses the existing `poison_pill::quarantine_decision()` logic
- All DB operations in quarantine path are transactional; errors are logged and swallowed to prevent cascading failures
- Metrics are recorded with best-effort workflow/queue name lookup; metric is still emitted with fallback labels on DB failure

https://claude.ai/code/session_01UozsG1xgsZ3tn4fFP2Cngb