### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/autumn-harvest/src/completion_trigger.rs
+++ b/autumn-harvest/src/completion_trigger.rs
@@ -1,3 +1,15 @@
+//! Cross-workflow and DAG completion triggers.
+//!
+//! Completion triggers allow event-driven continuation by automatically starting
+//! new workflows or DAG runs when a source workflow reaches a terminal state
+//! (e.g., `Completed` or `Failed`).
+//!
+//! This module manages the dispatch of these triggers, handling cross-shard routing
+//! via an outbox pattern (`harvest_completion_trigger_outbox`) and enforcing
+//! concurrency limits and priority inheritance. It allows independent DAGs and
+//! workflows to be loosely coupled, forming larger orchestrations without hardcoded
+//! parent-child dependencies.
+
 use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use uuid::Uuid;

--- a/autumn-harvest/src/eligibility.rs
+++ b/autumn-harvest/src/eligibility.rs
@@ -1,3 +1,13 @@
+//! Worker capability matching and requirement parsing DSL.
+//!
+//! This module provides a small domain-specific language (DSL) for targeting workflows
+//! and tasks to specific workers based on their capability labels. Workers report
+//! their capabilities (like `gpu=true`, `region=eu-west-1`) on startup, and workflows
+//! declare requirements (like `gpu = true, region in [eu-west-1, us-east-1]`).
+//!
+//! The engine parses these requirement strings at dispatch time using `parse_requirements`
+//! and evaluates them against connected workers using `matches_requirements`.
+
 use std::collections::HashMap;
 
 /// A single capability requirement for task execution.
@@ -27,6 +37,23 @@ fn strip_quotes(s: &str) -> &str {
 /// # Errors
 ///
 /// Returns an error string if the requirement syntax is invalid or if it contains an empty key.
+///
+/// ## Examples
+///
+/// ```
+/// use autumn_harvest::eligibility::{parse_requirements, Requirement};
+///
+/// let reqs = parse_requirements("gpu = true, region in [eu-west-1, us-east-1]").unwrap();
+/// assert_eq!(reqs.len(), 2);
+/// assert!(matches!(
+///     &reqs[0],
+///     Requirement::Exact { key, value } if key == "gpu" && value == "true"
+/// ));
+/// assert!(matches!(
+///     &reqs[1],
+///     Requirement::In { key, values } if key == "region" && values.len() == 2
+/// ));
+/// ```
 pub fn parse_requirements(s: &str) -> Result<Vec<Requirement>, String> {
     let s = s.trim();
     if s.is_empty() {
@@ -191,6 +218,29 @@ fn parse_single_requirement(token: &str) -> Result<Requirement, String> {
 }
 
 /// Evaluates if a worker's capability labels satisfy the requirements.
+///
+/// Returns `true` if all requirements are satisfied by the provided labels. If any
+/// requirement references a key not present in the labels, or if the value does
+/// not match, it returns `false`.
+///
+/// ## Examples
+///
+/// ```
+/// use autumn_harvest::eligibility::{parse_requirements, matches_requirements};
+/// use std::collections::HashMap;
+///
+/// let reqs = parse_requirements("gpu = true, region in [eu-west-1, us-east-1]").unwrap();
+///
+/// let mut matching_worker = HashMap::new();
+/// matching_worker.insert("gpu".to_string(), "true".to_string());
+/// matching_worker.insert("region".to_string(), "eu-west-1".to_string());
+/// assert!(matches_requirements(&reqs, &matching_worker));
+///
+/// let mut rejecting_worker = HashMap::new();
+/// rejecting_worker.insert("gpu".to_string(), "false".to_string());
+/// rejecting_worker.insert("region".to_string(), "eu-west-1".to_string());
+/// assert!(!matches_requirements(&reqs, &rejecting_worker));
+/// ```
 #[must_use]
 pub fn matches_requirements<S: std::hash::BuildHasher>(
     requirements: &[Requirement],

--- a/autumn-harvest/src/schedule_decision.rs
+++ b/autumn-harvest/src/schedule_decision.rs
@@ -1,3 +1,16 @@
+//! Schedule decisions tracking.
+//!
+//! When a schedule's cron expression fires or an interval elapses, the engine evaluates whether
+//! to start the target workflow. A schedule decision represents the outcome of this evaluation.
+//! These decisions are persisted to the `harvest_schedule_decisions` table to provide operators
+//! with a durable audit trail of why a scheduled workflow did or did not start at a particular time.
+//!
+//! Reasons for skipping a workflow start include concurrency limits (e.g., `max_active_runs`),
+//! the schedule being paused, or prior runs still being active without a `catchup` policy.
+//!
+//! This module provides functions to safely record these decisions (swallowing database
+//! errors to preserve scheduler progress) and to purge old decisions based on retention policies.
+
 use crate::models::NewScheduleDecision;
 use crate::schema::harvest_schedule_decisions;
 use crate::telemetry::MetricsRecorder;
@@ -53,7 +66,7 @@ pub async fn record_decision_graceful(
 ///
 /// # Errors
 ///
-/// Returns a [`database_error`] if the database query execution fails.
+/// Returns a `database_error` if the database query execution fails.
 pub async fn purge_old_schedule_decisions(
     conn: &mut AsyncPgConnection,
     retention_days: i64,


### PR DESCRIPTION
📖 Chapter: Added module-level (`//!`) documentation to three core orchestrator modules: `eligibility.rs`, `completion_trigger.rs`, and `schedule_decision.rs`.

🔦 Insight:
- `eligibility`: Explained the worker capability matching DSL and how operators target specific capabilities.
- `completion_trigger`: Clarified how cross-workflow and DAG triggers stitch together independent orchestrations using the outbox pattern.
- `schedule_decision`: Documented the durable audit trail for cron firings/skips.

🧪 Example: Added executable `/// ## Examples` doctests for `parse_requirements` and `matches_requirements` in the eligibility module. Also fixed a broken intra-doc link pointing to `database_error`.

---
*PR created automatically by Jules for task [5472078456277516715](https://jules.google.com/task/5472078456277516715) started by @madmax983*