### PR TITLE
Surface activity heartbeat checkpoint payloads in workflow stack API

### DIFF
--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -1075,6 +1075,24 @@ struct PendingActivity {
     heartbeat_deadline: Option<chrono::DateTime<chrono::Utc>>,
 }
 
+/// Compute the cap decision for a stored heartbeat checkpoint payload from a
+/// borrow, without cloning. Returns `(truncated, bytes)`: `truncated` is `true`
+/// when a payload exists and exceeds `cap`; `bytes` is the observed serialized
+/// size whenever a payload exists. A `cap` of `0` means uncapped. Pure (#503).
+///
+/// This is the borrow-based core shared by the API response projection
+/// (`project_heartbeat_details`) and the UI cell renderer so neither path
+/// clones an over-cap payload merely to discard it.
+pub(crate) fn heartbeat_details_truncation(
+    value: Option<&serde_json::Value>,
+    cap: u64,
+) -> (bool, Option<u64>) {
+    value.map_or((false, None), |v| {
+        let bytes = serde_json::to_string(v).map_or(0, |s| s.len() as u64);
+        (cap > 0 && bytes > cap, Some(bytes))
+    })
+}
+
 /// Project a stored heartbeat checkpoint payload onto the describe response,
 /// bounded by the activity-result payload cap (#252) so a pathological payload
 /// cannot bloat the stack response. Returns `(payload, truncated, bytes)`:
@@ -1082,18 +1100,17 @@ struct PendingActivity {
 /// when absent or over-cap; `truncated` is `true` only in the over-cap case;
 /// `bytes` is the observed serialized size whenever a payload exists. A `cap`
 /// of `0` means uncapped. Pure and strictly non-mutating (issue #503).
+///
+/// Takes the payload by value so the owned value flows through to the response
+/// with **zero clones** on the API hot path (returned when within the cap,
+/// dropped when over-cap).
 pub(crate) fn project_heartbeat_details(
     details: Option<serde_json::Value>,
     cap: u64,
 ) -> (Option<serde_json::Value>, bool, Option<u64>) {
-    details.map_or((None, false, None), |value| {
-        let bytes = serde_json::to_string(&value).map_or(0, |s| s.len() as u64);
-        if cap > 0 && bytes > cap {
-            (None, true, Some(bytes))
-        } else {
-            (Some(value), false, Some(bytes))
-        }
-    })
+    let (truncated, bytes) = heartbeat_details_truncation(details.as_ref(), cap);
+    let payload = if truncated { None } else { details };
+    (payload, truncated, bytes)
 }
 
 #[derive(Debug, Serialize)]
@@ -19360,6 +19377,27 @@ mod tests {
             .iter()
             .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
             .collect()
+    }
+
+    #[test]
+    fn heartbeat_details_truncation_borrow_decisions() {
+        // Absent payload.
+        assert_eq!(heartbeat_details_truncation(None, 1024), (false, None));
+        // Within cap.
+        let small = serde_json::json!({"processed": 4500, "total": 10000});
+        let (truncated, bytes) = heartbeat_details_truncation(Some(&small), 1024);
+        assert!(!truncated);
+        assert_eq!(
+            bytes,
+            Some(serde_json::to_string(&small).unwrap().len() as u64)
+        );
+        // Over cap.
+        let big = serde_json::json!({"blob": "x".repeat(100)});
+        let (truncated, bytes) = heartbeat_details_truncation(Some(&big), 16);
+        assert!(truncated);
+        assert!(bytes.unwrap() > 16);
+        // Zero cap is uncapped.
+        assert!(!heartbeat_details_truncation(Some(&big), 0).0);
     }
 
     #[test]

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -3088,6 +3088,7 @@ pub const fn management_api_response_fields()
                 "pending_signals",
                 "buffered_signals",
                 "pending_child_workflows",
+                "checkpoints_truncated_for_budget",
                 "last_event_id",
             ]),
         ),
@@ -5289,6 +5290,12 @@ async fn get_workflow_stack(
         .filter(harvest_task_queue::workflow_exec_id.eq(Some(exec_uuid)))
         .filter(harvest_task_queue::task_type.eq("activity"))
         .filter(harvest_task_queue::state.eq_any(["PENDING", "CLAIMED", "RUNNING", "BACKOFF"]))
+        // Stable ordering so the cumulative checkpoint budget (#503) keeps/omits
+        // the same checkpoints deterministically across calls and query plans.
+        .order((
+            harvest_task_queue::scheduled_at.asc(),
+            harvest_task_queue::id.asc(),
+        ))
         .select(autumn_harvest::models::TaskQueueItem::as_select())
         .load::<autumn_harvest::models::TaskQueueItem>(&mut conn)
         .await

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -1055,10 +1055,45 @@ struct PendingActivity {
     task_status: String,
     claimed_by_worker_id: Option<String>,
     last_heartbeat_at: Option<chrono::DateTime<chrono::Utc>>,
+    /// Latest heartbeat checkpoint payload reported by the activity via
+    /// `ctx.heartbeat(...)` — the current value of
+    /// `harvest_task_queue.heartbeat_details` (issue #503). `null` when no
+    /// heartbeat payload has been flushed, or when the stored payload exceeds
+    /// the activity-result payload cap (see `heartbeat_details_truncated`).
+    /// Read-only: surfacing this never mutates the column or affects
+    /// retry-resume semantics.
+    heartbeat_details: Option<serde_json::Value>,
+    /// `true` when the stored heartbeat payload exceeded the configured
+    /// activity-result payload cap (#252) and was withheld from the response;
+    /// inspect `heartbeat_details_bytes` for the size.
+    heartbeat_details_truncated: bool,
+    /// Observed byte size of the stored heartbeat payload, when one exists.
+    heartbeat_details_bytes: Option<u64>,
     next_retry_at: Option<chrono::DateTime<chrono::Utc>>,
     schedule_to_start_deadline: Option<chrono::DateTime<chrono::Utc>>,
     start_to_close_deadline: Option<chrono::DateTime<chrono::Utc>>,
     heartbeat_deadline: Option<chrono::DateTime<chrono::Utc>>,
+}
+
+/// Project a stored heartbeat checkpoint payload onto the describe response,
+/// bounded by the activity-result payload cap (#252) so a pathological payload
+/// cannot bloat the stack response. Returns `(payload, truncated, bytes)`:
+/// `payload` is the verbatim value when present and within the cap, or `None`
+/// when absent or over-cap; `truncated` is `true` only in the over-cap case;
+/// `bytes` is the observed serialized size whenever a payload exists. A `cap`
+/// of `0` means uncapped. Pure and strictly non-mutating (issue #503).
+pub(crate) fn project_heartbeat_details(
+    details: Option<serde_json::Value>,
+    cap: u64,
+) -> (Option<serde_json::Value>, bool, Option<u64>) {
+    details.map_or((None, false, None), |value| {
+        let bytes = serde_json::to_string(&value).map_or(0, |s| s.len() as u64);
+        if cap > 0 && bytes > cap {
+            (None, true, Some(bytes))
+        } else {
+            (Some(value), false, Some(bytes))
+        }
+    })
 }
 
 #[derive(Debug, Serialize)]
@@ -5180,6 +5215,13 @@ async fn get_workflow_stack(
         }
     }
 
