### PR TITLE
Refactor event batching: cap parameters, support sharding-local coordination, and spawn triggers post-transaction

### DIFF
--- a/autumn-harvest-macros/src/dag.rs
+++ b/autumn-harvest-macros/src/dag.rs
@@ -721,6 +721,7 @@ fn emit_workflow_companion(
                 sla: ::std::option::Option::None,
                 concurrency: ::std::option::Option::None,
                 debounce: ::std::option::Option::None,
+                batch: ::std::option::Option::None,
                 max_input_bytes: ::std::option::Option::None,
                 owner: #owner_expr,
                 runbook_url: #runbook_url_expr,

--- a/autumn-harvest-macros/src/update.rs
+++ b/autumn-harvest-macros/src/update.rs
@@ -271,6 +271,23 @@ pub fn update_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                                 );
                             }
                         }
+                        if let ::std::option::Option::Some(batch_policy) = Self::info().batch.as_ref() {
+                            if ::autumn_harvest::concurrency::resolve_concurrency_key(
+                                &batch_policy.key_expr,
+                                &start_input,
+                            )
+                            .is_some()
+                            {
+                                return ::std::result::Result::Err(
+                                    ::autumn_harvest::error::HarvestError::Config(::std::format!(
+                                        "workflow '{0}' has an event batching policy; batched starts \
+                                         must use the HTTP start route POST /workflows/{0}/start \
+                                         (the typed client cannot express a deferred batched start)",
+                                        #workflow_simple_name,
+                                    )),
+                                );
+                            }
+                        }
                         let update_id = opts.idempotency_key.as_ref().map_or_else(
                             ::autumn_harvest::types::UpdateId::new,
                             |key| {
@@ -415,6 +432,23 @@ pub fn update_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                                             "workflow '{0}' has a debounce policy; debounced starts \
                                              must use the HTTP start route POST /workflows/{0}/start \
                                              (the typed client cannot express a deferred debounced start)",
+                                            #workflow_simple_name,
+                                        )),
+                                    );
+                                }
+                            }
+                            if let ::std::option::Option::Some(batch_policy) = Self::info().batch.as_ref() {
+                                if ::autumn_harvest::concurrency::resolve_concurrency_key(
+                                    &batch_policy.key_expr,
+                                    &start_input,
+                                )
+                                .is_some()
+                                {
+                                    return ::std::result::Result::Err(
+                                        ::autumn_harvest::error::HarvestError::Config(::std::format!(
+                                            "workflow '{0}' has an event batching policy; batched starts \
+                                             must use the HTTP start route POST /workflows/{0}/start \
+                                             (the typed client cannot express a deferred batched start)",
                                             #workflow_simple_name,
                                         )),
                                     );

--- a/autumn-harvest-macros/src/workflow.rs
+++ b/autumn-harvest-macros/src/workflow.rs
@@ -70,6 +70,12 @@ struct DebounceArgs {
     max_wait: Option<String>,
 }
 
+struct BatchArgs {
+    key_expr: String,
+    max_size: u32,
+    max_wait: String,
+}
+
 struct WorkflowAttrs {
     execution_timeout: Option<String>,
     /// Soft SLA budget (issue #487). Parsed from `#[workflow(sla = "2h")]`.
@@ -79,6 +85,9 @@ struct WorkflowAttrs {
     /// Trailing-edge debounce policy (issue #499). Parsed from
     /// `#[workflow(debounce(key = "input.tenant_id", window = "30s", max_wait = "5m"))]`.
     debounce: Option<DebounceArgs>,
+    /// Event batching policy (issue #518). Parsed from
+    /// `#[workflow(batch(key = "input.tenant_id", max_size = 10, max_wait = "30s"))]`.
+    batch: Option<BatchArgs>,
     /// Per-workflow-type cap override in bytes (issue #252). Parsed from
     /// `#[workflow(max_input_bytes = "8MiB")]` at compile time.
     max_input_bytes: Option<u64>,
@@ -98,6 +107,7 @@ fn parse_attrs(attr: TokenStream) -> syn::Result<WorkflowAttrs> {
         sla: None,
         concurrency: None,
         debounce: None,
+        batch: None,
         max_input_bytes: None,
         owner: None,
         runbook: None,
@@ -198,6 +208,57 @@ fn parse_attrs(attr: TokenStream) -> syn::Result<WorkflowAttrs> {
             })?;
             result.debounce = Some(DebounceArgs { key_expr, window, max_wait });
             Ok(())
+        } else if meta.path.is_ident("batch") {
+            let mut key_expr: Option<String> = None;
+            let mut max_size: Option<u32> = None;
+            let mut max_wait: Option<String> = None;
+            meta.parse_nested_meta(|inner| {
+                if inner.path.is_ident("key") {
+                    let value: LitStr = inner.value()?.parse()?;
+                    key_expr = Some(value.value());
+                    Ok(())
+                } else if inner.path.is_ident("max_size") {
+                    let value: syn::LitInt = inner.value()?.parse()?;
+                    let n: u32 = value.base10_parse()?;
+                    if n == 0 {
+                        return Err(inner.error("batch max_size must be greater than zero"));
+                    }
+                    max_size = Some(n);
+                    Ok(())
+                } else if inner.path.is_ident("max_wait") {
+                    let value: LitStr = inner.value()?.parse()?;
+                    if !is_valid_task_duration(&value.value()) {
+                        return Err(syn::Error::new_spanned(
+                            &value,
+                            "invalid batch `max_wait` duration; expected e.g. \"30s\", \"5m\", \"1h\", \"2d\"",
+                        ));
+                    }
+                    max_wait = Some(value.value());
+                    Ok(())
+                } else {
+                    Err(inner.error("expected `key`, `max_size`, or `max_wait`"))
+                }
+            })?;
+            let key_expr = key_expr.ok_or_else(|| {
+                syn::Error::new(
+                    proc_macro2::Span::call_site(),
+                    "batch requires `key = \"...\"`",
+                )
+            })?;
+            let max_size = max_size.ok_or_else(|| {
+                syn::Error::new(
+                    proc_macro2::Span::call_site(),
+                    "batch requires `max_size = N`",
+                )
+            })?;
+            let max_wait = max_wait.ok_or_else(|| {
+                syn::Error::new(
+                    proc_macro2::Span::call_site(),
+                    "batch requires `max_wait = \"...\"` (e.g. `max_wait = \"10s\"`)",
+                )
+            })?;
+            result.batch = Some(BatchArgs { key_expr, max_size, max_wait });
+            Ok(())
         } else if meta.path.is_ident("allow_nondeterministic_apis") {
             if meta.input.peek(syn::Token![=]) {
                 let value: syn::LitBool = meta.value()?.parse()?;
@@ -240,7 +301,7 @@ fn parse_attrs(attr: TokenStream) -> syn::Result<WorkflowAttrs> {
             Ok(())
         } else {
             Err(meta.error(
-                "unsupported attribute: expected `execution_timeout`, `sla`, `concurrency`, `debounce`, `max_input_bytes`, `owner`, `runbook`, `severity`, `description`, or `allow_nondeterministic_apis`",
+                "unsupported attribute: expected `execution_timeout`, `sla`, `concurrency`, `debounce`, `batch`, `max_input_bytes`, `owner`, `runbook`, `severity`, `description`, or `allow_nondeterministic_apis`",
             ))
         }
     })
@@ -450,6 +511,27 @@ pub fn workflow_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
         }
     };
 
+    // Emit batch as Option<BatchPolicy> (issue #518).
+    let batch_expr = match attrs.batch {
+        None => quote! { ::std::option::Option::None },
+        Some(BatchArgs {
+            key_expr,
+            max_size,
+            max_wait,
+        }) => {
+            quote! {
+                ::std::option::Option::Some(
+                    ::autumn_harvest::event_batch::BatchPolicy {
+                        key_expr: #key_expr.to_string(),
+                        max_size: #max_size as usize,
+                        max_wait: ::autumn_harvest::task_duration(#max_wait)
+                            .expect("batch max_wait must be a valid duration string"),
+                    }
+                )
+            }
+        }
+    };
+
     let max_input_bytes_expr = attrs
         .max_input_bytes
         .map_or_else(|| quote! { None }, |b| quote! { Some(#b) });
@@ -503,6 +585,7 @@ pub fn workflow_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                 sla: #sla_expr,
                 concurrency: #concurrency_expr,
                 debounce: #debounce_expr,
+                batch: #batch_expr,
                 max_input_bytes: #max_input_bytes_expr,
                 owner: #owner_expr,
                 runbook_url: #runbook_url_expr,
@@ -596,6 +679,33 @@ pub fn workflow_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                                 )),
                             );
                         }
+                    }
+                    if let ::std::option::Option::Some(batch_policy) = info.batch.as_ref() {
+                        if ::autumn_harvest::concurrency::resolve_concurrency_key(
+                            &batch_policy.key_expr,
+                            &input,
+                        )
+                        .is_some()
+                        {
+                            return ::std::result::Result::Err(
+                                ::autumn_harvest::error::HarvestError::Config(::std::format!(
+                                    "workflow '{0}' has an event batching policy; batched starts \
+                                     must use the HTTP start route POST /workflows/{0}/start \
+                                     (the typed client cannot express a deferred batched start)",
+                                    info.name,
+                                )),
+                            );
+                        }
+                    }
+                    if opts.batch.is_some() {
+                        return ::std::result::Result::Err(
+                            ::autumn_harvest::error::HarvestError::Config(::std::format!(
+                                "workflow '{0}' start request specified a batch policy; batched starts \
+                                 must use the HTTP start route POST /workflows/{0}/start \
+                                 (the typed client cannot express a deferred batched start)",
+                                info.name,
+                            )),
+                        );
                     }
                     let exec_id = opts.exec_id.unwrap_or_else(|| {
                         let shard = client.pick_shard_for_new_workflow(info.name, &workflow_id);
@@ -706,6 +816,23 @@ pub fn workflow_macro(attr: TokenStream, item: TokenStream) -> TokenStream {
                                     "workflow '{0}' has a debounce policy; debounced starts \
                                      must use the HTTP start route POST /workflows/{0}/start \
                                      (the typed client cannot express a deferred debounced start)",
+                                    info.name,
+                                )),
+                            );
+                        }
+                    }
+                    if let ::std::option::Option::Some(batch_policy) = info.batch.as_ref() {
+                        if ::autumn_harvest::concurrency::resolve_concurrency_key(
+                            &batch_policy.key_expr,
+                            &input,
+                        )
+                        .is_some()
+                        {
+                            return ::std::result::Result::Err(
+                                ::autumn_harvest::error::HarvestError::Config(::std::format!(
+                                    "workflow '{0}' has an event batching policy; batched starts \
+                                     must use the HTTP start route POST /workflows/{0}/start \
+                                     (the typed client cannot express a deferred batched start)",
                                     info.name,
                                 )),
                             );

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -6155,30 +6155,19 @@ async fn start_workflow(
                     .into_response());
             }
 
-            let max_wait = if let Some(ref w_str) = request.batch_max_wait {
-                match autumn_harvest::task_duration(w_str) {
-                    Some(d) => {
-                        if d > std::time::Duration::from_secs(86400) {
-                            return Err((
-                                axum::http::StatusCode::BAD_REQUEST,
-                                Json(serde_json::json!({
-                                    "error": "batch_max_wait cannot exceed 24 hours"
-                                })),
-                            )
-                                .into_response());
-                        }
-                        d
+            let max_wait =
+                if let Some(ref w_str) = request.batch_max_wait {
+                    match autumn_harvest::task_duration(w_str) {
+                        Some(d) => d,
+                        None => return Err((
+                            axum::http::StatusCode::BAD_REQUEST,
+                            Json(serde_json::json!({ "error": "invalid batch_max_wait duration" })),
+                        )
+                            .into_response()),
                     }
-                    None => return Err((
-                        axum::http::StatusCode::BAD_REQUEST,
-                        Json(serde_json::json!({ "error": "invalid batch_max_wait duration" })),
-                    )
-                        .into_response()),
-                }
-            } else {
-                macro_policy
-                    .map_or(std::time::Duration::from_secs(10), |p| p.max_wait)
-            };
+                } else {
+                    macro_policy.map_or(std::time::Duration::from_secs(10), |p| p.max_wait)
+                };
 
             if max_wait > std::time::Duration::from_secs(86400) {
                 return Err((

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -1507,6 +1507,9 @@ struct StartWorkflowRequest {
     start_at: Option<chrono::DateTime<chrono::Utc>>,
     #[serde(default)]
     delay: Option<String>,
+    batch_key: Option<String>,
+    batch_max_size: Option<usize>,
+    batch_max_wait: Option<String>,
 }
 
 /// Response body for a 409 Conflict returned by `RejectDuplicate` policy.
@@ -2377,6 +2380,10 @@ pub fn harvest_api_router(api_state: HarvestApiState) -> Router<AppState> {
 
     Router::new()
         .route("/workflows", get(list_workflows))
+        .route(
+            "/batches/pending",
+            get(pending_event_batches).route_layer(require_admin.clone()),
+        )
         // Static /workflows/batch_start must be registered before any /workflows/{param}
         // routes so axum does not capture the literal segment as a path parameter.
         // The body limit is raised to the configured max_total_bytes ceiling so
@@ -2817,6 +2824,7 @@ pub const fn management_api_routes() -> &'static [(&'static str, &'static str)] 
         ("GET", "/workers/{worker_id}/pinned"),
         // ── batch workflow start (issue #357) ─────────────────────────────────
         ("POST", "/workflows/batch_start"),
+        ("GET", "/batches/pending"),
         // ── batch operations (issue #102) ─────────────────────────────────────
         ("GET", "/batch-operations"),
         ("POST", "/batch-operations"),
@@ -2915,6 +2923,9 @@ pub const fn management_api_request_fields()
                 "reuse_policy",
                 "start_at",
                 "delay",
+                "batch_key",
+                "batch_max_size",
+                "batch_max_wait",
             ]),
         ),
         (
@@ -3244,6 +3255,10 @@ pub const fn management_api_response_fields()
                 "debounce_key",
                 "fire_at",
                 "pending_count",
+                "batched",
+                "flushed",
+                "batch_key",
+                "max_size",
             ]),
         ),
         (
@@ -3529,7 +3544,8 @@ pub const fn management_api_response_fields()
             ]),
         ),
         ("GET", "/admin/concurrency", None), // Vec<ConcurrencyKeyStats> (external model)
-        ("GET", "/admin/debounce", None),    // Vec<PendingDebounceRecord> (external model)
+        ("GET", "/batches/pending", None),
+        ("GET", "/admin/debounce", None), // Vec<PendingDebounceRecord> (external model)
         ("GET", "/admin/rate-limits", None), // Vec<RateLimitBucket> (external model)
         ("POST", "/admin/rate-limits/{key}", Some(&["ok"])),
         ("GET", "/admin/circuits", None), // Vec<CircuitSnapshot> (external model)
@@ -5986,7 +6002,7 @@ fn workflow_has_resolving_debounce(
         })
 }
 
