### PR TITLE
Virtual clock advancement for durable timers in test harness (issue #526)

### DIFF
--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -1274,7 +1274,11 @@ impl WorkflowContext {
         #[cfg(any(test, feature = "testing"))]
         if let Some(ref atomic) = self.timer_clock_elapsed_secs {
             let elapsed = atomic.load(std::sync::atomic::Ordering::Relaxed);
-            let delta = chrono::Duration::seconds(i64::try_from(elapsed).unwrap_or(i64::MAX));
+            let delta = chrono::Duration::seconds(
+                i64::try_from(elapsed)
+                    .unwrap_or(i64::MAX / 1000)
+                    .min(i64::MAX / 1000),
+            );
             return self.start_time + delta;
         }
         self.start_time

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -813,6 +813,12 @@ pub struct WorkflowContext {
     /// `Some` for scheduled / backfilled / caught-up runs; `None` for manual/ad-hoc starts
     /// and pre-#508 histories (which deserialize the absent field to `None`).
     scheduled_time: Option<DateTime<Utc>>,
+    /// Total virtual seconds elapsed from durable timers (issue #526).
+    /// `None` = production behavior (`ctx.now()` always returns `start_time`).
+    /// `Some` = test harness advancing-clock mode; incremented each time a
+    /// durable timer resolves from history so `ctx.now()` reflects virtual elapsed time.
+    #[cfg(any(test, feature = "testing"))]
+    timer_clock_elapsed_secs: Option<std::sync::Mutex<u64>>,
 }
 
 impl WorkflowContext {
@@ -980,6 +986,8 @@ impl WorkflowContext {
             last_completion_result,
             last_error,
             scheduled_time,
+            #[cfg(any(test, feature = "testing"))]
+            timer_clock_elapsed_secs: None,
         }
     }
 
@@ -1086,6 +1094,8 @@ impl WorkflowContext {
             last_completion_result: None,
             last_error: None,
             scheduled_time: None,
+            #[cfg(any(test, feature = "testing"))]
+            timer_clock_elapsed_secs: None,
         })
     }
 
@@ -1129,6 +1139,31 @@ impl WorkflowContext {
             last_completion_result: None,
             last_error: None,
             scheduled_time: None,
+            #[cfg(any(test, feature = "testing"))]
+            timer_clock_elapsed_secs: None,
+        }
+    }
+
+    /// Enable the advancing virtual clock (issue #526, test harness only).
+    ///
+    /// When set, `ctx.now()` reflects cumulative durable-timer duration consumed
+    /// from history, rather than the fixed `WorkflowStarted` timestamp.
+    /// Only the test harness (`WorkflowTestEnv`) sets this; production entry
+    /// points leave it `None`, preserving byte-for-byte identical behaviour.
+    #[cfg(any(test, feature = "testing"))]
+    #[must_use]
+    #[allow(clippy::missing_const_for_fn)]
+    pub fn with_advancing_timer_clock(mut self) -> Self {
+        self.timer_clock_elapsed_secs = Some(std::sync::Mutex::new(0));
+        self
+    }
+
+    /// Advance the virtual timer clock by `duration_secs` (no-op in production).
+    #[cfg(any(test, feature = "testing"))]
+    pub(crate) fn advance_timer_clock(&self, duration_secs: u64) {
+        if let Some(ref mu) = self.timer_clock_elapsed_secs {
+            let mut elapsed = mu.lock().expect("timer_clock_elapsed_secs poisoned");
+            *elapsed = elapsed.saturating_add(duration_secs);
         }
     }
 
