### PR TITLE
Add typed comparison/set predicates for search attributes (issue #506)

### DIFF
--- a/autumn-harvest-cli/src/lib.rs
+++ b/autumn-harvest-cli/src/lib.rs
@@ -612,6 +612,13 @@ enum WorkflowCommand {
         /// AND multiple predicates together.
         #[arg(long = "search-attr", value_name = "KEY=VALUE")]
         search_attr: Vec<String>,
+        /// Filter by a typed comparison/set predicate over a search attribute,
+        /// `key:op:value` where op is one of eq, ne, gt, gte, lt, lte, in,
+        /// exists (e.g. `amount:gt:10000`, `phase:in:blocked,awaiting_approval`,
+        /// `phase:exists`). Repeat to AND multiple predicates together. Forwarded
+        /// verbatim to the `search_attr_filter` API param (issue #506).
+        #[arg(long = "search-attr-filter", value_name = "KEY:OP:VALUE")]
+        search_attr_filter: Vec<String>,
         /// Filter by owner (exact match).
         #[arg(long)]
         owner: Option<String>,
@@ -2750,6 +2757,7 @@ fn workflow_request(command: &WorkflowCommand) -> Result<ApiRequest, CliError> {
             state,
             workflow_name,
             search_attr,
+            search_attr_filter,
             owner,
             no_progress_minutes,
             include_sleeping,
@@ -2758,6 +2766,7 @@ fn workflow_request(command: &WorkflowCommand) -> Result<ApiRequest, CliError> {
             state,
             workflow_name.as_deref(),
             search_attr,
+            search_attr_filter,
             owner.as_deref(),
             *no_progress_minutes,
             *include_sleeping,
@@ -3863,11 +3872,13 @@ fn build_handoff_list_path(
     format!("/admin/external-handoffs?{query}")
 }
 
+#[allow(clippy::too_many_arguments)]
 fn build_workflow_list_path(
     limit: Option<i64>,
     states: &[String],
     workflow_name: Option<&str>,
     search_attrs: &[String],
+    search_attr_filters: &[String],
     owner: Option<&str>,
     no_progress_minutes: Option<i64>,
     include_sleeping: bool,
@@ -3889,6 +3900,12 @@ fn build_workflow_list_path(
             .split_once('=')
             .ok_or_else(|| CliError::InvalidSearchAttr { value: raw.clone() })?;
         params.push(("search_attr", format!("{key}:{value}")));
+    }
+    // Issue #506: typed comparison/set predicates forwarded verbatim. The server
+    // owns validation (op grammar, numeric coercion, top-level-key rule), so the
+    // CLI is a thin passthrough and returns the API's `400` message on error.
+    for raw in search_attr_filters {
+        params.push(("search_attr_filter", raw.clone()));
     }
     if let Some(o) = owner {
         params.push(("owner", o.to_string()));

--- a/autumn-harvest-cli/tests/request_mapping.rs
+++ b/autumn-harvest-cli/tests/request_mapping.rs
@@ -214,6 +214,31 @@ fn workflow_list_filters_map_to_query_string() {
 }
 
 #[test]
+fn workflow_list_search_attr_filter_maps_to_query_string() {
+    // Issue #506: typed comparison/set predicates forwarded verbatim to the
+    // `search_attr_filter` API param. The CLI does not transform the value.
+    let list = Cli::try_parse_from([
+        "harvest",
+        "workflow",
+        "list",
+        "--search-attr-filter",
+        "amount:gt:10000",
+        "--search-attr-filter",
+        "phase:in:blocked,awaiting_approval",
+    ])
+    .expect("predicate list args should parse");
+    let request = list.api_request().expect("list request should build");
+
+    assert_eq!(request.method, ApiMethod::Get);
+    assert_eq!(
+        request.path,
+        "/workflows?search_attr_filter=amount:gt:10000\
+         &search_attr_filter=phase:in:blocked,awaiting_approval"
+    );
+    assert_eq!(request.body, None);
+}
+
+#[test]
 fn workflow_list_supports_repeated_and_comma_states() {
     let list = Cli::try_parse_from([
         "harvest",

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -1896,6 +1896,31 @@ pub(crate) enum WorkflowSortOrder {
     Asc,
 }
 
+/// Numeric comparison operator for a search-attribute predicate (issue #506).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum CmpOp {
+    Gt,
+    Gte,
+    Lt,
+    Lte,
+}
+
+/// A typed comparison/set predicate over a single top-level search-attribute key
+/// (issue #506). Parsed from a `search_attr_filter=key:op:value` query param.
+#[derive(Debug, Clone)]
+pub(crate) enum SearchAttrPredicate {
+    /// `key:eq:value` — typed equality (numeric/bool/string coercion).
+    Eq { key: String, value: Value },
+    /// `key:ne:value` — key present and typed value differs.
+    Ne { key: String, value: Value },
+    /// `key:{gt,gte,lt,lte}:value` — numeric comparison; value parsed as f64.
+    Cmp { key: String, op: CmpOp, value: f64 },
+    /// `key:in:v1,v2,…` — membership in a typed set.
+    In { key: String, values: Vec<Value> },
+    /// `key:exists` — key is present with any value.
+    Exists { key: String },
+}
+
 /// Decoded keyset cursor for `GET /workflows` (issue #498).
 #[derive(Debug, Clone)]
 pub(crate) struct WorkflowListCursor {
@@ -1916,6 +1941,10 @@ pub(crate) struct WorkflowFilters {
     pub(crate) states: Vec<String>,
     pub(crate) workflow_name: Option<String>,
     pub(crate) search_attrs: Vec<Value>,
+    /// Typed comparison/set predicates over search attributes (issue #506).
+    /// Combined with `AND` against each other and against the legacy
+    /// `search_attrs` containment predicates above.
+    pub(crate) search_attr_predicates: Vec<SearchAttrPredicate>,
     pub(crate) started_after: Option<chrono::DateTime<chrono::Utc>>,
     pub(crate) started_before: Option<chrono::DateTime<chrono::Utc>>,
     /// Prefix match on the execution UUID cast to text (e.g. "abc123").
@@ -4186,12 +4215,152 @@ async fn get_registered_workflow_schema(
     )
 }
 
+/// Coerce a raw predicate token to a typed JSON scalar (issue #506).
+///
+/// A token that parses as a JSON number becomes a `Number`; the exact literals
+/// `true`/`false` become a `Bool`; everything else stays a `String`. This is the
+/// documented typed-coercion rule that lets `eq`/`ne`/`in` compare against the
+/// stored JSONB value by type (so `amount:eq:100` matches numeric `100`, not the
+/// string `"100"`).
+pub(crate) fn coerce_scalar(raw: &str) -> Value {
+    if let Ok(n) = raw.parse::<i64>() {
+        return Value::Number(n.into());
+    }
+    if let Ok(n) = raw.parse::<u64>() {
+        return Value::Number(n.into());
+    }
+    if let Some(num) = raw
+        .parse::<f64>()
+        .ok()
+        .and_then(serde_json::Number::from_f64)
+    {
+        return Value::Number(num);
+    }
+    match raw {
+        "true" => Value::Bool(true),
+        "false" => Value::Bool(false),
+        other => Value::String(other.to_string()),
+    }
+}
+
+/// Parse a single `search_attr_filter=key:op:value` query value into a typed
+/// predicate (issue #506).
+///
+/// Format: `key:op[:value]`. The value is the `splitn(3, ':')` remainder so it
+/// may itself contain `:` (RFC 3339 timestamps) and `,` (set members). Only
+/// top-level keys are supported — a `.`-path is rejected. All error paths return
+/// a `400` that names the offending input.
+pub(crate) fn parse_search_attr_filter(raw: &str) -> Result<SearchAttrPredicate, AutumnError> {
+    let mut parts = raw.splitn(3, ':');
+    let key = parts.next().unwrap_or("").trim();
+    let op = parts.next().map(str::trim);
+    let value = parts.next();
+
+    if key.is_empty() {
+        return Err(AutumnError::bad_request_msg(format!(
+            "search_attr_filter '{raw}' is missing a key"
+        )));
+    }
+    if key.contains('.') {
+        return Err(AutumnError::bad_request_msg(format!(
+            "search_attr_filter '{raw}': nested path expressions are not supported; \
+             only top-level search-attribute keys may be filtered"
+        )));
+    }
+    let Some(op) = op else {
+        return Err(AutumnError::bad_request_msg(format!(
+            "search_attr_filter '{raw}'; expected 'key:op:value' \
+             (op ∈ eq, ne, gt, gte, lt, lte, in, exists)"
+        )));
+    };
+
+    // Helper: a value is required for every op except `exists`.
+    let require_value = |raw: &str, op: &str| -> Result<String, AutumnError> {
+        value.map_or_else(
+            || {
+                Err(AutumnError::bad_request_msg(format!(
+                    "search_attr_filter '{raw}': operator '{op}' requires a value"
+                )))
+            },
+            |v| Ok(v.to_string()),
+        )
+    };
+
+    let cmp = |op_name: &str, op: CmpOp| -> Result<SearchAttrPredicate, AutumnError> {
+        let v = require_value(raw, op_name)?;
+        let parsed = v.trim().parse::<f64>().map_err(|_| {
+            AutumnError::bad_request_msg(format!(
+                "search_attr_filter '{raw}': operator '{op_name}' requires a numeric value, got '{v}'"
+            ))
+        })?;
+        if !parsed.is_finite() {
+            return Err(AutumnError::bad_request_msg(format!(
+                "search_attr_filter '{raw}': operator '{op_name}' requires a finite numeric value, got '{v}'"
+            )));
+        }
+        Ok(SearchAttrPredicate::Cmp {
+            key: key.to_string(),
+            op,
+            value: parsed,
+        })
+    };
+
+    match op {
+        "eq" => Ok(SearchAttrPredicate::Eq {
+            key: key.to_string(),
+            value: coerce_scalar(&require_value(raw, "eq")?),
+        }),
+        "ne" => Ok(SearchAttrPredicate::Ne {
+            key: key.to_string(),
+            value: coerce_scalar(&require_value(raw, "ne")?),
+        }),
+        "gt" => cmp("gt", CmpOp::Gt),
+        "gte" => cmp("gte", CmpOp::Gte),
+        "lt" => cmp("lt", CmpOp::Lt),
+        "lte" => cmp("lte", CmpOp::Lte),
+        "in" => {
+            let v = require_value(raw, "in")?;
+            let values: Vec<Value> = v
+                .split(',')
+                .map(str::trim)
+                .filter(|s| !s.is_empty())
+                .map(coerce_scalar)
+                .collect();
+            if values.is_empty() {
+                return Err(AutumnError::bad_request_msg(format!(
+                    "search_attr_filter '{raw}': operator 'in' requires a non-empty comma-separated list"
+                )));
+            }
+            Ok(SearchAttrPredicate::In {
+                key: key.to_string(),
+                values,
+            })
+        }
+        "exists" => {
+            if value.is_some() {
+                return Err(AutumnError::bad_request_msg(format!(
+                    "search_attr_filter '{raw}': operator 'exists' takes no value"
+                )));
+            }
+            Ok(SearchAttrPredicate::Exists {
+                key: key.to_string(),
+            })
+        }
+        other => Err(AutumnError::bad_request_msg(format!(
+            "search_attr_filter '{raw}': unknown operator '{other}'; \
+             expected one of eq, ne, gt, gte, lt, lte, in, exists"
+        ))),
+    }
+}
+
 /// Parse the management-API query string into a `WorkflowFilters`.
 ///
 /// State values are comma-separated (or repeated `state=`) and validated
 /// against `KNOWN_WORKFLOW_STATES`. `search_attr=` values must be `key:value`
 /// and are repeatable; each entry contributes a separate JSONB containment
-/// predicate so repeats narrow rather than widen.
+/// predicate so repeats narrow rather than widen. `search_attr_filter=` values
+/// are typed comparison/set predicates (issue #506), also repeatable and
+/// combined with `AND`.
 #[allow(clippy::too_many_lines)]
 pub(crate) fn parse_workflow_filters(
     pairs: &[(String, String)],
@@ -4258,6 +4427,11 @@ pub(crate) fn parse_workflow_filters(
                 let mut object = serde_json::Map::with_capacity(1);
                 object.insert(attr_key.to_string(), Value::String(raw_val.to_string()));
                 filters.search_attrs.push(Value::Object(object));
+            }
+            // Issue #506: typed comparison/set predicates. Repeatable; ANDed.
+            "search_attr_filter" => {
+                let predicate = parse_search_attr_filter(value)?;
+                filters.search_attr_predicates.push(predicate);
             }
             "failure_cause" => {
                 let trimmed = value.trim();
@@ -15017,12 +15191,15 @@ async fn db_conn_for_dag(
     db_conn_for_shard(api_state, runtime.router.pick_for_dag(dag_name)).await
 }
 
+#[allow(clippy::too_many_lines)]
 pub(crate) async fn load_workflows(
     conn: &mut AsyncPgConnection,
     filters: &WorkflowFilters,
 ) -> HarvestResult<Vec<WorkflowExecution>> {
     use diesel::dsl::sql;
-    use diesel::sql_types::{BigInt, Bool, Jsonb, Text, Timestamptz, Uuid as SqlUuid};
+    use diesel::sql_types::{
+        Array, BigInt, Bool, Double, Jsonb, Text, Timestamptz, Uuid as SqlUuid,
+    };
 
     // Honor `filters.limit` exactly. Direct callers (e.g. the DAG-runs UI loader
     // `load_dag_runs_from_owning_shard`) render every row returned, so the
@@ -15100,6 +15277,60 @@ pub(crate) async fn load_workflows(
     // `search_attrs`; ANDing predicates means repeated keys narrow the result set.
     for predicate in &filters.search_attrs {
         query = query.filter(sql::<Bool>("search_attrs @> ").bind::<Jsonb, _>(predicate.clone()));
+    }
+    // Issue #506: typed comparison/set predicates. Every fragment stays on an
+    // index path — `@>` (containment) and `?` (key existence) both hit the
+    // existing `idx_harvest_we_search` GIN index; comparison ops narrow on `?`
+    // then recheck the numeric cast. The key is always a *bound* `Text` param
+    // (never interpolated), so dynamic keys are injection-safe. The `Cmp`
+    // operator literal comes from the fixed `CmpOp` enum.
+    for predicate in &filters.search_attr_predicates {
+        query = match predicate {
+            SearchAttrPredicate::Eq { key, value } => {
+                let object = serde_json::json!({ key.clone(): value.clone() });
+                query.filter(sql::<Bool>("search_attrs @> ").bind::<Jsonb, _>(object))
+            }
+            SearchAttrPredicate::Ne { key, value } => {
+                let object = serde_json::json!({ key.clone(): value.clone() });
+                query.filter(
+                    sql::<Bool>("(search_attrs ? ")
+                        .bind::<Text, _>(key.clone())
+                        .sql(" AND NOT (search_attrs @> ")
+                        .bind::<Jsonb, _>(object)
+                        .sql("))"),
+                )
+            }
+            SearchAttrPredicate::Cmp { key, op, value } => {
+                let head = sql::<Bool>("(search_attrs ? ")
+                    .bind::<Text, _>(key.clone())
+                    .sql(" AND jsonb_typeof(search_attrs -> ")
+                    .bind::<Text, _>(key.clone())
+                    .sql(") = 'number' AND (search_attrs ->> ")
+                    .bind::<Text, _>(key.clone());
+                // Fold the operator (from the fixed `CmpOp` enum) into a single
+                // static literal per branch so the fragment never chains two
+                // raw-SQL pieces back to back.
+                let body = match op {
+                    CmpOp::Gt => head.sql(")::numeric > "),
+                    CmpOp::Gte => head.sql(")::numeric >= "),
+                    CmpOp::Lt => head.sql(")::numeric < "),
+                    CmpOp::Lte => head.sql(")::numeric <= "),
+                };
+                query.filter(body.bind::<Double, _>(*value).sql(")"))
+            }
+            SearchAttrPredicate::In { key, values } => query.filter(
+                sql::<Bool>("(search_attrs ? ")
+                    .bind::<Text, _>(key.clone())
+                    .sql(" AND search_attrs -> ")
+                    .bind::<Text, _>(key.clone())
+                    .sql(" = ANY(")
+                    .bind::<Array<Jsonb>, _>(values.clone())
+                    .sql("))"),
+            ),
+            SearchAttrPredicate::Exists { key } => {
+                query.filter(sql::<Bool>("search_attrs ? ").bind::<Text, _>(key.clone()))
+            }
+        };
     }
     if let Some(cause) = &filters.failure_cause {
         let predicate = serde_json::json!({ "failure_cause": cause });
@@ -20062,6 +20293,209 @@ mod tests {
         let err = parse_workflow_filters(&pairs(&[("limit", "abc")]))
             .expect_err("non-numeric limit must error");
         assert!(err.to_string().contains("invalid limit"));
+    }
+
+    // ── Issue #506: typed comparison & set predicates ───────────────────────
+
+    #[test]
+    fn coerce_scalar_infers_number_bool_and_string() {
+        assert_eq!(coerce_scalar("42"), serde_json::json!(42));
+        assert_eq!(coerce_scalar("-7"), serde_json::json!(-7));
+        assert_eq!(coerce_scalar("3.5"), serde_json::json!(3.5));
+        assert_eq!(coerce_scalar("true"), serde_json::json!(true));
+        assert_eq!(coerce_scalar("false"), serde_json::json!(false));
+        assert_eq!(coerce_scalar("blocked"), serde_json::json!("blocked"));
+        // "True" is not an exact bool literal -> string.
+        assert_eq!(coerce_scalar("True"), serde_json::json!("True"));
+    }
+
+    #[test]
+    fn parse_search_attr_filter_eq_coerces_value() {
+        match parse_search_attr_filter("amount:eq:100").expect("eq parses") {
+            SearchAttrPredicate::Eq { key, value } => {
+                assert_eq!(key, "amount");
+                assert_eq!(value, serde_json::json!(100));
+            }
+            other => panic!("expected Eq, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_search_attr_filter_ne_coerces_value() {
+        match parse_search_attr_filter("phase:ne:blocked").expect("ne parses") {
+            SearchAttrPredicate::Ne { key, value } => {
+                assert_eq!(key, "phase");
+                assert_eq!(value, serde_json::json!("blocked"));
+            }
+            other => panic!("expected Ne, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_search_attr_filter_comparison_ops_require_numbers() {
+        for (raw, op) in [
+            ("amount:gt:9", CmpOp::Gt),
+            ("amount:gte:9", CmpOp::Gte),
+            ("amount:lt:9", CmpOp::Lt),
+            ("amount:lte:9", CmpOp::Lte),
+        ] {
+            match parse_search_attr_filter(raw).expect("cmp parses") {
+                SearchAttrPredicate::Cmp {
+                    key,
+                    op: got,
+                    value,
+                } => {
+                    assert_eq!(key, "amount");
+                    assert_eq!(got, op);
+                    assert!((value - 9.0).abs() < f64::EPSILON);
+                }
+                other => panic!("expected Cmp, got {other:?}"),
+            }
+        }
+    }
+
+    #[test]
+    fn parse_search_attr_filter_rejects_non_numeric_comparison_value() {
+        let err = parse_search_attr_filter("amount:gt:lots")
+            .expect_err("non-numeric gt value must error");
+        let msg = err.to_string();
+        assert!(msg.contains("gt"), "message should name the op: {msg}");
+        assert!(
+            msg.contains("numeric"),
+            "message should mention numeric: {msg}"
+        );
+    }
+
+    #[test]
+    fn parse_search_attr_filter_in_splits_and_coerces() {
+        match parse_search_attr_filter("phase:in:blocked,awaiting_approval").expect("in parses") {
+            SearchAttrPredicate::In { key, values } => {
+                assert_eq!(key, "phase");
+                assert_eq!(
+                    values,
+                    vec![
+                        serde_json::json!("blocked"),
+                        serde_json::json!("awaiting_approval"),
+                    ]
+                );
+            }
+            other => panic!("expected In, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_search_attr_filter_in_coerces_numeric_set() {
+        match parse_search_attr_filter("retry_count:in:1,2,3").expect("numeric in parses") {
+            SearchAttrPredicate::In { values, .. } => {
+                assert_eq!(
+                    values,
+                    vec![
+                        serde_json::json!(1),
+                        serde_json::json!(2),
+                        serde_json::json!(3),
+                    ]
+                );
+            }
+            other => panic!("expected In, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_search_attr_filter_exists_takes_no_value() {
+        match parse_search_attr_filter("phase:exists").expect("exists parses") {
+            SearchAttrPredicate::Exists { key } => assert_eq!(key, "phase"),
+            other => panic!("expected Exists, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_search_attr_filter_rejects_value_on_exists() {
+        let err = parse_search_attr_filter("phase:exists:oops")
+            .expect_err("exists with value must error");
+        assert!(err.to_string().contains("exists"));
+    }
+
+    #[test]
+    fn parse_search_attr_filter_rejects_unknown_op() {
+        let err = parse_search_attr_filter("amount:between:1").expect_err("unknown op must error");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("between") || msg.contains("operator"),
+            "msg: {msg}"
+        );
+    }
+
+    #[test]
+    fn parse_search_attr_filter_rejects_nested_path_key() {
+        let err = parse_search_attr_filter("a.b:eq:1").expect_err("nested path key must error");
+        let msg = err.to_string();
+        assert!(
+            msg.contains("nested") || msg.contains("top-level"),
+            "msg: {msg}"
+        );
+    }
+
+    #[test]
+    fn parse_search_attr_filter_rejects_empty_key() {
+        let err = parse_search_attr_filter(":eq:1").expect_err("empty key must error");
+        assert!(err.to_string().contains("key"));
+    }
+
+    #[test]
+    fn parse_search_attr_filter_rejects_missing_value_for_eq() {
+        let err = parse_search_attr_filter("amount:eq").expect_err("eq without value must error");
+        assert!(err.to_string().contains("value") || err.to_string().contains("eq"));
+    }
+
+    #[test]
+    fn parse_search_attr_filter_value_may_contain_colon() {
+        // RFC 3339 timestamps contain ':'; the value is the splitn(3) remainder.
+        match parse_search_attr_filter("ts:eq:2026-01-01T00:00:00Z").expect("colon value parses") {
+            SearchAttrPredicate::Eq { key, value } => {
+                assert_eq!(key, "ts");
+                assert_eq!(value, serde_json::json!("2026-01-01T00:00:00Z"));
+            }
+            other => panic!("expected Eq, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_workflow_filters_collects_search_attr_filter_predicates() {
+        let filters = parse_workflow_filters(&pairs(&[
+            ("search_attr_filter", "amount:gt:10000"),
+            ("search_attr_filter", "phase:in:blocked,awaiting_approval"),
+        ]))
+        .expect("predicates parse");
+        assert_eq!(filters.search_attr_predicates.len(), 2);
+        assert!(matches!(
+            filters.search_attr_predicates[0],
+            SearchAttrPredicate::Cmp { op: CmpOp::Gt, .. }
+        ));
+        assert!(matches!(
+            filters.search_attr_predicates[1],
+            SearchAttrPredicate::In { .. }
+        ));
+    }
+
+    #[test]
+    fn parse_workflow_filters_legacy_search_attr_is_unchanged_string_containment() {
+        // Legacy shorthand stays byte-for-byte: value is always a JSON string,
+        // not coerced to a number.
+        let filters = parse_workflow_filters(&pairs(&[("search_attr", "customer_id:42")]))
+            .expect("legacy search_attr parses");
+        assert_eq!(filters.search_attrs.len(), 1);
+        assert_eq!(
+            filters.search_attrs[0]["customer_id"],
+            serde_json::json!("42")
+        );
+        assert!(filters.search_attr_predicates.is_empty());
+    }
+
+    #[test]
+    fn parse_workflow_filters_propagates_search_attr_filter_errors() {
+        let err = parse_workflow_filters(&pairs(&[("search_attr_filter", "amount:gt:nope")]))
+            .expect_err("bad predicate must propagate 400");
+        assert!(err.to_string().contains("numeric"));
     }
 
     #[test]

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -1913,8 +1913,15 @@ pub(crate) enum SearchAttrPredicate {
     Eq { key: String, value: Value },
     /// `key:ne:value` — key present and typed value differs.
     Ne { key: String, value: Value },
-    /// `key:{gt,gte,lt,lte}:value` — numeric comparison; value parsed as f64.
-    Cmp { key: String, op: CmpOp, value: f64 },
+    /// `key:{gt,gte,lt,lte}:value` — numeric comparison. `value` is the
+    /// validated, trimmed numeric *text* (not an f64): it is bound and cast
+    /// `::numeric` in SQL so the comparison stays exact even for integers
+    /// beyond f64's 2^53 mantissa (issue #506 review).
+    Cmp {
+        key: String,
+        op: CmpOp,
+        value: String,
+    },
     /// `key:in:v1,v2,…` — membership in a typed set.
     In { key: String, values: Vec<Value> },
     /// `key:exists` — key is present with any value.
@@ -4288,7 +4295,12 @@ pub(crate) fn parse_search_attr_filter(raw: &str) -> Result<SearchAttrPredicate,
 
     let cmp = |op_name: &str, op: CmpOp| -> Result<SearchAttrPredicate, AutumnError> {
         let v = require_value(raw, op_name)?;
-        let parsed = v.trim().parse::<f64>().map_err(|_| {
+        let trimmed = v.trim();
+        // Validate it is a finite number so a bad value fails fast with 400
+        // rather than as a runtime `::numeric` cast error, but keep the original
+        // trimmed text — it is bound and cast `::numeric` in SQL, preserving full
+        // precision for integers beyond f64's 2^53 mantissa.
+        let parsed = trimmed.parse::<f64>().map_err(|_| {
             AutumnError::bad_request_msg(format!(
                 "search_attr_filter '{raw}': operator '{op_name}' requires a numeric value, got '{v}'"
             ))
@@ -4301,18 +4313,20 @@ pub(crate) fn parse_search_attr_filter(raw: &str) -> Result<SearchAttrPredicate,
         Ok(SearchAttrPredicate::Cmp {
             key: key.to_string(),
             op,
-            value: parsed,
+            value: trimmed.to_string(),
         })
     };
 
     match op {
+        // Trim the value before coercion so whitespace can't silently flip the
+        // inferred type (matches the `in`/comparison ops, issue #506 review).
         "eq" => Ok(SearchAttrPredicate::Eq {
             key: key.to_string(),
-            value: coerce_scalar(&require_value(raw, "eq")?),
+            value: coerce_scalar(require_value(raw, "eq")?.trim()),
         }),
         "ne" => Ok(SearchAttrPredicate::Ne {
             key: key.to_string(),
-            value: coerce_scalar(&require_value(raw, "ne")?),
+            value: coerce_scalar(require_value(raw, "ne")?.trim()),
         }),
         "gt" => cmp("gt", CmpOp::Gt),
         "gte" => cmp("gte", CmpOp::Gte),
@@ -15191,15 +15205,100 @@ async fn db_conn_for_dag(
     db_conn_for_shard(api_state, runtime.router.pick_for_dag(dag_name)).await
 }
 
+/// Apply the legacy `search_attr` containment predicates and the typed
+/// `search_attr_filter` comparison/set predicates (issue #506) to a boxed
+/// `harvest_workflow_executions` query.
+///
+/// Shared by `load_workflows` and `load_stalled_workflows` so both list code
+/// paths filter identically — without this the `no_progress_minutes` (stalled)
+/// path silently ignored every search-attribute filter (issue #506 review).
+///
+/// Every fragment stays on an index path: `@>` (containment) and `?` (key
+/// existence) both hit the existing `idx_harvest_we_search` GIN index;
+/// comparison ops narrow on `?` then recheck a `::numeric` cast. The key is
+/// always a *bound* `Text` param (never interpolated), so dynamic keys are
+/// injection-safe; the `Cmp` operator literal comes from the fixed `CmpOp` enum.
+/// Columns are qualified with `harvest_workflow_executions.` so the fragments
+/// are unambiguous inside the stalled loader's correlated-subquery context.
+fn apply_search_attr_filters<'a>(
+    mut query: harvest_workflow_executions::BoxedQuery<'a, diesel::pg::Pg>,
+    legacy: &[Value],
+    predicates: &[SearchAttrPredicate],
+) -> harvest_workflow_executions::BoxedQuery<'a, diesel::pg::Pg> {
+    use diesel::dsl::sql;
+    use diesel::sql_types::{Array, Bool, Jsonb, Text};
+
+    // Legacy `search_attr=key:value` exact-match containment. Repeated keys
+    // narrow the result set (AND).
+    for predicate in legacy {
+        query = query.filter(
+            sql::<Bool>("harvest_workflow_executions.search_attrs @> ")
+                .bind::<Jsonb, _>(predicate.clone()),
+        );
+    }
+    for predicate in predicates {
+        query = match predicate {
+            SearchAttrPredicate::Eq { key, value } => {
+                let object = serde_json::json!({ key.clone(): value.clone() });
+                query.filter(
+                    sql::<Bool>("harvest_workflow_executions.search_attrs @> ")
+                        .bind::<Jsonb, _>(object),
+                )
+            }
+            SearchAttrPredicate::Ne { key, value } => {
+                let object = serde_json::json!({ key.clone(): value.clone() });
+                query.filter(
+                    sql::<Bool>("(harvest_workflow_executions.search_attrs ? ")
+                        .bind::<Text, _>(key.clone())
+                        .sql(" AND NOT (harvest_workflow_executions.search_attrs @> ")
+                        .bind::<Jsonb, _>(object)
+                        .sql("))"),
+                )
+            }
+            SearchAttrPredicate::Cmp { key, op, value } => {
+                let head = sql::<Bool>("(harvest_workflow_executions.search_attrs ? ")
+                    .bind::<Text, _>(key.clone())
+                    .sql(" AND jsonb_typeof(harvest_workflow_executions.search_attrs -> ")
+                    .bind::<Text, _>(key.clone())
+                    .sql(") = 'number' AND (harvest_workflow_executions.search_attrs ->> ")
+                    .bind::<Text, _>(key.clone());
+                // Fold the operator (from the fixed `CmpOp` enum) into a single
+                // static literal per branch so the fragment never chains two
+                // raw-SQL pieces back to back. The threshold is bound as text and
+                // cast `::numeric` so the comparison is exact even past 2^53.
+                let body = match op {
+                    CmpOp::Gt => head.sql(")::numeric > "),
+                    CmpOp::Gte => head.sql(")::numeric >= "),
+                    CmpOp::Lt => head.sql(")::numeric < "),
+                    CmpOp::Lte => head.sql(")::numeric <= "),
+                };
+                query.filter(body.bind::<Text, _>(value.clone()).sql("::numeric)"))
+            }
+            SearchAttrPredicate::In { key, values } => query.filter(
+                sql::<Bool>("(harvest_workflow_executions.search_attrs ? ")
+                    .bind::<Text, _>(key.clone())
+                    .sql(" AND harvest_workflow_executions.search_attrs -> ")
+                    .bind::<Text, _>(key.clone())
+                    .sql(" = ANY(")
+                    .bind::<Array<Jsonb>, _>(values.clone())
+                    .sql("))"),
+            ),
+            SearchAttrPredicate::Exists { key } => query.filter(
+                sql::<Bool>("harvest_workflow_executions.search_attrs ? ")
+                    .bind::<Text, _>(key.clone()),
+            ),
+        };
+    }
+    query
+}
+
 #[allow(clippy::too_many_lines)]
 pub(crate) async fn load_workflows(
     conn: &mut AsyncPgConnection,
     filters: &WorkflowFilters,
 ) -> HarvestResult<Vec<WorkflowExecution>> {
     use diesel::dsl::sql;
-    use diesel::sql_types::{
-        Array, BigInt, Bool, Double, Jsonb, Text, Timestamptz, Uuid as SqlUuid,
-    };
+    use diesel::sql_types::{BigInt, Bool, Jsonb, Text, Timestamptz, Uuid as SqlUuid};
 
     // Honor `filters.limit` exactly. Direct callers (e.g. the DAG-runs UI loader
     // `load_dag_runs_from_owning_shard`) render every row returned, so the
@@ -15272,66 +15371,14 @@ pub(crate) async fn load_workflows(
     if let Some(severity) = &filters.severity {
         query = query.filter(harvest_workflow_executions::severity.eq(severity.clone()));
     }
-    // Each search_attr filter contributes its own `search_attrs @> {...}` predicate.
-    // The `@>` operator hits the existing `idx_harvest_we_search` GIN index on
-    // `search_attrs`; ANDing predicates means repeated keys narrow the result set.
-    for predicate in &filters.search_attrs {
-        query = query.filter(sql::<Bool>("search_attrs @> ").bind::<Jsonb, _>(predicate.clone()));
-    }
-    // Issue #506: typed comparison/set predicates. Every fragment stays on an
-    // index path — `@>` (containment) and `?` (key existence) both hit the
-    // existing `idx_harvest_we_search` GIN index; comparison ops narrow on `?`
-    // then recheck the numeric cast. The key is always a *bound* `Text` param
-    // (never interpolated), so dynamic keys are injection-safe. The `Cmp`
-    // operator literal comes from the fixed `CmpOp` enum.
-    for predicate in &filters.search_attr_predicates {
-        query = match predicate {
-            SearchAttrPredicate::Eq { key, value } => {
-                let object = serde_json::json!({ key.clone(): value.clone() });
-                query.filter(sql::<Bool>("search_attrs @> ").bind::<Jsonb, _>(object))
-            }
-            SearchAttrPredicate::Ne { key, value } => {
-                let object = serde_json::json!({ key.clone(): value.clone() });
-                query.filter(
-                    sql::<Bool>("(search_attrs ? ")
-                        .bind::<Text, _>(key.clone())
-                        .sql(" AND NOT (search_attrs @> ")
-                        .bind::<Jsonb, _>(object)
-                        .sql("))"),
-                )
-            }
-            SearchAttrPredicate::Cmp { key, op, value } => {
-                let head = sql::<Bool>("(search_attrs ? ")
-                    .bind::<Text, _>(key.clone())
-                    .sql(" AND jsonb_typeof(search_attrs -> ")
-                    .bind::<Text, _>(key.clone())
-                    .sql(") = 'number' AND (search_attrs ->> ")
-                    .bind::<Text, _>(key.clone());
-                // Fold the operator (from the fixed `CmpOp` enum) into a single
-                // static literal per branch so the fragment never chains two
-                // raw-SQL pieces back to back.
-                let body = match op {
-                    CmpOp::Gt => head.sql(")::numeric > "),
-                    CmpOp::Gte => head.sql(")::numeric >= "),
-                    CmpOp::Lt => head.sql(")::numeric < "),
-                    CmpOp::Lte => head.sql(")::numeric <= "),
-                };
-                query.filter(body.bind::<Double, _>(*value).sql(")"))
-            }
-            SearchAttrPredicate::In { key, values } => query.filter(
-                sql::<Bool>("(search_attrs ? ")
-                    .bind::<Text, _>(key.clone())
-                    .sql(" AND search_attrs -> ")
-                    .bind::<Text, _>(key.clone())
-                    .sql(" = ANY(")
-                    .bind::<Array<Jsonb>, _>(values.clone())
-                    .sql("))"),
-            ),
-            SearchAttrPredicate::Exists { key } => {
-                query.filter(sql::<Bool>("search_attrs ? ").bind::<Text, _>(key.clone()))
-            }
-        };
-    }
+    // Legacy `search_attr` containment + typed `search_attr_filter` predicates
+    // (issue #506). Centralized so the stalled-workflow loader applies the exact
+    // same filtering — see `apply_search_attr_filters`.
+    query = apply_search_attr_filters(
+        query,
+        &filters.search_attrs,
+        &filters.search_attr_predicates,
+    );
     if let Some(cause) = &filters.failure_cause {
         let predicate = serde_json::json!({ "failure_cause": cause });
         query = query.filter(sql::<Bool>("search_attrs @> ").bind::<Jsonb, _>(predicate));
@@ -15525,6 +15572,16 @@ pub(crate) async fn load_stalled_workflows(
             .bind::<BigInt, _>(i64::try_from(min_events).unwrap_or(i64::MAX)),
         );
     }
+
+    // Honor the search-attribute filters on the stalled path too (issue #506
+    // review): without this, `?no_progress_minutes=N&search_attr_filter=…` (or
+    // the legacy `&search_attr=…`) returned every stalled row because this
+    // loader bypasses `load_workflows`.
+    query = apply_search_attr_filters(
+        query,
+        &filters.search_attrs,
+        &filters.search_attr_predicates,
+    );
 
     if !filters.include_sleeping {
         // Include an execution if it has any non-timer pending work, OR has no
@@ -20347,10 +20404,42 @@ mod tests {
                 } => {
                     assert_eq!(key, "amount");
                     assert_eq!(got, op);
-                    assert!((value - 9.0).abs() < f64::EPSILON);
+                    // Stored as the validated numeric *text* (issue #506 review),
+                    // not an f64 — so precision is preserved for the SQL cast.
+                    assert_eq!(value, "9");
                 }
                 other => panic!("expected Cmp, got {other:?}"),
             }
+        }
+    }
+
+    #[test]
+    fn parse_search_attr_filter_comparison_preserves_large_integer_precision() {
+        // 2^53 + 1 — not exactly representable as f64. The predicate must keep
+        // the exact text so the `::numeric` SQL cast compares precisely.
+        match parse_search_attr_filter("amount:gt:9007199254740993").expect("cmp parses") {
+            SearchAttrPredicate::Cmp { value, .. } => {
+                assert_eq!(value, "9007199254740993");
+            }
+            other => panic!("expected Cmp, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_search_attr_filter_eq_ne_trim_whitespace_before_coercion() {
+        // Surrounding whitespace must not flip the inferred type (issue #506
+        // review): a trimmed numeric value coerces to a number, not a string.
+        match parse_search_attr_filter("amount:eq: 100").expect("eq parses") {
+            SearchAttrPredicate::Eq { value, .. } => {
+                assert_eq!(value, serde_json::json!(100));
+            }
+            other => panic!("expected Eq, got {other:?}"),
+        }
+        match parse_search_attr_filter("phase:ne: blocked ").expect("ne parses") {
+            SearchAttrPredicate::Ne { value, .. } => {
+                assert_eq!(value, serde_json::json!("blocked"));
+            }
+            other => panic!("expected Ne, got {other:?}"),
         }
     }
 

--- a/autumn-harvest-plugin/tests/workflow_filter_integration.rs
+++ b/autumn-harvest-plugin/tests/workflow_filter_integration.rs
@@ -1320,3 +1320,92 @@ async fn workflow_search_attr_predicate_applies_across_shards_with_pagination() 
         "predicate must select exactly the >10k rows across shards, no dup/skip"
     );
 }
+
+/// Backdate every event of an execution so it appears stalled (no event in the
+/// last N minutes) to the `no_progress_minutes` scanner.
+async fn backdate_events(database_url: &str, exec_id: ExecutionId, minutes: i64) {
+    let mut conn = <AsyncPgConnection as AsyncConnection>::establish(database_url)
+        .await
+        .expect("failed to connect to backdate events");
+    diesel::sql_query(format!(
+        "UPDATE harvest_events SET timestamp = NOW() - INTERVAL '{minutes} minutes' \
+         WHERE workflow_exec_id = '{}'",
+        exec_id.as_uuid()
+    ))
+    .execute(&mut conn)
+    .await
+    .expect("backdate update should succeed");
+}
+
+/// Regression for issue #506 review finding #1: `search_attr_filter` (and the
+/// legacy `search_attr`) must narrow the stalled-workflow (`no_progress_minutes`)
+/// path, not be silently dropped.
+#[tokio::test]
+async fn stalled_workflow_path_applies_search_attr_predicate() {
+    let (database_url, _container) = setup_single_database().await;
+    let pool = build_pool(&database_url);
+    let api_state = HarvestApiState::new();
+    api_state.install_storage_pool(HarvestDbPool::from(pool));
+    let app = harvest_api_router(api_state).with_state(test_app_state_without_database());
+
+    let blocked = seed_workflow(
+        &database_url,
+        ShardId::new(0),
+        "payment",
+        "wf-stalled-blocked",
+        Some(json!({ "phase": "blocked", "amount": 50000 })),
+    )
+    .await;
+    let open = seed_workflow(
+        &database_url,
+        ShardId::new(0),
+        "payment",
+        "wf-stalled-open",
+        Some(json!({ "phase": "open", "amount": 10 })),
+    )
+    .await;
+    // Make both look stalled: no event progress for 10 minutes.
+    backdate_events(&database_url, blocked, 10).await;
+    backdate_events(&database_url, open, 10).await;
+
+    // Typed predicate must narrow the stalled set to only the blocked row.
+    let (status, body) = get_json(
+        &app,
+        "/workflows?no_progress_minutes=5&search_attr_filter=phase:eq:blocked",
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(
+        workflow_ids(&body),
+        vec!["wf-stalled-blocked".to_string()],
+        "stalled path must honor search_attr_filter"
+    );
+
+    // Numeric comparison on the stalled path too.
+    let (_, body) = get_json(
+        &app,
+        "/workflows?no_progress_minutes=5&search_attr_filter=amount:gt:1000",
+    )
+    .await;
+    assert_eq!(workflow_ids(&body), vec!["wf-stalled-blocked".to_string()]);
+
+    // Legacy search_attr is also honored on the stalled path now.
+    let (_, body) = get_json(
+        &app,
+        "/workflows?no_progress_minutes=5&search_attr=phase:open",
+    )
+    .await;
+    assert_eq!(workflow_ids(&body), vec!["wf-stalled-open".to_string()]);
+
+    // Sanity: without a predicate, both stalled rows are returned.
+    let (_, body) = get_json(&app, "/workflows?no_progress_minutes=5").await;
+    let mut ids = workflow_ids(&body);
+    ids.sort();
+    assert_eq!(
+        ids,
+        vec![
+            "wf-stalled-blocked".to_string(),
+            "wf-stalled-open".to_string()
+        ]
+    );
+}

--- a/autumn-harvest-plugin/tests/workflow_filter_integration.rs
+++ b/autumn-harvest-plugin/tests/workflow_filter_integration.rs
@@ -1051,3 +1051,272 @@ async fn workflow_list_pagination_sharded_global_order() {
     assert_eq!(all_ids[1], "wf-s0-2");
     assert_eq!(all_ids[2], "wf-s1-1");
 }
+
+// ─── Issue #506: typed comparison & set predicates ──────────────────────────
+
+/// Extract `workflow_id`s from either a bare array or a `{ workflows: [...] }`
+/// pagination envelope (issue #498), so predicate tests can run with or without
+/// pagination params.
+fn workflow_ids_any(value: &Value) -> Vec<String> {
+    let array = value
+        .as_array()
+        .or_else(|| value.get("workflows").and_then(Value::as_array))
+        .expect("expected a workflow array or a paginated envelope");
+    array
+        .iter()
+        .map(|row| {
+            row["workflow_id"]
+                .as_str()
+                .expect("workflow_id must be a string")
+                .to_string()
+        })
+        .collect()
+}
+
+/// Seed a `{ amount, phase, retry_count }` fixture covering numeric and string
+/// attributes, then prove each predicate isolates exactly the right subset.
+#[tokio::test]
+#[allow(clippy::too_many_lines)]
+async fn workflow_search_attr_predicate_comparison_and_set() {
+    let (database_url, _container) = setup_single_database().await;
+    let pool = build_pool(&database_url);
+    let api_state = HarvestApiState::new();
+    api_state.install_storage_pool(HarvestDbPool::from(pool));
+    let app = harvest_api_router(api_state).with_state(test_app_state_without_database());
+
+    // amount/phase/retry_count fixtures. `small-amount` deliberately probes the
+    // string-vs-number coercion regression: amount=100 must sort ABOVE amount=20
+    // numerically, not lexically ("100" < "20" as strings).
+    let _big = seed_workflow(
+        &database_url,
+        ShardId::new(0),
+        "payment",
+        "wf-big",
+        Some(json!({ "amount": 15000, "phase": "blocked", "retry_count": 5 })),
+    )
+    .await;
+    let _mid = seed_workflow(
+        &database_url,
+        ShardId::new(0),
+        "payment",
+        "wf-mid",
+        Some(json!({ "amount": 100, "phase": "awaiting_approval", "retry_count": 3 })),
+    )
+    .await;
+    let _small = seed_workflow(
+        &database_url,
+        ShardId::new(0),
+        "payment",
+        "wf-small",
+        Some(json!({ "amount": 20, "phase": "running", "retry_count": 0 })),
+    )
+    .await;
+    // A row whose amount is stored as a STRING — comparison ops must exclude it
+    // (typed numeric comparison only matches number-typed stored values).
+    let _stramount = seed_workflow(
+        &database_url,
+        ShardId::new(0),
+        "payment",
+        "wf-str-amount",
+        Some(json!({ "amount": "99999", "phase": "blocked", "retry_count": 9 })),
+    )
+    .await;
+
+    // amount > 10000 → only the 15000 row (string "99999" excluded).
+    let (status, body) = get_json(&app, "/workflows?search_attr_filter=amount:gt:10000").await;
+    assert_eq!(status, StatusCode::OK);
+    assert_eq!(workflow_ids_any(&body), vec!["wf-big".to_string()]);
+
+    // Numeric regression: amount > 20 → {15000, 100} but NOT 20 and NOT the
+    // string "99999". If this were lexical, "100" > "20" would be false.
+    let (_, body) = get_json(&app, "/workflows?search_attr_filter=amount:gt:20").await;
+    let mut ids = workflow_ids_any(&body);
+    ids.sort();
+    assert_eq!(ids, vec!["wf-big".to_string(), "wf-mid".to_string()]);
+
+    // phase IN (blocked, awaiting_approval) → union (string set).
+    let (_, body) = get_json(
+        &app,
+        "/workflows?search_attr_filter=phase:in:blocked,awaiting_approval",
+    )
+    .await;
+    let mut ids = workflow_ids_any(&body);
+    ids.sort();
+    assert_eq!(
+        ids,
+        vec![
+            "wf-big".to_string(),
+            "wf-mid".to_string(),
+            "wf-str-amount".to_string(),
+        ]
+    );
+
+    // retry_count >= 3 AND phase = blocked → intersection. Only wf-big
+    // (retry 5, blocked) and wf-str-amount (retry 9, blocked) qualify.
+    let (_, body) = get_json(
+        &app,
+        "/workflows?search_attr_filter=retry_count:gte:3&search_attr_filter=phase:eq:blocked",
+    )
+    .await;
+    let mut ids = workflow_ids_any(&body);
+    ids.sort();
+    assert_eq!(ids, vec!["wf-big".to_string(), "wf-str-amount".to_string()]);
+
+    // phase exists → every row has a phase key (all 4).
+    let (_, body) = get_json(&app, "/workflows?search_attr_filter=phase:exists").await;
+    assert_eq!(workflow_ids_any(&body).len(), 4);
+
+    // amount < 100 → only the 20 row (numeric; string "99999" excluded).
+    let (_, body) = get_json(&app, "/workflows?search_attr_filter=amount:lt:100").await;
+    assert_eq!(workflow_ids_any(&body), vec!["wf-small".to_string()]);
+
+    // phase != blocked → key present and not "blocked": wf-mid + wf-small.
+    let (_, body) = get_json(&app, "/workflows?search_attr_filter=phase:ne:blocked").await;
+    let mut ids = workflow_ids_any(&body);
+    ids.sort();
+    assert_eq!(ids, vec!["wf-mid".to_string(), "wf-small".to_string()]);
+}
+
+/// Malformed predicates return `400` naming the offending param; nested `.`-path
+/// keys are rejected.
+#[tokio::test]
+async fn workflow_search_attr_predicate_invalid_returns_400() {
+    let (database_url, _container) = setup_single_database().await;
+    let pool = build_pool(&database_url);
+    let api_state = HarvestApiState::new();
+    api_state.install_storage_pool(HarvestDbPool::from(pool));
+    let app = harvest_api_router(api_state).with_state(test_app_state_without_database());
+
+    // Unknown operator.
+    let (status, body) = get_json(&app, "/workflows?search_attr_filter=amount:between:1").await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(
+        body.to_string().contains("between"),
+        "error should name the bad op, got {body}"
+    );
+
+    // Non-numeric value for a comparison op.
+    let (status, body) = get_json(&app, "/workflows?search_attr_filter=amount:gt:lots").await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(
+        body.to_string().contains("numeric"),
+        "error should explain numeric requirement, got {body}"
+    );
+
+    // Nested path key.
+    let (status, body) = get_json(&app, "/workflows?search_attr_filter=a.b:eq:1").await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert!(
+        body.to_string().contains("nested") || body.to_string().contains("top-level"),
+        "error should reject nested paths, got {body}"
+    );
+
+    // Missing value for eq.
+    let (status, _) = get_json(&app, "/workflows?search_attr_filter=amount:eq").await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+/// A comparison predicate narrows on the `?` key-existence operator, which hits
+/// the existing `idx_harvest_we_search` GIN index — proving the index path
+/// rather than a full per-row scan (issue #506 AC).
+#[tokio::test]
+async fn workflow_search_attr_predicate_comparison_uses_gin_index() {
+    let (database_url, _container) = setup_single_database().await;
+
+    let _seed = seed_workflow(
+        &database_url,
+        ShardId::new(0),
+        "payment",
+        "wf-explain",
+        Some(json!({ "amount": 15000 })),
+    )
+    .await;
+
+    let mut conn = <AsyncPgConnection as AsyncConnection>::establish(&database_url)
+        .await
+        .expect("failed to connect for EXPLAIN");
+    conn.batch_execute("SET enable_seqscan = off")
+        .await
+        .expect("disable seqscan should succeed");
+
+    // Mirrors the SQL the Cmp predicate builds: existence narrows on GIN, then a
+    // numeric recheck.
+    let plans: Vec<ExplainRow> = diesel::sql_query(
+        "EXPLAIN SELECT id FROM harvest_workflow_executions \
+         WHERE search_attrs ? 'amount' \
+         AND jsonb_typeof(search_attrs -> 'amount') = 'number' \
+         AND (search_attrs ->> 'amount')::numeric > 10000",
+    )
+    .load(&mut conn)
+    .await
+    .expect("EXPLAIN should succeed");
+
+    let plan_text = plans
+        .into_iter()
+        .map(|row| row.plan)
+        .collect::<Vec<_>>()
+        .join("\n");
+    assert!(
+        plan_text.contains("idx_harvest_we_search"),
+        "expected EXPLAIN plan to use idx_harvest_we_search, got:\n{plan_text}"
+    );
+}
+
+/// Predicates push down per shard and the k-way merge composes with keyset
+/// pagination — no row duplicated or skipped (issue #506 cross-shard AC).
+#[tokio::test]
+async fn workflow_search_attr_predicate_applies_across_shards_with_pagination() {
+    let ((shard0_url, shard1_url), _container) = setup_sharded_databases().await;
+    let api_state = HarvestApiState::new();
+    api_state.install_storage_pool(build_two_shard_pool(&shard0_url, &shard1_url));
+    let app = harvest_api_router(api_state).with_state(test_app_state_without_database());
+
+    // Three matching rows spread across two shards, plus one non-matching row.
+    for (url, shard, id, amount) in [
+        (&shard0_url, ShardId::new(0), "wf-s0-a", 50000),
+        (&shard0_url, ShardId::new(0), "wf-s0-b", 30000),
+        (&shard1_url, ShardId::new(1), "wf-s1-a", 20000),
+        (&shard1_url, ShardId::new(1), "wf-s1-low", 5),
+    ] {
+        let _ = seed_workflow(
+            url,
+            shard,
+            "payment",
+            id,
+            Some(json!({ "amount": amount, "phase": "blocked" })),
+        )
+        .await;
+    }
+
+    // Page through amount > 10000 with page_size=2; expect exactly the 3 >10k
+    // rows across pages, each once, never the amount=5 row.
+    let mut all_ids: Vec<String> = Vec::new();
+    let mut uri =
+        "/workflows?search_attr_filter=amount:gt:10000&page_size=2&order=desc".to_string();
+    loop {
+        let (status, body) = get_json(&app, uri.clone()).await;
+        assert_eq!(status, StatusCode::OK);
+        all_ids.extend(workflow_ids_any(&body));
+        match body.get("next_cursor").and_then(Value::as_str) {
+            Some(cursor) => {
+                uri = format!(
+                    "/workflows?search_attr_filter=amount:gt:10000&page_size=2&order=desc&cursor={cursor}"
+                );
+            }
+            None => break,
+        }
+    }
+
+    let mut sorted = all_ids.clone();
+    sorted.sort();
+    sorted.dedup();
+    assert_eq!(
+        sorted,
+        vec![
+            "wf-s0-a".to_string(),
+            "wf-s0-b".to_string(),
+            "wf-s1-a".to_string()
+        ],
+        "predicate must select exactly the >10k rows across shards, no dup/skip"
+    );
+}

--- a/docs/api-contract.json
+++ b/docs/api-contract.json
@@ -50,7 +50,14 @@
           "in": "query",
           "required": false,
           "repeated": true,
-          "description": "Search attribute filter in key:value form. May be repeated."
+          "description": "Search attribute filter in key:value form (exact-match string equality). May be repeated."
+        },
+        {
+          "name": "search_attr_filter",
+          "in": "query",
+          "required": false,
+          "repeated": true,
+          "description": "Typed comparison/set predicate over search attributes in key:op:value form, op in {eq, ne, gt, gte, lt, lte, in, exists} (issue #506). Repeatable; ANDed. Numeric values compare numerically, booleans as booleans, else strings. Comparison ops require a numeric value. Malformed predicates and nested .-paths return 400. Backed by the existing idx_harvest_we_search GIN index (no migration)."
         },
         {
           "name": "limit",

--- a/docs/management-api.md
+++ b/docs/management-api.md
@@ -190,7 +190,8 @@ The command exits cleanly when the server sends `event: stream-end`.
 | `workflow_id` | string | Filter by logical workflow ID |
 | `state` | string | Filter by execution state (e.g. `RUNNING`, `COMPLETED`) |
 | `limit` | integer | Maximum rows to return (default 200, max 200) |
-| `search_attr` | repeated | `key:value` pairs against `search_attrs` JSONB |
+| `search_attr` | repeated | `key:value` pairs against `search_attrs` JSONB (exact-match equality; value is always a string) |
+| `search_attr_filter` | repeated | Typed comparison/set predicate `key:op:value` against `search_attrs` JSONB. See [Typed search-attribute predicates](#typed-search-attribute-predicates-getworkflows). |
 | `no_progress_minutes` | integer | Return stalled workflows with no task activity for N minutes |
 | `sla_breached` | bool | Filter to executions that have breached their SLA |
 | `page_size` | integer | Per-page limit for keyset pagination (1–200; overrides `limit`). Presence activates the opt-in paginated envelope. |
@@ -259,6 +260,84 @@ curl "/workflows?state=RUNNING&page_size=50&cursor=abc123"
 - The `no_progress_minutes` (stalled-workflow) filter always returns a bare array regardless of pagination parameters.
 - `page_size` and `limit` are aliases; if both are present `page_size` wins.
 - On a sharded deployment each shard is queried independently with the same cursor and `page_size+1` limit; the results are k-way merged and truncated to `page_size` before the response is returned. See `docs/sharding.md` for the cross-shard keyset contract.
+
+### Typed search-attribute predicates (`GET /workflows`)
+
+> Issue #506. The `search_attr_filter` param adds typed comparison/set filtering
+> over search attributes. The legacy `search_attr=key:value` param is unchanged
+> (exact-match string equality) and stays fully backward compatible.
+
+Each `search_attr_filter` value has the form `key:op:value`. The param is
+repeatable; multiple predicates are combined with **AND** (matching the repeated
+`search_attr` semantics). Disjunction (OR) is out of scope in this slice.
+
+| `op` | Value | Meaning |
+|------|-------|---------|
+| `eq` | scalar | typed equality — `amount:eq:100` matches numeric `100`, not the string `"100"` |
+| `ne` | scalar | key present **and** typed value differs |
+| `gt` `gte` `lt` `lte` | number | numeric comparison; the value must parse as a number |
+| `in` | comma list | membership in a typed set, e.g. `phase:in:blocked,awaiting_approval` |
+| `exists` | *(none)* | key is present with any value |
+
+**Typed coercion (documented, explicit).** The value's text drives the type:
+
+- A value that parses as a JSON number is compared **numerically**, so
+  `amount:gt:20` returns `amount=100` (numeric ordering), not a lexical
+  `"100" < "20"` false negative, and never a string-vs-number false positive.
+- The exact literals `true` / `false` compare as **booleans**.
+- Everything else compares as a **string**.
+
+For `eq` / `ne` / `in` the coerced value is matched against the stored JSONB
+value **by type** (so `phase:eq:blocked` only matches string-typed `"blocked"`,
+and `retry_count:eq:3` only matches number-typed `3`).
+
+**Comparison ops are numeric-only.** `gt` / `gte` / `lt` / `lte` require the
+value to parse as a number — a non-numeric value (e.g. `amount:gt:lots`) returns
+`400`. Numeric comparison matches only rows whose stored attribute is itself
+number-typed; a row whose attribute is stored as a string is **excluded** from a
+numeric comparison (it is a different type), never a false match.
+
+**Top-level keys only.** Filtering operates on top-level search-attribute keys
+(the shape #159 writes). A nested `.`-path (e.g. `a.b:eq:1`) is rejected `400`.
+
+**Error handling.** Malformed predicates — unknown op, missing value where
+required, non-numeric value for a comparison op, nested `.`-path, empty key,
+value supplied to `exists` — return `400` with a message naming the offending
+`search_attr_filter` input. Unknown query params remain ignored (non-breaking).
+
+**Index path.** Every predicate stays on an index path rather than a full
+per-row scan: `eq`/`in`/`exists` and the existence-narrowing leg of `ne` and the
+comparison ops all hit the existing `idx_harvest_we_search` GIN index
+(`USING GIN (search_attrs)`, `jsonb_ops`) via the `@>` (containment) and `?`
+(key-existence) operators; comparison ops then recheck the numeric cast on the
+narrowed candidate set. No new index or migration is required. See
+`docs/sharding.md` for the cross-shard pushdown contract.
+
+**Composition.** `search_attr_filter` composes with `state`, time-range,
+`cursor`, `page_size`, and `order` — every predicate is pushed down to each
+shard's `WHERE` clause and the matching rows are k-way merged exactly as the
+keyset pagination path, with no row duplicated or skipped under concurrent
+inserts.
+
+```bash
+# Numeric range + set, paginated, across shards:
+curl "/workflows?search_attr_filter=amount:gt:10000\
+&search_attr_filter=phase:in:blocked,awaiting_approval&page_size=50"
+
+# Retry cohort intersected with a business phase:
+curl "/workflows?search_attr_filter=retry_count:gte:3&search_attr_filter=phase:eq:blocked"
+
+# Presence check:
+curl "/workflows?search_attr_filter=phase:exists"
+
+# Rejected (400) — non-numeric value for a numeric op:
+curl "/workflows?search_attr_filter=amount:gt:lots"
+```
+
+The `harvest workflow list` CLI accepts the same syntax via the repeatable
+`--search-attr-filter key:op:value` flag (forwarded verbatim to this param). The
+embedded Vantage UI workflows list defers to the equality-only `search_attr`
+filter in this slice; a predicate-aware UI form is a follow-up.
 
 ## Workflow Stack (describe)
 

--- a/docs/management-api.md
+++ b/docs/management-api.md
@@ -257,7 +257,7 @@ curl "/workflows?state=RUNNING&page_size=50&cursor=abc123"
 
 ### Notes
 
-- The `no_progress_minutes` (stalled-workflow) filter always returns a bare array regardless of pagination parameters.
+- The `no_progress_minutes` (stalled-workflow) filter always returns a bare array regardless of pagination parameters (cursor pagination is not supported on this path). The `state`, time-range, `search_attr`, and `search_attr_filter` filters **are** applied on the stalled path, so they compose with `no_progress_minutes`.
 - `page_size` and `limit` are aliases; if both are present `page_size` wins.
 - On a sharded deployment each shard is queried independently with the same cursor and `page_size+1` limit; the results are k-way merged and truncated to `page_size` before the response is returned. See `docs/sharding.md` for the cross-shard keyset contract.
 

--- a/docs/search-attributes.md
+++ b/docs/search-attributes.md
@@ -162,6 +162,36 @@ Both forms are equivalent. The attribute map is updated in the database before
 the workflow's next suspension, so filter results reflect the current phase
 within one worker poll cycle (< 1 s p95 under normal load).
 
+### Comparison and set predicates (issue #506)
+
+Equality containment answers "is this attribute exactly X". For range, set, and
+inequality questions, `GET /workflows` also accepts a repeatable
+`search_attr_filter=key:op:value` param, where `op` ∈
+`{eq, ne, gt, gte, lt, lte, in, exists}`:
+
+```bash
+# Numeric range — only runs over $10k:
+GET /workflows?search_attr_filter=amount:gt:10000
+
+# Set membership (union):
+GET /workflows?search_attr_filter=phase:in:blocked,awaiting_approval
+
+# Retry cohort intersected with a phase (AND):
+GET /workflows?search_attr_filter=retry_count:gte:3&search_attr_filter=phase:eq:blocked
+
+# Presence:
+GET /workflows?search_attr_filter=phase:exists
+```
+
+Values that parse as numbers compare numerically (so `amount:gt:20` returns
+`amount=100`, not a lexical false negative); booleans compare as booleans;
+everything else as strings. Comparison ops (`gt`/`gte`/`lt`/`lte`) require a
+numeric value and match only number-typed stored values. Only top-level keys are
+filterable — a nested `.`-path is rejected `400`. Multiple predicates are ANDed.
+The predicates reuse the existing `idx_harvest_we_search` GIN index (no
+migration). See `docs/management-api.md` for the full grammar and
+`docs/sharding.md` for the cross-shard pushdown contract.
+
 ## Durability
 
 Search attributes are stored in the `search_attrs JSONB` column of

--- a/docs/sharding.md
+++ b/docs/sharding.md
@@ -141,3 +141,43 @@ CREATE INDEX IF NOT EXISTS idx_harvest_we_created_id
 ```
 
 This index must be present on every shard for deep-page performance to remain flat. The migration is idempotent (`IF NOT EXISTS`) and runs automatically with `diesel migration run`.
+
+## Cross-shard typed search-attribute predicates (`search_attr_filter`, issue #506)
+
+The `search_attr_filter=key:op:value` predicates (comparison/set filtering over
+`search_attrs`) are pushed down to **each shard's `WHERE` clause** and the
+matching rows are k-way merged exactly as the keyset pagination path above — the
+predicate is part of the shared per-shard query, so it composes with `state`,
+time-range, `cursor`, `page_size`, and `order` with no extra round-trips and no
+row duplicated or skipped under concurrent inserts.
+
+### Per-shard SQL and index strategy
+
+Every predicate stays on an index path rather than a full per-row scan by
+reusing the existing `idx_harvest_we_search` GIN index
+(`USING GIN (search_attrs)`, default `jsonb_ops`), which supports both `@>`
+(containment) and `?` (key existence):
+
+| `op` | Per-shard predicate | Index leg |
+|------|--------------------|-----------|
+| `eq` | `search_attrs @> '{"key": <typed>}'` | GIN `@>` |
+| `ne` | `search_attrs ? 'key' AND NOT (search_attrs @> '{"key": <typed>}')` | GIN `?` narrows |
+| `gt`/`gte`/`lt`/`lte` | `search_attrs ? 'key' AND jsonb_typeof(search_attrs -> 'key') = 'number' AND (search_attrs ->> 'key')::numeric <op> $val` | GIN `?` narrows, numeric recheck |
+| `in` | `search_attrs ? 'key' AND search_attrs -> 'key' = ANY($vals::jsonb[])` | GIN `?` narrows |
+| `exists` | `search_attrs ? 'key'` | GIN `?` |
+
+The key is always a **bound** parameter (never string-interpolated), so dynamic
+keys are injection-safe; the comparison operator literal comes from a fixed
+internal enum. Because the existing GIN index already covers `@>` and `?`,
+**no new index and no migration are required** — there is no column change to
+`harvest_workflow_executions`, no `harvest_events` change, and no new
+`WorkflowEvent` variant. This index must be present on every shard (it ships in
+the initial `20260409000000_harvest_initial` migration).
+
+### Typed coercion is shard-stable
+
+The value→type coercion (number / boolean / string) is a pure function of the
+predicate text, so every shard derives the identical typed comparison and the
+merged result is deterministic. Numeric comparison matches only number-typed
+stored values; a value stored as a string on one shard is excluded uniformly on
+all shards, never a partial false match.


### PR DESCRIPTION
## Summary

Implements typed comparison and set filtering over search attributes via a new repeatable `search_attr_filter=key:op:value` query parameter on `GET /workflows`. This complements the legacy `search_attr=key:value` exact-match containment filter with range, inequality, set membership, and existence checks.

## Key Changes

- **New enum types** (`CmpOp`, `SearchAttrPredicate`) to represent typed predicates: `Eq`, `Ne`, `Cmp` (gt/gte/lt/lte), `In`, and `Exists`.

- **Typed scalar coercion** (`coerce_scalar` function): values that parse as JSON numbers compare numerically; exact literals `true`/`false` compare as booleans; everything else as strings. This ensures `amount:gt:20` returns `amount=100` (numeric ordering), not a lexical false negative.

- **Predicate parser** (`parse_search_attr_filter`): parses `key:op:value` format with comprehensive error handling. Rejects nested `.`-path keys (top-level only), non-numeric values for comparison ops, and malformed input with `400` responses naming the offending param.

- **SQL generation** in `load_workflows`: each predicate stays on the existing `idx_harvest_we_search` GIN index via `@>` (containment) and `?` (key existence) operators. Comparison ops narrow on `?` then recheck the numeric cast. No new index or migration required.

- **Cross-shard pushdown**: predicates are part of the per-shard `WHERE` clause and compose with keyset pagination, state filters, and time ranges with no extra round-trips.

- **CLI support** (`autumn-harvest-cli`): new `--search-attr-filter` flag (repeatable) forwarded verbatim to the API param.

- **Comprehensive tests**: unit tests for coercion and parsing; integration tests proving numeric vs. lexical ordering, type-safe matching, GIN index usage, and cross-shard pagination correctness.

- **Documentation**: updated `management-api.md`, `search-attributes.md`, `sharding.md`, and `api-contract.json` with grammar, examples, and index strategy.

## Implementation Details

- **Type safety**: comparison ops (`gt`/`gte`/`lt`/`lte`) require numeric values and match only number-typed stored attributes; string-typed attributes are excluded (not a false match).
- **AND semantics**: multiple `search_attr_filter` params are combined with AND, matching the legacy `search_attr` behavior.
- **Injection safety**: keys are always bound parameters (never interpolated); operator literals come from a fixed enum.
- **Backward compatibility**: legacy `search_attr=key:value` remains unchanged (exact-match string equality); unknown query params are ignored.

https://claude.ai/code/session_01DGT8sW3RQVKBgsv9aZbLiy