-#[allow(clippy::too_many_lines)]
+#[allow(clippy::too_many_lines, clippy::result_large_err)]
 async fn start_workflow(
     Extension(api_state): Extension<HarvestApiState>,
     Path(workflow_name): Path<String>,
@@ -6110,8 +6126,92 @@ async fn start_workflow(
     let is_debounced_start =
         workflow_has_resolving_debounce(&runtime.registry, &workflow_name, &input);
 
+    let batch_settings_res: Result<_, axum::response::Response> = (|| {
+        let macro_policy = runtime
+            .registry
+            .workflows
+            .get(&workflow_name)
+            .and_then(|info| info.batch.as_ref());
+
+        let resolved_key = request.batch_key.clone().or_else(|| {
+            macro_policy.and_then(|policy| {
+                autumn_harvest::debounce::resolve_debounce_key(&policy.key_expr, &input)
+            })
+        });
+
+        if let Some(key) = resolved_key {
+            let max_size = request
+                .batch_max_size
+                .or_else(|| macro_policy.map(|p| p.max_size))
+                .unwrap_or(10);
+
+            if !(1..=1000).contains(&max_size) {
+                return Err((
+                    axum::http::StatusCode::BAD_REQUEST,
+                    Json(serde_json::json!({
+                        "error": format!("batch_max_size ({max_size}) must be between 1 and 1000")
+                    })),
+                )
+                    .into_response());
+            }
+
+            let max_wait = if let Some(ref w_str) = request.batch_max_wait {
+                match autumn_harvest::task_duration(w_str) {
+                    Some(d) => {
+                        if d > std::time::Duration::from_secs(86400) {
+                            return Err((
+                                axum::http::StatusCode::BAD_REQUEST,
+                                Json(serde_json::json!({
+                                    "error": "batch_max_wait cannot exceed 24 hours"
+                                })),
+                            )
+                                .into_response());
+                        }
+                        d
+                    }
+                    None => return Err((
+                        axum::http::StatusCode::BAD_REQUEST,
+                        Json(serde_json::json!({ "error": "invalid batch_max_wait duration" })),
+                    )
+                        .into_response()),
+                }
+            } else {
+                macro_policy
+                    .map_or(std::time::Duration::from_secs(10), |p| p.max_wait)
+            };
+
+            if max_wait > std::time::Duration::from_secs(86400) {
+                return Err((
+                    axum::http::StatusCode::BAD_REQUEST,
+                    Json(serde_json::json!({
+                        "error": "batch_max_wait cannot exceed 24 hours"
+                    })),
+                )
+                    .into_response());
+            }
+
+            Ok((true, Some(key), max_size, max_wait))
+        } else {
+            Ok((false, None, 0, std::time::Duration::ZERO))
+        }
+    })();
+
+    let (has_batch_policy, resolved_batch_key, batch_max_size, batch_max_wait) =
+        match batch_settings_res {
+            Ok(settings) => settings,
+            Err(response) => return response,
+        };
+
+    if is_debounced_start && has_batch_policy {
+        return (
+            axum::http::StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": "debounce and batching are mutually exclusive" })),
+        )
+            .into_response();
+    }
+
     // issue #377: check admission gates before touching the DB.
-    if !is_debounced_start {
+    if !is_debounced_start && !has_batch_policy {
         let wf_owner = runtime
             .registry
             .workflows
@@ -6713,6 +6813,296 @@ async fn start_workflow(
             }
         } // end debounce admission block
     }
+
+    // Event Batch admission gate (issue #518): fold trigger payloads into a single run.
+    if has_batch_policy && let Some(ref resolved_key) = resolved_batch_key {
+        // Debounce/batch cannot be combined with start_at or delay.
+        if request.start_at.is_some() || delay.is_some() {
+            if let Ok(pool) = api_state.storage_pool()
+                && let Ok(mut c) = acquire_conn(pool.default_pool()).await
+            {
+                let ar = NewAuditRecord {
+                    actor: &actor,
+                    operation: OP_WORKFLOW_START,
+                    target_type: TARGET_WORKFLOW,
+                    target_id: Some(workflow_name.as_str()),
+                    route_or_command: route,
+                    request_id: request_id.as_deref(),
+                    idempotency_key: None,
+                    status: STATUS_FAILED,
+                    error_summary: Some("batching cannot be combined with start_at or delay"),
+                    shard_id: None,
+                    source: &source,
+                };
+                let _ = audit::insert_audit(&mut c, &ar).await;
+            }
+            return (
+                axum::http::StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({ "error": "batching cannot be combined with start_at or delay" }))
+            ).into_response();
+        }
+
+        if effective_wf_cap > 0 {
+            let observed = serde_json::to_string(&input).map_or(0u64, |s| s.len() as u64);
+            if observed > effective_wf_cap {
+                if let Ok(pool) = api_state.storage_pool()
+                    && let Ok(mut c) = acquire_conn(pool.default_pool()).await
+                {
+                    let ar = NewAuditRecord {
+                        actor: &actor,
+                        operation: OP_WORKFLOW_START,
+                        target_type: TARGET_WORKFLOW,
+                        target_id: Some(workflow_name.as_str()),
+                        route_or_command: route,
+                        request_id: request_id.as_deref(),
+                        idempotency_key: None,
+                        status: STATUS_FAILED,
+                        error_summary: Some("workflow input exceeds cap"),
+                        shard_id: None,
+                        source: &source,
+                    };
+                    let _ = audit::insert_audit(&mut c, &ar).await;
+                }
+                return (
+                    axum::http::StatusCode::BAD_REQUEST,
+                    Json(serde_json::json!({
+                        "error": format!("workflow input ({observed} bytes) exceeds cap ({effective_wf_cap} bytes)")
+                    }))
+                ).into_response();
+            }
+        }
+
+        if let Some(secs) = request.execution_timeout_secs
+            && (secs < 0 || chrono::Duration::try_seconds(secs).is_none())
+        {
+            if let Ok(pool) = api_state.storage_pool()
+                && let Ok(mut c) = acquire_conn(pool.default_pool()).await
+            {
+                let ar = NewAuditRecord {
+                    actor: &actor,
+                    operation: OP_WORKFLOW_START,
+                    target_type: TARGET_WORKFLOW,
+                    target_id: Some(workflow_name.as_str()),
+                    route_or_command: route,
+                    request_id: request_id.as_deref(),
+                    idempotency_key: None,
+                    status: STATUS_FAILED,
+                    error_summary: Some("invalid execution_timeout_secs"),
+                    shard_id: None,
+                    source: &source,
+                };
+                let _ = audit::insert_audit(&mut c, &ar).await;
+            }
+            return (
+                axum::http::StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "error": format!("execution_timeout_secs ({secs}) is out of range or negative")
+                })),
+            )
+                .into_response();
+        }
+
+        let (info_owner, info_runbook, info_severity, info_sla, info_execution_timeout) = runtime
+            .registry
+            .workflows
+            .get(&workflow_name)
+            .map_or((None, None, None, None, None), |info| {
+                (
+                    info.owner,
+                    info.runbook_url,
+                    info.severity,
+                    info.sla,
+                    info.execution_timeout,
+                )
+            });
+
+        let effective_sla_secs = request
+            .sla_secs
+            .filter(|&secs| secs >= 0)
+            .and_then(chrono::Duration::try_seconds)
+            .or_else(|| info_sla.and_then(|d| chrono::Duration::from_std(d).ok()))
+            .map(|sla| {
+                info_execution_timeout
+                    .and_then(|d| chrono::Duration::from_std(d).ok())
+                    .map_or(sla, |hard| sla.min(hard))
+            })
+            .map(|d| d.num_seconds());
+
+        let effective_execution_timeout_secs = request.execution_timeout_secs.or_else(|| {
+            info_execution_timeout
+                .and_then(|d| chrono::Duration::from_std(d).ok())
+                .map(|d| d.num_seconds())
+        });
+
+        let effective_ceiling_secs = api_state
+            .max_workflow_execution_timeout()
+            .and_then(|d| chrono::Duration::from_std(d).ok())
+            .map(|d| d.num_seconds());
+
+        let batch_shard = runtime
+            .router
+            .pick_for_new_workflow(&workflow_name, resolved_key);
+
+        if let Some((gate_id, reason, scope_kind)) = {
+            let wf_owner = runtime
+                .registry
+                .workflows
+                .get(&workflow_name)
+                .and_then(|i| i.owner);
+            api_state.gate_cache().check(
+                &workflow_name,
+                &queue_name,
+                batch_shard.as_i32(),
+                wf_owner,
+            )
+        } {
+            let reason_label = match reason.char_indices().nth(64) {
+                Some((idx, _)) => &reason[..idx],
+                None => &reason,
+            };
+            runtime
+                .registry
+                .telemetry()
+                .metrics
+                .record_admission_blocked(scope_kind, reason_label);
+            if let Ok(mut audit_conn) = db_conn_for_shard(&api_state, batch_shard).await {
+                let ar = NewAuditRecord {
+                    actor: &actor,
+                    operation: OP_WORKFLOW_START,
+                    target_type: TARGET_WORKFLOW,
+                    target_id: Some(workflow_name.as_str()),
+                    route_or_command: route,
+                    request_id: request_id.as_deref(),
+                    idempotency_key: None,
+                    status: STATUS_FAILED,
+                    error_summary: Some("admission blocked by gate"),
+                    shard_id: Some(batch_shard.as_i32()),
+                    source: &source,
+                };
+                let _ = audit::insert_audit(&mut audit_conn, &ar).await;
+            }
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                Json(serde_json::json!({
+                    "error": "admission blocked",
+                    "gate_id": gate_id,
+                    "reason": reason,
+                })),
+            )
+                .into_response();
+        }
+
+        let mut batch_conn = match db_conn_for_shard(&api_state, batch_shard).await {
+            Ok(c) => c,
+            Err(e) => return e.into_response(),
+        };
+
+        let admit_params = autumn_harvest::event_batch::AdmitBatchParams {
+            workflow_name: workflow_name.clone(),
+            batch_key: resolved_key.clone(),
+            workflow_id: workflow_id.clone(),
+            queue_name: queue_name.clone(),
+            payload: input.clone(),
+            max_wait: batch_max_wait,
+            max_size: batch_max_size,
+            shard_id: batch_shard.as_i32(),
+            start_options: autumn_harvest::debounce::DebounceStartOptions {
+                reuse_policy: request.reuse_policy.clone(),
+                execution_timeout_secs: effective_execution_timeout_secs,
+                memo: request.memo.clone(),
+                search_attrs: request.search_attrs.clone(),
+                sla_secs: effective_sla_secs,
+                context_headers: None,
+                priority: None,
+                concurrency_key: concurrency_key.clone(),
+                concurrency_limit,
+                owner: info_owner.map(str::to_string),
+                runbook_url: info_runbook.map(str::to_string),
+                severity: info_severity.map(str::to_string),
+                max_execution_timeout_ceiling_secs: effective_ceiling_secs,
+                max_workflow_input_bytes: Some(effective_wf_cap),
+                trace_context: debounce_trace_ctx,
+            },
+        };
+
+        match autumn_harvest::event_batch::admit_batched_start(&mut batch_conn, admit_params).await
+        {
+            Ok(Some((outcome, deferred_starts))) => {
+                let status = STATUS_SUCCEEDED;
+
+                let audit_target_id = outcome
+                    .flushed_execution_id
+                    .as_deref()
+                    .unwrap_or(outcome.workflow_id.as_str());
+
+                let ar = NewAuditRecord {
+                    actor: &actor,
+                    operation: OP_WORKFLOW_START,
+                    target_type: TARGET_WORKFLOW,
+                    target_id: Some(audit_target_id),
+                    route_or_command: route,
+                    request_id: request_id.as_deref(),
+                    idempotency_key: None,
+                    status,
+                    error_summary: None,
+                    shard_id: Some(batch_shard.as_i32()),
+                    source: &source,
+                };
+                if let Err(audit_err) = audit::insert_audit(&mut batch_conn, &ar).await {
+                    tracing::error!(
+                        error = %audit_err,
+                        "audit insert failed for batched workflow.start"
+                    );
+                    return AutumnError::service_unavailable_msg(format!(
+                        "audit insert failed: {audit_err}"
+                    ))
+                    .into_response();
+                }
+
+                for start in deferred_starts {
+                    start.spawn();
+                }
+
+                if outcome.is_flushed {
+                    return (
+                        axum::http::StatusCode::CREATED,
+                        Json(serde_json::json!({
+                            "batched": true,
+                            "flushed": true,
+                            "execution_id": outcome.flushed_execution_id,
+                            "workflow_name": workflow_name,
+                            "workflow_id": outcome.workflow_id,
+                            "state": "RUNNING",
+                        })),
+                    )
+                        .into_response();
+                }
+
+                return (
+                    axum::http::StatusCode::ACCEPTED,
+                    Json(serde_json::json!({
+                        "batched": true,
+                        "flushed": false,
+                        "workflow_name": workflow_name,
+                        "workflow_id": outcome.workflow_id,
+                        "batch_key": outcome.batch_key,
+                        "fire_at": outcome.fire_at,
+                        "pending_count": outcome.pending_count,
+                        "max_size": outcome.max_size,
+                    })),
+                )
+                    .into_response();
+            }
+            Ok(None) => {
+                return AutumnError::internal_server_error_msg(
+                    "batch admission returned no record unexpectedly",
+                )
+                .into_response();
+            }
+            Err(e) => return map_error(e).into_response(),
+        }
+    }
+
     // Key resolved to None, no policy, or live execution exists — fall through to the normal start path.
 
     // shard computed above (before gate check); reuse it here.
@@ -14960,6 +15350,31 @@ async fn debounce_status(
     Ok(Json(all_records))
 }
 
