### PR TITLE
⚡ Bolt: Remove unnecessary allocations in stalled workflow queries

### DIFF
--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -14469,10 +14469,7 @@ pub(crate) async fn load_stalled_workflows(
     // Checking all task_type values mirrors the sleeping-filter predicate so that
     // an execution with a stuck workflow task is not mislabelled no_pending_work.
     let has_activity: HashSet<uuid::Uuid> = harvest_task_queue::table
-        .filter(
-            harvest_task_queue::workflow_exec_id
-                .eq_any(exec_ids.iter().map(|id| Some(*id)).collect::<Vec<_>>()),
-        )
+        .filter(harvest_task_queue::workflow_exec_id.eq_any(exec_ids.iter().map(|id| Some(*id))))
         .filter(harvest_task_queue::state.eq_any(["PENDING", "CLAIMED", "RUNNING", "BACKOFF"]))
         .select(harvest_task_queue::workflow_exec_id)
         .distinct()
@@ -14485,10 +14482,7 @@ pub(crate) async fn load_stalled_workflows(
 
     // ── Step 4: non-terminal child workflows ────────────────────────────────
     let has_child: HashSet<uuid::Uuid> = harvest_workflow_executions::table
-        .filter(
-            harvest_workflow_executions::parent_id
-                .eq_any(exec_ids.iter().map(|id| Some(*id)).collect::<Vec<_>>()),
-        )
+        .filter(harvest_workflow_executions::parent_id.eq_any(exec_ids.iter().map(|id| Some(*id))))
         .filter(harvest_workflow_executions::state.ne_all([
             "COMPLETED",
             "FAILED",


### PR DESCRIPTION
💡 What: Removed intermediate `.collect::<Vec<_>>()` when querying stalled workflows in `autumn-harvest-plugin/src/api.rs`.
🎯 Why: To avoid unnecessary heap allocations per execution batch checked.
📊 Impact: Reduces heap allocs when checking for stalled executions by leveraging diesel's `eq_any` ability to accept iterators directly.
🔬 Measurement: Check the PR diff for removed `.collect::<Vec<_>>()`.

---
*PR created automatically by Jules for task [15361522258187819490](https://jules.google.com/task/15361522258187819490) started by @madmax983*