### PR TITLE
⚡ Bolt: Remove unnecessary `.collect::<Vec<_>>()` on hot path in `api.rs`

### DIFF
--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -16670,10 +16670,9 @@ pub(crate) async fn load_stalled_workflows(
     // Checking all task_type values mirrors the sleeping-filter predicate so that
     // an execution with a stuck workflow task is not mislabelled no_pending_work.
     let has_activity: HashSet<uuid::Uuid> = harvest_task_queue::table
-        .filter(
-            harvest_task_queue::workflow_exec_id
-                .eq_any(exec_ids.iter().map(|id| Some(*id)).collect::<Vec<_>>()),
-        )
+        // ⚡ Bolt: Pass `&exec_ids` directly instead of collecting into an intermediate `Vec<Option<Uuid>>`.
+        // This avoids an O(N) heap allocation on this hot path.
+        .filter(harvest_task_queue::workflow_exec_id.eq_any(&exec_ids))
         .filter(harvest_task_queue::state.eq_any(["PENDING", "CLAIMED", "RUNNING", "BACKOFF"]))
         .select(harvest_task_queue::workflow_exec_id)
         .distinct()
@@ -16686,10 +16685,9 @@ pub(crate) async fn load_stalled_workflows(
 
     // ── Step 4: non-terminal child workflows ────────────────────────────────
     let has_child: HashSet<uuid::Uuid> = harvest_workflow_executions::table
-        .filter(
-            harvest_workflow_executions::parent_id
-                .eq_any(exec_ids.iter().map(|id| Some(*id)).collect::<Vec<_>>()),
-        )
+        // ⚡ Bolt: Pass `&exec_ids` directly instead of collecting into an intermediate `Vec<Option<Uuid>>`.
+        // This avoids an O(N) heap allocation on this hot path.
+        .filter(harvest_workflow_executions::parent_id.eq_any(&exec_ids))
         .filter(harvest_workflow_executions::state.ne_all([
             "COMPLETED",
             "FAILED",


### PR DESCRIPTION
💡 What: Replaced `.eq_any(exec_ids.iter().map(|id| Some(*id)).collect::<Vec<_>>())` with `.eq_any(&exec_ids)` in `autumn-harvest-plugin/src/api.rs`. Diesel `eq_any` can natively handle references to nullable/non-nullable mapped types without mapping to intermediate Options and collecting.

🎯 Why: The original implementation mapped the UUIDs to `Some(*id)` and explicitly collected them into an intermediate `Vec<Option<Uuid>>`. This caused an unnecessary O(N) heap allocation and loop iteration inside high-volume data-loading functions like `load_stalled_workflows`.

📊 Impact: Reduces heap allocations by 2 per query cycle in a hot database polling function, keeping more operations firmly on the stack and reducing garbage generation in the async runtime.

🔬 Measurement: Compile with `cargo check` and run the plugin tests using `cargo test -p autumn-harvest-plugin --lib` to verify the logic and queries remain intact. No breaking behavior since the generated SQL `IN` clause behaves exactly the same.

---
*PR created automatically by Jules for task [14059003830090046175](https://jules.google.com/task/14059003830090046175) started by @madmax983*