+    // Reuse the #252 activity-result payload cap as the response-side guard for
+    // heartbeat checkpoints (issue #503); fall back to the documented default
+    // when no runtime is installed (read-only mount).
+    let heartbeat_details_cap = api_state.runtime().ok().map_or(
+        autumn_harvest::builder::DEFAULT_MAX_ACTIVITY_RESULT_BYTES,
+        |rt| rt.registry.max_activity_result_bytes,
+    );
     let pending_activities = tasks
         .into_iter()
         .map(|t| {
@@ -5197,6 +5239,8 @@ async fn get_workflow_stack(
                 t.state
             };
 
+            let (heartbeat_details, heartbeat_details_truncated, heartbeat_details_bytes) =
+                project_heartbeat_details(t.heartbeat_details, heartbeat_details_cap);
             PendingActivity {
                 activity_exec_id: t.id.to_string(),
                 activity_name: t.activity_name.unwrap_or_default(),
@@ -5207,6 +5251,9 @@ async fn get_workflow_stack(
                 task_status,
                 claimed_by_worker_id: t.worker_id,
                 last_heartbeat_at: t.last_heartbeat_at,
+                heartbeat_details,
+                heartbeat_details_truncated,
+                heartbeat_details_bytes,
                 next_retry_at: None,
                 schedule_to_start_deadline: t.schedule_to_start.map(|d| t.scheduled_at + d),
                 start_to_close_deadline: t.started_at.zip(t.start_to_close).map(|(s, d)| s + d),
@@ -5238,6 +5285,9 @@ async fn get_workflow_stack(
             task_status: task.state.clone(),
             claimed_by_worker_id: None,
             last_heartbeat_at: None,
+            heartbeat_details: None,
+            heartbeat_details_truncated: false,
+            heartbeat_details_bytes: None,
             next_retry_at: None,
             schedule_to_start_deadline: None,
             start_to_close_deadline: Some(task.deadline_at),
@@ -19310,6 +19360,44 @@ mod tests {
             .iter()
             .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
             .collect()
+    }
+
+    #[test]
+    fn project_heartbeat_details_none_is_absent() {
+        let (payload, truncated, bytes) = project_heartbeat_details(None, 1024);
+        assert!(payload.is_none());
+        assert!(!truncated);
+        assert!(bytes.is_none());
+    }
+
+    #[test]
+    fn project_heartbeat_details_under_cap_is_verbatim() {
+        let stored = serde_json::json!({"processed": 4500, "total": 10000});
+        let (payload, truncated, bytes) = project_heartbeat_details(Some(stored.clone()), 1024);
+        assert_eq!(payload, Some(stored.clone()));
+        assert!(!truncated);
+        let expected = serde_json::to_string(&stored).unwrap().len() as u64;
+        assert_eq!(bytes, Some(expected));
+    }
+
+    #[test]
+    fn project_heartbeat_details_over_cap_is_truncated() {
+        let stored = serde_json::json!({"blob": "x".repeat(100)});
+        let observed = serde_json::to_string(&stored).unwrap().len() as u64;
+        let (payload, truncated, bytes) = project_heartbeat_details(Some(stored), 16);
+        assert!(payload.is_none(), "over-cap payload must be withheld");
+        assert!(truncated);
+        assert_eq!(bytes, Some(observed));
+        assert!(bytes.unwrap() > 16);
+    }
+
+    #[test]
+    fn project_heartbeat_details_zero_cap_is_uncapped() {
+        let stored = serde_json::json!({"blob": "x".repeat(10_000)});
+        let (payload, truncated, bytes) = project_heartbeat_details(Some(stored.clone()), 0);
+        assert_eq!(payload, Some(stored));
+        assert!(!truncated, "cap of 0 means uncapped passthrough");
+        assert!(bytes.is_some());
     }
 
     #[test]

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -1144,38 +1144,59 @@ pub(crate) fn project_heartbeat_details(
     (payload, truncated, bytes)
 }
 
-/// Apply a single cumulative checkpoint-byte budget across all pending
-/// activities in one stack response so a fan-out workflow with many
-/// heartbeating activities can't return roughly `count × cap` bytes (#503
-/// review). Walks the activities in order, summing the size of each *included*
-/// checkpoint; once the running total would exceed `budget`, later checkpoints
-/// are withheld (`heartbeat_details = None`, `heartbeat_details_omitted_for_budget
-/// = true`) while their `heartbeat_details_bytes` size is still reported.
+/// Pure cumulative checkpoint-budget core, shared by the stack API and the
+/// Vantage detail UI (#503 review). Given each entry's *included-checkpoint*
+/// byte size in order (`None` = no payload to budget — absent or already
+/// withheld by its own per-activity cap), return per-entry omit-for-budget
+/// decisions under a single cumulative `budget`.
 ///
-/// The first payload-bearing checkpoint is always kept, even if it alone
-/// exceeds the budget, so a single legitimately large checkpoint from an
-/// activity with a raised per-activity cap stays visible (preserving the #1
-/// per-activity-cap fix). A `budget` of `0` disables the response budget.
-/// Returns `true` when at least one checkpoint was withheld for budget.
-fn apply_checkpoint_response_budget(activities: &mut [PendingActivity], budget: u64) -> bool {
-    if budget == 0 {
-        return false;
-    }
+/// The first payload-bearing entry is always kept (decision `false`), even if
+/// it alone exceeds the budget, so a single legitimately large checkpoint from
+/// an activity with a raised per-activity cap stays visible. A `budget` of `0`
+/// disables budgeting (all decisions `false`).
+pub(crate) fn checkpoint_budget_decisions(sizes: &[Option<u64>], budget: u64) -> Vec<bool> {
     let mut running: u64 = 0;
+    sizes
+        .iter()
+        .copied()
+        .map(|size| {
+            size.is_some_and(|s| {
+                let over = budget > 0 && running > 0 && running.saturating_add(s) > budget;
+                if !over {
+                    running = running.saturating_add(s);
+                }
+                over
+            })
+        })
+        .collect()
+}
+
+/// Apply [`checkpoint_budget_decisions`] to a stack response so a fan-out
+/// workflow with many heartbeating activities can't return roughly
+/// `count × cap` bytes (#503 review). Withheld checkpoints get
+/// `heartbeat_details = None` + `heartbeat_details_omitted_for_budget = true`,
+/// while their `heartbeat_details_bytes` size is still reported. Returns `true`
+/// when at least one checkpoint was withheld for budget.
+fn apply_checkpoint_response_budget(activities: &mut [PendingActivity], budget: u64) -> bool {
+    // Only entries with an included payload participate in the budget; absent or
+    // individually-truncated entries (`heartbeat_details == None`) map to `None`.
+    let sizes: Vec<Option<u64>> = activities
+        .iter()
+        .map(|pa| {
+            pa.heartbeat_details
+                .is_some()
+                .then(|| pa.heartbeat_details_bytes.unwrap_or(0))
+        })
+        .collect();
     let mut any_withheld = false;
-    for pa in activities.iter_mut() {
-        // Skip entries with no included payload (absent, or already withheld by
-        // their own per-activity cap) — they contribute nothing to the budget.
-        if pa.heartbeat_details.is_none() {
-            continue;
-        }
-        let size = pa.heartbeat_details_bytes.unwrap_or(0);
-        if running > 0 && running.saturating_add(size) > budget {
+    for (pa, omit) in activities
+        .iter_mut()
+        .zip(checkpoint_budget_decisions(&sizes, budget))
+    {
+        if omit {
             pa.heartbeat_details = None;
             pa.heartbeat_details_omitted_for_budget = true;
             any_withheld = true;
-        } else {
-            running = running.saturating_add(size);
         }
     }
     any_withheld
@@ -19614,6 +19635,35 @@ mod tests {
         assert!(!withheld, "200 bytes of payload fit within 250");
         assert!(items[1].heartbeat_details.is_some());
         assert!(items[2].heartbeat_details.is_some());
+    }
+
+    #[test]
+    fn checkpoint_budget_decisions_core() {
+        // Disabled.
+        assert_eq!(
+            checkpoint_budget_decisions(&[Some(100), Some(100)], 0),
+            vec![false, false]
+        );
+        // Within budget.
+        assert_eq!(
+            checkpoint_budget_decisions(&[Some(100), Some(100)], 1000),
+            vec![false, false]
+        );
+        // Over budget: third withheld; first two fit.
+        assert_eq!(
+            checkpoint_budget_decisions(&[Some(100), Some(100), Some(100)], 250),
+            vec![false, false, true]
+        );
+        // First always kept even if oversized; rest withheld.
+        assert_eq!(
+            checkpoint_budget_decisions(&[Some(10_000), Some(10)], 1000),
+            vec![false, true]
+        );
+        // None entries (absent / individually truncated) never count or omit.
+        assert_eq!(
+            checkpoint_budget_decisions(&[None, Some(100), None, Some(200)], 250),
+            vec![false, false, false, true]
+        );
     }
 
     #[test]

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -1075,6 +1075,22 @@ struct PendingActivity {
     heartbeat_deadline: Option<chrono::DateTime<chrono::Utc>>,
 }
 
+/// A `std::io::Write` sink that counts bytes and discards them. Used to measure
+/// the serialized size of a heartbeat checkpoint without allocating a full copy
+/// of a potentially pathological (multi-MiB) payload (#503 review).
+struct ByteCountWriter(u64);
+
+impl std::io::Write for ByteCountWriter {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0 += buf.len() as u64;
+        Ok(buf.len())
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
 /// Compute the cap decision for a stored heartbeat checkpoint payload from a
 /// borrow, without cloning. Returns `(truncated, bytes)`: `truncated` is `true`
 /// when a payload exists and exceeds `cap`; `bytes` is the observed serialized
@@ -1082,13 +1098,16 @@ struct PendingActivity {
 ///
 /// This is the borrow-based core shared by the API response projection
 /// (`project_heartbeat_details`) and the UI cell renderer so neither path
-/// clones an over-cap payload merely to discard it.
+/// clones an over-cap payload merely to discard it. The serialized size is
+/// measured with a non-allocating counting writer so an oversized checkpoint
+/// is never materialized into a second buffer just to be withheld.
 pub(crate) fn heartbeat_details_truncation(
     value: Option<&serde_json::Value>,
     cap: u64,
 ) -> (bool, Option<u64>) {
     value.map_or((false, None), |v| {
-        let bytes = serde_json::to_string(v).map_or(0, |s| s.len() as u64);
+        let mut counter = ByteCountWriter(0);
+        let bytes = serde_json::to_writer(&mut counter, v).map_or(0, |()| counter.0);
         (cap > 0 && bytes > cap, Some(bytes))
     })
 }
@@ -5234,8 +5253,11 @@ async fn get_workflow_stack(
 
     // Reuse the #252 activity-result payload cap as the response-side guard for
     // heartbeat checkpoints (issue #503); fall back to the documented default
-    // when no runtime is installed (read-only mount).
-    let heartbeat_details_cap = api_state.runtime().ok().map_or(
+    // when no runtime is installed (read-only mount). The effective cap is
+    // resolved per-activity below so an activity configured with a higher
+    // `max_result_bytes` keeps full checkpoint visibility.
+    let stack_runtime = api_state.runtime().ok();
+    let default_heartbeat_cap = stack_runtime.as_ref().map_or(
         autumn_harvest::builder::DEFAULT_MAX_ACTIVITY_RESULT_BYTES,
         |rt| rt.registry.max_activity_result_bytes,
     );
@@ -5256,8 +5278,18 @@ async fn get_workflow_stack(
                 t.state
             };
 
+            // Judge the checkpoint against this activity's effective result cap
+            // (per-activity override raised against the global ceiling), matching
+            // the worker, so configured large-payload activities aren't wrongly
+            // truncated (#503 review).
+            let heartbeat_cap = stack_runtime
+                .as_ref()
+                .zip(t.activity_name.as_deref())
+                .map_or(default_heartbeat_cap, |(rt, name)| {
+                    rt.registry.activity_result_cap(name)
+                });
             let (heartbeat_details, heartbeat_details_truncated, heartbeat_details_bytes) =
-                project_heartbeat_details(t.heartbeat_details, heartbeat_details_cap);
+                project_heartbeat_details(t.heartbeat_details, heartbeat_cap);
             PendingActivity {
                 activity_exec_id: t.id.to_string(),
                 activity_name: t.activity_name.unwrap_or_default(),

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -1001,6 +1001,11 @@ struct WorkflowStackResponse {
     pending_signals: Vec<PendingSignal>,
     buffered_signals: Vec<BufferedSignal>,
     pending_child_workflows: Vec<PendingChildWorkflow>,
+    /// `true` when one or more pending-activity heartbeat checkpoints were
+    /// withheld because the cumulative per-response checkpoint budget was
+    /// exhausted (#503 review). Affected entries carry
+    /// `heartbeat_details_omitted_for_budget: true`.
+    checkpoints_truncated_for_budget: bool,
     last_event_id: i64,
 }
 
@@ -1044,7 +1049,7 @@ impl From<WorkflowExecution> for StalledWorkflowRow {
     }
 }
 
-#[derive(Debug, Serialize)]
+#[derive(Debug, Clone, Serialize)]
 struct PendingActivity {
     activity_exec_id: String,
     activity_name: String,
@@ -1063,10 +1068,17 @@ struct PendingActivity {
     /// Read-only: surfacing this never mutates the column or affects
     /// retry-resume semantics.
     heartbeat_details: Option<serde_json::Value>,
-    /// `true` when the stored heartbeat payload exceeded the configured
-    /// activity-result payload cap (#252) and was withheld from the response;
-    /// inspect `heartbeat_details_bytes` for the size.
+    /// `true` when the stored heartbeat payload exceeded this activity's
+    /// effective result-payload cap (#252) and was withheld from the response;
+    /// inspect `heartbeat_details_bytes` for the size. This reflects the
+    /// *individual* payload's own size only — see `heartbeat_details_omitted_for_budget`
+    /// for the cross-activity response budget.
     heartbeat_details_truncated: bool,
+    /// `true` when this checkpoint was within its own cap but was withheld
+    /// because the cumulative per-response checkpoint budget was already
+    /// exhausted by earlier activities (#503 review). `heartbeat_details_bytes`
+    /// still reports its size.
+    heartbeat_details_omitted_for_budget: bool,
     /// Observed byte size of the stored heartbeat payload, when one exists.
     heartbeat_details_bytes: Option<u64>,
     next_retry_at: Option<chrono::DateTime<chrono::Utc>>,
@@ -1130,6 +1142,43 @@ pub(crate) fn project_heartbeat_details(
     let (truncated, bytes) = heartbeat_details_truncation(details.as_ref(), cap);
     let payload = if truncated { None } else { details };
     (payload, truncated, bytes)
+}
+
+/// Apply a single cumulative checkpoint-byte budget across all pending
+/// activities in one stack response so a fan-out workflow with many
+/// heartbeating activities can't return roughly `count × cap` bytes (#503
+/// review). Walks the activities in order, summing the size of each *included*
+/// checkpoint; once the running total would exceed `budget`, later checkpoints
+/// are withheld (`heartbeat_details = None`, `heartbeat_details_omitted_for_budget
+/// = true`) while their `heartbeat_details_bytes` size is still reported.
+///
+/// The first payload-bearing checkpoint is always kept, even if it alone
+/// exceeds the budget, so a single legitimately large checkpoint from an
+/// activity with a raised per-activity cap stays visible (preserving the #1
+/// per-activity-cap fix). A `budget` of `0` disables the response budget.
+/// Returns `true` when at least one checkpoint was withheld for budget.
+fn apply_checkpoint_response_budget(activities: &mut [PendingActivity], budget: u64) -> bool {
+    if budget == 0 {
+        return false;
+    }
+    let mut running: u64 = 0;
+    let mut any_withheld = false;
+    for pa in activities.iter_mut() {
+        // Skip entries with no included payload (absent, or already withheld by
+        // their own per-activity cap) — they contribute nothing to the budget.
+        if pa.heartbeat_details.is_none() {
+            continue;
+        }
+        let size = pa.heartbeat_details_bytes.unwrap_or(0);
+        if running > 0 && running.saturating_add(size) > budget {
+            pa.heartbeat_details = None;
+            pa.heartbeat_details_omitted_for_budget = true;
+            any_withheld = true;
+        } else {
+            running = running.saturating_add(size);
+        }
+    }
+    any_withheld
 }
 
 #[derive(Debug, Serialize)]
@@ -5210,6 +5259,7 @@ async fn get_workflow_stack(
             pending_signals: Vec::new(),
             buffered_signals: Vec::new(),
             pending_child_workflows: Vec::new(),
+            checkpoints_truncated_for_budget: false,
             last_event_id,
         }));
     }
@@ -5302,6 +5352,7 @@ async fn get_workflow_stack(
                 last_heartbeat_at: t.last_heartbeat_at,
                 heartbeat_details,
                 heartbeat_details_truncated,
+                heartbeat_details_omitted_for_budget: false,
                 heartbeat_details_bytes,
                 next_retry_at: None,
                 schedule_to_start_deadline: t.schedule_to_start.map(|d| t.scheduled_at + d),
@@ -5336,6 +5387,7 @@ async fn get_workflow_stack(
             last_heartbeat_at: None,
             heartbeat_details: None,
             heartbeat_details_truncated: false,
+            heartbeat_details_omitted_for_budget: false,
             heartbeat_details_bytes: None,
             next_retry_at: None,
             schedule_to_start_deadline: None,
@@ -5349,6 +5401,11 @@ async fn get_workflow_stack(
         .collect::<Vec<_>>();
     let mut pending_activities = pending_activities;
     pending_activities.extend(external_pending);
+    // Bound the total checkpoint bytes returned across all pending activities so
+    // a large fan-out can't return roughly `count × cap` bytes (#503 review).
+    // The per-response budget reuses the global activity-result cap.
+    let checkpoints_truncated_for_budget =
+        apply_checkpoint_response_budget(&mut pending_activities, default_heartbeat_cap);
     let pending_local_activities = harvest_events::table
         .filter(harvest_events::workflow_exec_id.eq(exec_uuid))
         .filter(harvest_events::event_type.eq_any([
@@ -5497,6 +5554,7 @@ async fn get_workflow_stack(
         pending_signals,
         buffered_signals,
         pending_child_workflows,
+        checkpoints_truncated_for_budget,
         last_event_id,
     }))
 }
@@ -19468,6 +19526,94 @@ mod tests {
         assert_eq!(payload, Some(stored));
         assert!(!truncated, "cap of 0 means uncapped passthrough");
         assert!(bytes.is_some());
+    }
+
+    fn pending_with_checkpoint(bytes: Option<u64>) -> PendingActivity {
+        PendingActivity {
+            activity_exec_id: "a".to_string(),
+            activity_name: "act".to_string(),
+            queue: "default".to_string(),
+            scheduled_at: chrono::Utc::now(),
+            attempt: 0,
+            max_attempts: 1,
+            task_status: "RUNNING".to_string(),
+            claimed_by_worker_id: None,
+            last_heartbeat_at: None,
+            heartbeat_details: bytes.map(|_| serde_json::json!({"k": "v"})),
+            heartbeat_details_truncated: false,
+            heartbeat_details_omitted_for_budget: false,
+            heartbeat_details_bytes: bytes,
+            next_retry_at: None,
+            schedule_to_start_deadline: None,
+            start_to_close_deadline: None,
+            heartbeat_deadline: None,
+        }
+    }
+
+    #[test]
+    fn checkpoint_budget_zero_is_disabled() {
+        let mut items = vec![pending_with_checkpoint(Some(100)); 5];
+        let withheld = apply_checkpoint_response_budget(&mut items, 0);
+        assert!(!withheld);
+        assert!(items.iter().all(|i| i.heartbeat_details.is_some()));
+    }
+
+    #[test]
+    fn checkpoint_budget_keeps_items_within_total() {
+        let mut items = vec![pending_with_checkpoint(Some(100)); 3];
+        let withheld = apply_checkpoint_response_budget(&mut items, 1000);
+        assert!(!withheld);
+        assert!(items.iter().all(|i| i.heartbeat_details.is_some()));
+        assert!(
+            items
+                .iter()
+                .all(|i| !i.heartbeat_details_omitted_for_budget)
+        );
+    }
+
+    #[test]
+    fn checkpoint_budget_withholds_past_total_in_order() {
+        // Budget 250: first two (100+100) fit; third pushes over and is withheld.
+        let mut items = vec![pending_with_checkpoint(Some(100)); 3];
+        let withheld = apply_checkpoint_response_budget(&mut items, 250);
+        assert!(withheld);
+        assert!(items[0].heartbeat_details.is_some());
+        assert!(items[1].heartbeat_details.is_some());
+        assert!(items[2].heartbeat_details.is_none());
+        assert!(items[2].heartbeat_details_omitted_for_budget);
+        // Size is still reported for the withheld entry, and it is not marked as
+        // individually truncated.
+        assert_eq!(items[2].heartbeat_details_bytes, Some(100));
+        assert!(!items[2].heartbeat_details_truncated);
+    }
+
+    #[test]
+    fn checkpoint_budget_always_keeps_first_even_if_oversized() {
+        // A single checkpoint larger than the whole budget is still shown so a
+        // raised per-activity cap keeps full visibility (#503).
+        let mut items = vec![
+            pending_with_checkpoint(Some(10_000)),
+            pending_with_checkpoint(Some(10)),
+        ];
+        let withheld = apply_checkpoint_response_budget(&mut items, 1000);
+        assert!(items[0].heartbeat_details.is_some(), "first is always kept");
+        assert!(!items[0].heartbeat_details_omitted_for_budget);
+        assert!(items[1].heartbeat_details.is_none());
+        assert!(withheld);
+    }
+
+    #[test]
+    fn checkpoint_budget_skips_absent_payloads() {
+        // Entries with no included payload don't consume budget.
+        let mut items = vec![
+            pending_with_checkpoint(None),
+            pending_with_checkpoint(Some(100)),
+            pending_with_checkpoint(Some(100)),
+        ];
+        let withheld = apply_checkpoint_response_budget(&mut items, 250);
+        assert!(!withheld, "200 bytes of payload fit within 250");
+        assert!(items[1].heartbeat_details.is_some());
+        assert!(items[2].heartbeat_details.is_some());
     }
 
     #[test]

--- a/autumn-harvest-plugin/src/ui.rs
+++ b/autumn-harvest-plugin/src/ui.rs
@@ -3974,34 +3974,103 @@ fn render_workflow_detail(
     layout(&title, &body, "../")
 }
 
+/// Per-row checkpoint rendering decision for the pending-activities table, after
+/// applying both the per-activity cap and the cumulative per-page budget (#503
+/// review). Carries the observed byte size for the marker text.
+#[derive(Clone, Copy)]
+enum CheckpointCellState {
+    /// No heartbeat checkpoint has been flushed.
+    Absent,
+    /// Render the checkpoint JSON (within its cap and the page budget).
+    Show,
+    /// Withheld because this payload's own size exceeded its activity cap.
+    Truncated(u64),
+    /// Withheld because the cumulative per-page checkpoint budget was exhausted.
+    OmittedForBudget(u64),
+}
+
+/// Build the per-row checkpoint decisions for the pending-activities table,
+/// mirroring the stack API (#503 review): each checkpoint is judged against its
+/// activity's effective cap (per-activity `max_result_bytes` raised against the
+/// global ceiling), then a cumulative per-page budget — the global cap — bounds
+/// the total rendered bytes so a large fan-out can't generate a huge HTML page.
+/// The first payload-bearing checkpoint is always shown. The byte size is
+/// measured once here via the shared non-allocating counter; the renderer reads
+/// the resulting state without re-serializing.
+fn plan_checkpoint_cells(blocked_on: &BlockedOnData) -> Vec<CheckpointCellState> {
+    let per_item: Vec<(bool, Option<u64>)> = blocked_on
+        .activities
+        .iter()
+        .map(|item| {
+            let cap = item
+                .activity_name
+                .as_deref()
+                .and_then(|n| blocked_on.heartbeat_caps.get(n).copied())
+                .unwrap_or(blocked_on.heartbeat_details_cap);
+            crate::api::heartbeat_details_truncation(item.heartbeat_details.as_ref(), cap)
+        })
+        .collect();
+    // Only present, not-individually-truncated checkpoints participate in the
+    // cumulative budget.
+    let sizes: Vec<Option<u64>> = per_item
+        .iter()
+        .map(|(truncated, bytes)| match bytes {
+            Some(b) if !truncated => Some(*b),
+            _ => None,
+        })
+        .collect();
+    let omit = crate::api::checkpoint_budget_decisions(&sizes, blocked_on.heartbeat_details_cap);
+    per_item
+        .iter()
+        .zip(omit)
+        .map(
+            |((truncated, bytes), omit_budget)| match (bytes, truncated, omit_budget) {
+                (None, _, _) => CheckpointCellState::Absent,
+                (Some(b), true, _) => CheckpointCellState::Truncated(*b),
+                (Some(b), false, true) => CheckpointCellState::OmittedForBudget(*b),
+                (Some(_), false, false) => CheckpointCellState::Show,
+            },
+        )
+        .collect()
+}
+
 /// Render the latest heartbeat checkpoint payload for a pending activity as a
-/// collapsible JSON cell, bounded by the response-side payload cap (#503). Shows
-/// `"—"` when no checkpoint has been flushed and a truncation marker when the
-/// stored payload exceeds the cap.
-fn render_heartbeat_checkpoint_cell(item: &TaskQueueItem, cap: u64) -> Markup {
-    // Borrow-based cap check — never clones the payload, so an over-cap blob is
-    // not copied onto the heap merely to be discarded (#503 PR review).
-    let (truncated, bytes) =
-        crate::api::heartbeat_details_truncation(item.heartbeat_details.as_ref(), cap);
+/// collapsible JSON cell, from the precomputed [`CheckpointCellState`] (#503).
+/// Shows `"—"` when absent, a truncation marker when over the activity cap, and
+/// an omission marker when withheld by the per-page budget.
+fn render_heartbeat_checkpoint_cell(item: &TaskQueueItem, state: CheckpointCellState) -> Markup {
     html! {
-        @if truncated {
-            span title="heartbeat payload exceeds the response size cap" {
-                "truncated (" (bytes.unwrap_or(0)) " bytes)"
+        @match state {
+            CheckpointCellState::Absent => "—",
+            CheckpointCellState::Show => {
+                @if let Some(value) = item.heartbeat_details.as_ref() {
+                    details {
+                        summary { "checkpoint" }
+                        pre { (pretty_json(value)) }
+                    }
+                } @else {
+                    "—"
+                }
             }
-        } @else if let Some(value) = item.heartbeat_details.as_ref() {
-            details {
-                summary { "checkpoint" }
-                pre { (pretty_json(value)) }
+            CheckpointCellState::Truncated(bytes) => {
+                span title="heartbeat payload exceeds the response size cap" {
+                    "truncated (" (bytes) " bytes)"
+                }
             }
-        } @else {
-            "—"
+            CheckpointCellState::OmittedForBudget(bytes) => {
+                span title="omitted: per-page checkpoint budget exceeded" {
+                    "omitted (" (bytes) " bytes)"
+                }
+            }
         }
     }
 }
 
 /// Render the "Pending activities" table, including each activity's latest
-/// heartbeat checkpoint judged against its effective (per-activity) cap (#503).
+/// heartbeat checkpoint judged against its effective (per-activity) cap and the
+/// cumulative per-page checkpoint budget (#503).
 fn render_pending_activities_table(blocked_on: &BlockedOnData) -> Markup {
+    let cell_states = plan_checkpoint_cells(blocked_on);
     html! {
         table {
             thead {
@@ -4015,19 +4084,14 @@ fn render_pending_activities_table(blocked_on: &BlockedOnData) -> Markup {
                 }
             }
             tbody {
-                @for item in &blocked_on.activities {
-                    @let cap = item
-                        .activity_name
-                        .as_deref()
-                        .and_then(|n| blocked_on.heartbeat_caps.get(n).copied())
-                        .unwrap_or(blocked_on.heartbeat_details_cap);
+                @for (item, state) in blocked_on.activities.iter().zip(cell_states) {
                     tr {
                         td { (item.activity_name.as_deref().unwrap_or("—")) }
                         td { code { (&item.state) } }
                         td { (item.attempt) }
                         td { (format_timestamp(Some(item.scheduled_at))) }
                         td { (format_timestamp(item.last_heartbeat_at)) }
-                        td { (render_heartbeat_checkpoint_cell(item, cap)) }
+                        td { (render_heartbeat_checkpoint_cell(item, state)) }
                     }
                 }
             }

--- a/autumn-harvest-plugin/src/ui.rs
+++ b/autumn-harvest-plugin/src/ui.rs
@@ -274,10 +274,16 @@ struct BlockedOnData {
     external_tasks: Vec<ExternalTask>,
     timers: Vec<HarvestTimer>,
     signals: Vec<HarvestSignal>,
-    /// Response-side byte cap applied to each pending activity's heartbeat
-    /// checkpoint payload before rendering (#252 activity-result cap, #503).
-    /// `0` = uncapped.
+    /// Default response-side byte cap applied to a pending activity's heartbeat
+    /// checkpoint payload before rendering (global #252 activity-result cap,
+    /// #503). `0` = uncapped. Used when no per-activity override applies.
     heartbeat_details_cap: u64,
+    /// Per-activity effective heartbeat checkpoint cap, keyed by activity name
+    /// (per-activity `max_result_bytes` raised against the global ceiling),
+    /// matching the API stack handler so configured large-payload activities
+    /// keep full checkpoint visibility (#503 review). Missing names fall back to
+    /// `heartbeat_details_cap`.
+    heartbeat_caps: std::collections::HashMap<String, u64>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1020,13 +1026,14 @@ async fn workflow_detail_ui(
         autumn_harvest::builder::DEFAULT_MAX_ACTIVITY_RESULT_BYTES,
         |r| r.registry().max_activity_result_bytes,
     );
-    let blocked_on = load_blocked_on_data(
+    let mut blocked_on = load_blocked_on_data(
         &mut conn,
         exec_uuid,
         &execution.state,
         heartbeat_details_cap,
     )
     .await?;
+    resolve_blocked_on_heartbeat_caps(&api_state, &mut blocked_on);
 
     // Resolve the continue-as-new threshold from the runtime registry if available.
     // This is a lightweight read of an in-memory value — no extra DB query.
@@ -1070,6 +1077,7 @@ async fn load_blocked_on_data(
             timers: vec![],
             signals: vec![],
             heartbeat_details_cap,
+            heartbeat_caps: std::collections::HashMap::new(),
         });
     }
 
@@ -1131,7 +1139,28 @@ async fn load_blocked_on_data(
         timers,
         signals,
         heartbeat_details_cap,
+        heartbeat_caps: std::collections::HashMap::new(),
     })
+}
+
+/// Resolve each pending activity's effective heartbeat checkpoint cap
+/// (per-activity `max_result_bytes` raised against the global ceiling),
+/// mirroring the stack API so a configured large-payload activity keeps full
+/// checkpoint visibility in the UI too (#503 review). No-op when no runtime is
+/// installed (the global default cap then applies at render time).
+fn resolve_blocked_on_heartbeat_caps(api_state: &HarvestApiState, blocked_on: &mut BlockedOnData) {
+    if let Ok(rt) = api_state.runtime() {
+        let registry = rt.registry();
+        blocked_on.heartbeat_caps = blocked_on
+            .activities
+            .iter()
+            .filter_map(|t| t.activity_name.clone())
+            .map(|name| {
+                let cap = registry.activity_result_cap(&name);
+                (name, cap)
+            })
+            .collect();
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -3970,6 +3999,42 @@ fn render_heartbeat_checkpoint_cell(item: &TaskQueueItem, cap: u64) -> Markup {
     }
 }
 
+/// Render the "Pending activities" table, including each activity's latest
+/// heartbeat checkpoint judged against its effective (per-activity) cap (#503).
+fn render_pending_activities_table(blocked_on: &BlockedOnData) -> Markup {
+    html! {
+        table {
+            thead {
+                tr {
+                    th { "Activity" }
+                    th { "State" }
+                    th { "Attempt" }
+                    th { "Scheduled" }
+                    th { "Last heartbeat" }
+                    th { "Checkpoint" }
+                }
+            }
+            tbody {
+                @for item in &blocked_on.activities {
+                    @let cap = item
+                        .activity_name
+                        .as_deref()
+                        .and_then(|n| blocked_on.heartbeat_caps.get(n).copied())
+                        .unwrap_or(blocked_on.heartbeat_details_cap);
+                    tr {
+                        td { (item.activity_name.as_deref().unwrap_or("—")) }
+                        td { code { (&item.state) } }
+                        td { (item.attempt) }
+                        td { (format_timestamp(Some(item.scheduled_at))) }
+                        td { (format_timestamp(item.last_heartbeat_at)) }
+                        td { (render_heartbeat_checkpoint_cell(item, cap)) }
+                    }
+                }
+            }
+        }
+    }
+}
+
 fn render_blocked_on_panel(blocked_on: &BlockedOnData) -> Markup {
     let has_anything = !blocked_on.activities.is_empty()
         || !blocked_on.external_tasks.is_empty()
@@ -3984,30 +4049,7 @@ fn render_blocked_on_panel(blocked_on: &BlockedOnData) -> Markup {
             } @else {
                 @if !blocked_on.activities.is_empty() {
                     h3 style="margin-top:8px" { "Pending activities" }
-                    table {
-                        thead {
-                            tr {
-                                th { "Activity" }
-                                th { "State" }
-                                th { "Attempt" }
-                                th { "Scheduled" }
-                                th { "Last heartbeat" }
-                                th { "Checkpoint" }
-                            }
-                        }
-                        tbody {
-                            @for item in &blocked_on.activities {
-                                tr {
-                                    td { (item.activity_name.as_deref().unwrap_or("—")) }
-                                    td { code { (&item.state) } }
-                                    td { (item.attempt) }
-                                    td { (format_timestamp(Some(item.scheduled_at))) }
-                                    td { (format_timestamp(item.last_heartbeat_at)) }
-                                    td { (render_heartbeat_checkpoint_cell(item, blocked_on.heartbeat_details_cap)) }
-                                }
-                            }
-                        }
-                    }
+                    (render_pending_activities_table(blocked_on))
                 }
                 @if !blocked_on.external_tasks.is_empty() {
                     h3 style="margin-top:8px" { "Pending external activities" }
@@ -7756,6 +7798,7 @@ mod tests {
             timers: vec![],
             signals: vec![],
             heartbeat_details_cap: 0,
+            heartbeat_caps: std::collections::HashMap::new(),
         }
     }
 

--- a/autumn-harvest-plugin/src/ui.rs
+++ b/autumn-harvest-plugin/src/ui.rs
@@ -3950,17 +3950,19 @@ fn render_workflow_detail(
 /// `"—"` when no checkpoint has been flushed and a truncation marker when the
 /// stored payload exceeds the cap.
 fn render_heartbeat_checkpoint_cell(item: &TaskQueueItem, cap: u64) -> Markup {
-    let (payload, truncated, bytes) =
-        crate::api::project_heartbeat_details(item.heartbeat_details.clone(), cap);
+    // Borrow-based cap check — never clones the payload, so an over-cap blob is
+    // not copied onto the heap merely to be discarded (#503 PR review).
+    let (truncated, bytes) =
+        crate::api::heartbeat_details_truncation(item.heartbeat_details.as_ref(), cap);
     html! {
-        @if let Some(ref value) = payload {
+        @if truncated {
+            span title="heartbeat payload exceeds the response size cap" {
+                "truncated (" (bytes.unwrap_or(0)) " bytes)"
+            }
+        } @else if let Some(value) = item.heartbeat_details.as_ref() {
             details {
                 summary { "checkpoint" }
                 pre { (pretty_json(value)) }
-            }
-        } @else if truncated {
-            span title="heartbeat payload exceeds the response size cap" {
-                "truncated (" (bytes.unwrap_or(0)) " bytes)"
             }
         } @else {
             "—"

--- a/autumn-harvest-plugin/src/ui.rs
+++ b/autumn-harvest-plugin/src/ui.rs
@@ -1091,7 +1091,12 @@ async fn load_blocked_on_data(
                 .or(harvest_task_queue::state.eq("BACKOFF")),
         )
         .filter(harvest_task_queue::task_type.eq("activity"))
-        .order(harvest_task_queue::scheduled_at.asc())
+        // Stable ordering (id tiebreaker) so the per-page checkpoint budget
+        // (#503) keeps/omits the same checkpoints deterministically.
+        .order((
+            harvest_task_queue::scheduled_at.asc(),
+            harvest_task_queue::id.asc(),
+        ))
         .limit(20)
         .select(TaskQueueItem::as_select())
         .load::<TaskQueueItem>(conn)

--- a/autumn-harvest-plugin/src/ui.rs
+++ b/autumn-harvest-plugin/src/ui.rs
@@ -274,6 +274,10 @@ struct BlockedOnData {
     external_tasks: Vec<ExternalTask>,
     timers: Vec<HarvestTimer>,
     signals: Vec<HarvestSignal>,
+    /// Response-side byte cap applied to each pending activity's heartbeat
+    /// checkpoint payload before rendering (#252 activity-result cap, #503).
+    /// `0` = uncapped.
+    heartbeat_details_cap: u64,
 }
 
 #[derive(Debug, Deserialize)]
@@ -1009,8 +1013,20 @@ async fn workflow_detail_ui(
         .map_err(database_error)
         .map_err(map_error)?;
 
-    // Load blocked-on data for non-terminal workflows.
-    let blocked_on = load_blocked_on_data(&mut conn, exec_uuid, &execution.state).await?;
+    // Load blocked-on data for non-terminal workflows. Reuse the #252
+    // activity-result payload cap as the response-side guard for heartbeat
+    // checkpoints (#503); fall back to the default when no runtime is installed.
+    let heartbeat_details_cap = api_state.runtime().ok().map_or(
+        autumn_harvest::builder::DEFAULT_MAX_ACTIVITY_RESULT_BYTES,
+        |r| r.registry().max_activity_result_bytes,
+    );
+    let blocked_on = load_blocked_on_data(
+        &mut conn,
+        exec_uuid,
+        &execution.state,
+        heartbeat_details_cap,
+    )
+    .await?;
 
     // Resolve the continue-as-new threshold from the runtime registry if available.
     // This is a lightweight read of an in-memory value — no extra DB query.
@@ -1045,6 +1061,7 @@ async fn load_blocked_on_data(
     conn: &mut AsyncPgConnection,
     exec_uuid: uuid::Uuid,
     state: &str,
+    heartbeat_details_cap: u64,
 ) -> Result<BlockedOnData, AutumnError> {
     if is_terminal_workflow_state(state) {
         return Ok(BlockedOnData {
@@ -1052,6 +1069,7 @@ async fn load_blocked_on_data(
             external_tasks: vec![],
             timers: vec![],
             signals: vec![],
+            heartbeat_details_cap,
         });
     }
 
@@ -1112,6 +1130,7 @@ async fn load_blocked_on_data(
         external_tasks,
         timers,
         signals,
+        heartbeat_details_cap,
     })
 }
 
@@ -3926,6 +3945,29 @@ fn render_workflow_detail(
     layout(&title, &body, "../")
 }
 
+/// Render the latest heartbeat checkpoint payload for a pending activity as a
+/// collapsible JSON cell, bounded by the response-side payload cap (#503). Shows
+/// `"—"` when no checkpoint has been flushed and a truncation marker when the
+/// stored payload exceeds the cap.
+fn render_heartbeat_checkpoint_cell(item: &TaskQueueItem, cap: u64) -> Markup {
+    let (payload, truncated, bytes) =
+        crate::api::project_heartbeat_details(item.heartbeat_details.clone(), cap);
+    html! {
+        @if let Some(ref value) = payload {
+            details {
+                summary { "checkpoint" }
+                pre { (pretty_json(value)) }
+            }
+        } @else if truncated {
+            span title="heartbeat payload exceeds the response size cap" {
+                "truncated (" (bytes.unwrap_or(0)) " bytes)"
+            }
+        } @else {
+            "—"
+        }
+    }
+}
+
 fn render_blocked_on_panel(blocked_on: &BlockedOnData) -> Markup {
     let has_anything = !blocked_on.activities.is_empty()
         || !blocked_on.external_tasks.is_empty()
@@ -3947,6 +3989,8 @@ fn render_blocked_on_panel(blocked_on: &BlockedOnData) -> Markup {
                                 th { "State" }
                                 th { "Attempt" }
                                 th { "Scheduled" }
+                                th { "Last heartbeat" }
+                                th { "Checkpoint" }
                             }
                         }
                         tbody {
@@ -3956,6 +4000,8 @@ fn render_blocked_on_panel(blocked_on: &BlockedOnData) -> Markup {
                                     td { code { (&item.state) } }
                                     td { (item.attempt) }
                                     td { (format_timestamp(Some(item.scheduled_at))) }
+                                    td { (format_timestamp(item.last_heartbeat_at)) }
+                                    td { (render_heartbeat_checkpoint_cell(item, blocked_on.heartbeat_details_cap)) }
                                 }
                             }
                         }
@@ -7707,6 +7753,7 @@ mod tests {
             external_tasks: vec![],
             timers: vec![],
             signals: vec![],
+            heartbeat_details_cap: 0,
         }
     }
 

--- a/autumn-harvest-plugin/tests/api_scheduler_integration.rs
+++ b/autumn-harvest-plugin/tests/api_scheduler_integration.rs
@@ -2831,6 +2831,9 @@ async fn harvest_api_stack_endpoint_surfaces_heartbeat_checkpoint() {
         pending[0]["last_heartbeat_at"].is_string(),
         "last_heartbeat_at remains present"
     );
+    // A small, in-budget checkpoint is not budget-omitted (#503 review).
+    assert_eq!(pending[0]["heartbeat_details_omitted_for_budget"], false);
+    assert_eq!(payload["checkpoints_truncated_for_budget"], false);
 }
 
 #[tokio::test]

--- a/autumn-harvest-plugin/tests/api_scheduler_integration.rs
+++ b/autumn-harvest-plugin/tests/api_scheduler_integration.rs
@@ -2759,6 +2759,144 @@ async fn harvest_api_stack_endpoint_surfaces_rate_limit_throttling() {
         pending[0]["task_status"],
         "waiting on rate_limit_key=test_rate_limit_bucket"
     );
+    // An activity that has never heartbeated reports a null checkpoint (#503).
+    assert!(
+        pending[0]["heartbeat_details"].is_null(),
+        "heartbeat_details must be null when no checkpoint flushed"
+    );
+    assert_eq!(pending[0]["heartbeat_details_truncated"], false);
+    assert!(pending[0]["heartbeat_details_bytes"].is_null());
+}
+
+#[tokio::test]
+async fn harvest_api_stack_endpoint_surfaces_heartbeat_checkpoint() {
+    let (database_url, _container) = setup_test_database_url().await;
+    let pool = build_test_pool(&database_url);
+    let registry = approval_registry();
+    let api_state = HarvestApiState::new();
+    api_state.install_storage_pool(HarvestDbPool::from(pool.clone()));
+    api_state.install(HarvestApiRuntime::new(
+        Arc::clone(&registry),
+        Arc::new(HashMap::new()),
+        Arc::new(Vec::new()),
+        Some("test-worker".to_string()),
+        vec!["default".to_string()],
+        SchedulerMonitor::offline(),
+        HarvestRetentionRuntime::disabled(autumn_harvest::RetentionConfig::default()),
+        ShardRouter::single(),
+    ));
+    let app = harvest_api_router(api_state).with_state(test_app_state(pool));
+
+    let exec_id = insert_workflow_on_url(
+        &database_url,
+        ShardId::new(0),
+        "approval_workflow",
+        "stack-hb",
+    )
+    .await;
+
+    let mut conn = <AsyncPgConnection as AsyncConnection>::establish(&database_url)
+        .await
+        .expect("failed to connect for test setup");
+
+    let checkpoint = serde_json::json!({"processed": 4500, "total": 10000});
+    diesel::sql_query(
+        "INSERT INTO harvest_task_queue ( \
+            id, queue_name, task_type, workflow_exec_id, activity_name, input, state, priority, attempt, max_attempts, scheduled_at, started_at, last_heartbeat_at, heartbeat_details \
+         ) VALUES ( \
+            gen_random_uuid(), 'default', 'activity', $1, 'pipeline', '{}'::jsonb, 'RUNNING', 0, 0, 5, NOW(), NOW(), NOW(), $2 \
+         )",
+    )
+    .bind::<diesel::sql_types::Uuid, _>(exec_id.as_uuid())
+    .bind::<diesel::sql_types::Jsonb, _>(checkpoint.clone())
+    .execute(&mut conn)
+    .await
+    .expect("failed to insert heartbeating task");
+
+    let (status, payload) = get_json(&app, format!("/workflows/{exec_id}/stack")).await;
+    assert_eq!(status, StatusCode::OK);
+
+    let pending = payload["pending_activities"]
+        .as_array()
+        .expect("pending_activities must be an array");
+    assert_eq!(pending.len(), 1);
+    // The latest checkpoint payload is surfaced verbatim (#503).
+    assert_eq!(pending[0]["heartbeat_details"], checkpoint);
+    assert_eq!(pending[0]["heartbeat_details_truncated"], false);
+    assert!(
+        pending[0]["heartbeat_details_bytes"].as_u64().unwrap() > 0,
+        "byte size must be reported alongside the payload"
+    );
+    assert!(
+        pending[0]["last_heartbeat_at"].is_string(),
+        "last_heartbeat_at remains present"
+    );
+}
+
+#[tokio::test]
+async fn harvest_api_stack_endpoint_truncates_oversized_heartbeat_checkpoint() {
+    let (database_url, _container) = setup_test_database_url().await;
+    let pool = build_test_pool(&database_url);
+    let registry = approval_registry();
+    let api_state = HarvestApiState::new();
+    api_state.install_storage_pool(HarvestDbPool::from(pool.clone()));
+    api_state.install(HarvestApiRuntime::new(
+        Arc::clone(&registry),
+        Arc::new(HashMap::new()),
+        Arc::new(Vec::new()),
+        Some("test-worker".to_string()),
+        vec!["default".to_string()],
+        SchedulerMonitor::offline(),
+        HarvestRetentionRuntime::disabled(autumn_harvest::RetentionConfig::default()),
+        ShardRouter::single(),
+    ));
+    let app = harvest_api_router(api_state).with_state(test_app_state(pool));
+
+    let exec_id = insert_workflow_on_url(
+        &database_url,
+        ShardId::new(0),
+        "approval_workflow",
+        "stack-hb-big",
+    )
+    .await;
+
+    let mut conn = <AsyncPgConnection as AsyncConnection>::establish(&database_url)
+        .await
+        .expect("failed to connect for test setup");
+
+    // Default activity-result cap is 2 MiB; a 2.1 MiB blob must trip the guard.
+    let big_blob = "x".repeat(2 * 1024 * 1024 + 100 * 1024);
+    let checkpoint = serde_json::json!({ "blob": big_blob });
+    diesel::sql_query(
+        "INSERT INTO harvest_task_queue ( \
+            id, queue_name, task_type, workflow_exec_id, activity_name, input, state, priority, attempt, max_attempts, scheduled_at, started_at, last_heartbeat_at, heartbeat_details \
+         ) VALUES ( \
+            gen_random_uuid(), 'default', 'activity', $1, 'pipeline', '{}'::jsonb, 'RUNNING', 0, 0, 5, NOW(), NOW(), NOW(), $2 \
+         )",
+    )
+    .bind::<diesel::sql_types::Uuid, _>(exec_id.as_uuid())
+    .bind::<diesel::sql_types::Jsonb, _>(checkpoint)
+    .execute(&mut conn)
+    .await
+    .expect("failed to insert oversized heartbeating task");
+
+    let (status, payload) = get_json(&app, format!("/workflows/{exec_id}/stack")).await;
+    assert_eq!(status, StatusCode::OK);
+
+    let pending = payload["pending_activities"]
+        .as_array()
+        .expect("pending_activities must be an array");
+    assert_eq!(pending.len(), 1);
+    // Over-cap payload is withheld; only the truncation marker + size are returned (#503).
+    assert!(
+        pending[0]["heartbeat_details"].is_null(),
+        "over-cap payload must be withheld"
+    );
+    assert_eq!(pending[0]["heartbeat_details_truncated"], true);
+    assert!(
+        pending[0]["heartbeat_details_bytes"].as_u64().unwrap() > 2 * 1024 * 1024,
+        "reported size must exceed the 2 MiB cap"
+    );
 }
 
 #[tokio::test]

--- a/autumn-harvest-plugin/tests/ui_integration.rs
+++ b/autumn-harvest-plugin/tests/ui_integration.rs
@@ -2483,6 +2483,43 @@ async fn detail_page_blocked_on_panel_for_running_workflow() {
     );
 }
 
+/// Detail page renders the latest heartbeat checkpoint payload for a running
+/// heartbeating activity (issue #503).
+#[tokio::test]
+async fn detail_page_renders_heartbeat_checkpoint() {
+    let (database_url, _container) = setup_test_database_url().await;
+    let exec_id =
+        insert_workflow_on_url(&database_url, ShardId::new(0), "blocked_wf", "blocked-hb").await;
+
+    let mut conn = AsyncPgConnection::establish(&database_url).await.unwrap();
+    let task_id = uuid::Uuid::new_v4();
+    let sql = format!(
+        "INSERT INTO harvest_task_queue \
+            (id, queue_name, task_type, workflow_exec_id, activity_name, input, state, priority, \
+             attempt, max_attempts, scheduled_at, started_at, last_heartbeat_at, heartbeat_details) \
+         VALUES \
+            ('{task_id}', 'default', 'activity', '{exec_uuid}', 'pipeline', \
+             '{{}}', 'RUNNING', 0, 0, 3, NOW(), NOW(), NOW(), \
+             '{{\"processed\": 4500, \"total\": 10000}}'::jsonb)",
+        exec_uuid = exec_id.as_uuid()
+    );
+    conn.batch_execute(&sql)
+        .await
+        .expect("insert heartbeating task");
+
+    let app = build_single_shard_ui_app(&database_url);
+    let (status, html) = fetch_html(&app, &format!("/workflows/{exec_id}")).await;
+    assert_eq!(status, StatusCode::OK, "detail page should render: {html}");
+    assert!(
+        html.contains("Checkpoint"),
+        "pending-activities table should have a Checkpoint column: {html}"
+    );
+    assert!(
+        html.contains("processed") && html.contains("4500"),
+        "the latest heartbeat checkpoint payload should be rendered: {html}"
+    );
+}
+
 /// Cancel action in the UI redirects back to the detail page with a flash message.
 #[tokio::test]
 async fn detail_page_cancel_action_redirects_with_flash() {

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -413,6 +413,26 @@ impl HandlerRegistry {
     pub const fn history_policy(&self) -> WorkflowHistoryPolicy {
         self.history_policy
     }
+
+    /// Effective result-payload byte cap for the named activity (issue #252).
+    ///
+    /// Returns the per-activity `max_result_bytes` override raised against the
+    /// global `max_activity_result_bytes` ceiling (`override.max(global)`),
+    /// mirroring the worker's `effective_result_cap` resolution. Unknown
+    /// activities fall back to the global cap. Read-only.
+    ///
+    /// Used by the management stack endpoint (issue #503) so a heartbeat
+    /// checkpoint is judged against the same effective cap the activity's
+    /// result would be, rather than the global default only.
+    #[must_use]
+    pub fn activity_result_cap(&self, name: &str) -> u64 {
+        self.activities
+            .get(name)
+            .and_then(|a| a.max_result_bytes)
+            .map_or(self.max_activity_result_bytes, |per| {
+                per.max(self.max_activity_result_bytes)
+            })
+    }
 }
 
 impl std::fmt::Debug for HandlerRegistry {
@@ -8727,6 +8747,52 @@ mod tests {
         };
         let registry = Arc::new(HandlerRegistry::new(vec![], vec![]));
         assert!(Worker::new(cfg, registry).is_err());
+    }
+
+    #[test]
+    fn activity_result_cap_resolves_per_activity_override() {
+        fn act(name: &'static str, max_result_bytes: Option<u64>) -> ActivityInfo {
+            ActivityInfo {
+                name,
+                module: "test",
+                default_retry_policy: None,
+                default_start_to_close: None,
+                default_heartbeat_timeout: None,
+                default_schedule_to_start: None,
+                default_schedule_to_close: None,
+                default_queue: None,
+                max_concurrent: None,
+                concurrency_key: None,
+                is_local: false,
+                max_input_bytes: None,
+                max_result_bytes,
+                rate_limit_rps: None,
+                rate_limit_burst: None,
+                rate_limit_key: None,
+                circuit_breaker: None,
+                requires: None,
+                handler: |_ctx, input| Box::pin(async move { Ok(input) }),
+            }
+        }
+
+        let global = crate::builder::DEFAULT_MAX_ACTIVITY_RESULT_BYTES;
+        let registry = HandlerRegistry::new(
+            vec![],
+            vec![
+                act("plain", None),
+                act("big", Some(global * 4)),
+                act("tiny", Some(1024)),
+            ],
+        );
+
+        // No override -> global cap.
+        assert_eq!(registry.activity_result_cap("plain"), global);
+        // Higher override -> raised cap (full checkpoint visibility, #503).
+        assert_eq!(registry.activity_result_cap("big"), global * 4);
+        // Lower override -> never lowers below the global ceiling.
+        assert_eq!(registry.activity_result_cap("tiny"), global);
+        // Unknown activity -> global cap.
+        assert_eq!(registry.activity_result_cap("nonexistent"), global);
     }
 
     #[test]

--- a/docs/api-contract.json
+++ b/docs/api-contract.json
@@ -341,6 +341,7 @@
           "pending_signals",
           "buffered_signals",
           "pending_child_workflows",
+          "checkpoints_truncated_for_budget",
           "last_event_id"
         ]
       },

--- a/docs/management-api.md
+++ b/docs/management-api.md
@@ -259,3 +259,71 @@ curl "/workflows?state=RUNNING&page_size=50&cursor=abc123"
 - The `no_progress_minutes` (stalled-workflow) filter always returns a bare array regardless of pagination parameters.
 - `page_size` and `limit` are aliases; if both are present `page_size` wins.
 - On a sharded deployment each shard is queried independently with the same cursor and `page_size+1` limit; the results are k-way merged and truncated to `page_size` before the response is returned. See `docs/sharding.md` for the cross-shard keyset contract.
+
+## Workflow Stack (describe)
+
+### Endpoint
+
+```
+GET /workflows/{exec_id}/stack
+```
+
+Returns a point-in-time "describe" view of an in-flight workflow: its pending
+activities, local activities, external handoffs, timers, signals, buffered
+signals, and child workflows. This is the primary view for triaging a running
+execution. For a terminal execution the pending arrays are empty.
+
+### Pending activity heartbeat checkpoint (issue #503)
+
+Each entry in `pending_activities[]` surfaces the latest **heartbeat checkpoint
+payload** the activity reported via `ctx.heartbeat(...)` — the current value of
+`harvest_task_queue.heartbeat_details` for that task row, alongside the existing
+`last_heartbeat_at` timestamp. This lets an operator answer "how far has this
+in-flight activity progressed?" (e.g. `{"processed": 4500, "total": 10000}`)
+from a single API call, with zero direct database access.
+
+| Field | Type | Meaning |
+|-------|------|---------|
+| `last_heartbeat_at` | timestamp \| null | When the most recent heartbeat was flushed. |
+| `heartbeat_details` | JSON \| null | The latest checkpoint payload, verbatim as the activity reported it. `null` when no heartbeat has been flushed, **or** when the payload exceeded the response size cap (see `heartbeat_details_truncated`). |
+| `heartbeat_details_truncated` | bool | `true` when the stored payload exceeded the activity-result payload cap (issue #252, default **2 MiB**) and was withheld from the response. |
+| `heartbeat_details_bytes` | integer \| null | Observed serialized byte size of the stored payload, when one exists. With `heartbeat_details_truncated: true` this is the size of the withheld blob. |
+
+Notes:
+
+- **Regular activities only.** Local activities cannot heartbeat
+  (`ctx.heartbeat(...)` returns a `Config` error), so `pending_local_activities[]`
+  has no heartbeat checkpoint field.
+- **Read-only.** Surfacing the checkpoint never writes, clears, or alters the
+  column, and never affects retry-resume semantics
+  (`ActivityContext::heartbeat_details::<T>()` reads the same value unchanged).
+- **Shard-correct.** The handler routes by the execution's encoded shard; the
+  heartbeat column lives on the same shard as the task row, so no cross-shard
+  fan-out is introduced.
+- **Size-bounded.** The 2 MiB ceiling reuses the existing activity-result
+  payload cap rather than a new limit, so a pathological heartbeat payload
+  cannot bloat the describe response.
+
+### Example
+
+```bash
+curl "/api/harvest/workflows/$EXEC_ID/stack"
+```
+
+```json
+{
+  "exec_id": "…",
+  "workflow_name": "etl_pipeline",
+  "state": "RUNNING",
+  "pending_activities": [
+    {
+      "activity_name": "process_batch",
+      "task_status": "RUNNING",
+      "last_heartbeat_at": "2026-05-30T19:00:04Z",
+      "heartbeat_details": { "processed": 4500, "total": 10000 },
+      "heartbeat_details_truncated": false,
+      "heartbeat_details_bytes": 31
+    }
+  ]
+}
+```

--- a/docs/management-api.md
+++ b/docs/management-api.md
@@ -286,7 +286,7 @@ from a single API call, with zero direct database access.
 |-------|------|---------|
 | `last_heartbeat_at` | timestamp \| null | When the most recent heartbeat was flushed. |
 | `heartbeat_details` | JSON \| null | The latest checkpoint payload, verbatim as the activity reported it. `null` when no heartbeat has been flushed, **or** when the payload exceeded the response size cap (see `heartbeat_details_truncated`). |
-| `heartbeat_details_truncated` | bool | `true` when the stored payload exceeded the activity-result payload cap (issue #252, default **2 MiB**) and was withheld from the response. |
+| `heartbeat_details_truncated` | bool | `true` when the stored payload exceeded the activity's effective result-payload cap (issue #252) and was withheld from the response. |
 | `heartbeat_details_bytes` | integer \| null | Observed serialized byte size of the stored payload, when one exists. With `heartbeat_details_truncated: true` this is the size of the withheld blob. |
 
 Notes:
@@ -300,8 +300,11 @@ Notes:
 - **Shard-correct.** The handler routes by the execution's encoded shard; the
   heartbeat column lives on the same shard as the task row, so no cross-shard
   fan-out is introduced.
-- **Size-bounded.** The 2 MiB ceiling reuses the existing activity-result
-  payload cap rather than a new limit, so a pathological heartbeat payload
+- **Size-bounded.** The guard reuses the activity's effective result-payload
+  cap rather than a new limit: the per-activity `max_result_bytes` override
+  raised against the global ceiling (`override.max(global)`, default global
+  **2 MiB**), matching the worker. An activity configured to allow large
+  results keeps full checkpoint visibility, while a pathological payload still
   cannot bloat the describe response.
 
 ### Example

--- a/docs/management-api.md
+++ b/docs/management-api.md
@@ -285,9 +285,12 @@ from a single API call, with zero direct database access.
 | Field | Type | Meaning |
 |-------|------|---------|
 | `last_heartbeat_at` | timestamp \| null | When the most recent heartbeat was flushed. |
-| `heartbeat_details` | JSON \| null | The latest checkpoint payload, verbatim as the activity reported it. `null` when no heartbeat has been flushed, **or** when the payload exceeded the response size cap (see `heartbeat_details_truncated`). |
-| `heartbeat_details_truncated` | bool | `true` when the stored payload exceeded the activity's effective result-payload cap (issue #252) and was withheld from the response. |
-| `heartbeat_details_bytes` | integer \| null | Observed serialized byte size of the stored payload, when one exists. With `heartbeat_details_truncated: true` this is the size of the withheld blob. |
+| `heartbeat_details` | JSON \| null | The latest checkpoint payload, verbatim as the activity reported it. `null` when no heartbeat has been flushed, when the payload exceeded its own cap (`heartbeat_details_truncated`), or when it was withheld by the per-response budget (`heartbeat_details_omitted_for_budget`). |
+| `heartbeat_details_truncated` | bool | `true` when **this payload's own** size exceeded the activity's effective result-payload cap (issue #252) and was withheld. |
+| `heartbeat_details_omitted_for_budget` | bool | `true` when the payload was within its own cap but withheld because the cumulative per-response checkpoint budget was already exhausted by earlier activities (see the response-level `checkpoints_truncated_for_budget`). |
+| `heartbeat_details_bytes` | integer \| null | Observed serialized byte size of the stored payload, when one exists. Reported even when the payload is withheld (by either guard). |
+
+The top-level response also carries `checkpoints_truncated_for_budget` (bool): `true` when one or more checkpoints were withheld by the per-response budget.
 
 Notes:
 
@@ -300,12 +303,19 @@ Notes:
 - **Shard-correct.** The handler routes by the execution's encoded shard; the
   heartbeat column lives on the same shard as the task row, so no cross-shard
   fan-out is introduced.
-- **Size-bounded.** The guard reuses the activity's effective result-payload
-  cap rather than a new limit: the per-activity `max_result_bytes` override
-  raised against the global ceiling (`override.max(global)`, default global
-  **2 MiB**), matching the worker. An activity configured to allow large
-  results keeps full checkpoint visibility, while a pathological payload still
-  cannot bloat the describe response.
+- **Size-bounded (per checkpoint).** Each checkpoint is judged against the
+  activity's effective result-payload cap rather than a new limit: the
+  per-activity `max_result_bytes` override raised against the global ceiling
+  (`override.max(global)`, default global **2 MiB**), matching the worker. An
+  activity configured to allow large results keeps full checkpoint visibility,
+  while a pathological payload still cannot bloat the describe response.
+- **Size-bounded (per response).** A cumulative budget — the global
+  activity-result cap (**2 MiB**) — bounds the *total* checkpoint bytes across
+  all pending activities, so a large fan-out cannot return roughly
+  `count × cap` bytes. Checkpoints are kept in task order until the budget is
+  reached; the first payload-bearing checkpoint is always kept (so a single
+  legitimately large checkpoint stays visible), and later ones are withheld with
+  `heartbeat_details_omitted_for_budget: true`.
 
 ### Example
 
@@ -318,6 +328,7 @@ curl "/api/harvest/workflows/$EXEC_ID/stack"
   "exec_id": "…",
   "workflow_name": "etl_pipeline",
   "state": "RUNNING",
+  "checkpoints_truncated_for_budget": false,
   "pending_activities": [
     {
       "activity_name": "process_batch",
@@ -325,6 +336,7 @@ curl "/api/harvest/workflows/$EXEC_ID/stack"
       "last_heartbeat_at": "2026-05-30T19:00:04Z",
       "heartbeat_details": { "processed": 4500, "total": 10000 },
       "heartbeat_details_truncated": false,
+      "heartbeat_details_omitted_for_budget": false,
       "heartbeat_details_bytes": 31
     }
   ]

--- a/docs/runbooks/triage-pending-tasks-idle-workers.md
+++ b/docs/runbooks/triage-pending-tasks-idle-workers.md
@@ -2,6 +2,18 @@
 
 Use this runbook when an alert fires indicating that tasks are sitting in `PENDING` state on a queue while connected workers appear idle.
 
+> **First check for a heartbeating activity.** Before assuming an activity is
+> stalled, confirm it is actually stuck rather than just slow. Call
+> `GET /workflows/{exec_id}/stack` and read the activity's
+> `heartbeat_details` field on `pending_activities[]` (issue #503): it holds the
+> latest progress checkpoint the activity reported via `ctx.heartbeat(...)`
+> (e.g. `{"processed": 4500, "total": 10000}`). If the checkpoint is advancing
+> across successive calls, the activity is making forward progress and no
+> intervention is needed. A stale checkpoint (with a `last_heartbeat_at` far in
+> the past) points to a genuine stall — continue with the eligibility triage
+> below. `heartbeat_details` is `null` for activities that have not yet flushed
+> a heartbeat and for local activities (which do not heartbeat).
+
 To triage eligibility blocks, call the eligibility explainer API:
 
 ```text


### PR DESCRIPTION
## Summary

Adds heartbeat checkpoint payload visibility to the workflow stack describe endpoint (`GET /workflows/{exec_id}/stack`), allowing operators to monitor in-flight activity progress without direct database access. Implements issue #503.

## Changes

- **API response enhancement**: Extended `PendingActivity` struct with three new fields:
  - `heartbeat_details`: Latest checkpoint payload reported via `ctx.heartbeat(...)`, verbatim from `harvest_task_queue.heartbeat_details`
  - `heartbeat_details_truncated`: Boolean flag indicating payload was withheld due to size cap
  - `heartbeat_details_bytes`: Observed serialized byte size of the stored payload

- **Payload projection logic**: Added `project_heartbeat_details()` function that:
  - Returns `null` when no heartbeat has been flushed
  - Returns the verbatim payload when present and under the activity-result cap (2 MiB default, issue #252)
  - Returns `null` with `truncated: true` when payload exceeds the cap, preventing pathological blobs from bloating the response
  - Reuses the existing `#252` activity-result payload cap rather than introducing a new limit

- **UI rendering**: Updated workflow detail page to display heartbeat checkpoints in the pending activities table:
  - Added "Last heartbeat" and "Checkpoint" columns
  - Renders checkpoint as collapsible JSON when present and under cap
  - Shows truncation marker with byte size when over cap
  - Shows "—" when no checkpoint has been flushed

- **Documentation**: Added comprehensive section to `docs/management-api.md` explaining the heartbeat checkpoint fields, behavior, and example response. Updated `docs/runbooks/triage-pending-tasks-idle-workers.md` with guidance on using heartbeat checkpoints to distinguish stalled vs. slow activities.

- **Test coverage**: Added three integration tests for the API endpoint:
  - `harvest_api_stack_endpoint_surfaces_heartbeat_checkpoint`: Verifies normal checkpoint payload is surfaced verbatim
  - `harvest_api_stack_endpoint_truncates_oversized_heartbeat_checkpoint`: Verifies over-cap payloads are withheld with truncation marker
  - Updated existing `harvest_api_stack_endpoint_surfaces_rate_limit_throttling` to verify null checkpoint for activities that haven't heartbeated
  
  Added four unit tests for `project_heartbeat_details()` covering all cases: absent, under-cap, over-cap, and uncapped (cap=0).

  Added UI integration test `detail_page_renders_heartbeat_checkpoint` verifying checkpoint rendering on the detail page.

## Implementation Details

- **Read-only**: Surfacing the checkpoint never writes, clears, or alters the column, and never affects retry-resume semantics
- **Shard-correct**: The handler routes by execution's encoded shard; heartbeat column lives on the same shard as the task row
- **Size-bounded**: Reuses the 2 MiB activity-result cap to prevent response bloat
- **Local activities excluded**: Only regular activities can heartbeat; local activities have no checkpoint field
- **Fallback behavior**: When no runtime is installed (read-only mount), falls back to `DEFAULT_MAX_ACTIVITY_RESULT_BYTES` for the cap

https://claude.ai/code/session_012f19XJgaqaqgnn5b1rCc1x