### PR TITLE
⚒️ Forge: [Refactor Option extraction in start_harvest_runtime]

### DIFF
--- a/autumn-harvest-plugin/src/plugin.rs
+++ b/autumn-harvest-plugin/src/plugin.rs
@@ -430,20 +430,21 @@ async fn start_harvest_runtime(
                 let client = client.clone();
                 let harvest_db = state.extension::<crate::state::HarvestDbPool>();
 
-                let (owner, runbook_url, severity, info_sla, info_retry_policy) = state
-                    .extension::<std::sync::Arc<autumn_harvest::worker::HandlerRegistry>>()
-                    .and_then(|registry| {
-                        registry.workflows.get("webhook_delivery").map(|wf| {
-                            (
-                                wf.owner,
-                                wf.runbook_url,
-                                wf.severity,
-                                wf.sla,
-                                wf.retry_policy,
-                            )
-                        })
-                    })
-                    .unwrap_or((None, None, None, None, None));
+                let registry =
+                    state.extension::<std::sync::Arc<autumn_harvest::worker::HandlerRegistry>>();
+                let wf_info = registry
+                    .as_ref()
+                    .and_then(|r| r.workflows.get("webhook_delivery"));
+                let (owner, runbook_url, severity, info_sla, info_retry_policy) =
+                    wf_info.map_or((None, None, None, None, None), |wf| {
+                        (
+                            wf.owner,
+                            wf.runbook_url,
+                            wf.severity,
+                            wf.sla,
+                            wf.retry_policy.clone(),
+                        )
+                    });
                 let sla = info_sla.and_then(|d| autumn_harvest::chrono::Duration::from_std(d).ok());
                 let webhook_retry_policy = info_retry_policy;
 


### PR DESCRIPTION
🚮 Smell:
The `start_harvest_runtime` function in `autumn-harvest-plugin/src/plugin.rs` contained a deeply nested and unidiomatic approach for extracting metadata from the `HandlerRegistry`. It previously used `.and_then(|registry| { registry.workflows.get(...).map(|wf| { ... }) }).unwrap_or(...)`. In attempting to fix a compiler error with a `match` statement, it was still unnecessarily verbose and violated `clippy::option_if_let_else`.

✨ Solution:
Extracted the `registry` and `wf_info` variables for clarity, and used the `.map_or()` method on `wf_info` to provide the default empty tuple or the mapped struct fields, flattening the logic significantly.

🧼 Benefit:
Improves idiomatic Rust usage by resolving a clippy warning, flattens the pyramid of doom, and reduces cognitive load by separating extraction from mapping.

🛡️ Verification:
Ran `cargo clippy --all-targets --all-features -- -D warnings` and `cargo test -p autumn-harvest-plugin --lib` successfully. No logic changed.

---
*PR created automatically by Jules for task [14153190731684525546](https://jules.google.com/task/14153190731684525546) started by @madmax983*