### PR TITLE
🌟 Nova: [Chrome Trace DAG Exporter]

### DIFF
--- a/autumn-harvest/src/dag_trace.rs
+++ b/autumn-harvest/src/dag_trace.rs
@@ -1,0 +1,153 @@
+//! Chrome Trace Event Exporter for DAG profiles.
+//!
+//! Visualizes DAG execution timelines by exporting a `DagProfile` to the
+//! Chrome Trace Event format (viewable in Perfetto or `<chrome://tracing>`).
+//! Critical path tasks are colored differently to highlight bottlenecks.
+
+use crate::critical_path::CriticalPathResult;
+use crate::dag_profiler::{DagProfile, ProfilerEventKind};
+use serde_json::Value;
+use std::cmp::Reverse;
+use std::collections::{BinaryHeap, HashMap};
+
+/// Export a DAG profile and critical path analysis to a Chrome Trace Event JSON array.
+#[must_use]
+#[allow(clippy::cast_possible_truncation)]
+pub fn export_chrome_trace(profile: &DagProfile, critical_path: &CriticalPathResult) -> Value {
+    let mut events = Vec::new();
+
+    // Map each task index to a thread ID (tid) so concurrent tasks appear on different rows.
+    let mut available_tids = BinaryHeap::new();
+    // Default to a small pool of available TIDs
+    for i in 0..profile.peak_concurrency {
+        available_tids.push(Reverse(i as u32));
+    }
+
+    // We might need more if peak_concurrency calculation was conservative or zero.
+    let mut next_tid = profile.peak_concurrency as u32;
+
+    let mut active_tids = HashMap::new();
+
+    for event in &profile.timeline {
+        let ts_micros = event.time.as_micros() as u64;
+
+        match &event.kind {
+            ProfilerEventKind::TaskStarted(task_index, task_name) => {
+                let tid = if let Some(Reverse(id)) = available_tids.pop() {
+                    id
+                } else {
+                    let id = next_tid;
+                    next_tid += 1;
+                    id
+                };
+
+                active_tids.insert(*task_index, tid);
+
+                let is_critical = critical_path.path_indices.contains(task_index);
+                let cname = if is_critical { "bad" } else { "good" };
+
+                events.push(serde_json::json!({
+                    "name": task_name,
+                    "cat": "dag_task",
+                    "ph": "B",
+                    "ts": ts_micros,
+                    "pid": 1,
+                    "tid": tid,
+                    "cname": cname,
+                    "args": {
+                        "critical_path": is_critical
+                    }
+                }));
+            }
+            ProfilerEventKind::TaskCompleted(task_index, task_name) => {
+                let tid = active_tids.remove(task_index).unwrap_or(0);
+                available_tids.push(Reverse(tid));
+
+                events.push(serde_json::json!({
+                    "name": task_name,
+                    "cat": "dag_task",
+                    "ph": "E",
+                    "ts": ts_micros,
+                    "pid": 1,
+                    "tid": tid,
+                }));
+            }
+        }
+    }
+
+    serde_json::json!(events)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::critical_path::CriticalPathAnalyzer;
+    use crate::dag::DagBuilder;
+    use crate::dag_profiler::DagProfiler;
+    use std::time::Duration;
+
+    fn activity_a() {}
+    fn activity_b() {}
+    fn activity_c() {}
+    fn activity_d() {}
+
+    #[test]
+    fn test_export_chrome_trace_coloring() {
+        let mut builder = DagBuilder::new();
+        let start = builder.activity(activity_a);
+        let branch1 = builder.activity(activity_b).upstream(&start);
+        let branch2 = builder.activity(activity_c).upstream(&start);
+        let _end = builder
+            .activity(activity_d)
+            .upstream(&branch1)
+            .upstream(&branch2);
+
+        let dag = builder.build().unwrap();
+
+        // branch2 (C) is longer, so A -> C -> D is the critical path.
+        // branch1 (B) is not on the critical path.
+        let profiler = DagProfiler::new(dag.clone())
+            .mock_duration("activity_a", Duration::from_secs(1))
+            .mock_duration("activity_b", Duration::from_secs(2))
+            .mock_duration("activity_c", Duration::from_secs(5))
+            .mock_duration("activity_d", Duration::from_secs(1));
+        let profile = profiler.profile();
+
+        let analyzer = CriticalPathAnalyzer::new(dag)
+            .mock_duration("activity_a", Duration::from_secs(1))
+            .mock_duration("activity_b", Duration::from_secs(2))
+            .mock_duration("activity_c", Duration::from_secs(5))
+            .mock_duration("activity_d", Duration::from_secs(1));
+        let critical_path = analyzer.analyze();
+
+        let trace = export_chrome_trace(&profile, &critical_path);
+        let arr = trace.as_array().expect("Trace must be an array");
+        assert!(!arr.is_empty(), "Trace array must not be empty");
+
+        let mut a_found = false;
+        let mut b_found = false;
+        let mut c_found = false;
+
+        for event in arr {
+            if event["ph"] == "B" {
+                let name = event["name"].as_str().unwrap();
+                let cname = event["cname"].as_str().unwrap();
+
+                if name == "activity_a" {
+                    assert_eq!(cname, "bad", "activity_a is critical");
+                    a_found = true;
+                } else if name == "activity_b" {
+                    assert_eq!(cname, "good", "activity_b is not critical");
+                    b_found = true;
+                } else if name == "activity_c" {
+                    assert_eq!(cname, "bad", "activity_c is critical");
+                    c_found = true;
+                }
+            }
+        }
+
+        assert!(a_found, "activity_a B event not found");
+        assert!(b_found, "activity_b B event not found");
+        assert!(c_found, "activity_c B event not found");
+    }
+}

