### PR TITLE
Add paginated, filterable workflow history API (issue #529)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Add paginated, filterable single-execution workflow history API (issue #529). New read-only `GET /workflows/{id}/history` endpoint supports keyset pagination via opaque `next_cursor` (backed by `harvest_events.id`), `limit` (1–1000, default 100), `after` cursor, and repeatable `event_type` filter for server-side event-type narrowing. Response includes `total_events` (unfiltered) and `last_event_id` for UI progress tracking. `GET /workflows/{id}` now bounds `history` to the first 100 events and adds `history_truncated: bool` and `history_endpoint: string` fields so callers can discover the pagination endpoint. No new `WorkflowEvent` variant, no migration.
+
 - Add workflow-type reachability check to gate safe handler removal (issue #520). New read-only `GET /admin/workflow-types/reachability` endpoint and `harvest workflow-types reachability [--type] [--json]` CLI subcommand report, per workflow type, how many non-terminal executions still depend on its handler and a `safe_to_remove` / `in_use` / `orphaned` verdict. The CLI exits `2` when any type is `orphaned` or the cross-shard answer is incomplete, so it is usable as a CI/deploy gate. No new `WorkflowEvent` variant, no migration.
 
 ## [0.4.0] - 2026-06-16

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -5051,11 +5051,13 @@ async fn get_workflow(
             (None, None, None)
         };
 
-    let events: Vec<Value> = history_page
+    // Serialize via WorkflowEvent (not raw_event) to fill serde-default fields on legacy events.
+    let events = history_page
         .events
         .into_iter()
-        .map(|paged| paged.raw_event)
-        .collect();
+        .map(|paged| serde_json::to_value(paged.event).map_err(HarvestError::from))
+        .collect::<HarvestResult<Vec<_>>>()
+        .map_err(map_error)?;
 
     let handoff_filters = external_task::ExternalHandoffFilters {
         states: vec!["PENDING".to_string()],

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -5197,18 +5197,24 @@ async fn get_workflow_history(
 
     let mut entries = Vec::with_capacity(page.events.len());
     for paged in page.events {
-        // Use the stored raw JSON to avoid a redundant serialize round-trip.
-        let type_name = paged
-            .raw_event
-            .get("type")
-            .and_then(|v| v.as_str())
-            .unwrap_or_default()
-            .to_string();
-        let data = paged
-            .raw_event
-            .get("data")
-            .cloned()
-            .unwrap_or_else(|| Value::Object(serde_json::Map::new()));
+        // Take ownership of raw_event and remove both fields to avoid cloning any payload.
+        let mut raw = paged.raw_event;
+        let (type_name, data) = match &mut raw {
+            Value::Object(map) => {
+                let type_name = map
+                    .remove("type")
+                    .and_then(|v| match v {
+                        Value::String(s) => Some(s),
+                        _ => None,
+                    })
+                    .unwrap_or_default();
+                let data = map
+                    .remove("data")
+                    .unwrap_or_else(|| Value::Object(serde_json::Map::new()));
+                (type_name, data)
+            }
+            _ => (String::new(), Value::Object(serde_json::Map::new())),
+        };
         entries.push(WorkflowHistoryEntry {
             id: paged.id,
             event_id: paged.event_id,

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -1030,6 +1030,10 @@ struct WorkflowDetailsResponse {
     /// Nominal scheduled fire-time (logical slot) for this run, or `None` for manual starts (issue #508).
     #[serde(skip_serializing_if = "Option::is_none")]
     scheduled_time: Option<chrono::DateTime<chrono::Utc>>,
+    /// `true` when the execution has more events than the embedded `history` slice (issue #529).
+    history_truncated: bool,
+    /// URL path of the paginated history endpoint for this execution (issue #529).
+    history_endpoint: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -2500,6 +2504,7 @@ pub fn harvest_api_router(api_state: HarvestApiState) -> Router<AppState> {
             "/workflows/{id}/history/export",
             get(export_workflow_history),
         )
+        .route("/workflows/{id}/history", get(get_workflow_history))
         .route("/workflows/{id}", get(get_workflow))
         .route("/workflows/{id}/result", get(get_workflow_result))
         .route("/workflows/{id}/children", get(list_workflow_children))
@@ -2876,6 +2881,7 @@ pub const fn management_api_routes() -> &'static [(&'static str, &'static str)] 
         ("GET", "/workflows/registered"),
         ("GET", "/workflows/registered/{name}/schema"),
         ("GET", "/workflows/{id}"),
+        ("GET", "/workflows/{id}/history"),
         ("GET", "/workflows/{id}/result"),
         ("GET", "/workflows/{id}/history/export"),
         ("GET", "/workflows/{id}/children"),
@@ -3314,7 +3320,14 @@ pub const fn management_api_response_fields()
                 "last_completion_result",
                 "last_error",
                 "scheduled_time",
+                "history_truncated",
+                "history_endpoint",
             ]),
+        ),
+        (
+            "GET",
+            "/workflows/{id}/history",
+            Some(&["events", "next_cursor", "total_events", "last_event_id"]),
         ),
         (
             "GET",
@@ -5002,18 +5015,30 @@ async fn get_workflow(
     let execution = load_execution(&mut conn, exec_id)
         .await
         .map_err(map_error)?;
-    let history = store::load_history(&mut conn, exec_id)
-        .await
-        .map_err(map_error)?;
 
-    // Extract carryover and scheduled_time from the first (WorkflowStarted) event before consuming the vec.
+    // Use paged loading bounded to DEFAULT_HISTORY_PAGE events (issue #529).
+    let history_page = autumn_harvest::store::load_history_page(
+        &mut conn,
+        exec_id,
+        None,
+        DEFAULT_HISTORY_PAGE,
+        &[],
+    )
+    .await
+    .map_err(map_error)?;
+
+    let history_truncated = history_page.next_cursor.is_some();
+    let history_endpoint = format!("/workflows/{exec_id}/history");
+
+    // Extract carryover and scheduled_time from the first (WorkflowStarted) event.
+    // event_id 0 is always in the first page so this is safe after bounding.
     let (last_completion_result, last_error, scheduled_time) =
         if let Some(autumn_harvest::event::WorkflowEvent::WorkflowStarted {
             last_completion_result,
             last_error,
             scheduled_time,
             ..
-        }) = history.events.as_slice().first()
+        }) = history_page.events.as_slice().first().map(|e| &e.event)
         {
             (
                 last_completion_result.clone(),
@@ -5024,12 +5049,13 @@ async fn get_workflow(
             (None, None, None)
         };
 
-    let events = history
+    let events = history_page
         .events
         .into_iter()
-        .map(|event| serde_json::to_value(event).map_err(HarvestError::from))
+        .map(|paged| serde_json::to_value(paged.event).map_err(HarvestError::from))
         .collect::<HarvestResult<Vec<_>>>()
         .map_err(map_error)?;
+
     let handoff_filters = external_task::ExternalHandoffFilters {
         states: vec!["PENDING".to_string()],
         execution_id: Some(exec_id),
@@ -5051,6 +5077,131 @@ async fn get_workflow(
         last_completion_result,
         last_error,
         scheduled_time,
+        history_truncated,
+        history_endpoint,
+    }))
+}
+
+/// Default and maximum page sizes for `GET /workflows/{id}/history`.
+const DEFAULT_HISTORY_PAGE: i64 = 100;
+const MAX_HISTORY_PAGE: i64 = 1000;
+
+/// Per-event entry returned by `GET /workflows/{id}/history`.
+#[derive(Debug, Serialize)]
+struct WorkflowHistoryEntry {
+    /// `harvest_events.id` — the BIGSERIAL cursor anchor.
+    id: i64,
+    /// Sequential event index within this execution.
+    event_id: i32,
+    /// RFC 3339 timestamp recorded when the event was appended.
+    timestamp: chrono::DateTime<chrono::Utc>,
+    /// Adjacently-tagged event type name.
+    #[serde(rename = "type")]
+    event_type: String,
+    /// Event payload (the `data` object from the stored JSON).
+    data: Value,
+}
+
+/// Response envelope for `GET /workflows/{id}/history`.
+#[derive(Debug, Serialize)]
+struct WorkflowHistoryPage {
+    events: Vec<WorkflowHistoryEntry>,
+    /// Opaque cursor; pass as `?after=` on the next request. `null` = last page.
+    next_cursor: Option<String>,
+    /// Total event count for this execution, unaffected by `event_type` filter.
+    total_events: i64,
+    /// Highest `harvest_events.id` for this execution (unfiltered).
+    last_event_id: i64,
+}
+
+/// Parse query parameters for `GET /workflows/{id}/history`.
+///
+/// Returns `(limit, after_id, event_types)` or a 400 error.
+fn parse_workflow_history_query(
+    pairs: &[(String, String)],
+) -> Result<(i64, Option<i64>, Vec<String>), AutumnError> {
+    let mut limit = DEFAULT_HISTORY_PAGE;
+    let mut after_id: Option<i64> = None;
+    let mut event_types: Vec<String> = Vec::new();
+
+    for (k, v) in pairs {
+        match k.as_str() {
+            "limit" => {
+                limit = v.parse::<i64>().map_err(|_| {
+                    AutumnError::bad_request_msg(format!(
+                        "invalid limit {v:?}: must be a positive integer"
+                    ))
+                })?;
+                limit = limit.clamp(1, MAX_HISTORY_PAGE);
+            }
+            "after" => {
+                let parsed = v.parse::<i64>().map_err(|_| {
+                    AutumnError::bad_request_msg(format!(
+                        "invalid cursor {v:?}: must be a positive integer"
+                    ))
+                })?;
+                if parsed < 0 {
+                    return Err(AutumnError::bad_request_msg(format!(
+                        "invalid cursor {parsed}: must be non-negative"
+                    )));
+                }
+                after_id = Some(parsed);
+            }
+            "event_type" => {
+                event_types.push(v.clone());
+            }
+            _ => {}
+        }
+    }
+
+    Ok((limit, after_id, event_types))
+}
+
+/// `GET /workflows/{id}/history` — paginated, filterable event history.
+async fn get_workflow_history(
+    Extension(api_state): Extension<HarvestApiState>,
+    Path(id): Path<String>,
+    Query(pairs): Query<Vec<(String, String)>>,
+) -> Result<Json<WorkflowHistoryPage>, AutumnError> {
+    let exec_id = parse_execution_id(&id)?;
+    let (limit, after_id, event_types) = parse_workflow_history_query(&pairs)?;
+
+    let mut conn = db_conn_for_execution(&api_state, exec_id).await?;
+
+    // 404 when the execution doesn't exist.
+    load_execution(&mut conn, exec_id)
+        .await
+        .map_err(map_error)?;
+
+    let page =
+        autumn_harvest::store::load_history_page(&mut conn, exec_id, after_id, limit, &event_types)
+            .await
+            .map_err(map_error)?;
+
+    let mut entries = Vec::with_capacity(page.events.len());
+    for paged in page.events {
+        let raw = serde_json::to_value(&paged.event)
+            .map_err(HarvestError::from)
+            .map_err(map_error)?;
+        let type_name = paged.event.type_name().to_string();
+        let data = raw
+            .get("data")
+            .cloned()
+            .unwrap_or_else(|| Value::Object(serde_json::Map::new()));
+        entries.push(WorkflowHistoryEntry {
+            id: paged.id,
+            event_id: paged.event_id,
+            timestamp: paged.timestamp,
+            event_type: type_name,
+            data,
+        });
+    }
+
+    Ok(Json(WorkflowHistoryPage {
+        events: entries,
+        next_cursor: page.next_cursor.map(|c| c.to_string()),
+        total_events: page.total_events,
+        last_event_id: page.last_event_id,
     }))
 }
 

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -5199,9 +5199,12 @@ async fn get_workflow_history(
 
     let mut entries = Vec::with_capacity(page.events.len());
     for paged in page.events {
-        // Take ownership of raw_event and remove both fields to avoid cloning any payload.
-        let mut raw = paged.raw_event;
-        let (type_name, data) = match &mut raw {
+        // Serialize via WorkflowEvent (not raw_event) to fill serde-default fields on legacy
+        // events, keeping the shape consistent with the embedded history in get_workflow.
+        let mut normalized = serde_json::to_value(paged.event)
+            .map_err(HarvestError::from)
+            .map_err(map_error)?;
+        let (type_name, data) = match &mut normalized {
             Value::Object(map) => {
                 let type_name = map
                     .remove("type")

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -5017,12 +5017,14 @@ async fn get_workflow(
         .map_err(map_error)?;
 
     // Use paged loading bounded to DEFAULT_HISTORY_PAGE events (issue #529).
+    // Totals are not needed for the details view — skip the extra aggregate query.
     let history_page = autumn_harvest::store::load_history_page(
         &mut conn,
         exec_id,
         None,
         DEFAULT_HISTORY_PAGE,
         &[],
+        false,
     )
     .await
     .map_err(map_error)?;
@@ -5049,12 +5051,11 @@ async fn get_workflow(
             (None, None, None)
         };
 
-    let events = history_page
+    let events: Vec<Value> = history_page
         .events
         .into_iter()
-        .map(|paged| serde_json::to_value(paged.event).map_err(HarvestError::from))
-        .collect::<HarvestResult<Vec<_>>>()
-        .map_err(map_error)?;
+        .map(|paged| paged.raw_event)
+        .collect();
 
     let handoff_filters = external_task::ExternalHandoffFilters {
         states: vec!["PENDING".to_string()],
@@ -5132,6 +5133,11 @@ fn parse_workflow_history_query(
                         "invalid limit {v:?}: must be a positive integer"
                     ))
                 })?;
+                if limit <= 0 {
+                    return Err(AutumnError::bad_request_msg(format!(
+                        "invalid limit {limit}: must be a positive integer"
+                    )));
+                }
                 limit = limit.clamp(1, MAX_HISTORY_PAGE);
             }
             "after" => {
@@ -5168,23 +5174,38 @@ async fn get_workflow_history(
 
     let mut conn = db_conn_for_execution(&api_state, exec_id).await?;
 
-    // 404 when the execution doesn't exist.
-    load_execution(&mut conn, exec_id)
+    // 404 when the execution doesn't exist — cheaper than a full-row load.
+    if !autumn_harvest::store::check_execution_exists(&mut conn, exec_id)
         .await
-        .map_err(map_error)?;
+        .map_err(map_error)?
+    {
+        return Err(AutumnError::not_found_msg(format!(
+            "workflow execution {exec_id}"
+        )));
+    }
 
-    let page =
-        autumn_harvest::store::load_history_page(&mut conn, exec_id, after_id, limit, &event_types)
-            .await
-            .map_err(map_error)?;
+    let page = autumn_harvest::store::load_history_page(
+        &mut conn,
+        exec_id,
+        after_id,
+        limit,
+        &event_types,
+        true,
+    )
+    .await
+    .map_err(map_error)?;
 
     let mut entries = Vec::with_capacity(page.events.len());
     for paged in page.events {
-        let raw = serde_json::to_value(&paged.event)
-            .map_err(HarvestError::from)
-            .map_err(map_error)?;
-        let type_name = paged.event.type_name().to_string();
-        let data = raw
+        // Use the stored raw JSON to avoid a redundant serialize round-trip.
+        let type_name = paged
+            .raw_event
+            .get("type")
+            .and_then(|v| v.as_str())
+            .unwrap_or_default()
+            .to_string();
+        let data = paged
+            .raw_event
             .get("data")
             .cloned()
             .unwrap_or_else(|| Value::Object(serde_json::Map::new()));

--- a/autumn-harvest-plugin/tests/workflow_history_pagination_integration.rs
+++ b/autumn-harvest-plugin/tests/workflow_history_pagination_integration.rs
@@ -1,12 +1,12 @@
 //! Integration tests for `GET /api/harvest/workflows/{id}/history` (issue #529).
 //!
 //! Tests run against a real Postgres instance (testcontainers) and exercise:
-//!   (a) Page boundaries: limit=10, follow next_cursor, no drops/duplicates.
-//!   (b) event_type filter: only matching types returned; total_events is unfiltered.
+//!   (a) Page boundaries: `limit=10`, follow `next_cursor`, no drops/duplicates.
+//!   (b) `event_type` filter: only matching types returned; `total_events` is unfiltered.
 //!   (c) Append-during-paging stability: new events after page 1 visible on page 2.
 //!   (d) 404 for unknown execution id.
 //!   (e) 400 for malformed `after` cursor and non-integer `limit`.
-//!   (f) get_workflow truncation: history.len() <= 100, history_truncated=true, history_endpoint present.
+//!   (f) `get_workflow` truncation: `history.len()` <= 100, `history_truncated=true`, `history_endpoint` present.
 
 #![allow(clippy::too_many_lines)]
 
@@ -29,7 +29,6 @@ use autumn_web::AppState;
 use autumn_web::reexports::axum;
 use axum::body::Body;
 use axum::http::{Request, StatusCode};
-use chrono::Utc;
 use diesel_async::pooled_connection::AsyncDieselConnectionManager;
 use diesel_async::{AsyncConnection, AsyncPgConnection};
 use serde_json::{Value, json};
@@ -262,7 +261,7 @@ async fn seed_execution(conn: &mut AsyncPgConnection, workflow_id: &str) -> Exec
 }
 
 /// Append N `TimerStarted` events then N `TimerFired` events and return the
-/// total appended count (not counting the initial WorkflowStarted row).
+/// total appended count (not counting the initial `WorkflowStarted` row).
 async fn append_mixed_events(
     conn: &mut AsyncPgConnection,
     exec_id: ExecutionId,
@@ -287,7 +286,7 @@ async fn append_mixed_events(
     store::append_events(conn, exec_id, &events, next_id)
         .await
         .expect("append events");
-    next_id += events.len() as i32;
+    next_id += i32::try_from(events.len()).expect("event count fits i32");
     let _ = next_id;
     events.len()
 }
@@ -358,8 +357,8 @@ async fn history_non_integer_limit_returns_400() {
     assert_eq!(status, StatusCode::BAD_REQUEST);
 }
 
-/// (a) Page boundaries: limit=5, follow next_cursor to drain all events, no
-/// drops/duplicates, last page has next_cursor=null.
+/// (a) Page boundaries: `limit=5`, follow `next_cursor` to drain all events, no
+/// drops/duplicates, last page has `next_cursor=null`.
 #[tokio::test]
 async fn history_page_boundaries_no_drops_or_duplicates() {
     let (url, _container) = setup_database().await;
@@ -424,7 +423,7 @@ async fn history_page_boundaries_no_drops_or_duplicates() {
     assert_eq!(collected_ids.len(), 15, "must have collected all 15 events");
 }
 
-/// (b) event_type filter: only matching types returned; total_events is the
+/// (b) `event_type` filter: only matching types returned; `total_events` is the
 /// unfiltered count.
 #[tokio::test]
 async fn history_event_type_filter_returns_only_matching() {
@@ -469,7 +468,7 @@ async fn history_event_type_filter_returns_only_matching() {
     );
 }
 
-/// (b) Multiple event_type values (repeatable param).
+/// (b) Multiple `event_type` values (repeatable param).
 #[tokio::test]
 async fn history_multiple_event_type_filters() {
     let (url, _container) = setup_database().await;
@@ -555,8 +554,8 @@ async fn history_append_during_paging_stability() {
     );
 }
 
-/// (f) get_workflow truncation: when >100 events, history.len() <= 100,
-/// history_truncated=true, history_endpoint is present.
+/// (f) `get_workflow` truncation: when >100 events, `history.len()` <= 100,
+/// `history_truncated=true`, `history_endpoint` is present.
 #[tokio::test]
 async fn get_workflow_history_is_truncated_when_over_100_events() {
     let (url, _container) = setup_database().await;
@@ -593,7 +592,7 @@ async fn get_workflow_history_is_truncated_when_over_100_events() {
     );
 }
 
-/// Response shape: each event in the history page must have id, event_id, timestamp, type, data.
+/// Response shape: each event in the history page must have `id`, `event_id`, timestamp, type, data.
 #[tokio::test]
 async fn history_response_shape_has_required_fields() {
     let (url, _container) = setup_database().await;
@@ -642,7 +641,7 @@ async fn history_response_shape_has_required_fields() {
     assert!(first["data"].is_object(), "each event must have 'data'");
 }
 
-/// Unknown event_type names yield an empty events page (not a 400).
+/// Unknown `event_type` names yield an empty events page (not a 400).
 #[tokio::test]
 async fn history_unknown_event_type_yields_empty_page() {
     let (url, _container) = setup_database().await;

--- a/autumn-harvest-plugin/tests/workflow_history_pagination_integration.rs
+++ b/autumn-harvest-plugin/tests/workflow_history_pagination_integration.rs
@@ -1,0 +1,672 @@
+//! Integration tests for `GET /api/harvest/workflows/{id}/history` (issue #529).
+//!
+//! Tests run against a real Postgres instance (testcontainers) and exercise:
+//!   (a) Page boundaries: limit=10, follow next_cursor, no drops/duplicates.
+//!   (b) event_type filter: only matching types returned; total_events is unfiltered.
+//!   (c) Append-during-paging stability: new events after page 1 visible on page 2.
+//!   (d) 404 for unknown execution id.
+//!   (e) 400 for malformed `after` cursor and non-integer `limit`.
+//!   (f) get_workflow truncation: history.len() <= 100, history_truncated=true, history_endpoint present.
+
+#![allow(clippy::too_many_lines)]
+
+use std::sync::Arc;
+
+use autumn_harvest::scheduler::{DagCatalog, SchedulerMonitor};
+use autumn_harvest::shard::ShardRouter;
+use autumn_harvest::store;
+use autumn_harvest::types::{ActivityExecId, TimerId};
+use autumn_harvest::types::{ExecutionId, Priority, ShardId};
+use autumn_harvest::worker::{DbPool, HandlerRegistry};
+use autumn_harvest::{
+    StartWorkflowParams, WorkflowEvent, WorkflowIdReusePolicy, start_or_load_workflow_execution,
+};
+use autumn_harvest_plugin::HarvestDbPool;
+use autumn_harvest_plugin::api::{
+    HarvestApiRuntime, HarvestApiState, HarvestRetentionRuntime, harvest_api_router,
+};
+use autumn_web::AppState;
+use autumn_web::reexports::axum;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use chrono::Utc;
+use diesel_async::pooled_connection::AsyncDieselConnectionManager;
+use diesel_async::{AsyncConnection, AsyncPgConnection};
+use serde_json::{Value, json};
+use testcontainers::ContainerAsync;
+use testcontainers::ImageExt;
+use testcontainers_modules::postgres::Postgres;
+use testcontainers_modules::testcontainers::runners::AsyncRunner;
+use tower::ServiceExt;
+
+const INIT_SQL: &str = concat!(
+    include_str!("../../autumn-harvest/migrations/20260409000000_harvest_initial/up.sql"),
+    "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260619000000_harvest_task_queue_created_at/up.sql"
+    ),
+    "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260616000001_harvest_workflow_schedule_id/up.sql"
+    ),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260424000001_harvest_trace_context/up.sql"),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260427000000_harvest_continue_as_new/up.sql"),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260429000000_harvest_concurrency_key/up.sql"),
+    "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260430000000_harvest_workflow_schedules/up.sql"
+    ),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260430000001_harvest_external_tasks/up.sql"),
+    "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260508000000_harvest_external_task_updated_at/up.sql"
+    ),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260503000000_harvest_workflow_reset/up.sql"),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260505000000_harvest_heartbeat_details/up.sql"),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260506000000_harvest_audit_log/up.sql"),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260501000000_harvest_workers/up.sql"),
+    "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260508010000_harvest_workers_drain_deadline/up.sql"
+    ),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260509000000_harvest_build_routing/up.sql"),
+    "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260513000000_harvest_schedule_pause_metadata/up.sql"
+    ),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260514020000_harvest_task_activity_id/up.sql"),
+    "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260518000000_harvest_signal_idempotency/up.sql"
+    ),
+    "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260518000001_harvest_workflow_execution_timeout/up.sql"
+    ),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260613000000_harvest_workflow_sla/up.sql"),
+    "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260519000000_harvest_calendar_awareness/up.sql"
+    ),
+    "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260522000000_harvest_schedule_decisions/up.sql"
+    ),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260522000001_harvest_rate_limiting/up.sql"),
+    "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260526000001_harvest_parent_close_policy/up.sql"
+    ),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260530000000_harvest_schedule_ha_claim/up.sql"),
+    "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260601000001_harvest_poison_pill_strikes/up.sql"
+    ),
+    "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260601000002_harvest_ownership_metadata/up.sql"
+    ),
+    "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260603000000_harvest_completion_triggers/up.sql"
+    ),
+    include_str!("../../autumn-harvest/migrations/20260605000000_harvest_admission_gates/up.sql"),
+    include_str!(
+        "../../autumn-harvest/migrations/20260606000001_harvest_activity_schedule_to_close/up.sql"
+    ),
+    include_str!(
+        "../../autumn-harvest/migrations/20260607000000_harvest_worker_capability_labels/up.sql"
+    ),
+    include_str!(
+        "../../autumn-harvest/migrations/20260607000001_harvest_task_required_capabilities/up.sql"
+    ),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260607000002_harvest_workflow_pause/up.sql"),
+    "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260609000001_harvest_workflow_current_details/up.sql"
+    ),
+    "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260610000001_harvest_schedule_bounded_runs/up.sql"
+    ),
+    "\n",
+    include_str!(
+        "../../autumn-harvest/migrations/20260613000001_harvest_schedule_catchup_window/up.sql"
+    ),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260615000001_harvest_context_headers/up.sql"),
+    "\n",
+    include_str!("../../autumn-harvest/migrations/20260626000001_harvest_workflow_retry/up.sql")
+);
+
+type HarvestApiApp = axum::Router;
+
+async fn setup_database() -> (String, ContainerAsync<Postgres>) {
+    let container = Postgres::default()
+        .with_init_sql(INIT_SQL.to_string().into_bytes())
+        .with_tag("16")
+        .start()
+        .await
+        .expect("postgres container should start");
+    let host = container.get_host().await.unwrap();
+    let port = container.get_host_port_ipv4(5432).await.unwrap();
+    let url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+    (url, container)
+}
+
+fn build_pool(url: &str) -> DbPool {
+    let manager = AsyncDieselConnectionManager::<AsyncPgConnection>::new(url);
+    deadpool::managed::Pool::builder(manager)
+        .max_size(8)
+        .build()
+        .expect("pool should build")
+}
+
+fn build_app(pool: &DbPool) -> HarvestApiApp {
+    let api_state = HarvestApiState::new();
+    api_state.set_admin_auth_boundary(true);
+    api_state.install_storage_pool(HarvestDbPool::from(pool.clone()));
+    api_state.install(HarvestApiRuntime::new(
+        Arc::new(HandlerRegistry::new(vec![], vec![])),
+        Arc::new(DagCatalog::default()),
+        Arc::new(Vec::new()),
+        Some("history-pag-test".to_string()),
+        vec!["default".to_string()],
+        SchedulerMonitor::offline(),
+        HarvestRetentionRuntime::disabled(autumn_harvest::RetentionConfig::default()),
+        ShardRouter::default(),
+    ));
+    harvest_api_router(api_state).with_state(AppState::for_test().with_profile("test"))
+}
+
+async fn get_json(app: &HarvestApiApp, uri: &str) -> (StatusCode, Value) {
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(uri)
+                .header("x-harvest-admin", "true")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("GET request");
+    let status = response.status();
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX)
+        .await
+        .unwrap();
+    let json = if bytes.is_empty() {
+        Value::Null
+    } else {
+        serde_json::from_slice(&bytes)
+            .unwrap_or_else(|_| Value::String(String::from_utf8_lossy(&bytes).to_string()))
+    };
+    (status, json)
+}
+
+async fn seed_execution(conn: &mut AsyncPgConnection, workflow_id: &str) -> ExecutionId {
+    let exec_id = ExecutionId::new_for_shard(ShardId::new(0));
+    start_or_load_workflow_execution(
+        conn,
+        StartWorkflowParams {
+            workflow_name: "history-pag-wf",
+            workflow_id,
+            exec_id,
+            input: json!({"n": 1}),
+            parent_id: None,
+            queue_name: "default",
+            execution_timeout: None,
+            memo: None,
+            search_attrs: None,
+            reuse_policy: WorkflowIdReusePolicy::default(),
+            trace_context: None,
+            max_execution_timeout_ceiling: None,
+            concurrency_key: None,
+            concurrency_limit: None,
+            priority: Priority::default(),
+            max_workflow_input_bytes: 0,
+            start_at: None,
+            delay: None,
+            max_workflow_start_delay: None,
+            owner: None,
+            runbook_url: None,
+            severity: None,
+            context_headers: None,
+            sla: None,
+            schedule_id: None,
+            scheduled_for: None,
+            workflow_attempt: 1,
+            workflow_retry_policy: None,
+            retry_of_exec_id: None,
+            max_workflow_attempts_ceiling: None,
+        },
+    )
+    .await
+    .expect("seed workflow");
+    exec_id
+}
+
+/// Append N `TimerStarted` events then N `TimerFired` events and return the
+/// total appended count (not counting the initial WorkflowStarted row).
+async fn append_mixed_events(
+    conn: &mut AsyncPgConnection,
+    exec_id: ExecutionId,
+    n_per_type: usize,
+) -> usize {
+    let history = store::load_history(conn, exec_id).await.unwrap();
+    let mut next_id = history.next_event_id;
+    let mut events: Vec<WorkflowEvent> = Vec::new();
+
+    for i in 0..n_per_type {
+        events.push(WorkflowEvent::TimerStarted {
+            timer_id: TimerId::new(format!("t{i}")),
+            duration_secs: 60,
+        });
+    }
+    for i in 0..n_per_type {
+        events.push(WorkflowEvent::TimerFired {
+            timer_id: TimerId::new(format!("t{i}")),
+        });
+    }
+
+    store::append_events(conn, exec_id, &events, next_id)
+        .await
+        .expect("append events");
+    next_id += events.len() as i32;
+    let _ = next_id;
+    events.len()
+}
+
+/// Append N `ActivityScheduled` events, returning how many were appended.
+async fn append_activity_events(
+    conn: &mut AsyncPgConnection,
+    exec_id: ExecutionId,
+    n: usize,
+) -> usize {
+    let history = store::load_history(conn, exec_id).await.unwrap();
+    let mut events: Vec<WorkflowEvent> = Vec::new();
+    for i in 0..n {
+        events.push(WorkflowEvent::ActivityScheduled {
+            activity_id: ActivityExecId::new(),
+            name: format!("act{i}"),
+            input: json!(null),
+            queue: "default".to_string(),
+        });
+    }
+    store::append_events(conn, exec_id, &events, history.next_event_id)
+        .await
+        .expect("append activity events");
+    events.len()
+}
+
+// ─── RED phase tests ──────────────────────────────────────────────────────────
+
+/// (d) Unknown execution id → 404.
+#[tokio::test]
+async fn history_unknown_id_returns_404() {
+    let (url, _container) = setup_database().await;
+    let pool = build_pool(&url);
+    let app = build_app(&pool);
+
+    let unknown = ExecutionId::new_for_shard(ShardId::new(0));
+    let (status, _body) = get_json(&app, &format!("/workflows/{unknown}/history")).await;
+    assert_eq!(status, StatusCode::NOT_FOUND);
+}
+
+/// (e) Malformed `after` cursor → 400.
+#[tokio::test]
+async fn history_malformed_cursor_returns_400() {
+    let (url, _container) = setup_database().await;
+    let pool = build_pool(&url);
+    let app = build_app(&pool);
+    let mut conn = AsyncPgConnection::establish(&url).await.unwrap();
+
+    let exec_id = seed_execution(&mut conn, "bad-cursor-wf").await;
+    let (status, _body) = get_json(
+        &app,
+        &format!("/workflows/{exec_id}/history?after=not-a-number"),
+    )
+    .await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+/// (e) Non-integer `limit` → 400.
+#[tokio::test]
+async fn history_non_integer_limit_returns_400() {
+    let (url, _container) = setup_database().await;
+    let pool = build_pool(&url);
+    let app = build_app(&pool);
+    let mut conn = AsyncPgConnection::establish(&url).await.unwrap();
+
+    let exec_id = seed_execution(&mut conn, "bad-limit-wf").await;
+    let (status, _body) = get_json(&app, &format!("/workflows/{exec_id}/history?limit=abc")).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST);
+}
+
+/// (a) Page boundaries: limit=5, follow next_cursor to drain all events, no
+/// drops/duplicates, last page has next_cursor=null.
+#[tokio::test]
+async fn history_page_boundaries_no_drops_or_duplicates() {
+    let (url, _container) = setup_database().await;
+    let pool = build_pool(&url);
+    let app = build_app(&pool);
+    let mut conn = AsyncPgConnection::establish(&url).await.unwrap();
+
+    let exec_id = seed_execution(&mut conn, "page-bounds-wf").await;
+    // Append 15 extra events (on top of the initial WorkflowStarted) = 16 total.
+    append_mixed_events(&mut conn, exec_id, 7).await; // 7 TimerStarted + 7 TimerFired = 14
+    // Also append 2 more so total is 1 + 14 + 1 = 16; actually let's just use 15 total extra.
+    // WorkflowStarted is event 0 → +14 = 15 events total.
+
+    let limit = 5;
+    let mut collected_ids: Vec<i64> = Vec::new();
+    let mut cursor = String::new();
+    let mut page_count = 0;
+
+    loop {
+        let uri = if cursor.is_empty() {
+            format!("/workflows/{exec_id}/history?limit={limit}")
+        } else {
+            format!("/workflows/{exec_id}/history?limit={limit}&after={cursor}")
+        };
+        let (status, body) = get_json(&app, &uri).await;
+        assert_eq!(status, StatusCode::OK, "page {page_count}: body={body}");
+
+        let events = body["events"].as_array().expect("events must be array");
+        assert!(
+            events.len() <= limit,
+            "page must not exceed limit, got {}",
+            events.len()
+        );
+
+        for event in events {
+            let id = event["id"].as_i64().expect("each event must have i64 id");
+            assert!(
+                !collected_ids.contains(&id),
+                "duplicate row id {id} on page {page_count}"
+            );
+            collected_ids.push(id);
+        }
+
+        page_count += 1;
+
+        match body["next_cursor"].as_str() {
+            Some(nc) if !nc.is_empty() => cursor = nc.to_string(),
+            _ => break,
+        }
+    }
+
+    assert!(page_count > 1, "must have needed more than one page");
+    assert!(!collected_ids.is_empty(), "must have collected events");
+    // All IDs must be in ascending order across pages.
+    let mut sorted = collected_ids.clone();
+    sorted.sort_unstable();
+    assert_eq!(
+        collected_ids, sorted,
+        "event row ids must be in ascending order across pages"
+    );
+    // 15 total events (1 WorkflowStarted + 14 timer events).
+    assert_eq!(collected_ids.len(), 15, "must have collected all 15 events");
+}
+
+/// (b) event_type filter: only matching types returned; total_events is the
+/// unfiltered count.
+#[tokio::test]
+async fn history_event_type_filter_returns_only_matching() {
+    let (url, _container) = setup_database().await;
+    let pool = build_pool(&url);
+    let app = build_app(&pool);
+    let mut conn = AsyncPgConnection::establish(&url).await.unwrap();
+
+    let exec_id = seed_execution(&mut conn, "filter-wf").await;
+    // 5 TimerStarted + 5 TimerFired = 10, plus 1 WorkflowStarted = 11 total.
+    append_mixed_events(&mut conn, exec_id, 5).await;
+
+    // Filter to only TimerStarted.
+    let (status, body) = get_json(
+        &app,
+        &format!("/workflows/{exec_id}/history?event_type=TimerStarted&limit=100"),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+
+    let events = body["events"].as_array().expect("events array");
+    assert_eq!(
+        events.len(),
+        5,
+        "only TimerStarted events should be returned"
+    );
+    for ev in events {
+        assert_eq!(
+            ev["type"].as_str(),
+            Some("TimerStarted"),
+            "all filtered events must be TimerStarted"
+        );
+    }
+
+    // total_events reflects ALL events (unfiltered).
+    let total = body["total_events"]
+        .as_i64()
+        .expect("total_events must be i64");
+    assert_eq!(
+        total, 11,
+        "total_events must count all events including filtered-out ones"
+    );
+}
+
+/// (b) Multiple event_type values (repeatable param).
+#[tokio::test]
+async fn history_multiple_event_type_filters() {
+    let (url, _container) = setup_database().await;
+    let pool = build_pool(&url);
+    let app = build_app(&pool);
+    let mut conn = AsyncPgConnection::establish(&url).await.unwrap();
+
+    let exec_id = seed_execution(&mut conn, "multi-filter-wf").await;
+    append_mixed_events(&mut conn, exec_id, 3).await; // 3 TimerStarted + 3 TimerFired + 1 WorkflowStarted = 7
+
+    let (status, body) = get_json(
+        &app,
+        &format!(
+            "/workflows/{exec_id}/history?event_type=TimerStarted&event_type=TimerFired&limit=100"
+        ),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    let events = body["events"].as_array().expect("events array");
+    assert_eq!(events.len(), 6, "TimerStarted + TimerFired = 6");
+    for ev in events {
+        let t = ev["type"].as_str().unwrap_or("");
+        assert!(
+            t == "TimerStarted" || t == "TimerFired",
+            "unexpected event type: {t}"
+        );
+    }
+}
+
+/// (c) Append-during-paging stability: already-returned rows are not re-emitted
+/// and newly appended rows (higher id) are reachable via cursor.
+#[tokio::test]
+async fn history_append_during_paging_stability() {
+    let (url, _container) = setup_database().await;
+    let pool = build_pool(&url);
+    let app = build_app(&pool);
+    let mut conn = AsyncPgConnection::establish(&url).await.unwrap();
+
+    let exec_id = seed_execution(&mut conn, "append-paging-wf").await;
+    // Seed 5 events (1 WorkflowStarted already). Append 4 more.
+    append_activity_events(&mut conn, exec_id, 4).await;
+    // Total = 5 events.
+
+    // Page 1: limit=3 → get 3 rows, capture cursor.
+    let (status, page1) = get_json(&app, &format!("/workflows/{exec_id}/history?limit=3")).await;
+    assert_eq!(status, StatusCode::OK, "page1: {page1}");
+    let page1_events = page1["events"].as_array().unwrap();
+    assert_eq!(page1_events.len(), 3);
+    let cursor = page1["next_cursor"]
+        .as_str()
+        .expect("must have next_cursor");
+    let page1_ids: Vec<i64> = page1_events
+        .iter()
+        .map(|e| e["id"].as_i64().unwrap())
+        .collect();
+
+    // Append 3 more events while "between pages".
+    append_activity_events(&mut conn, exec_id, 3).await;
+
+    // Page 2: use cursor — must not see page1's rows; must see remaining old rows + new rows.
+    let (status, page2) = get_json(
+        &app,
+        &format!("/workflows/{exec_id}/history?limit=100&after={cursor}"),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "page2: {page2}");
+    let page2_events = page2["events"].as_array().unwrap();
+
+    // No page-1 ID should appear in page 2.
+    for ev in page2_events {
+        let id = ev["id"].as_i64().unwrap();
+        assert!(
+            !page1_ids.contains(&id),
+            "row id {id} from page 1 re-appeared on page 2"
+        );
+    }
+
+    // We started with 5 rows, appended 3 more = 8 total. Page1 took 3, so page2 must have 5.
+    assert_eq!(
+        page2_events.len(),
+        5,
+        "page2 must contain remaining 2 old + 3 new = 5 events"
+    );
+}
+
+/// (f) get_workflow truncation: when >100 events, history.len() <= 100,
+/// history_truncated=true, history_endpoint is present.
+#[tokio::test]
+async fn get_workflow_history_is_truncated_when_over_100_events() {
+    let (url, _container) = setup_database().await;
+    let pool = build_pool(&url);
+    let app = build_app(&pool);
+    let mut conn = AsyncPgConnection::establish(&url).await.unwrap();
+
+    let exec_id = seed_execution(&mut conn, "trunc-wf").await;
+    // Append 110 events to push over the 100-event page default.
+    append_activity_events(&mut conn, exec_id, 110).await;
+
+    let (status, body) = get_json(&app, &format!("/workflows/{exec_id}")).await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+
+    let history = body["history"].as_array().expect("history must be array");
+    assert!(
+        history.len() <= 100,
+        "get_workflow history must be bounded to <= 100 events, got {}",
+        history.len()
+    );
+
+    assert_eq!(
+        body["history_truncated"].as_bool(),
+        Some(true),
+        "history_truncated must be true when events exceed page size"
+    );
+
+    let endpoint = body["history_endpoint"]
+        .as_str()
+        .expect("history_endpoint must be present");
+    assert!(
+        endpoint.contains("/history"),
+        "history_endpoint must reference the history sub-route, got: {endpoint}"
+    );
+}
+
+/// Response shape: each event in the history page must have id, event_id, timestamp, type, data.
+#[tokio::test]
+async fn history_response_shape_has_required_fields() {
+    let (url, _container) = setup_database().await;
+    let pool = build_pool(&url);
+    let app = build_app(&pool);
+    let mut conn = AsyncPgConnection::establish(&url).await.unwrap();
+
+    let exec_id = seed_execution(&mut conn, "shape-wf").await;
+
+    let (status, body) = get_json(&app, &format!("/workflows/{exec_id}/history?limit=10")).await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+
+    // Top-level response fields.
+    assert!(
+        body["events"].is_array(),
+        "response must have 'events' array"
+    );
+    assert!(
+        body["total_events"].is_number(),
+        "response must have 'total_events' number"
+    );
+    assert!(
+        body["last_event_id"].is_number(),
+        "response must have 'last_event_id' number"
+    );
+    // next_cursor may be null (last page) or a string.
+    assert!(
+        body["next_cursor"].is_null() || body["next_cursor"].is_string(),
+        "next_cursor must be null or string"
+    );
+
+    // Per-event fields.
+    let events = body["events"].as_array().unwrap();
+    assert!(!events.is_empty(), "must have at least WorkflowStarted");
+    let first = &events[0];
+    assert!(first["id"].is_number(), "each event must have 'id'");
+    assert!(
+        first["event_id"].is_number(),
+        "each event must have 'event_id'"
+    );
+    assert!(
+        first["timestamp"].is_string(),
+        "each event must have 'timestamp'"
+    );
+    assert!(first["type"].is_string(), "each event must have 'type'");
+    assert!(first["data"].is_object(), "each event must have 'data'");
+}
+
+/// Unknown event_type names yield an empty events page (not a 400).
+#[tokio::test]
+async fn history_unknown_event_type_yields_empty_page() {
+    let (url, _container) = setup_database().await;
+    let pool = build_pool(&url);
+    let app = build_app(&pool);
+    let mut conn = AsyncPgConnection::establish(&url).await.unwrap();
+
+    let exec_id = seed_execution(&mut conn, "unknown-type-wf").await;
+
+    let (status, body) = get_json(
+        &app,
+        &format!("/workflows/{exec_id}/history?event_type=NonExistentEventType"),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    let events = body["events"].as_array().unwrap();
+    assert!(
+        events.is_empty(),
+        "unknown event_type must yield empty page"
+    );
+    // total_events still reflects the real total.
+    let total = body["total_events"].as_i64().unwrap();
+    assert_eq!(
+        total, 1,
+        "total_events counts WorkflowStarted regardless of filter"
+    );
+}

--- a/autumn-harvest/migrations/20260628000000_harvest_events_history_page_index/down.sql
+++ b/autumn-harvest/migrations/20260628000000_harvest_events_history_page_index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX IF EXISTS idx_harvest_events_history_page;

--- a/autumn-harvest/migrations/20260628000000_harvest_events_history_page_index/up.sql
+++ b/autumn-harvest/migrations/20260628000000_harvest_events_history_page_index/up.sql
@@ -1,0 +1,8 @@
+-- Support O(log n) keyset pagination on GET /workflows/{id}/history (issue #529).
+-- The (workflow_exec_id, id) composite index lets each page fetch walk in id order
+-- within an execution, so LIMIT is applied before materializing all rows rather
+-- than after sorting the full execution history.  The existing
+-- idx_harvest_events_exec covers (workflow_exec_id, event_id) and is used by
+-- load_history / load_history_since; this index covers the id-based cursor path.
+CREATE INDEX IF NOT EXISTS idx_harvest_events_history_page
+    ON harvest_events (workflow_exec_id, id);

--- a/autumn-harvest/src/audit.rs
+++ b/autumn-harvest/src/audit.rs
@@ -251,6 +251,8 @@ pub const CLASSIFIED_ROUTES: &[(&str, RouteClass)] = &[
     ),
     // Workflow terminal-output projection (issue #527): read-only long-poll.
     ("GET /workflows/{id}/result", RouteClass::ReadOnly),
+    // Paginated, filterable single-execution history (issue #529): read-only cursor walk.
+    ("GET /workflows/{id}/history", RouteClass::ReadOnly),
     ("GET /workflows/{id}/history/export", RouteClass::ReadOnly),
     ("GET /dags", RouteClass::ReadOnly),
     ("GET /dags/{dag_name}/runs", RouteClass::ReadOnly),
@@ -441,6 +443,7 @@ pub const EXCLUDED_ROUTES: &[&str] = &[
     // Updates are synchronous request/response, not tracked as operator
     // audit events in this slice; they appear in the workflow event history.
     "POST /workflows/{id}/update/{update_name}",
+    "GET /workflows/{id}/history",
     "GET /workflows/{id}/history/export",
     "GET /dags",
     "GET /dags/{dag_name}/runs",
@@ -519,6 +522,7 @@ pub const ALL_MUTATION_ROUTES: &[(&str, Option<&str>)] = &[
     ("POST /workflows/{id}/update/{update_name}", None),
     ("GET /workflows/{id}/update/{update_id}/result", None),
     ("GET /workflows/{id}/result", None),
+    ("GET /workflows/{id}/history", None),
     ("GET /workflows/{id}/history/export", None),
     // DAG management
     ("GET /dags", None),

--- a/autumn-harvest/src/store.rs
+++ b/autumn-harvest/src/store.rs
@@ -810,8 +810,11 @@ pub struct PagedHistoryEvent {
     pub event_id: i32,
     /// Wall-clock timestamp recorded when the event was appended.
     pub timestamp: chrono::DateTime<chrono::Utc>,
-    /// Deserialized workflow event.
+    /// Deserialized workflow event (for structured inspection and pattern matching).
     pub event: crate::event::WorkflowEvent,
+    /// Raw adjacently-tagged JSON exactly as stored in `harvest_events.event_data`.
+    /// Avoids a round-trip serialize when the caller only needs the wire representation.
+    pub raw_event: serde_json::Value,
 }
 
 /// Result of a paged history query.
@@ -828,6 +831,25 @@ pub struct HistoryPage {
     pub last_event_id: i64,
 }
 
+/// Returns `true` when a workflow execution with `exec_id` exists in the database.
+///
+/// Cheaper than [`load_execution`] when only presence needs to be confirmed
+/// because it projects only the primary key column.
+#[cfg(feature = "db")]
+pub async fn check_execution_exists(
+    conn: &mut AsyncPgConnection,
+    exec_id: ExecutionId,
+) -> crate::error::HarvestResult<bool> {
+    use diesel::dsl::exists;
+    diesel::select(exists(
+        harvest_workflow_executions::table
+            .filter(harvest_workflow_executions::id.eq(exec_id.as_uuid())),
+    ))
+    .get_result(conn)
+    .await
+    .map_err(crate::error::database_error)
+}
+
 /// Load a page of events for `exec_id`.
 ///
 /// - `after_id`: exclusive lower-bound cursor (`harvest_events.id`).  `None`
@@ -835,6 +857,9 @@ pub struct HistoryPage {
 /// - `limit`: maximum number of events to return (1–1000).
 /// - `event_types`: if non-empty, only return rows whose `event_type` is in
 ///   this list.  Unknown type names yield an empty page (not an error).
+/// - `include_totals`: when `true`, runs an extra `COUNT`/`MAX` aggregate
+///   query to populate `HistoryPage::total_events` and `HistoryPage::last_event_id`.
+///   Pass `false` when the caller doesn't need these fields to save a DB round-trip.
 ///
 /// # Errors
 ///
@@ -847,18 +872,23 @@ pub async fn load_history_page(
     after_id: Option<i64>,
     limit: i64,
     event_types: &[String],
+    include_totals: bool,
 ) -> crate::error::HarvestResult<HistoryPage> {
     use diesel::dsl::{count_star, max};
 
     // ── 1. Aggregate query: total events + last id (unfiltered) ──────────────
-    let (total_events, last_event_id): (i64, Option<i64>) = harvest_events::table
-        .filter(harvest_events::workflow_exec_id.eq(exec_id.as_uuid()))
-        .select((count_star(), max(harvest_events::id)))
-        .first(conn)
-        .await
-        .map_err(crate::error::database_error)?;
-
-    let last_event_id = last_event_id.unwrap_or(0);
+    // Skipped when the caller doesn't need totals (e.g. get_workflow bounded view).
+    let (total_events, last_event_id) = if include_totals {
+        let (total, last): (i64, Option<i64>) = harvest_events::table
+            .filter(harvest_events::workflow_exec_id.eq(exec_id.as_uuid()))
+            .select((count_star(), max(harvest_events::id)))
+            .first(conn)
+            .await
+            .map_err(crate::error::database_error)?;
+        (total, last.unwrap_or(0))
+    } else {
+        (0, 0)
+    };
 
     // ── 2. Page query: fetch limit+1 rows to detect next page ────────────────
     let fetch = limit + 1;
@@ -896,6 +926,7 @@ pub async fn load_history_page(
     // ── 4. Decode events ──────────────────────────────────────────────────────
     let mut events = Vec::with_capacity(rows.len());
     for row in rows {
+        let raw_event = row.event_data.clone();
         let event: crate::event::WorkflowEvent =
             serde_json::from_value(row.event_data).map_err(crate::error::HarvestError::from)?;
         events.push(PagedHistoryEvent {
@@ -903,6 +934,7 @@ pub async fn load_history_page(
             event_id: row.event_id,
             timestamp: row.timestamp,
             event,
+            raw_event,
         });
     }
 

--- a/autumn-harvest/src/store.rs
+++ b/autumn-harvest/src/store.rs
@@ -801,6 +801,119 @@ pub async fn load_events_after_row_id(
         .map_err(crate::error::database_error)
 }
 
+/// A single deserialized row from a paged history query.
+#[derive(Debug)]
+pub struct PagedHistoryEvent {
+    /// `harvest_events.id` — the BIGSERIAL row cursor anchor.
+    pub id: i64,
+    /// Sequential event index within this execution (`event_id` column).
+    pub event_id: i32,
+    /// Wall-clock timestamp recorded when the event was appended.
+    pub timestamp: chrono::DateTime<chrono::Utc>,
+    /// Deserialized workflow event.
+    pub event: crate::event::WorkflowEvent,
+}
+
+/// Result of a paged history query.
+#[derive(Debug)]
+pub struct HistoryPage {
+    /// The events on this page (at most `limit` entries).
+    pub events: Vec<PagedHistoryEvent>,
+    /// Opaque cursor to pass as `after` on the next request.  `None` when this
+    /// is the last page.
+    pub next_cursor: Option<i64>,
+    /// Total event count for this execution, ignoring any type filter.
+    pub total_events: i64,
+    /// Highest `harvest_events.id` for this execution (unfiltered).
+    pub last_event_id: i64,
+}
+
+/// Load a page of events for `exec_id`.
+///
+/// - `after_id`: exclusive lower-bound cursor (`harvest_events.id`).  `None`
+///   means start from the first event.
+/// - `limit`: maximum number of events to return (1–1000).
+/// - `event_types`: if non-empty, only return rows whose `event_type` is in
+///   this list.  Unknown type names yield an empty page (not an error).
+///
+/// # Errors
+///
+/// Returns [`crate::error::HarvestError::Database`] on query failure or if
+/// any stored event cannot be decoded.
+#[cfg(feature = "db")]
+pub async fn load_history_page(
+    conn: &mut AsyncPgConnection,
+    exec_id: ExecutionId,
+    after_id: Option<i64>,
+    limit: i64,
+    event_types: &[String],
+) -> crate::error::HarvestResult<HistoryPage> {
+    use diesel::dsl::{count_star, max};
+
+    // ── 1. Aggregate query: total events + last id (unfiltered) ──────────────
+    let (total_events, last_event_id): (i64, Option<i64>) = harvest_events::table
+        .filter(harvest_events::workflow_exec_id.eq(exec_id.as_uuid()))
+        .select((count_star(), max(harvest_events::id)))
+        .first(conn)
+        .await
+        .map_err(crate::error::database_error)?;
+
+    let last_event_id = last_event_id.unwrap_or(0);
+
+    // ── 2. Page query: fetch limit+1 rows to detect next page ────────────────
+    let fetch = limit + 1;
+    let mut query = harvest_events::table
+        .filter(harvest_events::workflow_exec_id.eq(exec_id.as_uuid()))
+        .order(harvest_events::id.asc())
+        .limit(fetch)
+        .into_boxed();
+
+    if let Some(after) = after_id {
+        query = query.filter(harvest_events::id.gt(after));
+    }
+    if !event_types.is_empty() {
+        query = query.filter(harvest_events::event_type.eq_any(event_types));
+    }
+
+    let mut rows: Vec<crate::models::HarvestEvent> = query
+        .select(crate::models::HarvestEvent::as_select())
+        .load(conn)
+        .await
+        .map_err(crate::error::database_error)?;
+
+    // ── 3. Detect next page using the extra row ───────────────────────────────
+    // `limit` is validated to [1, MAX_HISTORY_PAGE=1000] by the caller before this function is
+    // invoked, so the usize conversions below are always safe on any supported target.
+    let limit_usize = usize::try_from(limit).unwrap_or(usize::MAX);
+    let next_cursor = if rows.len() > limit_usize {
+        let cursor = rows[limit_usize - 1].id;
+        rows.truncate(limit_usize);
+        Some(cursor)
+    } else {
+        None
+    };
+
+    // ── 4. Decode events ──────────────────────────────────────────────────────
+    let mut events = Vec::with_capacity(rows.len());
+    for row in rows {
+        let event: crate::event::WorkflowEvent =
+            serde_json::from_value(row.event_data).map_err(crate::error::HarvestError::from)?;
+        events.push(PagedHistoryEvent {
+            id: row.id,
+            event_id: row.event_id,
+            timestamp: row.timestamp,
+            event,
+        });
+    }
+
+    Ok(HistoryPage {
+        events,
+        next_cursor,
+        total_events,
+        last_event_id,
+    })
+}
+
 /// Load the direct children of `parent_id` from one shard.
 ///
 /// Callers that need cross-shard discovery should call this once per shard and

--- a/docs/api-contract.json
+++ b/docs/api-contract.json
@@ -69,7 +69,7 @@
           "name": "page_size",
           "in": "query",
           "required": false,
-          "description": "Number of results per page (1–200). Activates the paginated response envelope {workflows, next_cursor}."
+          "description": "Number of results per page (1\u2013200). Activates the paginated response envelope {workflows, next_cursor}."
         },
         {
           "name": "cursor",
@@ -149,7 +149,9 @@
           "external_handoffs",
           "last_completion_result",
           "last_error",
-          "scheduled_time"
+          "scheduled_time",
+          "history_truncated",
+          "history_endpoint"
         ]
       },
       "error_responses": [
@@ -162,6 +164,64 @@
           "description": "Database error."
         }
       ]
+    },
+    {
+      "method": "GET",
+      "path": "/workflows/{id}/history",
+      "category": "workflow",
+      "read_only": true,
+      "description": "Paginated, filterable event history for a single workflow execution (issue #529). Cursor is the harvest_events.id (BIGSERIAL); absent next_cursor means last page.",
+      "params": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Execution UUID."
+        },
+        {
+          "name": "limit",
+          "in": "query",
+          "required": false,
+          "description": "Maximum events per page (1\u20131000, default 100)."
+        },
+        {
+          "name": "after",
+          "in": "query",
+          "required": false,
+          "description": "Exclusive cursor anchor (harvest_events.id). Opaque \u2014 treat as a string; absent means start from the first event."
+        },
+        {
+          "name": "event_type",
+          "in": "query",
+          "required": false,
+          "description": "Repeatable. Filter to matching event type discriminators (e.g. TimerStarted, ActivityCompleted). Unknown names yield an empty page."
+        }
+      ],
+      "request_body": null,
+      "success_response": {
+        "status": 200,
+        "fields": [
+          "events",
+          "next_cursor",
+          "total_events",
+          "last_event_id"
+        ]
+      },
+      "error_responses": [
+        {
+          "status": 400,
+          "description": "Malformed cursor or non-integer limit."
+        },
+        {
+          "status": 404,
+          "description": "Execution not found."
+        },
+        {
+          "status": 500,
+          "description": "Database error."
+        }
+      ],
+      "idempotency": "Fully idempotent; read-only."
     },
     {
       "method": "GET",
@@ -180,7 +240,7 @@
           "name": "wait",
           "in": "query",
           "required": false,
-          "description": "Optional wait duration such as 250ms, 5s, or 1m. Defaults to 0s. Values above the server ceiling (default 30s, configurable via set_workflow_result_max_wait) are silently clamped — not rejected with 400."
+          "description": "Optional wait duration such as 250ms, 5s, or 1m. Defaults to 0s. Values above the server ceiling (default 30s, configurable via set_workflow_result_max_wait) are silently clamped \u2014 not rejected with 400."
         }
       ],
       "request_body": null,
@@ -678,13 +738,27 @@
         "status": 201,
         "note": "Returns 200 when an existing live execution is attached rather than a fresh one started.",
         "fields": [
-          { "name": "execution_id" },
-          { "name": "workflow_name" },
-          { "name": "workflow_id" },
-          { "name": "state" },
-          { "name": "started_fresh" },
-          { "name": "update_id" },
-          { "name": "result" }
+          {
+            "name": "execution_id"
+          },
+          {
+            "name": "workflow_name"
+          },
+          {
+            "name": "workflow_id"
+          },
+          {
+            "name": "state"
+          },
+          {
+            "name": "started_fresh"
+          },
+          {
+            "name": "update_id"
+          },
+          {
+            "name": "result"
+          }
         ]
       },
       "error_responses": [
@@ -970,7 +1044,7 @@
       "path": "/workflows/{id}/activities/{activity_exec_id}/retry-now",
       "category": "workflow",
       "read_only": false,
-      "description": "Force a backing-off activity to retry immediately by advancing its scheduled_at to NOW() and waking an idle worker via pg_notify. Only PENDING tasks (including those waiting out exponential backoff) can be advanced. Local activities run inline and have no task-queue row — this endpoint does not apply to them.",
+      "description": "Force a backing-off activity to retry immediately by advancing its scheduled_at to NOW() and waking an idle worker via pg_notify. Only PENDING tasks (including those waiting out exponential backoff) can be advanced. Local activities run inline and have no task-queue row \u2014 this endpoint does not apply to them.",
       "idempotency": "Idempotent: calling on an already-eligible task (scheduled_at <= now) returns advanced=false and performs no update. Calling twice after advancing also returns advanced=false on the second call.",
       "params": [
         {
@@ -1003,7 +1077,7 @@
           "already_eligible"
         ],
         "field_notes": {
-          "advanced": "true when scheduled_at was moved to immediate eligibility; false otherwise. Note: advanced=true means scheduled_at was updated, not that the task will be dispatched immediately — per-queue rate-limit buckets and concurrency caps in claim_task can still defer actual dispatch.",
+          "advanced": "true when scheduled_at was moved to immediate eligibility; false otherwise. Note: advanced=true means scheduled_at was updated, not that the task will be dispatched immediately \u2014 per-queue rate-limit buckets and concurrency caps in claim_task can still defer actual dispatch.",
           "already_eligible": "Only meaningful when advanced=false. true=task was already claimable (idempotent no-op). false=a concurrent worker claimed the task between the SELECT and UPDATE (task is now RUNNING).",
           "next_retry_at": "The backdated scheduled_at written to the task when advanced=true (immediately claimable). null when advanced=false."
         }
@@ -1104,7 +1178,7 @@
       "category": "workflow",
       "read_only": false,
       "description": "Send a named signal to a running workflow execution. The request body is the signal payload itself (free-form JSON). Supply an exactly-once delivery key out-of-band via the Idempotency-Key header or the idempotency_key query param (issue #521).",
-      "idempotency": "Optional exactly-once delivery: when an Idempotency-Key header (or idempotency_key query param) is supplied, repeated deliveries with the same key for the same execution land exactly one SignalReceived event — the response reports signal_delivered=false for the deduped retries. Dedupe scope is shard-local, keyed on (execution_id, idempotency_key). Omitting the key reproduces the legacy at-least-once behavior (every call delivers a distinct signal event).",
+      "idempotency": "Optional exactly-once delivery: when an Idempotency-Key header (or idempotency_key query param) is supplied, repeated deliveries with the same key for the same execution land exactly one SignalReceived event \u2014 the response reports signal_delivered=false for the deduped retries. Dedupe scope is shard-local, keyed on (execution_id, idempotency_key). Omitting the key reproduces the legacy at-least-once behavior (every call delivers a distinct signal event).",
       "params": [
         {
           "name": "id",
@@ -1521,14 +1595,38 @@
         "note": "Returns 200 (not 201) when dry_run is true: the plan is computed and returned without any write, and new_run_exec_id / events_carried_over are omitted.",
         "free_form": false,
         "fields": [
-          { "name": "dry_run", "description": "True for a dry-run preview." },
-          { "name": "dag_name", "description": "The DAG name." },
-          { "name": "source_run_exec_id", "description": "The source DAG run execution id." },
-          { "name": "reset_to_event_id", "description": "Resolved 0-based reset event id passed to the #148 reset." },
-          { "name": "nodes_to_re_execute", "description": "Nodes that will re-execute on the new run." },
-          { "name": "nodes_carried_over", "description": "Nodes whose recorded results are carried over." },
-          { "name": "new_run_exec_id", "description": "The forked DAG run execution id (omitted on dry run)." },
-          { "name": "events_carried_over", "description": "Number of carried-over events on the new run (omitted on dry run)." }
+          {
+            "name": "dry_run",
+            "description": "True for a dry-run preview."
+          },
+          {
+            "name": "dag_name",
+            "description": "The DAG name."
+          },
+          {
+            "name": "source_run_exec_id",
+            "description": "The source DAG run execution id."
+          },
+          {
+            "name": "reset_to_event_id",
+            "description": "Resolved 0-based reset event id passed to the #148 reset."
+          },
+          {
+            "name": "nodes_to_re_execute",
+            "description": "Nodes that will re-execute on the new run."
+          },
+          {
+            "name": "nodes_carried_over",
+            "description": "Nodes whose recorded results are carried over."
+          },
+          {
+            "name": "new_run_exec_id",
+            "description": "The forked DAG run execution id (omitted on dry run)."
+          },
+          {
+            "name": "events_carried_over",
+            "description": "Number of carried-over events on the new run (omitted on dry run)."
+          }
         ]
       },
       "error_responses": [
@@ -1949,12 +2047,12 @@
           {
             "name": "dead_lettered_after",
             "required": false,
-            "description": "RFC 3339 timestamp — only redrive entries dead-lettered at or after this time."
+            "description": "RFC 3339 timestamp \u2014 only redrive entries dead-lettered at or after this time."
           },
           {
             "name": "dead_lettered_before",
             "required": false,
-            "description": "RFC 3339 timestamp — only redrive entries dead-lettered before this time."
+            "description": "RFC 3339 timestamp \u2014 only redrive entries dead-lettered before this time."
           },
           {
             "name": "error_contains",
@@ -4089,18 +4187,66 @@
       "request_body": {
         "free_form": false,
         "fields": [
-          { "name": "schedule_expr", "type": "string", "description": "Cron, interval, or manual expression (same format as POST /admin/schedules/workflow)." },
-          { "name": "timezone", "type": "string", "description": "IANA timezone for cron evaluation. Defaults to UTC." },
-          { "name": "catchup", "type": "boolean", "description": "Whether missed fires should be caught up. Informational only in preview; defaults to false." },
-          { "name": "max_active_runs", "type": "integer", "description": "Maximum concurrent runs. Used to set would_skip_if_active. Defaults to 1." },
-          { "name": "paused", "type": "boolean", "description": "If true, returns empty entries with is_paused=true." },
-          { "name": "jitter_secs", "type": "integer", "description": "Jitter window in seconds. 0 disables jitter. Validated via validate_jitter." },
-          { "name": "overlap_policy", "type": "string", "description": "One of: skip, buffer_one, buffer_all, cancel_other, terminate_other. Defaults to skip." },
-          { "name": "buffer_all_max", "type": "integer", "description": "Max buffered slots under buffer_all. Defaults to 100." },
-          { "name": "calendar", "type": "string", "description": "Optional named calendar for exclusion filtering. Returns 400 if not found." },
-          { "name": "skip_policy", "type": "string", "description": "One of: skip, run_next_business_day, run_prev_business_day. Defaults to skip." },
-          { "name": "count", "type": "integer", "description": "Number of entries to return. Defaults to 10, max 100." },
-          { "name": "from", "type": "string", "description": "ISO-8601 UTC start instant. Defaults to now." }
+          {
+            "name": "schedule_expr",
+            "type": "string",
+            "description": "Cron, interval, or manual expression (same format as POST /admin/schedules/workflow)."
+          },
+          {
+            "name": "timezone",
+            "type": "string",
+            "description": "IANA timezone for cron evaluation. Defaults to UTC."
+          },
+          {
+            "name": "catchup",
+            "type": "boolean",
+            "description": "Whether missed fires should be caught up. Informational only in preview; defaults to false."
+          },
+          {
+            "name": "max_active_runs",
+            "type": "integer",
+            "description": "Maximum concurrent runs. Used to set would_skip_if_active. Defaults to 1."
+          },
+          {
+            "name": "paused",
+            "type": "boolean",
+            "description": "If true, returns empty entries with is_paused=true."
+          },
+          {
+            "name": "jitter_secs",
+            "type": "integer",
+            "description": "Jitter window in seconds. 0 disables jitter. Validated via validate_jitter."
+          },
+          {
+            "name": "overlap_policy",
+            "type": "string",
+            "description": "One of: skip, buffer_one, buffer_all, cancel_other, terminate_other. Defaults to skip."
+          },
+          {
+            "name": "buffer_all_max",
+            "type": "integer",
+            "description": "Max buffered slots under buffer_all. Defaults to 100."
+          },
+          {
+            "name": "calendar",
+            "type": "string",
+            "description": "Optional named calendar for exclusion filtering. Returns 400 if not found."
+          },
+          {
+            "name": "skip_policy",
+            "type": "string",
+            "description": "One of: skip, run_next_business_day, run_prev_business_day. Defaults to skip."
+          },
+          {
+            "name": "count",
+            "type": "integer",
+            "description": "Number of entries to return. Defaults to 10, max 100."
+          },
+          {
+            "name": "from",
+            "type": "string",
+            "description": "ISO-8601 UTC start instant. Defaults to now."
+          }
         ]
       },
       "success_response": {
@@ -4152,10 +4298,26 @@
       "read_only": true,
       "description": "List schedule-decision records (fire/skip/overlap/catchup outcomes) across all schedules.",
       "params": [
-        { "name": "schedule_id", "type": "string", "description": "Filter by schedule UUID." },
-        { "name": "decision", "type": "string", "description": "Filter by decision kind (e.g. fired, skipped, overlap_skipped)." },
-        { "name": "reason", "type": "string", "description": "Filter by reason label." },
-        { "name": "limit", "type": "integer", "description": "Maximum number of records to return. Defaults to 50." }
+        {
+          "name": "schedule_id",
+          "type": "string",
+          "description": "Filter by schedule UUID."
+        },
+        {
+          "name": "decision",
+          "type": "string",
+          "description": "Filter by decision kind (e.g. fired, skipped, overlap_skipped)."
+        },
+        {
+          "name": "reason",
+          "type": "string",
+          "description": "Filter by reason label."
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "description": "Maximum number of records to return. Defaults to 50."
+        }
       ],
       "request_body": null,
       "success_response": {
@@ -4164,8 +4326,14 @@
         "fields": []
       },
       "error_responses": [
-        { "status": 400, "description": "Invalid schedule_id UUID." },
-        { "status": 503, "description": "Database unavailable." }
+        {
+          "status": 400,
+          "description": "Invalid schedule_id UUID."
+        },
+        {
+          "status": 503,
+          "description": "Database unavailable."
+        }
       ]
     },
     {
@@ -4175,9 +4343,21 @@
       "read_only": true,
       "description": "List schedule-decision records for a specific schedule.",
       "params": [
-        { "name": "decision", "type": "string", "description": "Filter by decision kind." },
-        { "name": "reason", "type": "string", "description": "Filter by reason label." },
-        { "name": "limit", "type": "integer", "description": "Maximum number of records to return. Defaults to 50." }
+        {
+          "name": "decision",
+          "type": "string",
+          "description": "Filter by decision kind."
+        },
+        {
+          "name": "reason",
+          "type": "string",
+          "description": "Filter by reason label."
+        },
+        {
+          "name": "limit",
+          "type": "integer",
+          "description": "Maximum number of records to return. Defaults to 50."
+        }
       ],
       "request_body": null,
       "success_response": {
@@ -4186,8 +4366,14 @@
         "fields": []
       },
       "error_responses": [
-        { "status": 404, "description": "Schedule not found." },
-        { "status": 503, "description": "Database unavailable." }
+        {
+          "status": 404,
+          "description": "Schedule not found."
+        },
+        {
+          "status": 503,
+          "description": "Database unavailable."
+        }
       ]
     },
     {
@@ -4544,11 +4730,19 @@
       "request_body": null,
       "success_response": {
         "status": 200,
-        "fields": ["policies", "reachability", "diverged_queues", "shard_errors"],
+        "fields": [
+          "policies",
+          "reachability",
+          "diverged_queues",
+          "shard_errors"
+        ],
         "notes": "diverged_queues lists queue names whose active build_id differs across shards, indicating a partial-write incident. shard_errors lists shards that could not be reached."
       },
       "error_responses": [
-        { "status": 503, "description": "Database unavailable." }
+        {
+          "status": 503,
+          "description": "Database unavailable."
+        }
       ]
     },
     {
@@ -4563,18 +4757,43 @@
         "required": true,
         "free_form": false,
         "fields": [
-          { "name": "queue_name", "required": true, "description": "Task queue to configure the build policy for." },
-          { "name": "build_id", "required": true, "description": "Build ID to assign to new workflow starts on this queue." },
-          { "name": "deployment_name", "required": false, "description": "Optional human-readable deployment label." }
+          {
+            "name": "queue_name",
+            "required": true,
+            "description": "Task queue to configure the build policy for."
+          },
+          {
+            "name": "build_id",
+            "required": true,
+            "description": "Build ID to assign to new workflow starts on this queue."
+          },
+          {
+            "name": "deployment_name",
+            "required": false,
+            "description": "Optional human-readable deployment label."
+          }
         ]
       },
       "success_response": {
         "status": 200,
-        "fields": ["id", "queue_name", "build_id", "deployment_name", "created_at", "updated_at"]
+        "fields": [
+          "id",
+          "queue_name",
+          "build_id",
+          "deployment_name",
+          "created_at",
+          "updated_at"
+        ]
       },
       "error_responses": [
-        { "status": 401, "description": "Unauthenticated request." },
-        { "status": 503, "description": "Database unavailable." }
+        {
+          "status": 401,
+          "description": "Unauthenticated request."
+        },
+        {
+          "status": 503,
+          "description": "Database unavailable."
+        }
       ]
     },
     {
@@ -4587,11 +4806,18 @@
       "request_body": null,
       "success_response": {
         "status": 200,
-        "fields": ["entries", "diverged_pairs", "shard_errors"],
+        "fields": [
+          "entries",
+          "diverged_pairs",
+          "shard_errors"
+        ],
         "notes": "entries is an array of BuildCompatEntry objects. diverged_pairs lists (build_id, compatible_with) pairs present on some shards but absent on others, indicating a partial fanout incident. shard_errors lists shards that could not be reached; non-empty means the list may be incomplete."
       },
       "error_responses": [
-        { "status": 503, "description": "Database unavailable." }
+        {
+          "status": 503,
+          "description": "Database unavailable."
+        }
       ]
     },
     {
@@ -4606,17 +4832,36 @@
         "required": true,
         "free_form": false,
         "fields": [
-          { "name": "build_id", "required": true, "description": "The worker build that will process tasks." },
-          { "name": "compatible_with", "required": true, "description": "The assigned build whose tasks the worker build may safely replay." }
+          {
+            "name": "build_id",
+            "required": true,
+            "description": "The worker build that will process tasks."
+          },
+          {
+            "name": "compatible_with",
+            "required": true,
+            "description": "The assigned build whose tasks the worker build may safely replay."
+          }
         ]
       },
       "success_response": {
         "status": 201,
-        "fields": ["id", "build_id", "compatible_with", "declared_at"]
+        "fields": [
+          "id",
+          "build_id",
+          "compatible_with",
+          "declared_at"
+        ]
       },
       "error_responses": [
-        { "status": 401, "description": "Unauthenticated request." },
-        { "status": 503, "description": "Database unavailable." }
+        {
+          "status": 401,
+          "description": "Unauthenticated request."
+        },
+        {
+          "status": 503,
+          "description": "Database unavailable."
+        }
       ]
     },
     {
@@ -4627,8 +4872,18 @@
       "description": "Revoke a compatibility declaration between two build IDs.",
       "idempotency": "Idempotent: revoking a non-existent pair returns revoked=false without error.",
       "params": [
-        { "name": "build_id", "in": "path", "required": true, "description": "The worker build." },
-        { "name": "compat_with", "in": "path", "required": true, "description": "The assigned build to remove from the compatibility set." }
+        {
+          "name": "build_id",
+          "in": "path",
+          "required": true,
+          "description": "The worker build."
+        },
+        {
+          "name": "compat_with",
+          "in": "path",
+          "required": true,
+          "description": "The assigned build to remove from the compatibility set."
+        }
       ],
       "request_body": {
         "required": false,
@@ -4637,11 +4892,19 @@
       },
       "success_response": {
         "status": 200,
-        "fields": ["revoked"]
+        "fields": [
+          "revoked"
+        ]
       },
       "error_responses": [
-        { "status": 401, "description": "Unauthenticated request." },
-        { "status": 503, "description": "Database unavailable." }
+        {
+          "status": 401,
+          "description": "Unauthenticated request."
+        },
+        {
+          "status": 503,
+          "description": "Database unavailable."
+        }
       ]
     },
     {
@@ -4656,20 +4919,35 @@
         "required": true,
         "free_form": false,
         "fields": [
-          { "name": "build_id", "required": true, "description": "The build ID to check for retirement readiness." }
+          {
+            "name": "build_id",
+            "required": true,
+            "description": "The build ID to check for retirement readiness."
+          }
         ]
       },
       "success_response": {
         "status": 200,
-        "fields": ["build_id", "safe_to_retire", "open_executions", "pending_tasks"]
+        "fields": [
+          "build_id",
+          "safe_to_retire",
+          "open_executions",
+          "pending_tasks"
+        ]
       },
       "error_responses": [
-        { "status": 401, "description": "Unauthenticated request." },
+        {
+          "status": 401,
+          "description": "Unauthenticated request."
+        },
         {
           "status": 409,
           "description": "Build has open executions or pending tasks and cannot be retired yet. Body contains the same fields showing current counts."
         },
-        { "status": 503, "description": "Database unavailable." }
+        {
+          "status": 503,
+          "description": "Database unavailable."
+        }
       ]
     },
     {
@@ -4680,13 +4958,19 @@
       "description": "List all active (non-lifted) admission gates.",
       "idempotency": "Read-only; always idempotent.",
       "params": [],
-      "request_body": { "required": false, "free_form": true },
+      "request_body": {
+        "required": false,
+        "free_form": true
+      },
       "success_response": {
         "status": 200,
         "free_form": true
       },
       "error_responses": [
-        { "status": 503, "description": "Database unavailable." }
+        {
+          "status": 503,
+          "description": "Database unavailable."
+        }
       ]
     },
     {
@@ -4701,22 +4985,61 @@
         "required": true,
         "free_form": false,
         "fields": [
-          { "name": "scope_kind", "required": true, "description": "One of: fleet, workflow_name, queue, shard_id, owner." },
-          { "name": "scope_value", "required": false, "description": "Required for non-fleet scopes." },
-          { "name": "reason", "required": true, "description": "Human-readable incident description." },
-          { "name": "message", "required": false, "description": "Optional extended message surfaced in the Vantage UI." },
-          { "name": "expires_at", "required": false, "description": "ISO 8601 timestamp after which the gate self-clears." }
+          {
+            "name": "scope_kind",
+            "required": true,
+            "description": "One of: fleet, workflow_name, queue, shard_id, owner."
+          },
+          {
+            "name": "scope_value",
+            "required": false,
+            "description": "Required for non-fleet scopes."
+          },
+          {
+            "name": "reason",
+            "required": true,
+            "description": "Human-readable incident description."
+          },
+          {
+            "name": "message",
+            "required": false,
+            "description": "Optional extended message surfaced in the Vantage UI."
+          },
+          {
+            "name": "expires_at",
+            "required": false,
+            "description": "ISO 8601 timestamp after which the gate self-clears."
+          }
         ]
       },
       "success_response": {
         "status": 201,
-        "fields": ["id", "scope_kind", "scope_value", "reason", "created_at", "expires_at"]
+        "fields": [
+          "id",
+          "scope_kind",
+          "scope_value",
+          "reason",
+          "created_at",
+          "expires_at"
+        ]
       },
       "error_responses": [
-        { "status": 400, "description": "Invalid scope_kind/scope_value combination or empty reason." },
-        { "status": 401, "description": "Unauthenticated request." },
-        { "status": 429, "description": "Active gate limit (100) reached." },
-        { "status": 503, "description": "Database unavailable." }
+        {
+          "status": 400,
+          "description": "Invalid scope_kind/scope_value combination or empty reason."
+        },
+        {
+          "status": 401,
+          "description": "Unauthenticated request."
+        },
+        {
+          "status": 429,
+          "description": "Active gate limit (100) reached."
+        },
+        {
+          "status": 503,
+          "description": "Database unavailable."
+        }
       ]
     },
     {
@@ -4727,16 +5050,33 @@
       "description": "Lift (soft-delete) an admission gate, immediately re-opening the blocked scope.",
       "idempotency": "Idempotent: lifting a gate that does not exist or is already lifted returns lifted=false without error.",
       "params": [
-        { "name": "id", "in": "path", "required": true, "description": "UUID of the gate to lift." }
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "UUID of the gate to lift."
+        }
       ],
-      "request_body": { "required": false, "free_form": false, "fields": [] },
+      "request_body": {
+        "required": false,
+        "free_form": false,
+        "fields": []
+      },
       "success_response": {
         "status": 200,
-        "fields": ["lifted"]
+        "fields": [
+          "lifted"
+        ]
       },
       "error_responses": [
-        { "status": 401, "description": "Unauthenticated request." },
-        { "status": 503, "description": "Database unavailable." }
+        {
+          "status": 401,
+          "description": "Unauthenticated request."
+        },
+        {
+          "status": 503,
+          "description": "Database unavailable."
+        }
       ]
     },
     {
@@ -4747,7 +5087,12 @@
       "description": "Get detailed worker and queue status eligibility and diagnostic breakdown for triaging stuck tasks in a specific queue.",
       "idempotency": "Read-only; always idempotent.",
       "params": [
-        { "name": "queue_name", "in": "path", "required": true, "description": "Target task queue name." }
+        {
+          "name": "queue_name",
+          "in": "path",
+          "required": true,
+          "description": "Target task queue name."
+        }
       ],
       "request_body": null,
       "success_response": {
@@ -4765,8 +5110,14 @@
         ]
       },
       "error_responses": [
-        { "status": 401, "description": "Unauthenticated request." },
-        { "status": 503, "description": "Database or shard unavailable." }
+        {
+          "status": 401,
+          "description": "Unauthenticated request."
+        },
+        {
+          "status": 503,
+          "description": "Database or shard unavailable."
+        }
       ]
     },
     {
@@ -4777,7 +5128,12 @@
       "description": "Get detailed worker eligibility and diagnostic breakdown narrowed to a single pending task.",
       "idempotency": "Read-only; always idempotent.",
       "params": [
-        { "name": "id", "in": "path", "required": true, "description": "Task UUID." }
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Task UUID."
+        }
       ],
       "request_body": null,
       "success_response": {
@@ -4796,9 +5152,18 @@
         ]
       },
       "error_responses": [
-        { "status": 401, "description": "Unauthenticated request." },
-        { "status": 404, "description": "Task not found across any shard." },
-        { "status": 503, "description": "Database or shard unavailable." }
+        {
+          "status": 401,
+          "description": "Unauthenticated request."
+        },
+        {
+          "status": 404,
+          "description": "Task not found across any shard."
+        },
+        {
+          "status": 503,
+          "description": "Database or shard unavailable."
+        }
       ]
     }
   ]

