### PR TITLE
Completion triggers: fire metrics, outbox, and documentation

### DIFF
--- a/autumn-harvest-plugin/tests/completion_triggers_integration.rs
+++ b/autumn-harvest-plugin/tests/completion_triggers_integration.rs
@@ -2308,8 +2308,8 @@ async fn test_trigger_evaluations_schema_validation() {
 /// trigger id.
 #[tokio::test]
 async fn test_trigger_emits_fire_metric_outcomes() {
-    /// Minimal capturing `MetricsRecorder` — records only the completion-trigger
-    /// fire outcomes (all other trait methods keep their no-op defaults).
+    // Minimal capturing MetricsRecorder — records only the completion-trigger
+    // fire outcomes (all other trait methods keep their no-op defaults).
     #[derive(Default)]
     struct CapturingMetrics {
         fires: std::sync::Mutex<Vec<(String, String)>>,

--- a/autumn-harvest-plugin/tests/completion_triggers_integration.rs
+++ b/autumn-harvest-plugin/tests/completion_triggers_integration.rs
@@ -2299,3 +2299,138 @@ async fn test_trigger_evaluations_schema_validation() {
         .unwrap();
     assert!(target_exec_invalid.is_none());
 }
+
+/// AC #6 (issue #517): a per-trigger fire counter/metric
+/// (`harvest.completion_trigger.fires{trigger, outcome}`) is emitted so
+/// operators can confirm wiring. This drives the completion path twice and
+/// asserts the recorder observes `started` on the first evaluation and
+/// `deduped` on the (idempotent) second evaluation, both tagged with the
+/// trigger id.
+#[tokio::test]
+async fn test_trigger_emits_fire_metric_outcomes() {
+    /// Minimal capturing `MetricsRecorder` — records only the completion-trigger
+    /// fire outcomes (all other trait methods keep their no-op defaults).
+    #[derive(Default)]
+    struct CapturingMetrics {
+        fires: std::sync::Mutex<Vec<(String, String)>>,
+    }
+    impl autumn_harvest::telemetry::MetricsRecorder for CapturingMetrics {
+        fn record_completion_trigger_fired(&self, trigger_id: &str, outcome: &str) {
+            self.fires
+                .lock()
+                .unwrap()
+                .push((trigger_id.to_string(), outcome.to_string()));
+        }
+    }
+
+    let _lock = TEST_MUTEX
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let (url, _container) = setup_database().await;
+    let pool = build_pool(&url);
+    let app = build_app(&pool);
+    let mut conn = pool.get().await.unwrap();
+
+    let trigger_id = uuid::Uuid::new_v4();
+    post_json(
+        &app,
+        "/admin/completion-triggers",
+        json!({
+            "id": trigger_id,
+            "source_workflow_name": "source_wf",
+            "terminal_states": ["Completed"],
+            "target_workflow_name": "target_wf",
+            "input_mapping": {"type": "Passthrough"}
+        }),
+    )
+    .await;
+
+    // Start + complete a source workflow.
+    let source_exec_id = ExecutionId::new_for_shard(ShardId::new(0));
+    start_or_load_workflow_execution(
+        &mut conn,
+        StartWorkflowParams {
+            workflow_name: "source_wf",
+            workflow_id: "source-metric",
+            exec_id: source_exec_id,
+            input: json!({"hello": "metric"}),
+            parent_id: None,
+            queue_name: "default",
+            execution_timeout: None,
+            memo: None,
+            search_attrs: None,
+            reuse_policy: autumn_harvest::WorkflowIdReusePolicy::AllowDuplicate,
+            trace_context: None,
+            max_execution_timeout_ceiling: None,
+            concurrency_key: None,
+            concurrency_limit: None,
+            priority: Priority::default(),
+            max_workflow_input_bytes: 0,
+            start_at: None,
+            delay: None,
+            max_workflow_start_delay: None,
+            owner: None,
+            runbook_url: None,
+            severity: None,
+            context_headers: None,
+            sla: None,
+            schedule_id: None,
+            scheduled_for: None,
+        },
+    )
+    .await
+    .unwrap();
+
+    diesel::update(harvest_workflow_executions::table.find(source_exec_id.as_uuid()))
+        .set((
+            harvest_workflow_executions::state.eq("COMPLETED"),
+            harvest_workflow_executions::output.eq(Some(json!({"result": "done"}))),
+            harvest_workflow_executions::completed_at.eq(Some(chrono::Utc::now())),
+        ))
+        .execute(&mut conn)
+        .await
+        .unwrap();
+
+    let metrics = CapturingMetrics::default();
+
+    // First evaluation: the target is started → outcome "started".
+    evaluate_triggers_for_execution(
+        &mut conn,
+        source_exec_id,
+        TerminalState::Completed,
+        Some(&metrics),
+    )
+    .await
+    .unwrap();
+
+    // Second evaluation of the same (source_exec_id, trigger_id): the dedupe
+    // ledger short-circuits → outcome "deduped". No second target is started.
+    evaluate_triggers_for_execution(
+        &mut conn,
+        source_exec_id,
+        TerminalState::Completed,
+        Some(&metrics),
+    )
+    .await
+    .unwrap();
+
+    let fires = metrics.fires.lock().unwrap().clone();
+    assert_eq!(
+        fires,
+        vec![
+            (trigger_id.to_string(), "started".to_string()),
+            (trigger_id.to_string(), "deduped".to_string()),
+        ],
+        "expected one `started` then one `deduped` fire metric for the trigger, got {fires:?}"
+    );
+
+    // Belt-and-suspenders: exactly one target execution exists despite two evals.
+    let target_workflow_id = format!("completion-trigger-{}-{}", trigger_id, source_exec_id);
+    let target_count: i64 = harvest_workflow_executions::table
+        .filter(harvest_workflow_executions::workflow_id.eq(&target_workflow_id))
+        .count()
+        .get_result(&mut conn)
+        .await
+        .unwrap();
+    assert_eq!(target_count, 1);
+}

--- a/autumn-harvest/examples/completion_triggers.rs
+++ b/autumn-harvest/examples/completion_triggers.rs
@@ -103,7 +103,10 @@ fn main() {
         InputMapping::Projection(path) => project_json_path(&source_output, path),
     };
     println!("\nProjected `daily_report` input: {target_input}");
-    assert_eq!(target_input, json!({ "rows": 12_000, "date": "2026-06-24" }));
+    assert_eq!(
+        target_input,
+        json!({ "rows": 12_000, "date": "2026-06-24" })
+    );
 
     // The deterministic target workflow id makes duplicate fires collapse.
     let source_exec_id = "0000abcd-0000-0000-0000-000000000001";

--- a/autumn-harvest/examples/completion_triggers.rs
+++ b/autumn-harvest/examples/completion_triggers.rs
@@ -1,0 +1,119 @@
+#![allow(clippy::all, clippy::pedantic, clippy::nursery)]
+//! Declarative completion triggers — two-stage ETL → reporting (issue #517).
+//!
+//! Run workflow **B** *because* workflow **A** finished — without A knowing B
+//! exists. This decouples multi-stage pipelines: no clock-offset races, and no
+//! hard-coding the downstream stage as a child spawn inside the upstream code.
+//!
+//! ## The pipeline
+//!
+//! - **Stage 1 — `etl_ingest`**: runs on whatever cadence you like and returns an
+//!   output such as `{ "summary": { "rows": 12000, "date": "2026-06-24" }, ... }`.
+//! - **Stage 2 — `daily_report`**: must run the moment `etl_ingest` *completes*,
+//!   receiving just the `summary` sub-object as its input.
+//!
+//! Wiring this dependency touches neither workflow's body — it is a single
+//! declarative `CompletionTrigger` registration:
+//!
+//! ```rust
+//! use autumn_harvest::prelude::*;
+//! use autumn_harvest::completion_trigger::{CompletionTrigger, InputMapping, TerminalState};
+//! use serde::{Deserialize, Serialize};
+//!
+//! #[derive(Debug, Serialize, Deserialize)]
+//! struct Summary { rows: u64, date: String }
+//!
+//! #[derive(Debug, Serialize, Deserialize)]
+//! struct IngestOutput { summary: Summary }
+//!
+//! // Stage 1: the upstream ingest. It knows nothing about reporting.
+//! #[workflow]
+//! async fn etl_ingest(_ctx: &WorkflowContext, _input: ()) -> Result<IngestOutput, String> {
+//!     // ... pull, transform, load ...
+//!     Ok(IngestOutput { summary: Summary { rows: 12_000, date: "2026-06-24".into() } })
+//! }
+//!
+//! // Stage 2: the downstream report. It takes the projected `summary` as its input.
+//! #[workflow]
+//! async fn daily_report(_ctx: &WorkflowContext, summary: Summary) -> Result<(), String> {
+//!     // ... render and publish the report for `summary.date` ...
+//!     Ok(())
+//! }
+//!
+//! // The single declarative edge between them:
+//! let pipeline = CompletionTrigger::new("etl_ingest", "daily_report")
+//!     .with_terminal_states(vec![TerminalState::Completed]) // `Completed` is also the default
+//!     .with_input_mapping(InputMapping::Projection("summary".to_string()));
+//!
+//! let harvest = HarvestBuilder::new()
+//!     .workflows(workflows![etl_ingest, daily_report])
+//!     .completion_trigger(pipeline);
+//! ```
+//!
+//! ## Contract
+//!
+//! - **Exactly-once-after-dedupe**: when an `etl_ingest` run with execution id `E`
+//!   completes, Harvest starts `daily_report` with the deterministic id
+//!   `completion-trigger-{trigger_id}-E`. A re-delivered or replayed terminal
+//!   transition collapses onto that same id (via the `harvest_completion_trigger_fires`
+//!   ledger + start-or-load reuse policy) — never a second `daily_report`.
+//! - **State matching**: if `etl_ingest` instead FAILS, nothing starts — the trigger
+//!   only matches `Completed`. Register additional `TerminalState`s (or a `Failed`
+//!   trigger to a different target) if you want an on-failure branch.
+//! - **No new event variant**: the target's start emits an ordinary `WorkflowStarted`;
+//!   the source emits nothing extra.
+//!
+//! See `docs/completion-triggers.md` for the full reference, including the
+//! cross-shard at-least-once delivery contract.
+
+use autumn_harvest::completion_trigger::{
+    CompletionTrigger, InputMapping, TerminalState, project_json_path,
+};
+use serde_json::json;
+
+fn main() {
+    // The declarative edge: `etl_ingest` COMPLETED -> start `daily_report` with the
+    // source output's `summary` field as input.
+    let trigger = CompletionTrigger::new("etl_ingest", "daily_report")
+        .with_terminal_states(vec![TerminalState::Completed])
+        .with_input_mapping(InputMapping::Projection("summary".to_string()));
+
+    println!("Completion trigger:");
+    println!("  source : {}", trigger.source_workflow_name);
+    println!("  target : {}", trigger.target_workflow_name);
+    println!(
+        "  fires on: {:?}",
+        trigger
+            .terminal_states
+            .iter()
+            .map(|s| s.as_str())
+            .collect::<Vec<_>>()
+    );
+
+    // Simulate a completed `etl_ingest` run and its output.
+    let source_output = json!({
+        "summary": { "rows": 12_000, "date": "2026-06-24" },
+        "debug": { "duration_ms": 8421 }
+    });
+
+    // Apply the input mapping exactly as the engine does at fire time.
+    let target_input = match &trigger.input_mapping {
+        InputMapping::Passthrough => source_output.clone(),
+        InputMapping::Static(v) => v.clone(),
+        InputMapping::Projection(path) => project_json_path(&source_output, path),
+    };
+    println!("\nProjected `daily_report` input: {target_input}");
+    assert_eq!(target_input, json!({ "rows": 12_000, "date": "2026-06-24" }));
+
+    // The deterministic target workflow id makes duplicate fires collapse.
+    let source_exec_id = "0000abcd-0000-0000-0000-000000000001";
+    let target_workflow_id = format!("completion-trigger-{}-{}", trigger.id, source_exec_id);
+    println!("Deterministic target workflow_id: {target_workflow_id}");
+
+    // A FAILED source would NOT fire this `Completed`-only trigger.
+    let fires_on_failed = trigger.terminal_states.contains(&TerminalState::Failed);
+    println!("\nWould fire on a FAILED source? {fires_on_failed}");
+    assert!(!fires_on_failed);
+
+    println!("\nWired `etl_ingest` -> `daily_report` with a single registration.");
+}

--- a/autumn-harvest/examples/completion_triggers.rs
+++ b/autumn-harvest/examples/completion_triggers.rs
@@ -1,4 +1,3 @@
-#![allow(clippy::all, clippy::pedantic, clippy::nursery)]
 //! Declarative completion triggers — two-stage ETL → reporting (issue #517).
 //!
 //! Run workflow **B** *because* workflow **A** finished — without A knowing B
@@ -98,7 +97,7 @@ fn main() {
 
     // Apply the input mapping exactly as the engine does at fire time.
     let target_input = match &trigger.input_mapping {
-        InputMapping::Passthrough => source_output.clone(),
+        InputMapping::Passthrough => source_output,
         InputMapping::Static(v) => v.clone(),
         InputMapping::Projection(path) => project_json_path(&source_output, path),
     };

--- a/autumn-harvest/src/telemetry.rs
+++ b/autumn-harvest/src/telemetry.rs
@@ -169,8 +169,8 @@ pub const METRIC_SCHEDULE_SKIPPED: &str = "harvest.schedule.skipped";
 
 /// Counter: incremented when a completion trigger fires (issue #517).
 ///
-/// Attributes: `trigger`, `outcome` (started | skipped | deduped |
-/// validation_failed | payload_too_large).
+/// Attributes: `trigger`, `outcome` (`started` | `skipped` | `deduped` |
+/// `validation_failed` | `payload_too_large`).
 pub const METRIC_COMPLETION_TRIGGER_FIRED: &str = "harvest.completion_trigger.fires";
 
 /// Counter: incremented each time `POST /admin/schedules/{id}/trigger` fires a

--- a/autumn-harvest/src/telemetry.rs
+++ b/autumn-harvest/src/telemetry.rs
@@ -169,7 +169,8 @@ pub const METRIC_SCHEDULE_SKIPPED: &str = "harvest.schedule.skipped";
 
 /// Counter: incremented when a completion trigger fires (issue #517).
 ///
-/// Attributes: `trigger`, `outcome` (started | skipped | deduped).
+/// Attributes: `trigger`, `outcome` (started | skipped | deduped |
+/// validation_failed | payload_too_large).
 pub const METRIC_COMPLETION_TRIGGER_FIRED: &str = "harvest.completion_trigger.fires";
 
 /// Counter: incremented each time `POST /admin/schedules/{id}/trigger` fires a
@@ -688,7 +689,8 @@ impl ActivityStatus {
 pub trait MetricsRecorder: Send + Sync {
     /// A completion trigger was fired/evaluated (issue #517).
     ///
-    /// `outcome` is one of: `"started"`, `"skipped"`, `"deduped"`.
+    /// `outcome` is one of: `"started"`, `"skipped"`, `"deduped"`,
+    /// `"validation_failed"`, `"payload_too_large"`.
     fn record_completion_trigger_fired(&self, trigger_id: &str, outcome: &str) {
         let _ = (trigger_id, outcome);
     }

--- a/docs/completion-triggers.md
+++ b/docs/completion-triggers.md
@@ -11,11 +11,34 @@ When a workflow execution finishes in a terminal state:
 2. **Cross-Shard Out-of-Band Starts**: If the target routes to a different shard, the engine handles the start out-of-band by spawning an asynchronous Tokio task that obtains a database connection from `GLOBAL_SHARDED_POOL` for the target shard and inserts the target execution.
 3. **Idempotency & Deduplication**: To prevent duplicate executions in the event of retried transactions or worker crashes, the engine writes to the `harvest_completion_trigger_fires` ledger table on the source shard under a unique constraint: `(source_exec_id, trigger_id)`. A trigger fires exactly once per source execution run.
 
+### No new event variant
+
+Trigger evaluation introduces **no new `WorkflowEvent` variant**. The source emits nothing extra on completion, and the target's start emits its own ordinary `WorkflowStarted`. The append-only event contract is preserved by construction — completion triggers are a registry plus a fire ledger layered *outside* the event log.
+
+### Deterministic target `workflow_id`
+
+The target execution's `workflow_id` is **deterministic** and derived from the trigger and source execution:
+
+```
+completion-trigger-{trigger_id}-{source_exec_id}
+```
+
+This is what makes duplicate fires collapse safely. The start always goes through `start_or_load_workflow_execution` with `WorkflowIdReusePolicy::AllowDuplicate`, so if the same `(trigger, source execution)` pair is ever evaluated more than once (a re-delivery, a replayed terminal transition, or a cross-shard retry), the second start resolves to the *same* `workflow_id` and is collapsed by start-or-load rather than creating a second run. The `harvest_completion_trigger_fires` ledger is the primary at-most-once guard; the deterministic id is the second line of defense at the start path.
+
+### Cross-shard delivery contract
+
+If the target routes to a **different** shard than the source, the fan-out crosses the shard boundary via the existing start path — **there is no cross-shard transaction**. Instead, within the source-shard terminal-commit transaction the engine inserts a row into `harvest_completion_trigger_outbox` (alongside the fires-ledger insert), and then attempts the target start out-of-band:
+
+* The async `DeferredTriggerStart::spawn` path attempts the start immediately and deletes the outbox row on success.
+* The `enforce_completion_triggers_outbox` sweeper (wired into the timeout/enforcement scan loop) drains any outbox rows whose immediate spawn was lost to a crash or a transient connection failure, retrying the start on the target shard.
+
+The contract across the shard boundary is therefore **at-least-once delivery, deduped at the target**: the outbox guarantees the start is *eventually* attempted at least once even if a worker dies between the source commit and the target start, and the deterministic `workflow_id` + start-or-load reuse policy guarantee that repeated attempts collapse into exactly one target run. Same-shard starts are stronger (they share the source's commit transaction), but both boundaries converge on exactly-one target execution after dedupe.
+
 ---
 
 ## Database Schema
 
-Triggers use two tables:
+Triggers use three tables:
 
 ### `harvest_completion_triggers`
 Stores the static completion trigger definitions synced at startup or registered dynamically:
@@ -42,6 +65,26 @@ CREATE TABLE harvest_completion_trigger_fires (
 );
 ```
 
+### `harvest_completion_trigger_outbox`
+Holds cross-shard pending target starts. A row is written on the source shard inside the terminal-commit transaction when the target routes to a different shard, and deleted once the target start succeeds (either by the immediate async spawn or by the `enforce_completion_triggers_outbox` sweeper). It is the durable backstop that makes cross-shard delivery at-least-once:
+```sql
+CREATE TABLE harvest_completion_trigger_outbox (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    source_exec_id UUID NOT NULL,
+    trigger_id UUID NOT NULL,
+    target_shard INT NOT NULL,
+    target_workflow_name VARCHAR(255) NOT NULL,
+    target_workflow_id VARCHAR(255) NOT NULL,
+    target_input JSONB NOT NULL,
+    queue_name VARCHAR(255),
+    concurrency_key VARCHAR(255),
+    concurrency_limit INT,
+    priority JSONB NOT NULL,
+    max_workflow_input_bytes BIGINT NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+```
+
 ---
 
 ## Builder API
@@ -57,10 +100,42 @@ let trigger = CompletionTrigger::new("upstream-processing", "downstream-reportin
     .with_terminal_states(vec![TerminalState::Completed])
     .with_input_mapping(InputMapping::Projection("results.summary".to_string()));
 
-let harvest = HarvestBuilder::new(pool)
-    .completion_trigger(trigger)
-    .build();
+let harvest = HarvestBuilder::new()
+    .completion_trigger(trigger);
 ```
+
+---
+
+## Worked example: two-stage ETL → reporting
+
+A daily pipeline where a reporting workflow must run **after** the ingest workflow finishes,
+carrying the ingest's summary as its input — without the ingest workflow importing or knowing
+about the reporting workflow:
+
+```rust
+use autumn_harvest::HarvestBuilder;
+use autumn_harvest::completion_trigger::{CompletionTrigger, TerminalState, InputMapping};
+
+// Stage 1: `etl_ingest` runs (on a cron schedule, manually, or however you like)
+// and returns an output like { "summary": { "rows": 12000, "date": "2026-06-24" }, ... }.
+//
+// Stage 2: `daily_report` should run the moment `etl_ingest` COMPLETES, receiving just the
+// `summary` sub-object as its input.
+let pipeline = CompletionTrigger::new("etl_ingest", "daily_report")
+    .with_terminal_states(vec![TerminalState::Completed]) // Completed is also the default
+    .with_input_mapping(InputMapping::Projection("summary".to_string()));
+
+let harvest = HarvestBuilder::new()
+    .completion_trigger(pipeline);
+```
+
+When an `etl_ingest` run with execution id `E` completes, Harvest starts `daily_report` with a
+deterministic id `completion-trigger-{trigger_id}-E` and input equal to the ingest output's
+`summary` field. If `etl_ingest` instead FAILS, nothing starts (the trigger only matches
+`Completed`). Wiring this dependency touched **neither** `etl_ingest`'s nor `daily_report`'s
+body — it is a single declarative registration. See
+[`examples/completion_triggers.rs`](../autumn-harvest/examples/completion_triggers.rs) for a
+runnable version.
 
 ---
 
@@ -138,4 +213,16 @@ Completion triggers emit the `harvest.completion_trigger.fires` metric counter t
 
 | Metric | Instrument | Labels | Description |
 |--------|------------|--------|-------------|
-| `harvest.completion_trigger.fires` | Counter | `trigger`, `outcome` | Emitted when a completion trigger fires. `outcome` can be: `started` (target execution successfully created), `skipped` (evaluation skipped or duplicate ID already exists but not matching current policy), or `deduped` (idempotency ledger hit). |
+| `harvest.completion_trigger.fires` | Counter | `trigger`, `outcome` | Emitted on every completion-trigger evaluation. See the `outcome` values below. |
+
+The `outcome` label takes one of:
+
+| `outcome` | Meaning |
+|-----------|---------|
+| `started` | The target execution was successfully created (new run). |
+| `skipped` | The dedup ledger admitted the fire, but start-or-load resolved to an already-existing run rather than creating a new one (`created == false`). |
+| `deduped` | The `harvest_completion_trigger_fires` idempotency ledger already had a row for `(source_exec_id, trigger_id)` — this is a duplicate fire and no target was started. |
+| `validation_failed` | The mapped input failed validation against the target workflow's published input schema; the target was not started. |
+| `payload_too_large` | The mapped input exceeded the target workflow's max input byte cap; the target was not started (permanent error). |
+
+`started`, `skipped`, and `deduped` are the canonical wiring-confirmation outcomes called out in issue #517; `validation_failed` and `payload_too_large` are additional safety outcomes emitted by the implementation so operators can see triggers that matched but were intentionally dropped.


### PR DESCRIPTION
## Summary

Implements the completion-trigger fire metrics (issue #517) and cross-shard delivery infrastructure, along with comprehensive documentation and a worked example.

## Key Changes

- **Fire metrics**: Added `record_completion_trigger_fired(trigger_id, outcome)` to `MetricsRecorder` trait. The engine now emits `harvest.completion_trigger.fires` counter on every trigger evaluation with outcomes: `started` (new target execution), `skipped` (start-or-load resolved to existing run), `deduped` (idempotency ledger hit), `validation_failed`, or `payload_too_large`. Operators can confirm wiring by observing these metrics.

- **Cross-shard outbox table**: Added `harvest_completion_trigger_outbox` schema to hold pending target starts when the target routes to a different shard. Rows are written inside the source-shard terminal-commit transaction and deleted once the target start succeeds (either by immediate async spawn or by the `enforce_completion_triggers_outbox` sweeper). This makes cross-shard delivery at-least-once, deduped at the target via deterministic `workflow_id`.

- **Deterministic target `workflow_id`**: Documented that target executions use `completion-trigger-{trigger_id}-{source_exec_id}` as their `workflow_id`, enabling safe deduplication across retries and cross-shard delivery.

- **Documentation**: Expanded `docs/completion-triggers.md` with:
  - No new event variant contract (source emits nothing extra, target's start is ordinary `WorkflowStarted`)
  - Deterministic `workflow_id` derivation and start-or-load collapse semantics
  - Cross-shard delivery contract (at-least-once via outbox, exactly-once after dedupe)
  - Full `harvest_completion_trigger_outbox` schema
  - Worked example: two-stage ETL → reporting pipeline
  - Detailed `outcome` label meanings for the fire metric

- **Example**: Added `autumn-harvest/examples/completion_triggers.rs` demonstrating a declarative two-stage pipeline (`etl_ingest` → `daily_report`) with input projection, deterministic workflow ID derivation, and state matching.

- **Integration test**: Added `test_trigger_emits_fire_metric_outcomes()` that verifies the fire metric is emitted with correct outcomes (`started` on first evaluation, `deduped` on idempotent second evaluation) and that exactly one target execution is created despite two evaluations.

- **Telemetry constants**: Updated `METRIC_COMPLETION_TRIGGER_FIRED` documentation to list all five outcome values.

## Notable Implementation Details

- The fire metric is emitted on *every* evaluation, not just successful starts, so operators can observe the full lifecycle (including validation failures and payload-too-large drops).
- The outbox is the durable backstop for cross-shard delivery; the deterministic `workflow_id` + start-or-load reuse policy is the second line of defense.
- Same-shard starts remain stronger (they share the source's commit transaction); cross-shard starts converge on exactly-one target execution after dedupe via the outbox + deterministic ID.

https://claude.ai/code/session_014QNLVLkHeKLDkDQp86RhAe