--- a/autumn-harvest/src/lib.rs
+++ b/autumn-harvest/src/lib.rs
@@ -70,6 +70,8 @@ pub mod dag_linter;
 pub mod dag_profiler;
 #[cfg(any(test, feature = "testing"))]
 pub mod dag_simulator;
+#[cfg(feature = "testing")]
+pub mod dag_trace;
 /// Debounced workflow starts — collapse trigger bursts into one run (issue #499).
 pub mod debounce;
 /// Deterministic workflow guardrails: static source-level check for replay-breaking patterns.
@@ -214,6 +216,8 @@ pub use dag_linter::{
 pub use dag_profiler::{DagProfile, DagProfiler, ProfilerEvent, ProfilerEventKind};
 #[cfg(any(test, feature = "testing"))]
 pub use dag_simulator::{DagSimulator, DagSimulatorResult};
+#[cfg(feature = "testing")]
+pub use dag_trace::export_chrome_trace;
 pub use det_check::{
     DetCheckReport, DetFinding, DetLocation, DetSeverity, DetSuppression, check_dir, check_file,
     check_source,


### PR DESCRIPTION
💡 **The Spark:** We have an in-memory DAG Profiler (`DagProfile`) that predicts timelines, and a `CriticalPathAnalyzer` that identifies the bottleneck path. Could we export this into a visualization format like Chrome Trace so operators can visually see what's blocking their DAG execution?

🚀 **The Feature:** Created `dag_trace.rs` which implements `export_chrome_trace`. It takes a `DagProfile` and a `CriticalPathResult` and emits a JSON array compatible with the Chrome Trace Event format (viewable in Perfetto or `chrome://tracing`). It automatically assigns thread IDs (`tid`) to parallel tasks using a `BinaryHeap` pool, and uses `cname` to color the critical path tasks red (`bad`) and non-critical tasks green (`good`).

🔮 **The Potential:** When orchestrating massive DAGs (e.g., ML pipelines or heavy ETL workflows), developers can now download a `.json` trace from Harvest and instantly visualize concurrency limits, wait states, and the critical path bottleneck in an industry-standard UI.

⚠️ **Risk:** Low. Completely isolated and purely additive. Exported under the existing `#[cfg(feature = "testing")]` gate alongside the profiler/analyzer.

---
*PR created automatically by Jules for task [7609776569507481360](https://jules.google.com/task/7609776569507481360) started by @madmax983*