--- a/docs/management-api.md
+++ b/docs/management-api.md
@@ -421,3 +421,96 @@ curl "/api/harvest/workflows/$EXEC_ID/stack"
   ]
 }
 ```
+
+## Single-execution history (paginated)
+
+### Endpoint
+
+```
+GET /workflows/{id}/history
+```
+
+Returns a bounded, paginated, filterable view of a single execution's event log.
+Use this endpoint to page through history incrementally for long-running executions,
+or to filter events by type during incident triage.
+
+### Parameters
+
+| Parameter | In | Required | Description |
+|-----------|----|----------|-------------|
+| `id` | path | yes | Execution UUID. |
+| `limit` | query | no | Maximum events per page (1–1000). Default: **100**. Values above 1000 are silently clamped to 1000. |
+| `after` | query | no | Exclusive cursor anchor. Opaque — treat as a string; absent means start from the first event. |
+| `event_type` | query | no | Repeatable. Filter to matching event type discriminators (e.g. `TimerStarted`, `ActivityCompleted`). Unknown type names yield an empty events array, not a 400. |
+
+### Cursor semantics
+
+- The cursor is the decimal string of `harvest_events.id` (a BIGSERIAL integer).
+- Pagination is exclusive: `after=N` returns rows with `id > N`, in ascending order.
+- Absent `next_cursor` in the response means you are on the last page.
+- The cursor is gap-tolerant and append-safe: concurrent event appends with higher `id`
+  values are always reachable via future pages; already-returned rows are never re-emitted.
+
+### Response shape
+
+```json
+{
+  "events": [
+    {
+      "id": 42,
+      "event_id": 0,
+      "timestamp": "2026-06-27T10:00:00Z",
+      "type": "WorkflowStarted",
+      "data": { "workflow_id": "my-wf", "input": { "n": 1 } }
+    }
+  ],
+  "next_cursor": "42",
+  "total_events": 350,
+  "last_event_id": 9999
+}
+```
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `events` | array | Events on this page (≤ `limit`). |
+| `next_cursor` | string \| null | Cursor for the next page. `null` = last page. |
+| `total_events` | integer | Total event count for this execution, **unaffected** by `event_type` filter. |
+| `last_event_id` | integer | Highest `harvest_events.id` for this execution (unfiltered). |
+
+Each entry in `events`:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | integer | `harvest_events.id` — the cursor anchor for keyset pagination. |
+| `event_id` | integer | Sequential event index within this execution (0-based). |
+| `timestamp` | string | RFC 3339 timestamp recorded when the event was appended. |
+| `type` | string | Event discriminator (e.g. `TimerStarted`, `ActivityCompleted`). |
+| `data` | object | Event payload (the `data` object from the adjacently-tagged stored JSON). |
+
+### `get_workflow` truncation contract
+
+`GET /workflows/{id}` now bounds `history` to the first **100** events and adds two
+new fields:
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `history_truncated` | boolean | `true` when the execution has more than 100 events and the embedded `history` is a partial view. |
+| `history_endpoint` | string | URL path of this paginated endpoint (e.g. `/workflows/{id}/history`). |
+
+`GET /workflows/{id}/history/export` (full history export) is unchanged.
+
+### Paging example
+
+```bash
+# Page 1 (first 50 events)
+curl -H "x-harvest-admin: true" \
+  "/api/harvest/workflows/$EXEC_ID/history?limit=50"
+
+# Page 2 (use next_cursor from page 1)
+curl -H "x-harvest-admin: true" \
+  "/api/harvest/workflows/$EXEC_ID/history?limit=50&after=$CURSOR"
+
+# Filter to only TimerStarted + TimerFired events
+curl -H "x-harvest-admin: true" \
+  "/api/harvest/workflows/$EXEC_ID/history?event_type=TimerStarted&event_type=TimerFired"
+```


### PR DESCRIPTION
## Summary

Implements a new read-only `GET /workflows/{id}/history` endpoint that provides paginated, filterable access to a single execution's event log. This addresses issue #529 and enables efficient browsing of long-running workflow histories without loading the entire event stream into memory.

## Key Changes

- **New API endpoint**: `GET /workflows/{id}/history` with keyset pagination using `harvest_events.id` as the cursor anchor
  - Query parameters: `limit` (1–1000, default 100), `after` (exclusive cursor), `event_type` (repeatable filter)
  - Response includes `events`, `next_cursor`, `total_events`, and `last_event_id`
  - Cursor semantics are gap-tolerant and append-safe: concurrent appends with higher IDs are always reachable; already-returned rows are never re-emitted

- **Database layer** (`autumn-harvest/src/store.rs`):
  - New `PagedHistoryEvent` struct wrapping deserialized events with row metadata (`id`, `event_id`, `timestamp`)
  - New `HistoryPage` result type with pagination state
  - New `check_execution_exists()` helper for efficient 404 detection
  - New `load_history_page()` async function supporting optional type filtering and configurable aggregate queries

- **API handler** (`autumn-harvest-plugin/src/api.rs`):
  - New `get_workflow_history()` handler with query parameter parsing and validation
  - New `WorkflowHistoryEntry` and `WorkflowHistoryPage` response types
  - Helper `parse_workflow_history_query()` for parameter extraction and error handling
  - Updated `get_workflow()` to use bounded history loading (DEFAULT_HISTORY_PAGE = 100) and populate new `history_truncated` and `history_endpoint` fields in `WorkflowDetailsResponse`

- **Integration tests** (`autumn-harvest-plugin/tests/workflow_history_pagination_integration.rs`):
  - Comprehensive test suite (672 lines) covering:
    - Page boundary correctness with no drops/duplicates
    - Event type filtering with unfiltered total counts
    - Append-during-paging stability
    - 404 for unknown execution IDs
    - 400 for malformed cursors and non-integer limits
    - History truncation in `get_workflow` response

- **Documentation**:
  - Updated `docs/api-contract.json` with new endpoint specification
  - New section in `docs/management-api.md` with cursor semantics, parameter descriptions, and response shape examples
  - Updated `CHANGELOG.md` with feature announcement

- **Routing and metadata**:
  - Registered new route in `harvest_api_router()`
  - Added to `management_api_routes()` and `management_api_response_fields()`
  - Classified as read-only in `autumn-harvest/src/audit.rs`

## Implementation Details

- **Cursor design**: Uses decimal string representation of `harvest_events.id` (BIGSERIAL) for simplicity and opacity
- **Pagination strategy**: Fetches `limit + 1` rows to detect whether a next page exists, avoiding a separate count query
- **Type filtering**: Unknown event type names yield empty results (not 400), allowing graceful degradation
- **Aggregate queries**: Optional `include_totals` parameter allows callers to skip expensive COUNT/MAX queries when not needed (e.g., bounded history in `get_workflow`)
- **History truncation**: `get_workflow` now signals when embedded history is truncated and provides the paginated endpoint URL for clients to fetch the full history

https://claude.ai/code/session_01Rmn1YEN6bKu5AqHrpnmyYM