### PR TITLE
👺 Havoc: [Panic] Slicing string with character index in eligibility requirements

### DIFF
--- a/autumn-harvest/src/eligibility.rs
+++ b/autumn-harvest/src/eligibility.rs
@@ -91,13 +91,8 @@ fn find_operator_indices(token: &str) -> (Option<usize>, Option<usize>) {
     let mut eq_idx = None;
     let mut in_idx = None;
     let mut in_quotes = None;
-    let token_chars: Vec<char> = token.chars().collect();
-    let token_lower = token.to_lowercase();
-    let token_lower_chars: Vec<char> = token_lower.chars().collect();
 
-    let mut i = 0;
-    while i < token_chars.len() {
-        let c = token_chars[i];
+    for (i, c) in token.char_indices() {
         match c {
             '\'' | '"' => {
                 if in_quotes == Some(c) {
@@ -109,20 +104,18 @@ fn find_operator_indices(token: &str) -> (Option<usize>, Option<usize>) {
             '=' if in_quotes.is_none() && eq_idx.is_none() => {
                 eq_idx = Some(i);
             }
-            _ => {
-                if in_quotes.is_none()
-                    && in_idx.is_none()
-                    && i + 3 < token_chars.len()
-                    && token_lower_chars[i] == ' '
-                    && token_lower_chars[i + 1] == 'i'
-                    && token_lower_chars[i + 2] == 'n'
-                    && token_lower_chars[i + 3] == ' '
+            ' ' if in_quotes.is_none() && in_idx.is_none() => {
+                let rest = &token[i..];
+                if rest.starts_with(" in ")
+                    || rest.starts_with(" IN ")
+                    || rest.starts_with(" In ")
+                    || rest.starts_with(" iN ")
                 {
                     in_idx = Some(i);
                 }
             }
+            _ => {}
         }
-        i += 1;
     }
     (eq_idx, in_idx)
 }
@@ -381,5 +374,14 @@ mod tests {
 
         // Empty requirements always match
         assert!(matches_requirements(&[], &labels));
+    }
+
+    use proptest::prelude::*;
+
+    proptest! {
+        #[test]
+        fn havoc_test_parse_requirements_does_not_panic(s in "\\PC*") {
+            let _ = parse_requirements(&s);
+        }
     }
 }


### PR DESCRIPTION
🧨 **The Trigger**: Input string with non-ASCII or multi-byte characters and `" in "` was causing a panic because `find_operator_indices` calculated characters but then accessed bytes. For example `✅=true` panicked on char mapping!
📉 **The Stack Trace**: `thread 'havoc_test_eligibility' panicked at autumn-harvest/src/eligibility.rs: byte index is not a char boundary; it is inside '✅' (bytes 0..3) of \`✅=true\``
🧪 **Reproduction**: Run `cargo test -p autumn-harvest --lib eligibility::tests::havoc_test_parse_requirements_does_not_panic`.
😈 **Comment**: You assumed characters and bytes were the same size. You were wrong. This fix correctly uses byte-slice independent prefix checks for the `in` operator mapping.

---
*PR created automatically by Jules for task [13446423862599412321](https://jules.google.com/task/13446423862599412321) started by @madmax983*