### PR TITLE
👺 Havoc: Fix char boundary panic in parse_requirements

### DIFF
--- a/autumn-harvest/src/eligibility.rs
+++ b/autumn-harvest/src/eligibility.rs
@@ -91,13 +91,8 @@ fn find_operator_indices(token: &str) -> (Option<usize>, Option<usize>) {
     let mut eq_idx = None;
     let mut in_idx = None;
     let mut in_quotes = None;
-    let token_chars: Vec<char> = token.chars().collect();
-    let token_lower = token.to_lowercase();
-    let token_lower_chars: Vec<char> = token_lower.chars().collect();
 
-    let mut i = 0;
-    while i < token_chars.len() {
-        let c = token_chars[i];
+    for (i, c) in token.char_indices() {
         match c {
             '\'' | '"' => {
                 if in_quotes == Some(c) {
@@ -112,17 +107,12 @@ fn find_operator_indices(token: &str) -> (Option<usize>, Option<usize>) {
             _ => {
                 if in_quotes.is_none()
                     && in_idx.is_none()
-                    && i + 3 < token_chars.len()
-                    && token_lower_chars[i] == ' '
-                    && token_lower_chars[i + 1] == 'i'
-                    && token_lower_chars[i + 2] == 'n'
-                    && token_lower_chars[i + 3] == ' '
+                    && token[i..].to_lowercase().starts_with(" in ")
                 {
                     in_idx = Some(i);
                 }
             }
         }
-        i += 1;
     }
     (eq_idx, in_idx)
 }

--- a/autumn-harvest/tests/havoc_tests.rs
+++ b/autumn-harvest/tests/havoc_tests.rs
@@ -60,3 +60,15 @@ fn test_havoc_external_task_duration_panic() {
     });
     assert!(res.is_ok());
 }
+
+#[test]
+fn test_havoc_eligibility_char_boundary_panic() {
+    let input = "ⷐ=";
+    let res = std::panic::catch_unwind(|| {
+        let _ = autumn_harvest::eligibility::parse_requirements(input);
+    });
+    assert!(
+        res.is_ok(),
+        "The system still crashes on non-ascii char boundaries during parse_requirements!"
+    );
+}


### PR DESCRIPTION
### 🧨 The Trigger
Input string with non-ASCII or multi-byte characters (e.g. `ⷐ=`) caused a character boundary panic in `parse_requirements` because the parser was iterating over a `Vec<char>` and using the character index as a byte index into the underlying string slice.

### 📉 The Stack Trace
```
thread 'test_find_operator_indices_does_not_panic' panicked at autumn-harvest/src/eligibility.rs:131:25:
byte index 1 is not a char boundary; it is inside 'ⷐ' (bytes 0..3) of `ⷐ=`
```

### 🧪 Reproduction
Run `cargo test -p autumn-harvest --test havoc_tests` with the input `"ⷐ="` parsed through `autumn_harvest::eligibility::parse_requirements`.

### 😈 Comment
You assumed every `char` was exactly 1 byte. The chaos gods of UTF-8 have punished this assumption. By transitioning to `.char_indices()`, we now accurately track byte offsets and appease the string slicing rules.

---
*PR created automatically by Jules for task [14326856557574307122](https://jules.google.com/task/14326856557574307122) started by @madmax983*