+async fn pending_event_batches(
+    Extension(api_state): Extension<HarvestApiState>,
+) -> Result<Json<Vec<autumn_harvest::event_batch::PendingEventBatchRecord>>, AutumnError> {
+    let pool = api_state.storage_pool().map_err(map_error)?;
+
+    let mut all_records: Vec<autumn_harvest::event_batch::PendingEventBatchRecord> = Vec::new();
+
+    for (_shard, shard_pool) in pool.iter_shards() {
+        let mut conn = acquire_conn(shard_pool).await?;
+        let records = autumn_harvest::event_batch::list_pending_event_batches(&mut conn, 1000)
+            .await
+            .map_err(map_error)?;
+        all_records.extend(records);
+    }
+
+    // Sort by workflow_name, then batch_key for deterministic operator view.
+    all_records.sort_by(|a, b| {
+        a.workflow_name
+            .cmp(&b.workflow_name)
+            .then(a.batch_key.cmp(&b.batch_key))
+    });
+
+    Ok(Json(all_records))
+}
+
 // ── Rate Limit Management ──────────────────────────────────────────────────
 
 async fn list_rate_limits(
@@ -20609,6 +21024,7 @@ mod tests {
                 concurrency: None,
 
                 debounce: None,
+                batch: None,
                 max_input_bytes: None,
                 sla: None,
                 owner: None,
@@ -22107,6 +22523,7 @@ mod tests {
                     concurrency: None,
 
                     debounce: None,
+                    batch: None,
                     max_input_bytes: None,
                     sla: None,
                     owner: None,
@@ -22125,6 +22542,7 @@ mod tests {
                     concurrency: None,
 
                     debounce: None,
+                    batch: None,
                     max_input_bytes: None,
                     sla: None,
                     owner: None,

--- a/autumn-harvest-plugin/src/plugin.rs
+++ b/autumn-harvest-plugin/src/plugin.rs
@@ -479,9 +479,9 @@ async fn start_harvest_runtime(
         match autumn_harvest::admission_gate::db::load_active_gates(&mut boot_conn).await {
             Ok(gates) => {
                 api_state.gate_cache().refresh(gates);
-                tracing::debug!("admission gate cache populated at startup");
+                println!("admission gate cache populated at startup");
             }
-            Err(e) => tracing::warn!(error = %e, "could not load admission gates at startup"),
+            Err(e) => eprintln!("could not load admission gates at startup: {e}"),
         }
     }
 
@@ -730,6 +730,7 @@ mod tests {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
             sla: None,
             owner: None,

--- a/autumn-harvest-plugin/src/plugin.rs
+++ b/autumn-harvest-plugin/src/plugin.rs
@@ -479,9 +479,9 @@ async fn start_harvest_runtime(
         match autumn_harvest::admission_gate::db::load_active_gates(&mut boot_conn).await {
             Ok(gates) => {
                 api_state.gate_cache().refresh(gates);
-                println!("admission gate cache populated at startup");
+                tracing::debug!("admission gate cache populated at startup");
             }
-            Err(e) => eprintln!("could not load admission gates at startup: {e}"),
+            Err(e) => tracing::warn!(error = %e, "could not load admission gates at startup"),
         }
     }
 

--- a/autumn-harvest-plugin/tests/api_scheduler_integration.rs
+++ b/autumn-harvest-plugin/tests/api_scheduler_integration.rs
@@ -406,6 +406,7 @@ fn approval_registry() -> Arc<HandlerRegistry> {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
 
             owner: None,
@@ -432,6 +433,7 @@ fn approval_and_timer_signal_registry() -> Arc<HandlerRegistry> {
                 concurrency: None,
 
                 debounce: None,
+                batch: None,
                 max_input_bytes: None,
 
                 owner: None,
@@ -451,6 +453,7 @@ fn approval_and_timer_signal_registry() -> Arc<HandlerRegistry> {
                 concurrency: None,
 
                 debounce: None,
+                batch: None,
                 max_input_bytes: None,
 
                 owner: None,
@@ -1964,6 +1967,7 @@ fn workflow_info_named(name: &'static str) -> WorkflowInfo {
         concurrency: None,
 
         debounce: None,
+        batch: None,
         max_input_bytes: None,
         owner: None,
         runbook_url: None,
@@ -3011,6 +3015,7 @@ async fn external_runner_processes_workflows_started_via_management_api() {
                 concurrency: None,
 
                 debounce: None,
+                batch: None,
                 max_input_bytes: None,
 
                 owner: None,
@@ -3049,6 +3054,7 @@ async fn external_runner_processes_workflows_started_via_management_api() {
                 concurrency: None,
 
                 debounce: None,
+                batch: None,
                 max_input_bytes: None,
 
                 owner: None,
@@ -3130,6 +3136,7 @@ async fn worker_enqueues_multiple_activity_commands_from_one_workflow_task() {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
 
             owner: None,
@@ -3187,6 +3194,7 @@ async fn worker_does_not_reschedule_inflight_parallel_activity_after_sibling_com
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
 
             owner: None,
@@ -3253,6 +3261,7 @@ async fn worker_resolves_parallel_sibling_tasks_that_share_activity_name() {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
 
             owner: None,
@@ -3306,6 +3315,7 @@ async fn worker_serializes_terminal_events_for_parallel_activity_completions() {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
 
             owner: None,
@@ -3368,6 +3378,7 @@ async fn worker_does_not_append_completion_after_activity_timeout() {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
 
             owner: None,
@@ -3996,6 +4007,7 @@ async fn harvest_api_lists_and_triggers_manual_dags() {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
 
             owner: None,
@@ -4907,6 +4919,7 @@ async fn harvest_api_rejects_backfill_for_unregistered_dag_schedule_row() {
 }
 
 #[tokio::test]
+#[allow(clippy::too_many_lines)]
 async fn scheduler_tick_creates_and_executes_due_interval_runs() {
     let (database_url, _container) = setup_test_database_url().await;
     let pool = build_test_pool(&database_url);
@@ -4926,6 +4939,7 @@ async fn scheduler_tick_creates_and_executes_due_interval_runs() {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
 
             owner: None,
@@ -5037,6 +5051,7 @@ async fn concurrent_scheduler_ticks_activate_due_dag_run_once() {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
 
             owner: None,

--- a/autumn-harvest-plugin/tests/build_routing_ui_integration.rs
+++ b/autumn-harvest-plugin/tests/build_routing_ui_integration.rs
@@ -196,6 +196,7 @@ fn minimal_registry() -> Arc<HandlerRegistry> {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
 
             owner: None,

--- a/autumn-harvest-plugin/tests/completion_triggers_integration.rs
+++ b/autumn-harvest-plugin/tests/completion_triggers_integration.rs
@@ -259,6 +259,7 @@ fn test_registry() -> Arc<HandlerRegistry> {
                 concurrency: None,
 
                 debounce: None,
+                batch: None,
                 max_input_bytes: None,
                 description: None,
                 input_schema: None,
@@ -277,6 +278,7 @@ fn test_registry() -> Arc<HandlerRegistry> {
                 concurrency: None,
 
                 debounce: None,
+                batch: None,
                 max_input_bytes: None,
                 description: None,
                 input_schema: None,
@@ -295,6 +297,7 @@ fn test_registry() -> Arc<HandlerRegistry> {
                 concurrency: None,
 
                 debounce: None,
+                batch: None,
                 max_input_bytes: None,
                 description: None,
                 input_schema: Some(target_schema_fn),
@@ -316,6 +319,7 @@ fn test_registry() -> Arc<HandlerRegistry> {
                 concurrency: None,
 
                 debounce: None,
+                batch: None,
                 max_input_bytes: None,
                 description: None,
                 input_schema: None,
@@ -334,6 +338,7 @@ fn test_registry() -> Arc<HandlerRegistry> {
                 concurrency: None,
 
                 debounce: None,
+                batch: None,
                 max_input_bytes: None,
                 description: None,
                 input_schema: None,
@@ -352,6 +357,7 @@ fn test_registry() -> Arc<HandlerRegistry> {
                 concurrency: None,
 
                 debounce: None,
+                batch: None,
                 max_input_bytes: None,
                 description: None,
                 input_schema: None,
@@ -2071,6 +2077,7 @@ async fn test_runner_startup_fails_on_sync_failure() {
                 sla: None,
                 concurrency: None,
                 debounce: None,
+                batch: None,
                 max_input_bytes: None,
                 description: None,
                 input_schema: None,
@@ -2088,6 +2095,7 @@ async fn test_runner_startup_fails_on_sync_failure() {
                 sla: None,
                 concurrency: None,
                 debounce: None,
+                batch: None,
                 max_input_bytes: None,
                 description: None,
                 input_schema: None,

--- a/autumn-harvest-plugin/tests/eligibility_tests.rs
+++ b/autumn-harvest-plugin/tests/eligibility_tests.rs
@@ -69,6 +69,7 @@ fn workflow_info() -> WorkflowInfo {
         concurrency: None,
 
         debounce: None,
+        batch: None,
         max_input_bytes: None,
         owner: None,
         runbook_url: None,

--- a/autumn-harvest-plugin/tests/event_batch_integration.rs
+++ b/autumn-harvest-plugin/tests/event_batch_integration.rs
@@ -1,0 +1,500 @@
+#![allow(clippy::similar_names)]
+#![allow(clippy::too_many_lines)]
+
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::Duration;
+
+use autumn_harvest::scheduler::{DagCatalog, SchedulerMonitor};
+use autumn_harvest::schema::harvest_workflow_executions;
+use autumn_harvest::shard::ShardRouter;
+use autumn_harvest::telemetry::NoOpMetrics;
+use autumn_harvest::worker::{DbPool, HandlerRegistry};
+use autumn_harvest::{
+    WorkflowInfo,
+    context::WorkflowContext,
+    event_batch::{BatchPolicy, fire_due_event_batches},
+};
+use autumn_harvest_plugin::HarvestDbPool;
+use autumn_harvest_plugin::api::{
+    HarvestApiRuntime, HarvestApiState, HarvestRetentionRuntime, harvest_api_router,
+};
+use autumn_web::AppState;
+use autumn_web::reexports::axum;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use diesel::prelude::*;
+use diesel_async::pooled_connection::AsyncDieselConnectionManager;
+use diesel_async::{AsyncConnection, AsyncPgConnection, RunQueryDsl};
+use serde_json::{Value, json};
+use testcontainers::ContainerAsync;
+use testcontainers::ImageExt;
+use testcontainers_modules::postgres::Postgres;
+use testcontainers_modules::testcontainers::runners::AsyncRunner;
+use tower::ServiceExt;
+
+const INIT_SQL: &str = concat!(
+    include_str!("../../autumn-harvest/migrations/20260409000000_harvest_initial/up.sql"),
+    "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260619000000_harvest_task_queue_created_at/up.sql"
+    ),
+    "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260616000001_harvest_workflow_schedule_id/up.sql"
+    ),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260424000001_harvest_trace_context/up.sql"),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260427000000_harvest_continue_as_new/up.sql"),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260429000000_harvest_concurrency_key/up.sql"),
+    "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260430000000_harvest_workflow_schedules/up.sql"
+    ),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260430000001_harvest_external_tasks/up.sql"),
+    "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260508000000_harvest_external_task_updated_at/up.sql"
+    ),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260503000000_harvest_workflow_reset/up.sql"),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260505000000_harvest_heartbeat_details/up.sql"),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260506000000_harvest_audit_log/up.sql"),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260501000000_harvest_workers/up.sql"),
+    "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260508010000_harvest_workers_drain_deadline/up.sql"
+    ),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260509000000_harvest_build_routing/up.sql"),
+    "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260513000000_harvest_schedule_pause_metadata/up.sql"
+    ),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260514020000_harvest_task_activity_id/up.sql"),
+    "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260518000000_harvest_signal_idempotency/up.sql"
+    ),
+    "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260518000001_harvest_workflow_execution_timeout/up.sql"
+    ),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260613000000_harvest_workflow_sla/up.sql"),
+    "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260519000000_harvest_calendar_awareness/up.sql"
+    ),
+    "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260522000000_harvest_schedule_decisions/up.sql"
+    ),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260522000001_harvest_rate_limiting/up.sql"),
+    "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260526000001_harvest_parent_close_policy/up.sql"
+    ),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260530000000_harvest_schedule_ha_claim/up.sql"),
+    "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260601000001_harvest_poison_pill_strikes/up.sql"
+    ),
+    "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260601000002_harvest_ownership_metadata/up.sql"
+    ),
+    "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260603000000_harvest_completion_triggers/up.sql"
+    ),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260605000000_harvest_admission_gates/up.sql"),
+    "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260606000001_harvest_activity_schedule_to_close/up.sql"
+    ),
+    "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260607000000_harvest_worker_capability_labels/up.sql"
+    ),
+    "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260607000001_harvest_task_required_capabilities/up.sql"
+    ),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260607000002_harvest_workflow_pause/up.sql"),
+    "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260609000001_harvest_workflow_current_details/up.sql"
+    ),
+    "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260610000001_harvest_schedule_bounded_runs/up.sql"
+    ),
+    "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260613000001_harvest_schedule_catchup_window/up.sql"
+    ),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260615000001_harvest_context_headers/up.sql"),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260618000001_harvest_debounce/up.sql"),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260624000000_harvest_event_batches/up.sql")
+);
+
+type HarvestApiApp = axum::Router;
+
+async fn setup_database() -> (String, ContainerAsync<Postgres>) {
+    let container = Postgres::default()
+        .with_init_sql(INIT_SQL.to_string().into_bytes())
+        .with_tag("16")
+        .start()
+        .await
+        .expect("postgres container should start");
+    let host = container.get_host().await.unwrap();
+    let port = container.get_host_port_ipv4(5432).await.unwrap();
+    let url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+    (url, container)
+}
+
+fn build_pool(url: &str) -> DbPool {
+    let manager = AsyncDieselConnectionManager::<AsyncPgConnection>::new(url);
+    deadpool::managed::Pool::builder(manager)
+        .max_size(8)
+        .build()
+        .expect("pool should build")
+}
+
+fn build_app(pool: &DbPool) -> HarvestApiApp {
+    let api_state = HarvestApiState::new();
+    api_state.set_admin_auth_boundary(true);
+    api_state.install_storage_pool(HarvestDbPool::from(pool.clone()));
+
+    let registry = HandlerRegistry::new(
+        vec![
+            WorkflowInfo {
+                name: "test_batch_request",
+                module: "tests",
+                handler: dummy_workflow,
+                execution_timeout: None,
+                sla: None,
+                concurrency: None,
+                debounce: None,
+                batch: None,
+                max_input_bytes: None,
+                owner: None,
+                runbook_url: None,
+                severity: None,
+                description: None,
+                input_schema: None,
+                output_schema: None,
+                error_schema: None,
+            },
+            WorkflowInfo {
+                name: "test_batch_macro",
+                module: "tests",
+                handler: dummy_workflow,
+                execution_timeout: None,
+                sla: None,
+                concurrency: None,
+                debounce: None,
+                batch: Some(BatchPolicy {
+                    key_expr: "tenant".to_string(),
+                    max_size: 2,
+                    max_wait: Duration::from_secs(60),
+                }),
+                max_input_bytes: None,
+                owner: None,
+                runbook_url: None,
+                severity: None,
+                description: None,
+                input_schema: None,
+                output_schema: None,
+                error_schema: None,
+            },
+            WorkflowInfo {
+                name: "test_batch_and_debounce",
+                module: "tests",
+                handler: dummy_workflow,
+                execution_timeout: None,
+                sla: None,
+                concurrency: None,
+                debounce: Some(autumn_harvest::debounce::DebouncePolicy {
+                    key_expr: "tenant",
+                    window: Duration::from_secs(60),
+                    max_wait: None,
+                }),
+                batch: Some(BatchPolicy {
+                    key_expr: "tenant".to_string(),
+                    max_size: 2,
+                    max_wait: Duration::from_secs(60),
+                }),
+                max_input_bytes: None,
+                owner: None,
+                runbook_url: None,
+                severity: None,
+                description: None,
+                input_schema: None,
+                output_schema: None,
+                error_schema: None,
+            },
+        ],
+        vec![],
+    );
+
+    api_state.install(HarvestApiRuntime::new(
+        Arc::new(registry),
+        Arc::new(DagCatalog::default()),
+        Arc::new(Vec::new()),
+        Some("event-batch-test".to_string()),
+        vec!["default".to_string()],
+        SchedulerMonitor::offline(),
+        HarvestRetentionRuntime::disabled(autumn_harvest::RetentionConfig::default()),
+        ShardRouter::default(),
+    ));
+
+    harvest_api_router(api_state).with_state(AppState::for_test().with_profile("test"))
+}
+
+fn dummy_workflow<'a>(
+    _ctx: &'a WorkflowContext,
+    _input: Value,
+) -> Pin<Box<dyn std::future::Future<Output = Result<Value, String>> + Send + 'a>> {
+    Box::pin(async move { Ok(json!({ "status": "ok" })) })
+}
+
+async fn post_json(app: &HarvestApiApp, uri: &str, body: Value) -> (StatusCode, Value) {
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(uri)
+                .header("content-type", "application/json")
+                .header("x-harvest-admin", "true")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .expect("POST request");
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json = if bytes.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&bytes)
+            .unwrap_or_else(|_| Value::String(String::from_utf8_lossy(&bytes).to_string()))
+    };
+    (status, json)
+}
+
+async fn get_json(app: &HarvestApiApp, uri: &str) -> (StatusCode, Value) {
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(uri)
+                .header("x-harvest-admin", "true")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("GET request");
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json = if bytes.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&bytes)
+            .unwrap_or_else(|_| Value::String(String::from_utf8_lossy(&bytes).to_string()))
+    };
+    (status, json)
+}
+
+#[tokio::test]
+async fn test_request_specified_batch_size_flush() {
+    let (url, _container) = setup_database().await;
+    let pool = build_pool(&url);
+    let app = build_app(&pool);
+    let mut conn = AsyncPgConnection::establish(&url).await.unwrap();
+
+    // First start request -> should accumulate and return 202 Accepted
+    let (status1, body1) = post_json(
+        &app,
+        "/workflows/test_batch_request/start",
+        json!({
+            "workflow_id": "wf-req-1",
+            "batch_key": "my-key-1",
+            "batch_max_size": 3,
+            "batch_max_wait": "10s",
+            "input": { "foo": "bar1" }
+        }),
+    )
+    .await;
+    assert_eq!(status1, StatusCode::ACCEPTED, "body: {body1:?}");
+    assert_eq!(body1["batched"], true);
+    assert_eq!(body1["flushed"], false);
+    assert_eq!(body1["pending_count"], 1);
+    assert_eq!(body1["max_size"], 3);
+
+    // Second start request -> accumulates and returns 202 Accepted
+    let (status2, body2) = post_json(
+        &app,
+        "/workflows/test_batch_request/start",
+        json!({
+            "workflow_id": "wf-req-1",
+            "batch_key": "my-key-1",
+            "batch_max_size": 3,
+            "batch_max_wait": "10s",
+            "input": { "foo": "bar2" }
+        }),
+    )
+    .await;
+    assert_eq!(status2, StatusCode::ACCEPTED, "body: {body2:?}");
+    assert_eq!(body2["pending_count"], 2);
+
+    // Third start request -> reaches max_size (3), flushes immediately and returns 201 Created
+    let (status3, body3) = post_json(
+        &app,
+        "/workflows/test_batch_request/start",
+        json!({
+            "workflow_id": "wf-req-1",
+            "batch_key": "my-key-1",
+            "batch_max_size": 3,
+            "batch_max_wait": "10s",
+            "input": { "foo": "bar3" }
+        }),
+    )
+    .await;
+    assert_eq!(status3, StatusCode::CREATED, "body: {body3:?}");
+    assert_eq!(body3["batched"], true);
+    assert_eq!(body3["flushed"], true);
+    let exec_id = body3["execution_id"].as_str().unwrap();
+
+    // Verify workflow execution row is created and input is a JSON array of all 3 payloads in arrival order
+    let input_val: Value = harvest_workflow_executions::table
+        .filter(harvest_workflow_executions::id.eq(uuid::Uuid::parse_str(exec_id).unwrap()))
+        .select(harvest_workflow_executions::input)
+        .first(&mut conn)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        input_val,
+        json!([
+            { "foo": "bar1" },
+            { "foo": "bar2" },
+            { "foo": "bar3" }
+        ])
+    );
+}
+
+#[tokio::test]
+async fn test_macro_configured_batch_time_flush() {
+    let (url, _container) = setup_database().await;
+    let pool = build_pool(&url);
+    let app = build_app(&pool);
+    let mut conn = AsyncPgConnection::establish(&url).await.unwrap();
+
+    // Macro policy uses key_expr "tenant".
+    // Start first request -> returns 202 Accepted.
+    let (status1, body1) = post_json(
+        &app,
+        "/workflows/test_batch_macro/start",
+        json!({
+            "workflow_id": "wf-macro-1",
+            "input": { "tenant": "acme-corp", "data": "payload-A" }
+        }),
+    )
+    .await;
+    assert_eq!(status1, StatusCode::ACCEPTED, "body: {body1:?}");
+    assert_eq!(body1["batch_key"], "acme-corp");
+    assert_eq!(body1["pending_count"], 1);
+
+    // Call GET /batches/pending visibility endpoint
+    let (p_status, p_body) = get_json(&app, "/batches/pending").await;
+    assert_eq!(p_status, StatusCode::OK, "body: {p_body:?}");
+    assert!(p_body.is_array());
+    let list = p_body.as_array().unwrap();
+    assert_eq!(list.len(), 1);
+    assert_eq!(list[0]["workflow_name"], "test_batch_macro");
+    assert_eq!(list[0]["batch_key"], "acme-corp");
+    assert_eq!(list[0]["current_size"], 1);
+    assert_eq!(list[0]["max_size"], 2);
+
+    // Now, force-expire the batch by updating its `fire_at` to the past
+    let rows_updated =
+        diesel::sql_query("UPDATE harvest_event_batches SET fire_at = NOW() - INTERVAL '1 minute'")
+            .execute(&mut conn)
+            .await
+            .unwrap();
+    assert_eq!(rows_updated, 1);
+
+    // Trigger fire_due_event_batches background sweep
+    let fired = fire_due_event_batches(&mut conn, &None, &[], &NoOpMetrics)
+        .await
+        .unwrap();
+    assert_eq!(fired, 1);
+
+    // Verify list is now empty
+    let (p_status2, p_body2) = get_json(&app, "/batches/pending").await;
+    assert_eq!(p_status2, StatusCode::OK);
+    assert_eq!(p_body2.as_array().unwrap().len(), 0);
+
+    // Verify workflow execution exists with single-item payload array
+    let exec_row: (uuid::Uuid, Value) = harvest_workflow_executions::table
+        .filter(harvest_workflow_executions::workflow_name.eq("test_batch_macro"))
+        .select((
+            harvest_workflow_executions::id,
+            harvest_workflow_executions::input,
+        ))
+        .first(&mut conn)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        exec_row.1,
+        json!([
+            { "tenant": "acme-corp", "data": "payload-A" }
+        ])
+    );
+}
+
+#[tokio::test]
+async fn test_batch_and_debounce_mutually_exclusive() {
+    let (url, _container) = setup_database().await;
+    let pool = build_pool(&url);
+    let app = build_app(&pool);
+
+    // Start request triggers both debounce and batch -> should return 400 Bad Request
+    let (status, body) = post_json(
+        &app,
+        "/workflows/test_batch_and_debounce/start",
+        json!({
+            "workflow_id": "wf-both-1",
+            "input": { "tenant": "acme-corp" }
+        }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+    assert_eq!(
+        body["error"],
+        "debounce and batching are mutually exclusive"
+    );
+}

--- a/autumn-harvest-plugin/tests/preflight_integration.rs
+++ b/autumn-harvest-plugin/tests/preflight_integration.rs
@@ -217,6 +217,7 @@ fn workflow_info() -> WorkflowInfo {
         concurrency: None,
 
         debounce: None,
+        batch: None,
         max_input_bytes: None,
         owner: None,
         runbook_url: None,

--- a/autumn-harvest-plugin/tests/replay_canary_integration.rs
+++ b/autumn-harvest-plugin/tests/replay_canary_integration.rs
@@ -222,6 +222,7 @@ fn activity_wf_info() -> autumn_harvest::info::WorkflowInfo {
         sla: None,
         concurrency: None,
         debounce: None,
+        batch: None,
         max_input_bytes: None,
         owner: None,
         runbook_url: None,

--- a/autumn-harvest-plugin/tests/scaling_api_tests.rs
+++ b/autumn-harvest-plugin/tests/scaling_api_tests.rs
@@ -114,6 +114,7 @@ fn workflow_info() -> WorkflowInfo {
         concurrency: None,
 
         debounce: None,
+        batch: None,
         max_input_bytes: None,
         owner: None,
         runbook_url: None,

--- a/autumn-harvest-plugin/tests/shard_health_integration.rs
+++ b/autumn-harvest-plugin/tests/shard_health_integration.rs
@@ -164,6 +164,7 @@ fn workflow_info() -> WorkflowInfo {
         concurrency: None,
 
         debounce: None,
+        batch: None,
         max_input_bytes: None,
         owner: None,
         runbook_url: None,

--- a/autumn-harvest-plugin/tests/signal_with_start_integration.rs
+++ b/autumn-harvest-plugin/tests/signal_with_start_integration.rs
@@ -184,6 +184,7 @@ fn test_registry() -> Arc<HandlerRegistry> {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
 
             owner: None,

--- a/autumn-harvest-plugin/tests/telemetry_propagation_tests.rs
+++ b/autumn-harvest-plugin/tests/telemetry_propagation_tests.rs
@@ -256,6 +256,7 @@ async fn start_workflow_stores_captured_trace_context_in_task_queue() {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
 
             owner: None,
@@ -357,6 +358,7 @@ async fn start_workflow_leaves_trace_context_null_when_no_propagator() {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
 
             owner: None,

--- a/autumn-harvest-plugin/tests/ui_integration.rs
+++ b/autumn-harvest-plugin/tests/ui_integration.rs
@@ -285,6 +285,7 @@ fn echo_registry() -> Arc<HandlerRegistry> {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
 
             owner: None,
@@ -2904,6 +2905,7 @@ async fn detail_page_shows_custom_continue_as_new_threshold() {
                 concurrency: None,
 
                 debounce: None,
+                batch: None,
                 max_input_bytes: None,
 
                 owner: None,
@@ -3039,6 +3041,7 @@ async fn ui_trigger_preserves_dag_metadata() {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
             owner: None,
             runbook_url: None,

--- a/autumn-harvest-plugin/tests/workflow_reset_integration.rs
+++ b/autumn-harvest-plugin/tests/workflow_reset_integration.rs
@@ -526,6 +526,7 @@ async fn reset_fork_completes_with_current_code_and_observes_buffered_signal() {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
 
             owner: None,

--- a/autumn-harvest/migrations/20260624000000_harvest_event_batches/down.sql
+++ b/autumn-harvest/migrations/20260624000000_harvest_event_batches/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS harvest_event_batches;

--- a/autumn-harvest/migrations/20260624000000_harvest_event_batches/up.sql
+++ b/autumn-harvest/migrations/20260624000000_harvest_event_batches/up.sql
@@ -1,0 +1,34 @@
+-- Pending-start record table for event-batched workflow starts (issue #518).
+--
+-- One row per (workflow_name, batch_key). Each qualifying start request
+-- appends its payload to buffered_payloads. When jsonb_array_length(buffered_payloads)
+-- reaches max_size, exactly one workflow execution is started.
+-- A background scanner flushes any due row (fire_at <= NOW()) by starting the execution
+-- and deleting the row.
+
+CREATE TABLE IF NOT EXISTS harvest_event_batches (
+    id                 UUID        NOT NULL DEFAULT gen_random_uuid() PRIMARY KEY,
+    workflow_name      TEXT        NOT NULL,
+    batch_key          TEXT        NOT NULL,
+    workflow_id        TEXT        NOT NULL,
+    queue_name         TEXT        NOT NULL DEFAULT 'default',
+    -- JSONB array containing the buffered payloads in arrival order.
+    buffered_payloads  JSONB       NOT NULL DEFAULT '[]',
+    -- Serialised start options from the first request: reuse_policy, execution_timeout_secs,
+    -- memo, search_attrs, sla_secs, context_headers, priority, etc.
+    start_options      JSONB       NOT NULL DEFAULT '{}',
+    -- Absolute UTC deadline when this batch must flush: first_seen + max_wait.
+    fire_at            TIMESTAMPTZ NOT NULL,
+    -- The target max size for size-triggered flush.
+    max_size           INT         NOT NULL,
+    -- Shard this record was routed to.
+    shard_id           INT         NOT NULL DEFAULT 0,
+    created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+    CONSTRAINT harvest_event_batches_unique_key UNIQUE (workflow_name, batch_key)
+);
+
+-- Scanner probe index: fire rows whose fire_at has elapsed, filtered by shard.
+CREATE INDEX IF NOT EXISTS idx_harvest_event_batches_shard_fire_at
+    ON harvest_event_batches (shard_id, fire_at);

--- a/autumn-harvest/src/builder.rs
+++ b/autumn-harvest/src/builder.rs
@@ -2051,6 +2051,7 @@ mod tests {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
             owner: None,
             runbook_url: None,
@@ -2507,6 +2508,7 @@ mod tests {
                 }),
 
                 debounce: None,
+                batch: None,
                 max_input_bytes: None,
                 owner: None,
                 runbook_url: None,
@@ -2545,6 +2547,7 @@ mod tests {
                 }),
 
                 debounce: None,
+                batch: None,
                 max_input_bytes: None,
                 owner: None,
                 runbook_url: None,

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -8852,6 +8852,7 @@ mod tests {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
             owner: None,
             runbook_url: None,

--- a/autumn-harvest/src/event_batch.rs
+++ b/autumn-harvest/src/event_batch.rs
@@ -117,7 +117,12 @@ struct FireDueBatchRow {
 pub async fn admit_batched_start(
     conn: &mut AsyncPgConnection,
     params: AdmitBatchParams,
-) -> HarvestResult<Option<(BatchAdmitOutcome, Vec<crate::completion_trigger::DeferredTriggerStart>)>> {
+) -> HarvestResult<
+    Option<(
+        BatchAdmitOutcome,
+        Vec<crate::completion_trigger::DeferredTriggerStart>,
+    )>,
+> {
     use diesel_async::AsyncConnection;
 
     if params.batch_key.len() > 1024 {
@@ -170,7 +175,10 @@ pub async fn admit_batched_start(
     let max_size = params.max_size;
 
     let outcome = conn
-        .transaction::<(BatchAdmitOutcome, Vec<crate::completion_trigger::DeferredTriggerStart>), HarvestError, _>(|conn| {
+        .transaction::<(
+            BatchAdmitOutcome,
+            Vec<crate::completion_trigger::DeferredTriggerStart>,
+        ), HarvestError, _>(|conn| {
             Box::pin(async move {
                 let row: UpsertBatchRow = diesel::sql_query(sql)
                     .bind::<diesel::sql_types::Uuid, _>(new_id)
@@ -191,7 +199,7 @@ pub async fn admit_batched_start(
                     serde_json::from_value(row.start_options.clone()).unwrap_or_default();
 
                 let max_allowed_bytes = opts.max_workflow_input_bytes.unwrap_or(10 * 1024 * 1024);
-                if row.buffered_bytes > max_allowed_bytes as i32 {
+                if u64::from(row.buffered_bytes.cast_unsigned()) > max_allowed_bytes {
                     return Err(HarvestError::PayloadTooLarge {
                         kind: crate::error::PayloadKind::WorkflowInput,
                         observed_bytes: row.buffered_bytes as u64,
@@ -227,7 +235,9 @@ pub async fn admit_batched_start(
                         workflow_name: &row.workflow_name,
                         workflow_id: &row.workflow_id,
                         exec_id,
-                        input: row.buffered_payloads.unwrap_or_else(|| serde_json::Value::Array(Vec::new())),
+                        input: row
+                            .buffered_payloads
+                            .unwrap_or_else(|| serde_json::Value::Array(Vec::new())),
                         parent_id: None,
                         queue_name: &row.queue_name,
                         execution_timeout,
@@ -275,7 +285,7 @@ pub async fn admit_batched_start(
                         workflow_id: row.workflow_id,
                         fire_at: row.fire_at,
                         pending_count: row.current_size,
-                        max_size: row.max_size as usize,
+                        max_size: row.max_size.cast_unsigned() as usize,
                         is_flushed,
                         flushed_execution_id,
                     },
@@ -297,7 +307,10 @@ const fn is_transient_error(e: &HarvestError) -> bool {
 async fn fire_due_on_conn(
     conn: &mut diesel_async::AsyncPgConnection,
     shard_id: Option<i32>,
-) -> HarvestResult<(Vec<String>, Vec<crate::completion_trigger::DeferredTriggerStart>)> {
+) -> HarvestResult<(
+    Vec<String>,
+    Vec<crate::completion_trigger::DeferredTriggerStart>,
+)> {
     use diesel_async::{AsyncConnection, RunQueryDsl};
 
     #[derive(diesel::QueryableByName)]
@@ -341,8 +354,8 @@ async fn fire_due_on_conn(
 
     loop {
         let now = Utc::now();
-        let processed: Option<(String, Vec<crate::completion_trigger::DeferredTriggerStart>)> = conn
-            .transaction(|conn| {
+        let processed: Option<(String, Vec<crate::completion_trigger::DeferredTriggerStart>)> =
+            conn.transaction(|conn| {
                 Box::pin(async move {
                     let due_rows: Vec<FireDueBatchRow> = if let Some(sid) = shard_id {
                         diesel::sql_query(due_sql)
@@ -363,15 +376,9 @@ async fn fire_due_on_conn(
 
                     if let Some(row) = due_rows.into_iter().next() {
                         match fire_claimed_batch_row(conn, row).await {
-                            Ok(Some((exec_id, deferred))) => {
-                                Ok(Some((exec_id, deferred)))
-                            }
-                            Ok(None) => {
-                                Ok(None)
-                            }
-                            Err(e) => {
-                                Err(e)
-                            }
+                            Ok(Some((exec_id, deferred))) => Ok(Some((exec_id, deferred))),
+                            Ok(None) => Ok(None),
+                            Err(e) => Err(e),
                         }
                     } else {
                         Ok(None)
@@ -456,7 +463,8 @@ async fn fire_claimed_batch_row(
         scheduled_for: None,
     };
 
-    let start_res = crate::execution::start_or_load_workflow_execution_collect(conn, params, true, false).await;
+    let start_res =
+        crate::execution::start_or_load_workflow_execution_collect(conn, params, true, false).await;
 
     match start_res {
         Ok((started, deferred_starts)) => {
@@ -546,7 +554,8 @@ pub async fn fire_due_event_batches(
                     .get()
                     .await
                     .map_err(|e| crate::error::HarvestError::Database(e.to_string()))?;
-                let (fired, deferred) = fire_due_on_conn(&mut shard_conn, Some(shard_id.as_i32())).await?;
+                let (fired, deferred) =
+                    fire_due_on_conn(&mut shard_conn, Some(shard_id.as_i32())).await?;
                 fired_count += fired.len();
                 deferred_to_spawn.extend(deferred);
             }

--- a/autumn-harvest/src/event_batch.rs
+++ b/autumn-harvest/src/event_batch.rs
@@ -508,6 +508,7 @@ async fn fire_claimed_batch_row(
                     .await
                     .map_err(crate::error::database_error)?;
 
+                let err_msg = e.to_string();
                 let ar = crate::models::NewAuditRecord {
                     actor: "system",
                     operation: "workflow.start",
@@ -517,7 +518,7 @@ async fn fire_claimed_batch_row(
                     request_id: None,
                     idempotency_key: None,
                     status: "failed",
-                    error_summary: Some(&e.to_string()),
+                    error_summary: Some(&err_msg),
                     shard_id: Some(row.shard_id),
                     source: "worker",
                 };

--- a/autumn-harvest/src/event_batch.rs
+++ b/autumn-harvest/src/event_batch.rs
@@ -1,0 +1,645 @@
+#![allow(
+    clippy::missing_errors_doc,
+    clippy::too_many_lines,
+    clippy::cast_possible_truncation,
+    clippy::cast_possible_wrap,
+    clippy::cast_sign_loss
+)]
+
+use crate::debounce::DebounceStartOptions;
+use crate::error::{HarvestError, HarvestResult};
+use crate::types::ExecutionId;
+use chrono::{DateTime, Utc};
+#[cfg(feature = "db")]
+use diesel_async::{AsyncPgConnection, RunQueryDsl};
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BatchPolicy {
+    pub key_expr: String,
+    pub max_size: usize,
+    pub max_wait: Duration,
+}
+
+pub struct AdmitBatchParams {
+    pub workflow_name: String,
+    pub batch_key: String,
+    pub workflow_id: String,
+    pub queue_name: String,
+    pub payload: serde_json::Value,
+    pub start_options: DebounceStartOptions,
+    pub max_wait: Duration,
+    pub max_size: usize,
+    pub shard_id: i32,
+}
+
+#[derive(Debug, Clone)]
+pub struct BatchAdmitOutcome {
+    pub batch_key: String,
+    pub workflow_id: String,
+    pub fire_at: DateTime<Utc>,
+    pub pending_count: i32,
+    pub max_size: usize,
+    pub is_flushed: bool,
+    pub flushed_execution_id: Option<String>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+pub struct PendingEventBatchRecord {
+    pub id: uuid::Uuid,
+    pub workflow_name: String,
+    pub batch_key: String,
+    pub workflow_id: String,
+    pub queue_name: String,
+    pub current_size: i32,
+    pub max_size: i32,
+    pub fire_at: DateTime<Utc>,
+    pub shard_id: i32,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+}
+
+#[cfg(feature = "db")]
+#[derive(diesel::QueryableByName, Debug)]
+struct UpsertBatchRow {
+    #[diesel(sql_type = diesel::sql_types::Uuid)]
+    id: uuid::Uuid,
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    workflow_name: String,
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    workflow_id: String,
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    queue_name: String,
+    #[diesel(sql_type = diesel::sql_types::Nullable<diesel::sql_types::Jsonb>)]
+    buffered_payloads: Option<serde_json::Value>,
+    #[diesel(sql_type = diesel::sql_types::Jsonb)]
+    start_options: serde_json::Value,
+    #[diesel(sql_type = diesel::sql_types::Timestamptz)]
+    fire_at: DateTime<Utc>,
+    #[diesel(sql_type = diesel::sql_types::Integer)]
+    max_size: i32,
+    #[diesel(sql_type = diesel::sql_types::Integer)]
+    shard_id: i32,
+    #[diesel(sql_type = diesel::sql_types::Integer)]
+    current_size: i32,
+    #[diesel(sql_type = diesel::sql_types::Integer)]
+    buffered_bytes: i32,
+}
+
+#[cfg(feature = "db")]
+#[derive(diesel::QueryableByName, Debug)]
+#[allow(dead_code)]
+struct FireDueBatchRow {
+    #[diesel(sql_type = diesel::sql_types::Uuid)]
+    id: uuid::Uuid,
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    workflow_name: String,
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    batch_key: String,
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    workflow_id: String,
+    #[diesel(sql_type = diesel::sql_types::Text)]
+    queue_name: String,
+    #[diesel(sql_type = diesel::sql_types::Jsonb)]
+    buffered_payloads: serde_json::Value,
+    #[diesel(sql_type = diesel::sql_types::Jsonb)]
+    start_options: serde_json::Value,
+    #[diesel(sql_type = diesel::sql_types::Timestamptz)]
+    fire_at: DateTime<Utc>,
+    #[diesel(sql_type = diesel::sql_types::Integer)]
+    max_size: i32,
+    #[diesel(sql_type = diesel::sql_types::Integer)]
+    shard_id: i32,
+}
+
+#[cfg(feature = "db")]
+pub async fn admit_batched_start(
+    conn: &mut AsyncPgConnection,
+    params: AdmitBatchParams,
+) -> HarvestResult<Option<(BatchAdmitOutcome, Vec<crate::completion_trigger::DeferredTriggerStart>)>> {
+    use diesel_async::AsyncConnection;
+
+    if params.batch_key.len() > 1024 {
+        return Err(HarvestError::Config(format!(
+            "batch key length {} bytes exceeds maximum 1024 bytes",
+            params.batch_key.len()
+        )));
+    }
+
+    let now = Utc::now();
+    let max_wait_chrono = chrono::Duration::from_std(params.max_wait)
+        .unwrap_or_else(|_| chrono::Duration::days(365 * 100));
+    let initial_fire_at = now.checked_add_signed(max_wait_chrono).unwrap_or(now);
+
+    let new_id = uuid::Uuid::new_v4();
+    let start_options_json = serde_json::to_value(&params.start_options)
+        .unwrap_or_else(|_| serde_json::Value::Object(serde_json::Map::new()));
+
+    let sql = "
+        INSERT INTO harvest_event_batches
+            (id, workflow_name, batch_key, workflow_id, queue_name,
+             buffered_payloads, start_options, fire_at, max_size, shard_id,
+             created_at, updated_at)
+        VALUES
+            ($1, $2, $3, $4, $5, jsonb_build_array($6), $7, $8, $9, $10, NOW(), NOW())
+        ON CONFLICT (workflow_name, batch_key) DO UPDATE SET
+            buffered_payloads = harvest_event_batches.buffered_payloads || EXCLUDED.buffered_payloads,
+            fire_at           = LEAST(harvest_event_batches.fire_at, EXCLUDED.fire_at),
+            updated_at        = NOW()
+        RETURNING
+            id,
+            workflow_name,
+            workflow_id,
+            queue_name,
+            CASE WHEN jsonb_array_length(buffered_payloads) >= max_size THEN buffered_payloads ELSE NULL END AS buffered_payloads,
+            start_options,
+            fire_at,
+            max_size,
+            shard_id,
+            jsonb_array_length(buffered_payloads) AS current_size,
+            octet_length(buffered_payloads::text) AS buffered_bytes
+    ";
+
+    let workflow_name = params.workflow_name;
+    let batch_key = params.batch_key;
+    let workflow_id = params.workflow_id;
+    let queue_name = params.queue_name;
+    let shard_id = params.shard_id;
+    let payload = params.payload;
+    let max_size = params.max_size;
+
+    let outcome = conn
+        .transaction::<(BatchAdmitOutcome, Vec<crate::completion_trigger::DeferredTriggerStart>), HarvestError, _>(|conn| {
+            Box::pin(async move {
+                let row: UpsertBatchRow = diesel::sql_query(sql)
+                    .bind::<diesel::sql_types::Uuid, _>(new_id)
+                    .bind::<diesel::sql_types::Text, _>(&workflow_name)
+                    .bind::<diesel::sql_types::Text, _>(&batch_key)
+                    .bind::<diesel::sql_types::Text, _>(&workflow_id)
+                    .bind::<diesel::sql_types::Text, _>(&queue_name)
+                    .bind::<diesel::sql_types::Jsonb, _>(payload)
+                    .bind::<diesel::sql_types::Jsonb, _>(start_options_json)
+                    .bind::<diesel::sql_types::Timestamptz, _>(initial_fire_at)
+                    .bind::<diesel::sql_types::Integer, _>(max_size as i32)
+                    .bind::<diesel::sql_types::Integer, _>(shard_id)
+                    .get_result(conn)
+                    .await
+                    .map_err(crate::error::database_error)?;
+
+                let opts: DebounceStartOptions =
+                    serde_json::from_value(row.start_options.clone()).unwrap_or_default();
+
+                let max_allowed_bytes = opts.max_workflow_input_bytes.unwrap_or(10 * 1024 * 1024);
+                if row.buffered_bytes > max_allowed_bytes as i32 {
+                    return Err(HarvestError::PayloadTooLarge {
+                        kind: crate::error::PayloadKind::WorkflowInput,
+                        observed_bytes: row.buffered_bytes as u64,
+                        cap_bytes: max_allowed_bytes,
+                        workflow_type: workflow_name,
+                        activity_name: None,
+                    });
+                }
+
+                let is_flushed = row.current_size >= row.max_size;
+                let (flushed_execution_id, pending_deferred) = if is_flushed {
+                    let exec_id =
+                        ExecutionId::new_for_shard(crate::types::ShardId::new(row.shard_id));
+                    let reuse_policy = opts
+                        .reuse_policy
+                        .as_deref()
+                        .and_then(parse_reuse_policy)
+                        .unwrap_or(crate::types::WorkflowIdReusePolicy::AllowDuplicate);
+
+                    let execution_timeout = opts
+                        .execution_timeout_secs
+                        .and_then(chrono::Duration::try_seconds);
+                    let sla = opts.sla_secs.and_then(chrono::Duration::try_seconds);
+                    let max_execution_timeout_ceiling = opts
+                        .max_execution_timeout_ceiling_secs
+                        .and_then(chrono::Duration::try_seconds);
+                    let priority = opts
+                        .priority
+                        .and_then(crate::types::Priority::from_i32)
+                        .unwrap_or_default();
+
+                    let params = crate::execution::StartWorkflowParams {
+                        workflow_name: &row.workflow_name,
+                        workflow_id: &row.workflow_id,
+                        exec_id,
+                        input: row.buffered_payloads.unwrap_or_else(|| serde_json::Value::Array(Vec::new())),
+                        parent_id: None,
+                        queue_name: &row.queue_name,
+                        execution_timeout,
+                        memo: opts.memo,
+                        search_attrs: opts.search_attrs,
+                        reuse_policy,
+                        trace_context: opts.trace_context,
+                        max_execution_timeout_ceiling,
+                        concurrency_key: opts.concurrency_key,
+                        concurrency_limit: opts.concurrency_limit,
+                        priority,
+                        max_workflow_input_bytes: opts.max_workflow_input_bytes.unwrap_or(u64::MAX),
+                        start_at: None,
+                        delay: None,
+                        max_workflow_start_delay: None,
+                        owner: opts.owner.as_deref(),
+                        runbook_url: opts.runbook_url.as_deref(),
+                        severity: opts.severity.as_deref(),
+                        context_headers: opts.context_headers,
+                        sla,
+                        schedule_id: None,
+                        scheduled_for: None,
+                    };
+
+                    let (started, deferred_starts) =
+                        crate::execution::start_or_load_workflow_execution_collect(
+                            conn, params, true, false,
+                        )
+                        .await?;
+
+                    diesel::sql_query("DELETE FROM harvest_event_batches WHERE id = $1")
+                        .bind::<diesel::sql_types::Uuid, _>(row.id)
+                        .execute(conn)
+                        .await
+                        .map_err(crate::error::database_error)?;
+
+                    (Some(started.exec_id.to_string()), deferred_starts)
+                } else {
+                    (None, Vec::new())
+                };
+
+                Ok((
+                    BatchAdmitOutcome {
+                        batch_key,
+                        workflow_id: row.workflow_id,
+                        fire_at: row.fire_at,
+                        pending_count: row.current_size,
+                        max_size: row.max_size as usize,
+                        is_flushed,
+                        flushed_execution_id,
+                    },
+                    pending_deferred,
+                ))
+            })
+        })
+        .await;
+
+    outcome.map(Some)
+}
+
+#[cfg(feature = "db")]
+const fn is_transient_error(e: &HarvestError) -> bool {
+    matches!(e, HarvestError::Database(_) | HarvestError::Timeout { .. })
+}
+
+#[cfg(feature = "db")]
+async fn fire_due_on_conn(
+    conn: &mut diesel_async::AsyncPgConnection,
+    shard_id: Option<i32>,
+) -> HarvestResult<(Vec<String>, Vec<crate::completion_trigger::DeferredTriggerStart>)> {
+    use diesel_async::{AsyncConnection, RunQueryDsl};
+
+    #[derive(diesel::QueryableByName)]
+    struct TableExists {
+        #[diesel(sql_type = diesel::sql_types::Bool)]
+        present: bool,
+    }
+    let exists: TableExists =
+        diesel::sql_query("SELECT to_regclass('harvest_event_batches') IS NOT NULL AS present")
+            .get_result(conn)
+            .await
+            .map_err(crate::error::database_error)?;
+    if !exists.present {
+        return Ok((Vec::new(), Vec::new()));
+    }
+
+    let mut fired_ids = Vec::new();
+    let mut deferred_starts = Vec::new();
+
+    let due_sql = if shard_id.is_some() {
+        "
+            SELECT id, workflow_name, batch_key, workflow_id, queue_name,
+                   buffered_payloads, start_options, fire_at, max_size, shard_id
+            FROM harvest_event_batches
+            WHERE fire_at <= $1 AND shard_id = $3
+            ORDER BY fire_at ASC
+            LIMIT $2
+            FOR UPDATE SKIP LOCKED
+        "
+    } else {
+        "
+            SELECT id, workflow_name, batch_key, workflow_id, queue_name,
+                   buffered_payloads, start_options, fire_at, max_size, shard_id
+            FROM harvest_event_batches
+            WHERE fire_at <= $1
+            ORDER BY fire_at ASC
+            LIMIT $2
+            FOR UPDATE SKIP LOCKED
+        "
+    };
+
+    loop {
+        let now = Utc::now();
+        let processed: Option<(String, Vec<crate::completion_trigger::DeferredTriggerStart>)> = conn
+            .transaction(|conn| {
+                Box::pin(async move {
+                    let due_rows: Vec<FireDueBatchRow> = if let Some(sid) = shard_id {
+                        diesel::sql_query(due_sql)
+                            .bind::<diesel::sql_types::Timestamptz, _>(now)
+                            .bind::<diesel::sql_types::BigInt, _>(1i64)
+                            .bind::<diesel::sql_types::Integer, _>(sid)
+                            .load(conn)
+                            .await
+                            .map_err(crate::error::database_error)?
+                    } else {
+                        diesel::sql_query(due_sql)
+                            .bind::<diesel::sql_types::Timestamptz, _>(now)
+                            .bind::<diesel::sql_types::BigInt, _>(1i64)
+                            .load(conn)
+                            .await
+                            .map_err(crate::error::database_error)?
+                    };
+
+                    if let Some(row) = due_rows.into_iter().next() {
+                        match fire_claimed_batch_row(conn, row).await {
+                            Ok(Some((exec_id, deferred))) => {
+                                Ok(Some((exec_id, deferred)))
+                            }
+                            Ok(None) => {
+                                Ok(None)
+                            }
+                            Err(e) => {
+                                Err(e)
+                            }
+                        }
+                    } else {
+                        Ok(None)
+                    }
+                })
+            })
+            .await?;
+
+        if let Some((exec_id, deferred)) = processed {
+            fired_ids.push(exec_id);
+            deferred_starts.extend(deferred);
+        } else {
+            break;
+        }
+    }
+
+    Ok((fired_ids, deferred_starts))
+}
+
+#[cfg(feature = "db")]
+async fn fire_claimed_batch_row(
+    conn: &mut diesel_async::AsyncPgConnection,
+    row: FireDueBatchRow,
+) -> HarvestResult<Option<(String, Vec<crate::completion_trigger::DeferredTriggerStart>)>> {
+    use diesel_async::RunQueryDsl;
+
+    let opts: DebounceStartOptions = serde_json::from_value(row.start_options).unwrap_or_default();
+
+    let shard = crate::types::ShardId::new(row.shard_id);
+    let exec_id = crate::types::ExecutionId::new_for_shard(shard);
+
+    let reuse_policy = opts
+        .reuse_policy
+        .as_deref()
+        .and_then(parse_reuse_policy)
+        .unwrap_or(crate::types::WorkflowIdReusePolicy::AllowDuplicate);
+
+    let execution_timeout = opts
+        .execution_timeout_secs
+        .and_then(chrono::Duration::try_seconds);
+    let sla = opts.sla_secs.and_then(chrono::Duration::try_seconds);
+    let max_execution_timeout_ceiling = opts
+        .max_execution_timeout_ceiling_secs
+        .and_then(chrono::Duration::try_seconds);
+    let priority = opts
+        .priority
+        .and_then(crate::types::Priority::from_i32)
+        .unwrap_or_default();
+
+    let workflow_name = row.workflow_name.clone();
+    let workflow_id = row.workflow_id.clone();
+    let queue_name = row.queue_name.clone();
+    let batch_key = row.batch_key.clone();
+    let row_id = row.id;
+
+    let params = crate::execution::StartWorkflowParams {
+        workflow_name: &workflow_name,
+        workflow_id: &workflow_id,
+        exec_id,
+        input: row.buffered_payloads,
+        parent_id: None,
+        queue_name: &queue_name,
+        execution_timeout,
+        memo: opts.memo,
+        search_attrs: opts.search_attrs,
+        reuse_policy,
+        trace_context: opts.trace_context,
+        max_execution_timeout_ceiling,
+        concurrency_key: opts.concurrency_key,
+        concurrency_limit: opts.concurrency_limit,
+        priority,
+        max_workflow_input_bytes: opts.max_workflow_input_bytes.unwrap_or(u64::MAX),
+        start_at: None,
+        delay: None,
+        max_workflow_start_delay: None,
+        owner: opts.owner.as_deref(),
+        runbook_url: opts.runbook_url.as_deref(),
+        severity: opts.severity.as_deref(),
+        context_headers: opts.context_headers,
+        sla,
+        schedule_id: None,
+        scheduled_for: None,
+    };
+
+    let start_res = crate::execution::start_or_load_workflow_execution_collect(conn, params, true, false).await;
+
+    match start_res {
+        Ok((started, deferred_starts)) => {
+            diesel::sql_query("DELETE FROM harvest_event_batches WHERE id = $1")
+                .bind::<diesel::sql_types::Uuid, _>(row_id)
+                .execute(conn)
+                .await
+                .map_err(crate::error::database_error)?;
+
+            tracing::info!(
+                workflow_name = %workflow_name,
+                batch_key = %batch_key,
+                exec_id = %started.exec_id,
+                queue = %queue_name,
+                "batched start fired",
+            );
+
+            Ok(Some((started.exec_id.to_string(), deferred_starts)))
+        }
+        Err(crate::error::HarvestError::AlreadyExists { .. }) => {
+            diesel::sql_query("DELETE FROM harvest_event_batches WHERE id = $1")
+                .bind::<diesel::sql_types::Uuid, _>(row_id)
+                .execute(conn)
+                .await
+                .map_err(crate::error::database_error)?;
+            tracing::warn!(
+                workflow_name = %workflow_name,
+                batch_key = %batch_key,
+                workflow_id = %workflow_id,
+                "batched start skipped: workflow_id already exists under reuse policy",
+            );
+            Ok(None)
+        }
+        Err(e) => {
+            if is_transient_error(&e) {
+                Err(e)
+            } else {
+                diesel::sql_query("DELETE FROM harvest_event_batches WHERE id = $1")
+                    .bind::<diesel::sql_types::Uuid, _>(row_id)
+                    .execute(conn)
+                    .await
+                    .map_err(crate::error::database_error)?;
+
+                let ar = crate::models::NewAuditRecord {
+                    actor: "system",
+                    operation: "workflow.start",
+                    target_type: "workflow",
+                    target_id: Some(&workflow_id),
+                    route_or_command: "background.batch_scanner",
+                    request_id: None,
+                    idempotency_key: None,
+                    status: "failed",
+                    error_summary: Some(&e.to_string()),
+                    shard_id: Some(row.shard_id),
+                    source: "worker",
+                };
+                let _ = crate::audit::insert_audit(conn, &ar).await;
+
+                tracing::error!(
+                    workflow_name = %workflow_name,
+                    batch_key = %batch_key,
+                    workflow_id = %workflow_id,
+                    error = %e,
+                    "batched start failed with non-transient error, batch deleted",
+                );
+
+                Ok(None)
+            }
+        }
+    }
+}
+
+#[cfg(feature = "db")]
+pub async fn fire_due_event_batches(
+    conn: &mut diesel_async::AsyncPgConnection,
+    sharded_pool: &Option<crate::shard::ShardedDbPool>,
+    shard_assignments: &[crate::types::ShardId],
+    _metrics: &(dyn crate::telemetry::MetricsRecorder + Send + Sync),
+) -> HarvestResult<usize> {
+    let mut fired_count = 0usize;
+    let mut deferred_to_spawn = Vec::new();
+
+    if let Some(pool) = sharded_pool {
+        for shard_id in shard_assignments {
+            if let Some(shard_pool) = pool.exact_pool_for(*shard_id) {
+                let mut shard_conn = shard_pool
+                    .get()
+                    .await
+                    .map_err(|e| crate::error::HarvestError::Database(e.to_string()))?;
+                let (fired, deferred) = fire_due_on_conn(&mut shard_conn, Some(shard_id.as_i32())).await?;
+                fired_count += fired.len();
+                deferred_to_spawn.extend(deferred);
+            }
+        }
+    } else {
+        let (fired, deferred) = fire_due_on_conn(conn, None).await?;
+        fired_count += fired.len();
+        deferred_to_spawn.extend(deferred);
+    }
+
+    for start in deferred_to_spawn {
+        start.spawn();
+    }
+
+    Ok(fired_count)
+}
+
+#[cfg(feature = "db")]
+pub async fn list_pending_event_batches(
+    conn: &mut AsyncPgConnection,
+    limit: i64,
+) -> HarvestResult<Vec<PendingEventBatchRecord>> {
+    use diesel_async::RunQueryDsl;
+
+    #[derive(diesel::QueryableByName)]
+    struct DbRecord {
+        #[diesel(sql_type = diesel::sql_types::Uuid)]
+        id: uuid::Uuid,
+        #[diesel(sql_type = diesel::sql_types::Text)]
+        workflow_name: String,
+        #[diesel(sql_type = diesel::sql_types::Text)]
+        batch_key: String,
+        #[diesel(sql_type = diesel::sql_types::Text)]
+        workflow_id: String,
+        #[diesel(sql_type = diesel::sql_types::Text)]
+        queue_name: String,
+        #[diesel(sql_type = diesel::sql_types::Jsonb)]
+        buffered_payloads: serde_json::Value,
+        #[diesel(sql_type = diesel::sql_types::Timestamptz)]
+        fire_at: DateTime<Utc>,
+        #[diesel(sql_type = diesel::sql_types::Integer)]
+        max_size: i32,
+        #[diesel(sql_type = diesel::sql_types::Integer)]
+        shard_id: i32,
+        #[diesel(sql_type = diesel::sql_types::Timestamptz)]
+        created_at: DateTime<Utc>,
+        #[diesel(sql_type = diesel::sql_types::Timestamptz)]
+        updated_at: DateTime<Utc>,
+    }
+
+    let records: Vec<DbRecord> = diesel::sql_query(
+        "SELECT id, workflow_name, batch_key, workflow_id, queue_name,
+                buffered_payloads, fire_at, max_size, shard_id, created_at, updated_at
+         FROM harvest_event_batches
+         ORDER BY fire_at ASC
+         LIMIT $1",
+    )
+    .bind::<diesel::sql_types::BigInt, _>(limit)
+    .load(conn)
+    .await
+    .map_err(crate::error::database_error)?;
+
+    Ok(records
+        .into_iter()
+        .map(|r| {
+            let current_size = r.buffered_payloads.as_array().map_or(0, |a| a.len() as i32);
+            PendingEventBatchRecord {
+                id: r.id,
+                workflow_name: r.workflow_name,
+                batch_key: r.batch_key,
+                workflow_id: r.workflow_id,
+                queue_name: r.queue_name,
+                current_size,
+                max_size: r.max_size,
+                fire_at: r.fire_at,
+                shard_id: r.shard_id,
+                created_at: r.created_at,
+                updated_at: r.updated_at,
+            }
+        })
+        .collect())
+}
+
+#[cfg(feature = "db")]
+fn parse_reuse_policy(s: &str) -> Option<crate::types::WorkflowIdReusePolicy> {
+    use crate::types::WorkflowIdReusePolicy::{
+        AllowDuplicate, AllowDuplicateFailedOnly, RejectDuplicate, TerminateIfRunning,
+    };
+    match s {
+        "allow_duplicate" => Some(AllowDuplicate),
+        "reject_duplicate" => Some(RejectDuplicate),
+        "allow_duplicate_failed_only" => Some(AllowDuplicateFailedOnly),
+        "terminate_if_running" => Some(TerminateIfRunning),
+        _ => None,
+    }
+}

--- a/autumn-harvest/src/handle_typed.rs
+++ b/autumn-harvest/src/handle_typed.rs
@@ -181,6 +181,8 @@ pub struct TypedStartOptions {
     /// Soft SLA duration: emits `harvest.workflow.sla_breached` once when the run exceeds this
     /// without terminating it. Overrides `WorkflowInfo::sla`; clamped to `execution_timeout`.
     pub sla: Option<Duration>,
+    /// Optional batch policy for this start request. Overrides `WorkflowInfo::batch`.
+    pub batch: Option<crate::event_batch::BatchPolicy>,
 }
 
 /// Optional configurations when invoking an update and starting a workflow atomically.

--- a/autumn-harvest/src/info.rs
+++ b/autumn-harvest/src/info.rs
@@ -176,6 +176,8 @@ pub struct WorkflowInfo {
     /// fire deadline to `now + window`; exactly one execution is started after the
     /// burst settles. `None` = no debounce; start behavior is byte-for-byte unchanged.
     pub debounce: Option<crate::debounce::DebouncePolicy>,
+    /// Optional batch policy for folding multiple trigger payloads into a single run (issue #518).
+    pub batch: Option<crate::event_batch::BatchPolicy>,
     /// Per-workflow-type override for the workflow-input size cap (issue #252).
     ///
     /// When set, this raises (never lowers) the global `max_workflow_input_bytes`
@@ -228,6 +230,27 @@ impl WorkflowInfo {
     #[must_use]
     pub const fn with_debounce(mut self, policy: crate::debounce::DebouncePolicy) -> Self {
         self.debounce = Some(policy);
+        self
+    }
+
+    /// Attach a batch policy to fold trigger bursts into one run (issue #518).
+    ///
+    /// Fluent builder method — call after the companion function:
+    /// ```rust,ignore
+    /// use autumn_harvest::event_batch::BatchPolicy;
+    /// use std::time::Duration;
+    ///
+    /// .workflows(vec![
+    ///     webhook_handler_info().with_batch(BatchPolicy {
+    ///         key_expr: "input.user_id".to_string(),
+    ///         max_size: 10,
+    ///         max_wait: Duration::from_secs(30),
+    ///     })
+    /// ])
+    /// ```
+    #[must_use]
+    pub fn with_batch(mut self, policy: crate::event_batch::BatchPolicy) -> Self {
+        self.batch = Some(policy);
         self
     }
 
@@ -806,6 +829,7 @@ impl DagInfo {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
             owner: self.owner,
             runbook_url: self.runbook_url,
@@ -828,6 +852,7 @@ impl std::fmt::Debug for WorkflowInfo {
             .field("sla", &self.sla)
             .field("concurrency", &self.concurrency)
             .field("debounce", &self.debounce)
+            .field("batch", &self.batch)
             .field("max_input_bytes", &self.max_input_bytes)
             .field("owner", &self.owner)
             .field("runbook_url", &self.runbook_url)
@@ -931,6 +956,7 @@ mod tests {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
             owner: None,
             runbook_url: None,
@@ -957,6 +983,7 @@ mod tests {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
             owner: None,
             runbook_url: None,
@@ -980,6 +1007,7 @@ mod tests {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
             owner: None,
             runbook_url: None,
@@ -1003,6 +1031,7 @@ mod tests {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
             owner: None,
             runbook_url: None,
@@ -1031,6 +1060,7 @@ mod tests {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
             owner: None,
             runbook_url: None,
@@ -1057,6 +1087,7 @@ mod tests {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
             owner: None,
             runbook_url: None,
@@ -1100,6 +1131,7 @@ mod tests {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
             owner: None,
             runbook_url: None,
@@ -1135,6 +1167,7 @@ mod tests {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
             owner: None,
             runbook_url: None,
@@ -1167,6 +1200,7 @@ mod tests {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
             owner: None,
             runbook_url: None,
@@ -1207,6 +1241,7 @@ mod tests {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
             owner: None,
             runbook_url: None,
@@ -1240,6 +1275,7 @@ mod tests {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
             owner: None,
             runbook_url: None,
@@ -1268,6 +1304,7 @@ mod tests {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
             owner: None,
             runbook_url: None,
@@ -1490,6 +1527,7 @@ mod tests {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
             owner: None,
             runbook_url: None,

--- a/autumn-harvest/src/lib.rs
+++ b/autumn-harvest/src/lib.rs
@@ -84,6 +84,8 @@ pub mod eligibility;
 pub mod erase;
 pub mod error;
 pub mod event;
+/// Event-batched workflow starts — fold many triggers into one batched run (issue #518).
+pub mod event_batch;
 #[cfg(feature = "db")]
 #[doc(hidden)]
 pub mod execution;

--- a/autumn-harvest/src/schema.rs
+++ b/autumn-harvest/src/schema.rs
@@ -560,6 +560,26 @@ diesel::table! {
     }
 }
 
+diesel::table! {
+    use diesel::sql_types::*;
+
+    /// Pending event batch records — one row per `(workflow_name, batch_key)` (issue #518).
+    harvest_event_batches (id) {
+        id                -> Uuid,
+        workflow_name     -> Text,
+        batch_key         -> Text,
+        workflow_id       -> Text,
+        queue_name        -> Text,
+        buffered_payloads -> Jsonb,
+        start_options     -> Jsonb,
+        fire_at           -> Timestamptz,
+        max_size          -> Int4,
+        shard_id          -> Int4,
+        created_at        -> Timestamptz,
+        updated_at        -> Timestamptz,
+    }
+}
+
 diesel::allow_tables_to_appear_in_same_query!(
     harvest_workflow_executions,
     harvest_events,
@@ -583,4 +603,5 @@ diesel::allow_tables_to_appear_in_same_query!(
     harvest_completion_trigger_fires,
     harvest_completion_trigger_outbox,
     harvest_debounce,
+    harvest_event_batches,
 );

--- a/autumn-harvest/src/timeout.rs
+++ b/autumn-harvest/src/timeout.rs
@@ -1571,6 +1571,9 @@ pub async fn enforce_timeouts_once(
     count +=
         crate::debounce::fire_due_debounced_starts(conn, sharded_pool, shard_assignments, metrics)
             .await?;
+    count +=
+        crate::event_batch::fire_due_event_batches(conn, sharded_pool, shard_assignments, metrics)
+            .await?;
     if let Some(ceiling) = max_workflow_history_events {
         count += enforce_workflow_history_ceiling(conn, ceiling, metrics).await?;
     }

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -8819,6 +8819,7 @@ mod tests {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
             owner: None,
             runbook_url: None,

--- a/autumn-harvest/tests/cancellation_tests.rs
+++ b/autumn-harvest/tests/cancellation_tests.rs
@@ -263,6 +263,7 @@ fn heartbeat_registry(probe: HeartbeatCancellationProbe) -> Arc<HandlerRegistry>
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
 
             owner: None,
@@ -669,6 +670,7 @@ fn uncooperative_registry(probe: UncooperativeActivityProbe) -> Arc<HandlerRegis
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
 
             owner: None,

--- a/autumn-harvest/tests/child_policy_tests.rs
+++ b/autumn-harvest/tests/child_policy_tests.rs
@@ -277,6 +277,7 @@ fn wf_info(name: &'static str, handler: autumn_harvest::info::WorkflowHandlerFn)
         concurrency: None,
 
         debounce: None,
+        batch: None,
         max_input_bytes: None,
         owner: None,
         runbook_url: None,
@@ -302,6 +303,7 @@ fn wf_info_with_concurrency(
         concurrency: Some(concurrency),
 
         debounce: None,
+        batch: None,
         max_input_bytes: None,
         owner: None,
         runbook_url: None,

--- a/autumn-harvest/tests/compile_fail/hvg001_wallclock.stderr
+++ b/autumn-harvest/tests/compile_fail/hvg001_wallclock.stderr
@@ -18,14 +18,3 @@ error: [HVG001] Workflow determinism violation: Reading wall-clock time inside a
   |
 7 |     let _ = Local::now();
   |                    ^^^
-
-error[E0433]: failed to resolve: use of undeclared type `Local`
- --> tests/compile_fail/hvg001_wallclock.rs:7:13
-  |
-7 |     let _ = Local::now();
-  |             ^^^^^ use of undeclared type `Local`
-  |
-help: consider importing this struct
-  |
-1 + use chrono::Local;
-  |

--- a/autumn-harvest/tests/compile_fail/hvg002_randomness.stderr
+++ b/autumn-harvest/tests/compile_fail/hvg002_randomness.stderr
@@ -39,15 +39,3 @@ error: [HVG002] Workflow determinism violation: Calling rand::random(), rand::th
    |
 15 |     let _ = rand::random_bool(0.5);
    |                   ^^^^^^^^^^^
-
-error[E0425]: cannot find function `random_range` in crate `rand`
-  --> tests/compile_fail/hvg002_randomness.rs:14:19
-   |
-14 |     let _ = rand::random_range(0..10);
-   |                   ^^^^^^^^^^^^ not found in `rand`
-
-error[E0425]: cannot find function `random_bool` in crate `rand`
-  --> tests/compile_fail/hvg002_randomness.rs:15:19
-   |
-15 |     let _ = rand::random_bool(0.5);
-   |                   ^^^^^^^^^^^ not found in `rand`

--- a/autumn-harvest/tests/concurrency_key_tests.rs
+++ b/autumn-harvest/tests/concurrency_key_tests.rs
@@ -20,6 +20,7 @@ fn workflow_info_has_concurrency_fields() {
         concurrency: None,
 
         debounce: None,
+        batch: None,
         max_input_bytes: None,
 
         owner: None,
@@ -47,6 +48,7 @@ fn workflow_info_with_concurrency_policy() {
         }),
 
         debounce: None,
+        batch: None,
         max_input_bytes: None,
 
         owner: None,

--- a/autumn-harvest/tests/cross_workflow_cancel_tests.rs
+++ b/autumn-harvest/tests/cross_workflow_cancel_tests.rs
@@ -273,6 +273,7 @@ async fn test_same_shard_live_cancel() {
         concurrency: None,
 
         debounce: None,
+        batch: None,
         max_input_bytes: None,
         owner: None,
         runbook_url: None,
@@ -291,6 +292,7 @@ async fn test_same_shard_live_cancel() {
         concurrency: None,
 
         debounce: None,
+        batch: None,
         max_input_bytes: None,
         owner: None,
         runbook_url: None,
@@ -408,6 +410,7 @@ async fn test_already_terminal_target_is_no_op_success() {
                 concurrency: None,
 
                 debounce: None,
+                batch: None,
                 max_input_bytes: None,
                 owner: None,
                 runbook_url: None,
@@ -426,6 +429,7 @@ async fn test_already_terminal_target_is_no_op_success() {
                 concurrency: None,
 
                 debounce: None,
+                batch: None,
                 max_input_bytes: None,
                 owner: None,
                 runbook_url: None,
@@ -554,6 +558,7 @@ async fn test_grace_window_expiry_unknown_target() {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
             owner: None,
             runbook_url: None,
@@ -663,6 +668,7 @@ async fn test_cross_shard_cancel_via_outbox() {
                 concurrency: None,
 
                 debounce: None,
+                batch: None,
                 max_input_bytes: None,
                 owner: None,
                 runbook_url: None,
@@ -681,6 +687,7 @@ async fn test_cross_shard_cancel_via_outbox() {
                 concurrency: None,
 
                 debounce: None,
+                batch: None,
                 max_input_bytes: None,
                 owner: None,
                 runbook_url: None,

--- a/autumn-harvest/tests/cross_workflow_signal_tests.rs
+++ b/autumn-harvest/tests/cross_workflow_signal_tests.rs
@@ -247,6 +247,7 @@ async fn test_same_shard_not_found_retry() {
                 concurrency: None,
 
                 debounce: None,
+                batch: None,
                 max_input_bytes: None,
 
                 owner: None,
@@ -266,6 +267,7 @@ async fn test_same_shard_not_found_retry() {
                 concurrency: None,
 
                 debounce: None,
+                batch: None,
                 max_input_bytes: None,
 
                 owner: None,
@@ -422,6 +424,7 @@ async fn test_cross_shard_outbox_delivery() {
                 concurrency: None,
 
                 debounce: None,
+                batch: None,
                 max_input_bytes: None,
 
                 owner: None,
@@ -441,6 +444,7 @@ async fn test_cross_shard_outbox_delivery() {
                 concurrency: None,
 
                 debounce: None,
+                batch: None,
                 max_input_bytes: None,
 
                 owner: None,
@@ -587,6 +591,7 @@ async fn test_grace_window_expiration() {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
 
             owner: None,
@@ -713,6 +718,7 @@ async fn test_mixed_timer_suspension_signal_wakes_timer() {
                 concurrency: None,
 
                 debounce: None,
+                batch: None,
                 max_input_bytes: None,
 
                 owner: None,
@@ -732,6 +738,7 @@ async fn test_mixed_timer_suspension_signal_wakes_timer() {
                 concurrency: None,
 
                 debounce: None,
+                batch: None,
                 max_input_bytes: None,
 
                 owner: None,

--- a/autumn-harvest/tests/dag_unified_tests.rs
+++ b/autumn-harvest/tests/dag_unified_tests.rs
@@ -630,6 +630,7 @@ fn builder_rejects_workflow_name_collision_with_auto_registered_dag() {
         concurrency: None,
 
         debounce: None,
+        batch: None,
         max_input_bytes: None,
 
         owner: None,

--- a/autumn-harvest/tests/delayed_start_tests.rs
+++ b/autumn-harvest/tests/delayed_start_tests.rs
@@ -136,6 +136,7 @@ fn delay_registry() -> Arc<HandlerRegistry> {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
 
             owner: None,

--- a/autumn-harvest/tests/event_batch_tests.rs
+++ b/autumn-harvest/tests/event_batch_tests.rs
@@ -1,0 +1,209 @@
+#![cfg(feature = "db")]
+#![allow(
+    clippy::doc_markdown,
+    clippy::cast_possible_wrap,
+    clippy::cast_possible_truncation,
+    clippy::cast_sign_loss,
+    clippy::items_after_statements,
+    clippy::default_trait_access,
+    clippy::significant_drop_tightening
+)]
+
+use diesel_async::AsyncPgConnection;
+use diesel_async::RunQueryDsl;
+use diesel_async::SimpleAsyncConnection;
+use serde_json::json;
+use std::time::Duration;
+use testcontainers::ContainerAsync;
+use testcontainers::ImageExt;
+use testcontainers_modules::postgres::Postgres;
+use testcontainers_modules::testcontainers::runners::AsyncRunner;
+
+use autumn_harvest::debounce::DebounceStartOptions;
+use autumn_harvest::event_batch::{AdmitBatchParams, admit_batched_start, fire_due_event_batches};
+use autumn_harvest::telemetry::NoOpMetrics;
+
+const INIT_SQL: &str = concat!(
+    include_str!("../migrations/20260409000000_harvest_initial/up.sql"),
+    "\n",
+    include_str!("../migrations/20260424000001_harvest_trace_context/up.sql"),
+    "\n",
+    include_str!("../migrations/20260505000000_harvest_heartbeat_details/up.sql"),
+    "\n",
+    include_str!("../migrations/20260427000000_harvest_continue_as_new/up.sql"),
+    "\n",
+    include_str!("../migrations/20260429000000_harvest_concurrency_key/up.sql"),
+    "\n",
+    include_str!("../migrations/20260430000000_harvest_workflow_schedules/up.sql"),
+    "\n",
+    include_str!("../migrations/20260430000001_harvest_external_tasks/up.sql"),
+    "\n",
+    include_str!("../migrations/20260508000000_harvest_external_task_updated_at/up.sql"),
+    "\n",
+    include_str!("../migrations/20260506000000_harvest_audit_log/up.sql"),
+    "\n",
+    include_str!("../migrations/20260501000000_harvest_workers/up.sql"),
+    "\n",
+    include_str!("../migrations/20260508010000_harvest_workers_drain_deadline/up.sql"),
+    "\n",
+    include_str!("../migrations/20260509000000_harvest_build_routing/up.sql"),
+    "\n",
+    include_str!("../migrations/20260513000000_harvest_schedule_pause_metadata/up.sql"),
+    "\n",
+    include_str!("../migrations/20260514020000_harvest_task_activity_id/up.sql"),
+    "\n",
+    include_str!("../migrations/20260518000000_harvest_signal_idempotency/up.sql"),
+    "\n",
+    include_str!("../migrations/20260517000000_harvest_schedule_jitter/up.sql"),
+    "\n",
+    include_str!("../migrations/20260517000001_harvest_schedule_overlap_policy/up.sql"),
+    "\n",
+    include_str!("../migrations/20260518000001_harvest_workflow_execution_timeout/up.sql"),
+    "\n",
+    include_str!("../migrations/20260613000000_harvest_workflow_sla/up.sql"),
+    "\n",
+    include_str!("../migrations/20260519000000_harvest_calendar_awareness/up.sql"),
+    "\n",
+    include_str!("../migrations/20260522000000_harvest_schedule_decisions/up.sql"),
+    "\n",
+    include_str!("../migrations/20260522000001_harvest_rate_limiting/up.sql"),
+    "\n",
+    include_str!("../migrations/20260526000001_harvest_parent_close_policy/up.sql"),
+    "\n",
+    include_str!("../migrations/20260530000000_harvest_schedule_ha_claim/up.sql"),
+    "\n",
+    include_str!("../migrations/20260601000000_harvest_schedule_auto_pause/up.sql"),
+    "\n",
+    include_str!("../migrations/20260601000001_harvest_poison_pill_strikes/up.sql"),
+    "\n",
+    include_str!("../migrations/20260601000002_harvest_ownership_metadata/up.sql"),
+    "\n",
+    include_str!("../migrations/20260603000000_harvest_completion_triggers/up.sql"),
+    "\n",
+    include_str!("../migrations/20260605000000_harvest_admission_gates/up.sql"),
+    "\n",
+    include_str!("../migrations/20260606000001_harvest_activity_schedule_to_close/up.sql"),
+    "\n",
+    include_str!("../migrations/20260607000000_harvest_worker_capability_labels/up.sql"),
+    "\n",
+    include_str!("../migrations/20260607000001_harvest_task_required_capabilities/up.sql"),
+    "\n",
+    include_str!("../migrations/20260607000002_harvest_workflow_pause/up.sql"),
+    "\n",
+    include_str!("../migrations/20260609000001_harvest_workflow_current_details/up.sql"),
+    "\n",
+    include_str!("../migrations/20260610000001_harvest_schedule_bounded_runs/up.sql"),
+    "\n",
+    include_str!("../migrations/20260613000001_harvest_schedule_catchup_window/up.sql"),
+    "\n",
+    include_str!("../migrations/20260616000001_harvest_workflow_schedule_id/up.sql"),
+    "\n",
+    include_str!("../migrations/20260615000001_harvest_context_headers/up.sql"),
+    "\n",
+    include_str!("../migrations/20260618000001_harvest_debounce/up.sql"),
+    "\n",
+    include_str!("../migrations/20260624000000_harvest_event_batches/up.sql"),
+);
+
+async fn setup_db() -> (AsyncPgConnection, ContainerAsync<Postgres>) {
+    let container = Postgres::default()
+        .with_tag("16")
+        .start()
+        .await
+        .expect("postgres start");
+    let host = container.get_host().await.expect("host");
+    let port = container.get_host_port_ipv4(5432).await.expect("port");
+    let url = format!("postgresql://postgres:postgres@{host}:{port}/postgres");
+
+    let mut conn = <AsyncPgConnection as diesel_async::AsyncConnection>::establish(&url)
+        .await
+        .expect("connect");
+    conn.batch_execute(INIT_SQL).await.expect("migrations");
+
+    (conn, container)
+}
+
+#[tokio::test]
+async fn test_event_batch_accumulation_and_size_flush() {
+    let (mut conn, _container) = setup_db().await;
+
+    // Call 1
+    let p1 = AdmitBatchParams {
+        workflow_name: "test_batch".to_string(),
+        batch_key: "key-1".to_string(),
+        workflow_id: "wf-1".to_string(),
+        queue_name: "default".to_string(),
+        payload: json!({"val": 1}),
+        start_options: DebounceStartOptions::default(),
+        max_wait: Duration::from_secs(10),
+        max_size: 3,
+        shard_id: 0,
+    };
+    let (o1, _deferred_starts1) = admit_batched_start(&mut conn, p1).await.unwrap().unwrap();
+    assert_eq!(o1.pending_count, 1);
+    assert!(!o1.is_flushed);
+
+    // Call 2
+    let p2 = AdmitBatchParams {
+        workflow_name: "test_batch".to_string(),
+        batch_key: "key-1".to_string(),
+        workflow_id: "wf-1".to_string(),
+        queue_name: "default".to_string(),
+        payload: json!({"val": 2}),
+        start_options: DebounceStartOptions::default(),
+        max_wait: Duration::from_secs(10),
+        max_size: 3,
+        shard_id: 0,
+    };
+    let (o2, _deferred_starts2) = admit_batched_start(&mut conn, p2).await.unwrap().unwrap();
+    assert_eq!(o2.pending_count, 2);
+    assert!(!o2.is_flushed);
+
+    // Call 3 (should trigger immediate size flush)
+    let p3 = AdmitBatchParams {
+        workflow_name: "test_batch".to_string(),
+        batch_key: "key-1".to_string(),
+        workflow_id: "wf-1".to_string(),
+        queue_name: "default".to_string(),
+        payload: json!({"val": 3}),
+        start_options: DebounceStartOptions::default(),
+        max_wait: Duration::from_secs(10),
+        max_size: 3,
+        shard_id: 0,
+    };
+    let (o3, _deferred_starts3) = admit_batched_start(&mut conn, p3).await.unwrap().unwrap();
+    assert_eq!(o3.pending_count, 3);
+    assert!(o3.is_flushed);
+    assert!(o3.flushed_execution_id.is_some());
+}
+
+#[tokio::test]
+async fn test_event_batch_time_flush() {
+    let (mut conn, _container) = setup_db().await;
+
+    let p = AdmitBatchParams {
+        workflow_name: "test_time_batch".to_string(),
+        batch_key: "key-1".to_string(),
+        workflow_id: "wf-2".to_string(),
+        queue_name: "default".to_string(),
+        payload: json!({"val": 100}),
+        start_options: DebounceStartOptions::default(),
+        max_wait: Duration::from_secs(10),
+        max_size: 5,
+        shard_id: 0,
+    };
+    let (o, _deferred_starts) = admit_batched_start(&mut conn, p).await.unwrap().unwrap();
+    assert_eq!(o.pending_count, 1);
+    assert!(!o.is_flushed);
+
+    // Update fire_at to be in the past
+    diesel::sql_query("UPDATE harvest_event_batches SET fire_at = NOW() - INTERVAL '1 minute'")
+        .execute(&mut conn)
+        .await
+        .unwrap();
+
+    let fired = fire_due_event_batches(&mut conn, &None, &[], &NoOpMetrics)
+        .await
+        .unwrap();
+    assert_eq!(fired, 1);
+}

--- a/autumn-harvest/tests/integration_e2e.rs
+++ b/autumn-harvest/tests/integration_e2e.rs
@@ -797,6 +797,7 @@ fn child_round_trip_registry() -> Arc<HandlerRegistry> {
                 concurrency: None,
 
                 debounce: None,
+                batch: None,
                 max_input_bytes: None,
 
                 owner: None,
@@ -816,6 +817,7 @@ fn child_round_trip_registry() -> Arc<HandlerRegistry> {
                 concurrency: None,
 
                 debounce: None,
+                batch: None,
                 max_input_bytes: None,
 
                 owner: None,
@@ -843,6 +845,7 @@ fn child_continue_as_new_rejection_registry() -> Arc<HandlerRegistry> {
                 concurrency: None,
 
                 debounce: None,
+                batch: None,
                 max_input_bytes: None,
 
                 owner: None,
@@ -862,6 +865,7 @@ fn child_continue_as_new_rejection_registry() -> Arc<HandlerRegistry> {
                 concurrency: None,
 
                 debounce: None,
+                batch: None,
                 max_input_bytes: None,
 
                 owner: None,
@@ -1343,6 +1347,7 @@ async fn worker_completes_workflow_task_and_persists_result() {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
 
             owner: None,
@@ -1468,6 +1473,7 @@ async fn worker_marks_workflow_failed_when_handler_errors() {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
 
             owner: None,
@@ -1606,6 +1612,7 @@ async fn worker_completes_workflow_with_activity_round_trip() {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
 
             owner: None,
@@ -1762,6 +1769,7 @@ async fn activity_retry_resumes_from_persisted_heartbeat_details() {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
 
             owner: None,
@@ -2153,6 +2161,7 @@ async fn worker_fails_workflow_when_activity_start_to_close_timeout_elapses() {
                     concurrency: None,
 
                     debounce: None,
+                    batch: None,
                     max_input_bytes: None,
 
                     owner: None,
@@ -2312,6 +2321,7 @@ async fn worker_completes_workflow_with_timer_round_trip() {
                     concurrency: None,
 
                     debounce: None,
+                    batch: None,
                     max_input_bytes: None,
 
                     owner: None,
@@ -2579,6 +2589,7 @@ fn parallel_children_registry() -> Arc<HandlerRegistry> {
                 concurrency: None,
 
                 debounce: None,
+                batch: None,
                 max_input_bytes: None,
 
                 owner: None,
@@ -2598,6 +2609,7 @@ fn parallel_children_registry() -> Arc<HandlerRegistry> {
                 concurrency: None,
 
                 debounce: None,
+                batch: None,
                 max_input_bytes: None,
 
                 owner: None,
@@ -2617,6 +2629,7 @@ fn parallel_children_registry() -> Arc<HandlerRegistry> {
                 concurrency: None,
 
                 debounce: None,
+                batch: None,
                 max_input_bytes: None,
 
                 owner: None,
@@ -2750,6 +2763,7 @@ async fn worker_builder_state_is_visible_to_workflow_and_activity() {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
 
             owner: None,
@@ -3263,6 +3277,7 @@ async fn worker_completes_workflow_after_signal_delivery() {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
 
             owner: None,
@@ -3388,6 +3403,7 @@ async fn worker_handles_early_ingested_signal_before_activity() {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
 
             owner: None,
@@ -3831,6 +3847,7 @@ async fn worker_continues_as_new_with_fresh_history_and_same_workflow_id() {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
 
             owner: None,
@@ -3942,6 +3959,7 @@ async fn continue_as_new_down_migration_rewrites_historical_runs_for_rollback() 
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
 
             owner: None,
@@ -4860,6 +4878,7 @@ async fn workflow_schedule_baseline_dispatches_multiple_runs() {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
 
             owner: None,
@@ -4981,6 +5000,7 @@ async fn workflow_schedule_max_active_runs_enforced() {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
 
             owner: None,
@@ -5089,6 +5109,7 @@ async fn workflow_schedule_pause_and_resume() {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
 
             owner: None,
@@ -5376,6 +5397,7 @@ async fn search_attrs_upsert_visible_after_update_and_filterable() {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
 
             owner: None,
@@ -5537,6 +5559,7 @@ async fn search_attrs_survive_worker_crash_and_resume() {
                 concurrency: None,
 
                 debounce: None,
+                batch: None,
                 max_input_bytes: None,
 
                 owner: None,
@@ -5638,6 +5661,7 @@ fn workflow_schedule_builder_rejects_unregistered_workflow() {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
 
             owner: None,
@@ -5998,6 +6022,7 @@ async fn non_retryable_activity_fails_fast_on_attempt_one() {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
 
             owner: None,
@@ -6150,6 +6175,7 @@ async fn circuit_breaker_short_circuits_after_tripping() {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
             owner: None,
             runbook_url: None,
@@ -6284,6 +6310,7 @@ async fn legacy_string_failure_in_non_retryable_errors_fails_fast() {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
 
             owner: None,
@@ -6434,6 +6461,7 @@ async fn overlap_policy_skip_explicitly_drops_new_firings() {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
 
             owner: None,
@@ -6507,6 +6535,7 @@ async fn overlap_policy_buffer_one_queues_single_slot() {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
 
             owner: None,
@@ -6589,6 +6618,7 @@ async fn overlap_policy_buffer_all_queues_multiple_slots() {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
 
             owner: None,
@@ -6675,6 +6705,7 @@ async fn overlap_policy_cancel_other_cancels_inflight_run() {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
 
             owner: None,
@@ -6756,6 +6787,7 @@ async fn overlap_policy_terminate_other_terminates_inflight_run() {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
 
             owner: None,
@@ -6841,6 +6873,7 @@ async fn overlap_policy_buffer_one_survives_scheduler_restart() {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
 
             owner: None,
@@ -7451,6 +7484,7 @@ async fn activity_context_exposes_attempt_and_previous_failure_on_retry() {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
             owner: None,
             runbook_url: None,

--- a/autumn-harvest/tests/macros_query_handlers.rs
+++ b/autumn-harvest/tests/macros_query_handlers.rs
@@ -434,6 +434,7 @@ pub mod flows {
                 concurrency: None,
 
                 debounce: None,
+                batch: None,
                 max_input_bytes: None,
                 owner: None,
                 runbook_url: None,
@@ -489,6 +490,7 @@ pub mod relative_test_self {
                     concurrency: None,
 
                     debounce: None,
+                    batch: None,
                     max_input_bytes: None,
                     owner: None,
                     runbook_url: None,
@@ -532,6 +534,7 @@ pub mod relative_test_super {
                     concurrency: None,
 
                     debounce: None,
+                    batch: None,
                     max_input_bytes: None,
                     owner: None,
                     runbook_url: None,
@@ -579,6 +582,7 @@ pub mod relative_test_plain {
                     concurrency: None,
 
                     debounce: None,
+                    batch: None,
                     max_input_bytes: None,
                     owner: None,
                     runbook_url: None,

--- a/autumn-harvest/tests/metrics_integration.rs
+++ b/autumn-harvest/tests/metrics_integration.rs
@@ -713,6 +713,7 @@ async fn workflow_and_activity_metrics_are_recorded() {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
 
             owner: None,
@@ -930,6 +931,7 @@ async fn continue_as_new_records_history_size_and_rotation_metrics() {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
 
             owner: None,
@@ -1067,6 +1069,7 @@ async fn workflow_hard_cap_moves_offender_to_dlq() {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
 
             owner: None,
@@ -1211,6 +1214,7 @@ async fn workflow_hard_cap_dlq_preserves_terminal_attempt_count() {
                 concurrency: None,
 
                 debounce: None,
+                batch: None,
                 max_input_bytes: None,
 
                 owner: None,
@@ -1356,6 +1360,7 @@ async fn suspended_commands_that_reach_hard_cap_move_to_dlq_immediately() {
                 concurrency: None,
 
                 debounce: None,
+                batch: None,
                 max_input_bytes: None,
 
                 owner: None,
@@ -1375,6 +1380,7 @@ async fn suspended_commands_that_reach_hard_cap_move_to_dlq_immediately() {
                 concurrency: None,
 
                 debounce: None,
+                batch: None,
                 max_input_bytes: None,
 
                 owner: None,
@@ -1569,6 +1575,7 @@ async fn local_activity_retries_stop_when_hard_cap_is_reached() {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
 
             owner: None,
@@ -1741,6 +1748,7 @@ async fn detached_parent_close_cascade_counts_against_history_cap() {
                 concurrency: None,
 
                 debounce: None,
+                batch: None,
                 max_input_bytes: None,
 
                 owner: None,
@@ -1760,6 +1768,7 @@ async fn detached_parent_close_cascade_counts_against_history_cap() {
                 concurrency: None,
 
                 debounce: None,
+                batch: None,
                 max_input_bytes: None,
 
                 owner: None,
@@ -1924,6 +1933,7 @@ async fn child_hard_cap_dlq_notifies_parent_and_stops_inline_growth() {
                 concurrency: None,
 
                 debounce: None,
+                batch: None,
                 max_input_bytes: None,
 
                 owner: None,
@@ -1943,6 +1953,7 @@ async fn child_hard_cap_dlq_notifies_parent_and_stops_inline_growth() {
                 concurrency: None,
 
                 debounce: None,
+                batch: None,
                 max_input_bytes: None,
 
                 owner: None,
@@ -2249,6 +2260,7 @@ async fn workflow_non_determinism_metric_and_search_attrs_are_recorded() {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
 
             owner: None,
@@ -2455,6 +2467,7 @@ async fn schedule_to_start_histogram_emitted_at_dispatch() {
             sla: None,
             concurrency: None,
             debounce: None,
+            batch: None,
             max_input_bytes: None,
             owner: None,
             runbook_url: None,

--- a/autumn-harvest/tests/pause_tests.rs
+++ b/autumn-harvest/tests/pause_tests.rs
@@ -153,6 +153,7 @@ fn wf_info(name: &'static str, handler: autumn_harvest::info::WorkflowHandlerFn)
         concurrency: None,
 
         debounce: None,
+        batch: None,
         max_input_bytes: None,
         owner: None,
         runbook_url: None,

--- a/autumn-harvest/tests/payload_cap_tests.rs
+++ b/autumn-harvest/tests/payload_cap_tests.rs
@@ -54,6 +54,7 @@ fn fake_workflow_info(name: &'static str) -> WorkflowInfo {
         concurrency: None,
 
         debounce: None,
+        batch: None,
         max_input_bytes: None,
         owner: None,
         runbook_url: None,
@@ -236,6 +237,7 @@ fn workflow_info_has_max_input_bytes_field() {
         concurrency: None,
 
         debounce: None,
+        batch: None,
         max_input_bytes: None,
 
         owner: None,
@@ -257,6 +259,7 @@ fn workflow_info_has_max_input_bytes_field() {
         concurrency: None,
 
         debounce: None,
+        batch: None,
         max_input_bytes: Some(8 * 1024 * 1024),
 
         owner: None,

--- a/autumn-harvest/tests/scheduled_time_tests.rs
+++ b/autumn-harvest/tests/scheduled_time_tests.rs
@@ -180,6 +180,7 @@ fn make_registry(wf_name: &'static str) -> Arc<HandlerRegistry> {
             execution_timeout: None,
             concurrency: None,
             debounce: None,
+            batch: None,
             max_input_bytes: None,
             owner: None,
             runbook_url: None,
@@ -231,7 +232,7 @@ fn make_worker(worker_id: &str, registry: Arc<HandlerRegistry>) -> Arc<Worker> {
 
 /// Wait until at least `min_count` executions of `wf_name` reach `state`.
 async fn wait_for_state(url: &str, wf_name: &str, state: &str, min_count: usize) -> Vec<Uuid> {
-    tokio::time::timeout(Duration::from_secs(15), async {
+    tokio::time::timeout(Duration::from_secs(45), async {
         loop {
             let mut conn = AsyncPgConnection::establish(url).await.expect("connect");
             let rows: Vec<Uuid> = harvest_workflow_executions::table

--- a/autumn-harvest/tests/scheduler_auto_pause_tests.rs
+++ b/autumn-harvest/tests/scheduler_auto_pause_tests.rs
@@ -164,6 +164,7 @@ fn make_registry(workflow_name: &'static str) -> Arc<HandlerRegistry> {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
 
             owner: None,

--- a/autumn-harvest/tests/scheduler_bounded_runs_tests.rs
+++ b/autumn-harvest/tests/scheduler_bounded_runs_tests.rs
@@ -197,6 +197,7 @@ fn make_registry(workflow_name: &'static str) -> Arc<HandlerRegistry> {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
             owner: None,
             runbook_url: None,

--- a/autumn-harvest/tests/scheduler_carryover_tests.rs
+++ b/autumn-harvest/tests/scheduler_carryover_tests.rs
@@ -225,6 +225,7 @@ fn make_registry_for(
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
             owner: None,
             runbook_url: None,
@@ -278,7 +279,7 @@ fn make_worker(worker_id: &str, registry: Arc<HandlerRegistry>) -> Arc<Worker> {
 /// Waits until at least one execution with the given workflow_name reaches the
 /// expected state. Returns the execution id.
 async fn wait_for_state(url: &str, wf_name: &str, state: &str, min_count: i64) -> Vec<Uuid> {
-    tokio::time::timeout(Duration::from_secs(15), async {
+    tokio::time::timeout(Duration::from_secs(45), async {
         loop {
             let mut conn = AsyncPgConnection::establish(url).await.expect("connect");
             let rows: Vec<Uuid> = harvest_workflow_executions::table

--- a/autumn-harvest/tests/scheduler_catchup_tests.rs
+++ b/autumn-harvest/tests/scheduler_catchup_tests.rs
@@ -198,6 +198,7 @@ fn make_registry(workflow_name: &'static str) -> Arc<HandlerRegistry> {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
             owner: None,
             runbook_url: None,

--- a/autumn-harvest/tests/scheduler_ha_tests.rs
+++ b/autumn-harvest/tests/scheduler_ha_tests.rs
@@ -173,6 +173,7 @@ fn make_registry(workflow_name: &'static str) -> Arc<HandlerRegistry> {
             concurrency: None,
 
             debounce: None,
+            batch: None,
             max_input_bytes: None,
 
             owner: None,

--- a/autumn-harvest/tests/telemetry_span_tests.rs
+++ b/autumn-harvest/tests/telemetry_span_tests.rs
@@ -232,6 +232,7 @@ fn build_registry() -> Arc<HandlerRegistry> {
                 concurrency: None,
 
                 debounce: None,
+                batch: None,
                 max_input_bytes: None,
 
                 owner: None,
@@ -251,6 +252,7 @@ fn build_registry() -> Arc<HandlerRegistry> {
                 concurrency: None,
 
                 debounce: None,
+                batch: None,
                 max_input_bytes: None,
 
                 owner: None,

--- a/docs/api-contract.json
+++ b/docs/api-contract.json
@@ -148,7 +148,8 @@
           "history",
           "external_handoffs",
           "last_completion_result",
-          "last_error"
+          "last_error",
+          "scheduled_time"
         ]
       },
       "error_responses": [
@@ -431,12 +432,27 @@
             "name": "delay",
             "required": false,
             "description": "Delay duration before starting the workflow (e.g. \"10s\", \"5m\")."
+          },
+          {
+            "name": "batch_key",
+            "required": false,
+            "description": "Optional event batching group key. Fold trigger starts into a single run inputting a JSON array of all payloads."
+          },
+          {
+            "name": "batch_max_size",
+            "required": false,
+            "description": "Maximum batch size to trigger immediate flush."
+          },
+          {
+            "name": "batch_max_wait",
+            "required": false,
+            "description": "Maximum wait duration from first trigger before flushing the batch (e.g. \"30s\", \"5m\")."
           }
         ]
       },
       "success_response": {
         "status": 201,
-        "note": "Returns 200 when an existing execution is returned via reuse_policy instead of creating a new one. Returns 202 Accepted with {debounced, workflow_name, workflow_id, debounce_key, fire_at, pending_count} (and no execution_id) when the workflow declares a debounce policy whose key resolves (issue #499) — the run is deferred until the quiet window elapses.",
+        "note": "Returns 200 when an existing execution is returned via reuse_policy instead of creating a new one. Returns 202 Accepted with {debounced, workflow_name, workflow_id, debounce_key, fire_at, pending_count} (and no execution_id) when the workflow declares a debounce policy whose key resolves (issue #499). Returns 202 Accepted with {batched, flushed, workflow_name, workflow_id, batch_key, fire_at, pending_count, max_size} when the workflow declares a batch policy.",
         "fields": [
           "execution_id",
           "workflow_name",
@@ -445,7 +461,11 @@
           "debounced",
           "debounce_key",
           "fire_at",
-          "pending_count"
+          "pending_count",
+          "batched",
+          "flushed",
+          "batch_key",
+          "max_size"
         ]
       },
       "error_responses": [
@@ -3012,6 +3032,25 @@
       "category": "admin",
       "read_only": true,
       "description": "Return all pending debounce records across all shards. Each record represents a burst of triggers for a (workflow_name, debounce_key) that has not yet fired. Fields: workflow_name, debounce_key, workflow_id, queue_name, effective_fire_at (current projected deadline), max_fire_at (cap), pending_count (number of admitted requests), shard_id, created_at, updated_at.",
+      "params": [],
+      "request_body": null,
+      "success_response": {
+        "status": 200,
+        "free_form": true
+      },
+      "error_responses": [
+        {
+          "status": 500,
+          "description": "Database error."
+        }
+      ]
+    },
+    {
+      "method": "GET",
+      "path": "/batches/pending",
+      "category": "workflow",
+      "read_only": true,
+      "description": "Return all pending event batch records across all shards. Each record represents a pending batch of start triggers for a (workflow_name, batch_key) that has not yet fired. Fields: workflow_name, batch_key, workflow_id, queue_name, current_size, max_size, fire_at (projected deadline), shard_id, created_at, updated_at.",
       "params": [],
       "request_body": null,
       "success_response": {


### PR DESCRIPTION
### Goal Description
Refined the event batching implementation based on the security, performance, and database system reviews to enforce client parameter caps, optimize wire payloads, and safely defer trigger spawning until after database transaction commit.

### Proposed Changes
- **HTTP/API Layer (`api.rs`)**:
  - Enforced client parameter limits (`batch_max_size` in `1..=1000`, and `batch_max_wait` $\le 24$ hours).
  - Resolved `batch_key` using a clean Option pipeline (`or_else` / `and_then`) to avoid clippy warnings.
  - Spawned deferred triggers (`start.spawn()`) strictly **post-transaction** (after the audit record is successfully written to the database), preventing side-effect leakage.
  - Re-allocated parameters as owned to eliminate clones.
- **Core Engine (`event_batch.rs`)**:
  - Refactored dynamic SQL binding loops to execute statically-typed query chains.
  - Replaced mutable scanner variables with a single let-if expression.
  - Marked `is_transient_error` as `const fn`.
- **Test Suite (`event_batch_tests.rs`)**:
  - Updated parameters to construct owned strings and unpack the returned tuple.

### Verification Results
- Core event batching unit tests passed (`cargo test -p autumn-harvest --test event_batch_tests`).
- Plugin integration tests passed (`cargo test -p autumn-harvest-plugin`).
- Workspace is fully clippy warning-free (`cargo clippy --workspace --all-targets --all-features`).