### PR TITLE
⚡ Bolt: Remove intermediate allocations in Diesel eq_any queries

### DIFF
--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -15026,10 +15026,7 @@ pub(crate) async fn load_stalled_workflows(
     // Checking all task_type values mirrors the sleeping-filter predicate so that
     // an execution with a stuck workflow task is not mislabelled no_pending_work.
     let has_activity: HashSet<uuid::Uuid> = harvest_task_queue::table
-        .filter(
-            harvest_task_queue::workflow_exec_id
-                .eq_any(exec_ids.iter().map(|id| Some(*id)).collect::<Vec<_>>()),
-        )
+        .filter(harvest_task_queue::workflow_exec_id.eq_any(exec_ids.iter().map(|id| Some(*id))))
         .filter(harvest_task_queue::state.eq_any(["PENDING", "CLAIMED", "RUNNING", "BACKOFF"]))
         .select(harvest_task_queue::workflow_exec_id)
         .distinct()
@@ -15042,10 +15039,7 @@ pub(crate) async fn load_stalled_workflows(
 
     // ── Step 4: non-terminal child workflows ────────────────────────────────
     let has_child: HashSet<uuid::Uuid> = harvest_workflow_executions::table
-        .filter(
-            harvest_workflow_executions::parent_id
-                .eq_any(exec_ids.iter().map(|id| Some(*id)).collect::<Vec<_>>()),
-        )
+        .filter(harvest_workflow_executions::parent_id.eq_any(exec_ids.iter().map(|id| Some(*id))))
         .filter(harvest_workflow_executions::state.ne_all([
             "COMPLETED",
             "FAILED",

--- a/autumn-harvest/src/reset.rs
+++ b/autumn-harvest/src/reset.rs
@@ -1021,7 +1021,7 @@ async fn reapply_or_drop_signals(
     }
 
     if !signals.is_empty() {
-        let ids = signals.iter().map(|signal| signal.id).collect::<Vec<_>>();
+        let ids = signals.iter().map(|signal| signal.id);
         diesel::update(harvest_signals::table.filter(harvest_signals::id.eq_any(ids)))
             .set(harvest_signals::consumed.eq(true))
             .execute(conn)


### PR DESCRIPTION
**💡 What**: Removed unnecessary `.collect::<Vec<_>>()` calls before Diesel's `.eq_any()` in `load_stalled_workflows` and `reapply_or_drop_signals`. Passed iterators directly instead.
**🎯 Why**: Intermediate `Vec` allocations increase heap usage and CPU time unnecessarily when Diesel can consume iterators directly for simple primitive or identifier types. 
**📊 Impact**: Eliminates multiple heap allocations per call in key routines like `load_stalled_workflows`, which is a hot path for workflow polling and execution tracking.
**🔭 Measurement**: Execution correctness verified by running test suites for `autumn-harvest` and `autumn-harvest-plugin`. Heap allocation reduction can be measured through profiling the execution path.

---
*PR created automatically by Jules for task [6587470597660335993](https://jules.google.com/task/6587470597660335993) started by @madmax983*