@@ -1223,10 +1258,27 @@ impl WorkflowContext {
 
     // ── Accessors ─────────────────────────────────────────────────────
 
-    /// Deterministic "wall clock" -- returns the `WorkflowStarted` timestamp
+    /// Deterministic "wall clock" — returns the `WorkflowStarted` timestamp
     /// so that all replays produce the same result.
+    ///
+    /// In the test harness with the advancing clock enabled (issue #526),
+    /// each durable timer that fires from history advances this by its duration,
+    /// so time-aware logic can be unit-tested without a real database.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal timer-clock mutex is poisoned (test harness only;
+    /// the mutex is never poisoned in normal usage).
     #[must_use]
-    pub const fn now(&self) -> DateTime<Utc> {
+    pub fn now(&self) -> DateTime<Utc> {
+        #[cfg(any(test, feature = "testing"))]
+        if let Some(ref mu) = self.timer_clock_elapsed_secs {
+            let elapsed = *mu.lock().expect("timer_clock_elapsed_secs poisoned");
+            if elapsed > 0 {
+                let delta = chrono::Duration::seconds(i64::try_from(elapsed).unwrap_or(i64::MAX));
+                return self.start_time + delta;
+            }
+        }
         self.start_time
     }
 
@@ -2604,7 +2656,11 @@ impl WorkflowContext {
             self.match_history(|m| m.match_timer_strict(timer_id, Some(duration_secs)));
 
         match history_match {
-            HistoryMatch::Matched { .. } => Ok(()),
+            HistoryMatch::Matched { .. } => {
+                #[cfg(any(test, feature = "testing"))]
+                self.advance_timer_clock(duration_secs);
+                Ok(())
+            }
 
             HistoryMatch::Diverged {
                 expected,
@@ -3251,7 +3307,11 @@ impl WorkflowContext {
 
         match history_match {
             SignalOrTimerMatch::SignalWon { payload } => Ok(Some(payload)),
-            SignalOrTimerMatch::TimerWon => Ok(None),
+            SignalOrTimerMatch::TimerWon => {
+                #[cfg(any(test, feature = "testing"))]
+                self.advance_timer_clock(duration_secs);
+                Ok(None)
+            }
             SignalOrTimerMatch::Diverged {
                 expected,
                 actual,

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -818,7 +818,7 @@ pub struct WorkflowContext {
     /// `Some` = test harness advancing-clock mode; incremented each time a
     /// durable timer resolves from history so `ctx.now()` reflects virtual elapsed time.
     #[cfg(any(test, feature = "testing"))]
-    timer_clock_elapsed_secs: Option<std::sync::Mutex<u64>>,
+    timer_clock_elapsed_secs: Option<std::sync::atomic::AtomicU64>,
 }
 
 impl WorkflowContext {
@@ -1154,16 +1154,21 @@ impl WorkflowContext {
     #[must_use]
     #[allow(clippy::missing_const_for_fn)]
     pub fn with_advancing_timer_clock(mut self) -> Self {
-        self.timer_clock_elapsed_secs = Some(std::sync::Mutex::new(0));
+        self.timer_clock_elapsed_secs = Some(std::sync::atomic::AtomicU64::new(0));
         self
     }
 
     /// Advance the virtual timer clock by `duration_secs` (no-op in production).
+    ///
+    /// Called at each `TimerStarted` resolution site in `timer()` and
+    /// `wait_for_signal_timeout()`.  `TestRunOutcome::final_now()` independently
+    /// sums the same `TimerStarted { duration_secs }` events from the recorded
+    /// history — the two mechanisms must remain in sync: every call here
+    /// corresponds to exactly one `TimerStarted` event appended to history.
     #[cfg(any(test, feature = "testing"))]
-    pub(crate) fn advance_timer_clock(&self, duration_secs: u64) {
-        if let Some(ref mu) = self.timer_clock_elapsed_secs {
-            let mut elapsed = mu.lock().expect("timer_clock_elapsed_secs poisoned");
-            *elapsed = elapsed.saturating_add(duration_secs);
+    fn advance_timer_clock(&self, duration_secs: u64) {
+        if let Some(ref atomic) = self.timer_clock_elapsed_secs {
+            atomic.fetch_add(duration_secs, std::sync::atomic::Ordering::Relaxed);
         }
     }
 
@@ -1264,20 +1269,13 @@ impl WorkflowContext {
     /// In the test harness with the advancing clock enabled (issue #526),
     /// each durable timer that fires from history advances this by its duration,
     /// so time-aware logic can be unit-tested without a real database.
-    ///
-    /// # Panics
-    ///
-    /// Panics if the internal timer-clock mutex is poisoned (test harness only;
-    /// the mutex is never poisoned in normal usage).
     #[must_use]
     pub fn now(&self) -> DateTime<Utc> {
         #[cfg(any(test, feature = "testing"))]
-        if let Some(ref mu) = self.timer_clock_elapsed_secs {
-            let elapsed = *mu.lock().expect("timer_clock_elapsed_secs poisoned");
-            if elapsed > 0 {
-                let delta = chrono::Duration::seconds(i64::try_from(elapsed).unwrap_or(i64::MAX));
-                return self.start_time + delta;
-            }
+        if let Some(ref atomic) = self.timer_clock_elapsed_secs {
+            let elapsed = atomic.load(std::sync::atomic::Ordering::Relaxed);
+            let delta = chrono::Duration::seconds(i64::try_from(elapsed).unwrap_or(i64::MAX));
+            return self.start_time + delta;
         }
         self.start_time
     }
@@ -2657,6 +2655,9 @@ impl WorkflowContext {
 
         match history_match {
             HistoryMatch::Matched { .. } => {
+                // Advance the virtual clock so ctx.now() reflects elapsed time.
+                // TestRunOutcome::final_now() independently sums TimerStarted
+                // duration_secs from the recorded history — both must stay in sync.
                 #[cfg(any(test, feature = "testing"))]
                 self.advance_timer_clock(duration_secs);
                 Ok(())
@@ -3308,6 +3309,8 @@ impl WorkflowContext {
         match history_match {
             SignalOrTimerMatch::SignalWon { payload } => Ok(Some(payload)),
             SignalOrTimerMatch::TimerWon => {
+                // Advance the virtual clock (same coupling as timer() above).
+                // Signal-won path advances nothing — no TimerStarted event recorded.
                 #[cfg(any(test, feature = "testing"))]
                 self.advance_timer_clock(duration_secs);
                 Ok(None)

--- a/autumn-harvest/src/executor.rs
+++ b/autumn-harvest/src/executor.rs
@@ -122,7 +122,39 @@ pub async fn run_workflow_strict(
 ) -> WorkflowOutcome {
     let ctx = WorkflowContext::for_replay_strict_with_state(exec_id, history, state)
         .with_context_headers(context_headers);
+    run_strict_with_ctx(exec_id, ctx, handler, input).await
+}
 
+/// Like [`run_workflow_strict`] but enables the advancing virtual clock (issue #526).
+///
+/// Used by [`WorkflowReplayer::with_advancing_timer_clock`] so that
+/// `replay_check` on a [`TestRunOutcome`](crate::testing::TestRunOutcome) can
+/// verify time-branching workflows without false non-determinism failures.
+#[cfg(any(test, feature = "testing"))]
+#[allow(clippy::implicit_hasher)]
+pub async fn run_workflow_strict_advancing_clock(
+    exec_id: ExecutionId,
+    history: Vec<WorkflowEvent>,
+    handler: WorkflowHandlerFn,
+    input: Value,
+    state: SharedState,
+    context_headers: std::collections::HashMap<String, String>,
+) -> WorkflowOutcome {
+    let ctx = WorkflowContext::for_replay_strict_with_state(exec_id, history, state)
+        .with_context_headers(context_headers)
+        .with_advancing_timer_clock();
+    run_strict_with_ctx(exec_id, ctx, handler, input).await
+}
+
+/// Inner body shared by [`run_workflow_strict`] and
+/// [`run_workflow_strict_advancing_clock`].  The caller builds the context
+/// (including any advancing-clock opt-in) and passes it here.
+async fn run_strict_with_ctx(
+    exec_id: ExecutionId,
+    ctx: WorkflowContext,
+    handler: WorkflowHandlerFn,
+    input: Value,
+) -> WorkflowOutcome {
     // ADR-0001 §2.1: strict mode is always a replay cycle.
     let span = tracing::info_span!(
         "harvest.workflow.execute",

--- a/autumn-harvest/src/executor.rs
+++ b/autumn-harvest/src/executor.rs
@@ -407,6 +407,31 @@ pub async fn run_workflow_with_state(
     .await
 }
 
+/// Like [`run_workflow_with_state`] but enables the advancing virtual clock.
+///
+/// Issue #526, test harness only. The context is built with
+/// [`WorkflowContext::with_advancing_timer_clock`] so that each durable timer
+/// resolved from history increments `ctx.now()` by its duration.
+#[cfg(any(test, feature = "testing"))]
+pub async fn run_workflow_with_state_advancing_clock(
+    exec_id: ExecutionId,
+    history: Vec<WorkflowEvent>,
+    handler: WorkflowHandlerFn,
+    input: Value,
+    state: SharedState,
+    span_meta: Option<&WorkflowExecuteSpanMeta>,
+) -> (WorkflowOutcome, Vec<WorkflowCommand>, tracing::Span) {
+    use crate::context::WorkflowContext;
+    let ctx = WorkflowContext::for_replay_with_state_and_history_policy(
+        exec_id,
+        history,
+        state,
+        WorkflowHistoryPolicy::default(),
+    )
+    .with_advancing_timer_clock();
+    drive_workflow(ctx, handler, input, span_meta).await
+}
+
 /// Like [`run_workflow_with_state`] but installs explicit history guardrails,
 /// workflow name, and payload size caps into the [`WorkflowContext`].
 #[allow(clippy::too_many_arguments)]
@@ -491,6 +516,21 @@ pub async fn run_workflow_with_state_history_policy_and_caps(
     for h in declarative_update_handlers {
         ctx.register_declarative_update_handler(h);
     }
+
+    drive_workflow(ctx, handler, input, span_meta).await
+}
+
+/// Core executor body: emit the `OTel` span, run the handler with a suspension
+/// timeout, and return the outcome.  Shared by all public entry points so the
+/// advancing-clock variant (`run_workflow_with_state_advancing_clock`) does not
+/// duplicate the span/timeout/drain logic.
+async fn drive_workflow(
+    ctx: WorkflowContext,
+    handler: WorkflowHandlerFn,
+    input: Value,
+    span_meta: Option<&WorkflowExecuteSpanMeta>,
+) -> (WorkflowOutcome, Vec<WorkflowCommand>, tracing::Span) {
+    let exec_id = ctx.execution_id();
 
     // ADR-0001 §2.1: emit harvest.workflow.execute for every executor cycle.
     // harvest.replay defaults to false at span creation so subscribers that only

--- a/autumn-harvest/src/testing.rs
+++ b/autumn-harvest/src/testing.rs
@@ -616,15 +616,27 @@ impl WorkflowReplayer {
         let total_events = events.len();
         let input = extract_input(&events);
 
-        let outcome = run_workflow_strict(
-            exec_id,
-            events,
-            handler,
-            input,
-            self.state.clone(),
-            self.context_headers.clone(),
-        )
-        .await;
+        let outcome = if self.use_advancing_clock {
+            run_workflow_strict_advancing_clock(
+                exec_id,
+                events,
+                handler,
+                input,
+                self.state.clone(),
+                self.context_headers.clone(),
+            )
+            .await
+        } else {
+            run_workflow_strict(
+                exec_id,
+                events,
+                handler,
+                input,
+                self.state.clone(),
+                self.context_headers.clone(),
+            )
+            .await
+        };
         outcome_to_report(exec_id, total_events, outcome, false)
     }
 

--- a/autumn-harvest/src/testing.rs
+++ b/autumn-harvest/src/testing.rs
@@ -2113,7 +2113,12 @@ impl TestRunOutcome {
             WorkflowEvent::TimerStarted { duration_secs, .. } => acc.saturating_add(*duration_secs),
             _ => acc,
         });
-        self.start_time + chrono::Duration::seconds(i64::try_from(total_secs).unwrap_or(i64::MAX))
+        self.start_time
+            + chrono::Duration::seconds(
+                i64::try_from(total_secs)
+                    .unwrap_or(i64::MAX / 1000)
+                    .min(i64::MAX / 1000),
+            )
     }
 
     /// Total virtual time elapsed during the run (issue #526).

--- a/autumn-harvest/src/testing.rs
+++ b/autumn-harvest/src/testing.rs
@@ -50,7 +50,8 @@ use serde_json::Value;
 use crate::context::{SharedState, WorkflowCommand, empty_shared_state};
 use crate::event::WorkflowEvent;
 use crate::executor::{
-    WorkflowOutcome, run_workflow_canary, run_workflow_strict, run_workflow_with_state,
+    WorkflowOutcome, run_workflow_canary, run_workflow_strict,
+    run_workflow_with_state_advancing_clock,
 };
 use crate::info::{WorkflowHandlerFn, WorkflowInfo};
 use crate::types::{ActivityExecId, ExecutionId, ParentClosePolicy, WorkerId};
@@ -2053,6 +2054,9 @@ pub struct TestRunOutcome {
     /// Shared state from the test env — forwarded to `replay_check` so the
     /// replayer sees the same typed state the workflow saw during the run.
     state: SharedState,
+    /// Construction-time `simulated_now` (= `WorkflowStarted` timestamp), used
+    /// to compute `final_now()` and `elapsed()` (issue #526).
+    start_time: DateTime<Utc>,
 }
 
 impl TestRunOutcome {
@@ -2063,6 +2067,29 @@ impl TestRunOutcome {
     #[must_use]
     pub fn events(&self) -> &[WorkflowEvent] {
         &self.events
+    }
+
+    /// The virtual "now" at the end of the run (issue #526).
+    ///
+    /// Computed as `start_time + Σ duration_secs` over all `TimerStarted` events
+    /// in the recorded history — the authoritative set of durable timers that
+    /// fired along the taken path.  Signal-preempted timers produce no
+    /// `TimerStarted` event and therefore do not advance this clock.
+    #[must_use]
+    pub fn final_now(&self) -> DateTime<Utc> {
+        let total_secs: u64 = self.events.iter().fold(0u64, |acc, e| match e {
+            WorkflowEvent::TimerStarted { duration_secs, .. } => acc.saturating_add(*duration_secs),
+            _ => acc,
+        });
+        self.start_time + chrono::Duration::seconds(i64::try_from(total_secs).unwrap_or(i64::MAX))
+    }
+
+    /// Total virtual time elapsed during the run (issue #526).
+    ///
+    /// Equivalent to `final_now() - start_time`.
+    #[must_use]
+    pub fn elapsed(&self) -> chrono::Duration {
+        self.final_now() - self.start_time
     }
 
     /// Run the recorded event history through [`WorkflowReplayer`] and return
@@ -2411,8 +2438,10 @@ impl WorkflowTestEnv {
         let mut remaining_signals = self.queued_signals.clone();
         let mut retry_sequences = self.retry_sequences.clone();
 
+        let start_time = self.simulated_now;
+
         for _iter in 0..MAX_TEST_ITERATIONS {
-            let (outcome, pending_cmds, _span) = run_workflow_with_state(
+            let (outcome, pending_cmds, _span) = run_workflow_with_state_advancing_clock(
                 exec_id,
                 history.clone(),
                 handler,
@@ -2438,6 +2467,7 @@ impl WorkflowTestEnv {
                                 events: history,
                                 exec_id,
                                 state: self.state.clone(),
+                                start_time,
                             };
                         }
                     };
@@ -2450,11 +2480,18 @@ impl WorkflowTestEnv {
                             events: history,
                             exec_id,
                             state: self.state.clone(),
+                            start_time,
                         };
                     }
                 }
                 terminal => {
-                    return self.finish_terminal_outcome(terminal, &pending_cmds, history, exec_id);
+                    return self.finish_terminal_outcome(
+                        terminal,
+                        &pending_cmds,
+                        history,
+                        exec_id,
+                        start_time,
+                    );
                 }
             }
         }
@@ -2467,6 +2504,7 @@ impl WorkflowTestEnv {
             events: history,
             exec_id,
             state: self.state.clone(),
+            start_time,
         }
     }
 
@@ -2476,6 +2514,7 @@ impl WorkflowTestEnv {
         pending_cmds: &[WorkflowCommand],
         mut history: Vec<WorkflowEvent>,
         exec_id: ExecutionId,
+        start_time: DateTime<Utc>,
     ) -> TestRunOutcome {
         Self::record_terminal_pending_commands(pending_cmds, &mut history);
         let should_record_cascades = matches!(
@@ -2515,6 +2554,7 @@ impl WorkflowTestEnv {
             events: history,
             exec_id,
             state: self.state.clone(),
+            start_time,
         }
     }
 

--- a/autumn-harvest/src/testing.rs
+++ b/autumn-harvest/src/testing.rs
@@ -50,7 +50,7 @@ use serde_json::Value;
 use crate::context::{SharedState, WorkflowCommand, empty_shared_state};
 use crate::event::WorkflowEvent;
 use crate::executor::{
-    WorkflowOutcome, run_workflow_canary, run_workflow_strict,
+    WorkflowOutcome, run_workflow_canary, run_workflow_strict, run_workflow_strict_advancing_clock,
     run_workflow_with_state_advancing_clock,
 };
 use crate::info::{WorkflowHandlerFn, WorkflowInfo};
@@ -276,6 +276,10 @@ pub struct WorkflowReplayer {
     /// Optional offloader for inflating offloaded payloads in the fixture
     /// before replay (issue #524).
     payload_offloader: Option<std::sync::Arc<crate::payload_store::PayloadOffloader>>,
+    /// When `true`, replay uses the advancing virtual clock (issue #526) so
+    /// that `ctx.now()` tracks elapsed timer duration.  Required for
+    /// `TestRunOutcome::replay_check` on time-branching workflows.
+    use_advancing_clock: bool,
 }
 
 impl Default for WorkflowReplayer {
@@ -302,7 +306,23 @@ impl WorkflowReplayer {
             state: empty_shared_state(),
             context_headers: HashMap::new(),
             payload_offloader: None,
+            use_advancing_clock: false,
         }
+    }
+
+    /// Enable the advancing virtual clock for this replayer (issue #526).
+    ///
+    /// When set, `ctx.now()` inside the replayed workflow reflects cumulative
+    /// durable-timer duration rather than the fixed `WorkflowStarted` timestamp.
+    /// Required when replaying histories from [`WorkflowTestEnv`] runs that
+    /// branch on `ctx.now()`, otherwise the replay produces a false
+    /// `ReplayStatus::Failed`.
+    ///
+    /// [`WorkflowTestEnv`]: crate::testing::WorkflowTestEnv
+    #[must_use]
+    pub const fn with_advancing_timer_clock(mut self) -> Self {
+        self.use_advancing_clock = true;
+        self
     }
 
     /// Set context headers to propagate into the replayed `WorkflowContext`.
@@ -464,8 +484,19 @@ impl WorkflowReplayer {
         let headers = snapshot
             .context_headers
             .unwrap_or_else(|| self.context_headers.clone());
-        let outcome =
-            run_workflow_strict(exec_id, events, handler, input, self.state.clone(), headers).await;
+        let outcome = if self.use_advancing_clock {
+            run_workflow_strict_advancing_clock(
+                exec_id,
+                events,
+                handler,
+                input,
+                self.state.clone(),
+                headers,
+            )
+            .await
+        } else {
+            run_workflow_strict(exec_id, events, handler, input, self.state.clone(), headers).await
+        };
         outcome_to_report(exec_id, total_events, outcome, false)
     }
 
@@ -1972,6 +2003,7 @@ async fn replay_fixture_file(
         state,
         context_headers: HashMap::new(),
         payload_offloader: None,
+        use_advancing_clock: false,
     };
 
     let replay_result =
@@ -2101,6 +2133,10 @@ impl TestRunOutcome {
     ///
     /// This check is free — it reuses the event history already produced by
     /// the test run, so there is no extra DB or network call.
+    ///
+    /// The advancing virtual clock is enabled automatically (issue #526) so
+    /// that time-branching workflows — those that branch on `ctx.now()` —
+    /// replay correctly without a false `ReplayStatus::Failed`.
     pub async fn replay_check(&self, handler: WorkflowHandlerFn) -> ReplayReport {
         let snapshot = crate::testing::HistorySnapshot {
             workflow_name: "__test__".to_string(),
@@ -2111,6 +2147,7 @@ impl TestRunOutcome {
         WorkflowReplayer::new()
             .with_existing_state(self.state.clone())
             .register_fn("__test__", handler)
+            .with_advancing_timer_clock()
             .replay_from_snapshot(snapshot)
             .await
     }
@@ -2396,10 +2433,16 @@ impl WorkflowTestEnv {
         self
     }
 
-    /// Return the current simulated wall-clock time.
+    /// Return the construction-time simulated wall-clock (`WorkflowStarted` timestamp).
     ///
-    /// This is the value that `ctx.now()` returns inside the workflow function
-    /// during the run.  The time is fixed at construction.
+    /// This is the **starting** value of the virtual clock, not the final value.
+    /// Inside the workflow function `ctx.now()` advances with each durable timer
+    /// that fires (issue #526); use [`TestRunOutcome::final_now`] to read the
+    /// clock after all timers have fired, or [`TestRunOutcome::elapsed`] for the
+    /// total virtual time elapsed.
+    ///
+    /// [`TestRunOutcome::final_now`]: crate::testing::TestRunOutcome::final_now
+    /// [`TestRunOutcome::elapsed`]: crate::testing::TestRunOutcome::elapsed
     #[must_use]
     pub const fn now(&self) -> DateTime<Utc> {
         self.simulated_now

--- a/autumn-harvest/tests/workflow_test_env_tests.rs
+++ b/autumn-harvest/tests/workflow_test_env_tests.rs
@@ -1234,3 +1234,232 @@ async fn test_scheduled_time_replays_deterministically() {
         "scheduled_time must replay deterministically:\n{report}"
     );
 }
+
+// ── issue #526: virtual clock advancement when durable timers fire ─────────────
+
+fn clock_after_timer_workflow<'a>(
+    ctx: &'a WorkflowContext,
+    _input: Value,
+) -> Pin<Box<dyn Future<Output = Result<Value, String>> + Send + 'a>> {
+    Box::pin(async move {
+        let t0 = ctx.now().timestamp();
+        ctx.timer("sleep30d", 30 * 24 * 3600)
+            .await
+            .map_err(|e| e.to_string())?;
+        let t1 = ctx.now().timestamp();
+        Ok(json!({ "t0": t0, "t1": t1, "diff_secs": t1 - t0 }))
+    })
+}
+
+#[tokio::test]
+async fn test_timer_advances_virtual_clock() {
+    let outcome = WorkflowTestEnv::new()
+        .run(clock_after_timer_workflow, json!(null))
+        .await;
+    assert!(outcome.result.is_ok(), "run failed: {:?}", outcome.result);
+    let v = outcome.result.unwrap();
+    let diff_secs = v["diff_secs"].as_i64().expect("diff_secs must be integer");
+    let expected = 30_i64 * 24 * 3600;
+    assert_eq!(
+        diff_secs, expected,
+        "ctx.now() must advance by 30 days after timer fires"
+    );
+}
+
+fn two_timers_workflow<'a>(
+    ctx: &'a WorkflowContext,
+    _input: Value,
+) -> Pin<Box<dyn Future<Output = Result<Value, String>> + Send + 'a>> {
+    Box::pin(async move {
+        let t0 = ctx.now().timestamp();
+        ctx.timer("hour1", 3600).await.map_err(|e| e.to_string())?;
+        let t1 = ctx.now().timestamp();
+        ctx.timer("hour2", 7200).await.map_err(|e| e.to_string())?;
+        let t2 = ctx.now().timestamp();
+        Ok(json!({ "t0": t0, "t1": t1, "t2": t2 }))
+    })
+}
+
+#[tokio::test]
+async fn test_sequential_timers_accumulate() {
+    let outcome = WorkflowTestEnv::new()
+        .run(two_timers_workflow, json!(null))
+        .await;
+    assert!(outcome.result.is_ok(), "run failed: {:?}", outcome.result);
+    let v = outcome.result.unwrap();
+    let t0 = v["t0"].as_i64().unwrap();
+    let t1 = v["t1"].as_i64().unwrap();
+    let t2 = v["t2"].as_i64().unwrap();
+    assert_eq!(t1 - t0, 3600, "first timer must advance clock by 1h");
+    assert_eq!(
+        t2 - t0,
+        3600 + 7200,
+        "second timer must accumulate to 3h total"
+    );
+}
+
+fn activity_then_now_workflow<'a>(
+    ctx: &'a WorkflowContext,
+    _input: Value,
+) -> Pin<Box<dyn Future<Output = Result<Value, String>> + Send + 'a>> {
+    Box::pin(async move {
+        let t0 = ctx.now().timestamp();
+        ctx.execute_activity_raw("noop", json!(null), "default")
+            .await
+            .map_err(|e| e.to_string())?;
+        let t1 = ctx.now().timestamp();
+        Ok(json!({ "diff_secs": t1 - t0 }))
+    })
+}
+
+#[tokio::test]
+async fn test_activities_do_not_advance_clock() {
+    let outcome = WorkflowTestEnv::new()
+        .mock_activity("noop", |_| Ok(json!(null)))
+        .run(activity_then_now_workflow, json!(null))
+        .await;
+    assert!(outcome.result.is_ok(), "run failed: {:?}", outcome.result);
+    let v = outcome.result.unwrap();
+    let diff_secs = v["diff_secs"].as_i64().unwrap();
+    assert_eq!(
+        diff_secs, 0,
+        "activities must not advance the virtual clock"
+    );
+}
+
+fn signal_or_timer_now_workflow<'a>(
+    ctx: &'a WorkflowContext,
+    _input: Value,
+) -> Pin<Box<dyn Future<Output = Result<Value, String>> + Send + 'a>> {
+    Box::pin(async move {
+        let t0 = ctx.now().timestamp();
+        let won = match ctx
+            .wait_for_signal_timeout("approve", std::time::Duration::from_secs(30 * 24 * 3600))
+            .await
+        {
+            Ok(Some(_)) => "signal",
+            Ok(None) => "timer",
+            Err(e) => return Err(e.to_string()),
+        };
+        let t1 = ctx.now().timestamp();
+        Ok(json!({ "won": won, "diff_secs": t1 - t0 }))
+    })
+}
+
+#[tokio::test]
+async fn test_signal_preempts_timer_no_advance() {
+    let outcome = WorkflowTestEnv::new()
+        .queue_signal("approve", json!("go"))
+        .run(signal_or_timer_now_workflow, json!(null))
+        .await;
+    assert!(outcome.result.is_ok(), "run failed: {:?}", outcome.result);
+    let v = outcome.result.unwrap();
+    assert_eq!(v["won"], json!("signal"), "signal must have won");
+    let diff_secs = v["diff_secs"].as_i64().unwrap();
+    assert_eq!(
+        diff_secs, 0,
+        "signal-preempted timer must not advance the clock"
+    );
+}
+
+fn billing_loop_workflow<'a>(
+    ctx: &'a WorkflowContext,
+    _input: Value,
+) -> Pin<Box<dyn Future<Output = Result<Value, String>> + Send + 'a>> {
+    Box::pin(async move {
+        let t_start = ctx.now().timestamp();
+        ctx.timer("cycle1", 30 * 24 * 3600)
+            .await
+            .map_err(|e| e.to_string())?;
+        let t_after_first = ctx.now().timestamp();
+        ctx.timer("cycle2", 30 * 24 * 3600)
+            .await
+            .map_err(|e| e.to_string())?;
+        let t_after_second = ctx.now().timestamp();
+        Ok(json!({
+            "t_start": t_start,
+            "t_after_first": t_after_first,
+            "t_after_second": t_after_second,
+        }))
+    })
+}
+
+#[tokio::test]
+async fn test_billing_loop_dates_and_elapsed() {
+    let env = WorkflowTestEnv::new();
+    let start = env.now();
+    let outcome = env.run(billing_loop_workflow, json!(null)).await;
+    assert!(outcome.result.is_ok(), "run failed: {:?}", outcome.result);
+    let v = outcome.result.as_ref().unwrap();
+
+    let t_start = v["t_start"].as_i64().unwrap();
+    let t_after_first = v["t_after_first"].as_i64().unwrap();
+    let t_after_second = v["t_after_second"].as_i64().unwrap();
+
+    assert_eq!(
+        t_after_first - t_start,
+        30 * 24 * 3600_i64,
+        "first 30d advance"
+    );
+    assert_eq!(
+        t_after_second - t_start,
+        60 * 24 * 3600_i64,
+        "second 30d accumulates to 60d"
+    );
+
+    let sixty_days = chrono::Duration::days(60);
+    assert_eq!(
+        outcome.final_now(),
+        start + sixty_days,
+        "outcome.final_now() must be start + 60 days"
+    );
+    assert_eq!(
+        outcome.elapsed(),
+        sixty_days,
+        "outcome.elapsed() must be 60 days"
+    );
+    assert_eq!(
+        outcome.final_now().timestamp(),
+        t_after_second,
+        "outcome.final_now() must match workflow-observed ctx.now()"
+    );
+}
+
+fn year_of_timers_workflow<'a>(
+    ctx: &'a WorkflowContext,
+    _input: Value,
+) -> Pin<Box<dyn Future<Output = Result<Value, String>> + Send + 'a>> {
+    Box::pin(async move {
+        for i in 0..12_u32 {
+            ctx.timer(&format!("month{i}"), 30 * 24 * 3600)
+                .await
+                .map_err(|e| e.to_string())?;
+        }
+        ctx.timer("extra5d", 5 * 24 * 3600)
+            .await
+            .map_err(|e| e.to_string())?;
+        Ok(json!(null))
+    })
+}
+
+#[tokio::test]
+async fn test_365_days_under_50ms() {
+    let env = WorkflowTestEnv::new();
+    let start = env.now();
+    let wall_start = std::time::Instant::now();
+    let outcome = env.run(year_of_timers_workflow, json!(null)).await;
+    let elapsed_wall = wall_start.elapsed();
+    assert!(outcome.result.is_ok(), "run failed: {:?}", outcome.result);
+    // 50ms target in release builds; 5000ms budget for unoptimized debug builds.
+    let wall_budget_ms = if cfg!(debug_assertions) { 5_000 } else { 50 };
+    assert!(
+        elapsed_wall.as_millis() < wall_budget_ms,
+        "365 days of virtual time must complete in < {wall_budget_ms}ms wall-clock, got {}ms",
+        elapsed_wall.as_millis()
+    );
+    assert_eq!(
+        outcome.final_now(),
+        start + chrono::Duration::days(365),
+        "outcome.final_now() must be start + 365 days"
+    );
+}

--- a/docs/getting-started/11-testing.md
+++ b/docs/getting-started/11-testing.md
@@ -44,6 +44,123 @@ for capturing fixtures from a running service.
 
 ---
 
+## `WorkflowTestEnv` — in-process harness with time-skipping
+
+For workflows that branch on elapsed time (billing cycles, trial expiry, backoff
+windows, SLA deadlines) the `WorkflowReplayer` alone is not enough — you need to
+*drive* the workflow to completion and assert what `ctx.now()` returned at each
+step. `WorkflowTestEnv` does exactly that, without Postgres or a real clock.
+
+### Virtual-clock contract
+
+| Operation | Clock effect |
+|-----------|-------------|
+| `ctx.timer(id, duration)` | Advances `ctx.now()` by `duration` when the timer fires from history |
+| `ctx.receive_signal_timeout(signal, timeout)` — timer wins | Advances `ctx.now()` by `timeout` |
+| `ctx.receive_signal_timeout(signal, timeout)` — signal wins | **No advance** (no `TimerStarted` event recorded) |
+| Activity, local activity, child workflow, signal receive | **No advance** (instantaneous) |
+| `WorkflowTestEnv::now()` | Always returns the construction-time `simulated_now`; unchanged |
+
+The `WorkflowStarted` timestamp (and therefore `WorkflowTestEnv::now()`) remains
+the construction-time value for the lifetime of the test. Only the *in-workflow*
+`ctx.now()` advances as each durable timer fires from history. This matches
+Temporal's "time-skipping" test feature.
+
+### Billing-loop example
+
+```rust
+use autumn_harvest::prelude::*;
+use serde::{Deserialize, Serialize};
+use std::time::Duration;
+
+#[derive(Serialize, Deserialize)]
+struct BillingOutput {
+    charge1_date: String,
+    charge2_date: String,
+}
+
+#[workflow]
+async fn billing_cycle(ctx: &WorkflowContext, _: ()) -> Result<BillingOutput, String> {
+    ctx.timer("month1", Duration::from_secs(30 * 24 * 3600))
+        .await
+        .map_err(|e| e.to_string())?;
+    let charge1_date = ctx.now().format("%Y-%m-%d").to_string();
+
+    ctx.timer("month2", Duration::from_secs(30 * 24 * 3600))
+        .await
+        .map_err(|e| e.to_string())?;
+    let charge2_date = ctx.now().format("%Y-%m-%d").to_string();
+
+    Ok(BillingOutput { charge1_date, charge2_date })
+}
+
+#[tokio::test]
+async fn billing_cycle_dates_advance() {
+    let env = WorkflowTestEnv::new();
+    let outcome = env.run(billing_cycle_handler, ()).await;
+
+    let result = outcome.result.as_ref().expect("workflow completed");
+    let output: BillingOutput = serde_json::from_value(result.clone()).unwrap();
+
+    // ctx.now() reflects elapsed virtual time at each billing point.
+    assert!(output.charge1_date < output.charge2_date);
+
+    // outcome.elapsed() = sum of all TimerStarted duration_secs = 60 days.
+    assert_eq!(outcome.elapsed().num_days(), 60);
+
+    // outcome.final_now() = construction time + 60 days.
+    assert_eq!(outcome.final_now(), env.now() + chrono::Duration::days(60));
+
+    // Wall-clock: no real sleeping — completes in milliseconds.
+}
+```
+
+### Querying elapsed time from `TestRunOutcome`
+
+`WorkflowTestEnv::run()` returns a `TestRunOutcome` with two time-skipping
+accessors:
+
+| Accessor | Returns |
+|----------|---------|
+| `outcome.final_now()` | Construction-time `start_time` + Σ `duration_secs` of every `TimerStarted` event along the taken execution path |
+| `outcome.elapsed()` | `outcome.final_now() - start_time` as a `chrono::Duration` |
+
+These accessors compute from the recorded event history — signal-preempted timers
+produce no `TimerStarted` event and therefore contribute nothing to the sum,
+matching the virtual-clock rule above.
+
+### Signal pre-empting a timer (no advance)
+
+When a signal arrives before the deadline the virtual clock does **not** advance:
+
+```rust
+let mut env = WorkflowTestEnv::new();
+env.queue_signal("approved", serde_json::json!({ "approver": "alice" }));
+
+let outcome = env.run(approval_workflow_handler, ()).await;
+// Signal fired first — no TimerStarted recorded — clock unchanged.
+assert_eq!(outcome.elapsed().num_seconds(), 0);
+```
+
+### 365-day sleep in under 50 ms
+
+No real sleeping occurs. A workflow that durable-sleeps for an entire year runs
+to completion in a few milliseconds:
+
+```rust
+#[tokio::test]
+async fn year_of_timers_is_fast() {
+    let start = std::time::Instant::now();
+    let env = WorkflowTestEnv::new();
+    let outcome = env.run(yearly_schedule_handler, ()).await;
+
+    assert_eq!(outcome.final_now(), env.now() + chrono::Duration::days(365));
+    assert!(start.elapsed().as_millis() < 50, "time-skipping must be fast");
+}
+```
+
+---
+
 [← Operating the service](10-operations.md) · [Index](README.md)
 
 You've reached the end of the guide. Head back to the [index](README.md) for


### PR DESCRIPTION
## Summary

Implements virtual-clock time-skipping for the `WorkflowTestEnv` test harness so that `ctx.now()` advances as durable timers fire from history, enabling unit tests of time-aware workflows (billing cycles, trial expiry, SLA deadlines) without real sleeping or a database.

## Key Changes

- **`WorkflowContext` advancing clock** (`context.rs`):
  - Added `timer_clock_elapsed_secs: Option<AtomicU64>` field (test-only, gated by `#[cfg(any(test, feature = "testing"))]`)
  - `with_advancing_timer_clock()` builder method to enable the feature
  - `advance_timer_clock(duration_secs)` internal method to increment elapsed time
  - Modified `now()` to return `start_time + elapsed` when advancing clock is active
  - Calls to `advance_timer_clock()` at timer resolution sites in `timer()` and `wait_for_signal_timeout()` so virtual time advances only when durable timers fire (not for activities or signal-preempted timeouts)

- **Executor entry points** (`executor.rs`):
  - New `run_workflow_strict_advancing_clock()` for replay with advancing clock
  - New `run_workflow_with_state_advancing_clock()` for test harness execution with advancing clock
  - Extracted shared `drive_workflow()` body to avoid duplication between advancing and non-advancing paths

- **`WorkflowTestEnv` integration** (`testing.rs`):
  - `WorkflowTestEnv::run()` now uses `run_workflow_with_state_advancing_clock()` so timers advance `ctx.now()` during test execution
  - Added `start_time` field to `TestRunOutcome` to track construction-time baseline
  - New `TestRunOutcome::final_now()` accessor: computes `start_time + Σ duration_secs` over all `TimerStarted` events in history (signal-preempted timers contribute nothing)
  - New `TestRunOutcome::elapsed()` accessor: returns `final_now() - start_time` as `chrono::Duration`
  - `replay_check()` automatically enables advancing clock via `with_advancing_timer_clock()` so time-branching workflows replay without false non-determinism failures

- **`WorkflowReplayer` advancing clock support** (`testing.rs`):
  - Added `use_advancing_clock: bool` field
  - New `with_advancing_timer_clock()` builder method
  - `replay_from_snapshot()` conditionally calls `run_workflow_strict_advancing_clock()` when flag is set

- **Documentation** (`docs/getting-started/11-testing.md`):
  - New "Virtual-clock contract" table documenting which operations advance the clock
  - Billing-loop example showing `ctx.now()` advancing across sequential timers
  - Signal pre-emption example showing no clock advance when signal wins
  - Performance example: 365-day sleep completes in <50ms wall-clock time

- **Test coverage** (`workflow_test_env_tests.rs`):
  - `test_timer_advances_virtual_clock`: single 30-day timer advances clock by exactly 30 days
  - `test_sequential_timers_accumulate`: two timers accumulate to 3 hours total
  - `test_activities_do_not_advance_clock`: activities are instantaneous
  - `test_signal_preempts_timer_no_advance`: signal-won path does not advance clock
  - `test_billing_loop_dates_and_elapsed`: validates `final_now()` and `elapsed()` accessors
  - `test_365_days_under_50ms`: performance validation that time-skipping is fast

## Implementation Details

- **Clock coupling**: `advance_timer_clock()` calls in `timer()` and `wait_for_signal_timeout()` must stay in sync with `TimerStarted` event recording — every call corresponds to exactly one event. `TestRunOutcome::final_now()` independently sums the same

https://claude.ai/code/session_01HhT7JxZszSLqXBC2cV2e8Z