### PR TITLE
⚡ Bolt: Remove unnecessary allocations in retention.rs and reset.rs

### DIFF
--- a/autumn-harvest/src/reset.rs
+++ b/autumn-harvest/src/reset.rs
@@ -1021,7 +1021,7 @@ async fn reapply_or_drop_signals(
     }
 
     if !signals.is_empty() {
-        let ids = signals.iter().map(|signal| signal.id).collect::<Vec<_>>();
+        let ids = signals.iter().map(|signal| signal.id);
         diesel::update(harvest_signals::table.filter(harvest_signals::id.eq_any(ids)))
             .set(harvest_signals::consumed.eq(true))
             .execute(conn)

--- a/autumn-harvest/src/retention.rs
+++ b/autumn-harvest/src/retention.rs
@@ -617,7 +617,7 @@ async fn run_shard_tick(
                 .map_err(database_error)?;
 
                 if !rows.is_empty() {
-                    let ids: Vec<uuid::Uuid> = rows.iter().map(|r| r.id).collect();
+                    let ids = rows.iter().map(|r| r.id);
                     diesel::update(
                         harvest_workflow_executions::table
                             .filter(harvest_workflow_executions::id.eq_any(ids)),
@@ -637,7 +637,7 @@ async fn run_shard_tick(
         drop(conn);
 
         if !candidates.is_empty() {
-            let ids: Vec<uuid::Uuid> = candidates.iter().map(|r| r.id).collect();
+            let ids = candidates.iter().map(|r| r.id);
             guard
                 .active_ids
                 .lock()


### PR DESCRIPTION
## 💡 What

Removed intermediate `.collect::<Vec<_>>()` calls in `retention.rs` and `reset.rs` when feeding query arguments to `diesel::eq_any()` and `std::collections::HashSet::extend()`. 

## 🎯 Why

Both `eq_any()` from Diesel and `.extend()` on `HashSet` accept any type that implements `IntoIterator`. Collecting into a heap-allocated `Vec` first is an unnecessary intermediate memory allocation that forces the program to do more work and puts pressure on the allocator. Passing the `Iterator` directly is a zero-cost abstraction.

## 📊 Impact

Reduces heap allocations by removing intermediate arrays when querying and updating active worker IDs during garbage collection, retention polling, and workflow resets.

## 🔭 Measurement

Run `cargo bench` or profile with heaptrack during workflow operations to observe fewer `Vec` allocations in `run_shard_tick` and `reapply_or_drop_signals`. Verification passes with `cargo test -p autumn-harvest --lib`.

---
*PR created automatically by Jules for task [15482837028993798912](https://jules.google.com/task/15482837028993798912) started by @madmax983*