### PR TITLE
⚒️ Forge: [Refactor BulkDlqFilter logic]

### DIFF
--- a/autumn-harvest/src/dlq.rs
+++ b/autumn-harvest/src/dlq.rs
@@ -507,29 +507,8 @@ pub async fn count_bulk_filter_matches(
     filter: &BulkDlqFilter,
 ) -> HarvestResult<i64> {
     use crate::schema::harvest_dead_letters::dsl;
-    use diesel::dsl::sql;
-    use diesel::sql_types::{Bool, Text};
 
-    let mut query = dsl::harvest_dead_letters.into_boxed();
-
-    if let Some(ref name) = filter.activity_name {
-        query = query.filter(dsl::activity_name.eq(name.clone()));
-    }
-    if let Some(ref wf_name) = filter.workflow_name {
-        query = query.filter(
-            sql::<Bool>("workflow_exec_id IN (SELECT id FROM harvest_workflow_executions WHERE workflow_name = ")
-                .bind::<Text, _>(wf_name.clone())
-                .sql(")"),
-        );
-    }
-    if let Some(after) = filter.failed_after {
-        query = query.filter(dsl::failed_at.ge(after));
-    }
-    if let Some(before) = filter.failed_before {
-        query = query.filter(dsl::failed_at.lt(before));
-    }
-
-    query
+    apply_bulk_filter(dsl::harvest_dead_letters.into_boxed(), filter)
         .count()
         .get_result(conn)
         .await
@@ -543,13 +522,27 @@ async fn query_dead_letters_for_bulk(
     filter: &BulkDlqFilter,
 ) -> HarvestResult<Vec<DeadLetter>> {
     use crate::schema::harvest_dead_letters::dsl;
+
+    apply_bulk_filter(
+        dsl::harvest_dead_letters
+            .into_boxed()
+            .order(dsl::failed_at.asc())
+            .limit(filter.effective_limit()),
+        filter,
+    )
+    .select(DeadLetter::as_select())
+    .load(conn)
+    .await
+    .map_err(crate::error::database_error)
+}
+
+fn apply_bulk_filter<'a>(
+    mut query: crate::schema::harvest_dead_letters::BoxedQuery<'a, diesel::pg::Pg>,
+    filter: &BulkDlqFilter,
+) -> crate::schema::harvest_dead_letters::BoxedQuery<'a, diesel::pg::Pg> {
+    use crate::schema::harvest_dead_letters::dsl;
     use diesel::dsl::sql;
     use diesel::sql_types::{Bool, Text};
-
-    let mut query = dsl::harvest_dead_letters
-        .into_boxed()
-        .order(dsl::failed_at.asc())
-        .limit(filter.effective_limit());
 
     if let Some(ref name) = filter.activity_name {
         query = query.filter(dsl::activity_name.eq(name.clone()));
@@ -569,10 +562,6 @@ async fn query_dead_letters_for_bulk(
     }
 
     query
-        .select(DeadLetter::as_select())
-        .load(conn)
-        .await
-        .map_err(crate::error::database_error)
 }
 
 /// Bulk replay dead-letter entries matching `filter`.


### PR DESCRIPTION
### 🚮 Smell
The functions `count_bulk_filter_matches` and `query_dead_letters_for_bulk` in `autumn-harvest/src/dlq.rs` duplicated the exact same 15+ lines of Diesel query building logic to apply `BulkDlqFilter` conditions. This violates the DRY principle and increases the maintenance burden (e.g., if a new filter field is added, it must be added in both places).

### ✨ Solution
Extracted the shared `query = query.filter(...)` logic into a new private helper function named `apply_bulk_filter`. The helper takes the base `BoxedQuery` and the `BulkDlqFilter` reference, applies the conditions, and returns the modified query.

### 🧼 Benefit
Reduces cognitive load, eliminates duplicate code, and prevents bugs that could arise from modifying one filter logic block but forgetting to update the other. The intent of both functions is now much clearer.

### 🛡️ Verification
Tests passed. No logic changed. Verified locally via `cargo check` and `cargo test -p autumn-harvest --lib`. Code was formatted with `cargo fmt` and checked with `cargo clippy`.

---
*PR created automatically by Jules for task [5370769707470517938](https://jules.google.com/task/5370769707470517938) started by @madmax983*