### PR TITLE
👺 Havoc: [Fix UTF-8 slicing panic in eligibility parser]

### DIFF
--- a/autumn-harvest/src/eligibility.rs
+++ b/autumn-harvest/src/eligibility.rs
@@ -91,13 +91,8 @@ fn find_operator_indices(token: &str) -> (Option<usize>, Option<usize>) {
     let mut eq_idx = None;
     let mut in_idx = None;
     let mut in_quotes = None;
-    let token_chars: Vec<char> = token.chars().collect();
-    let token_lower = token.to_lowercase();
-    let token_lower_chars: Vec<char> = token_lower.chars().collect();
 
-    let mut i = 0;
-    while i < token_chars.len() {
-        let c = token_chars[i];
+    for (i, c) in token.char_indices() {
         match c {
             '\'' | '"' => {
                 if in_quotes == Some(c) {
@@ -112,17 +107,12 @@ fn find_operator_indices(token: &str) -> (Option<usize>, Option<usize>) {
             _ => {
                 if in_quotes.is_none()
                     && in_idx.is_none()
-                    && i + 3 < token_chars.len()
-                    && token_lower_chars[i] == ' '
-                    && token_lower_chars[i + 1] == 'i'
-                    && token_lower_chars[i + 2] == 'n'
-                    && token_lower_chars[i + 3] == ' '
+                    && token.get(i..i + 4).is_some_and(|s| s.eq_ignore_ascii_case(" in "))
                 {
                     in_idx = Some(i);
                 }
             }
         }
-        i += 1;
     }
     (eq_idx, in_idx)
 }

--- a/autumn-harvest/tests/havoc_tests.rs
+++ b/autumn-harvest/tests/havoc_tests.rs
@@ -60,3 +60,15 @@ fn test_havoc_external_task_duration_panic() {
     });
     assert!(res.is_ok());
 }
+
+#[test]
+fn test_havoc_eligibility_parse() {
+    use autumn_harvest::eligibility::parse_requirements;
+    let res = std::panic::catch_unwind(|| {
+        let _ = parse_requirements("𐮩=\"\"");
+    });
+    assert!(
+        res.is_ok(),
+        "The system still crashes on invalid char boundaries in eligibility parsing!"
+    );
+}


### PR DESCRIPTION
🧨 **The Trigger:** Input string containing multi-byte UTF-8 characters like `𐮩=""` passed to the eligibility parser.
📉 **The Stack Trace:** `thread 'parse_doesnt_crash' panicked at autumn-harvest/src/eligibility.rs:131:25: byte index 1 is not a char boundary; it is inside '𐮩' (bytes 0..4)`
🧪 **Reproduction:** Run `cargo test -p autumn-harvest --test havoc_tests test_havoc_eligibility_parse`
😈 **Comment:** You assumed every character was exactly 1 byte. You were wrong.

---
*PR created automatically by Jules for task [9932294285267642208](https://jules.google.com/task/9932294285267642208) started by @madmax983*