### PR TITLE
Batch reset by semantic point (issue #538)

### DIFF
--- a/autumn-harvest-cli/src/lib.rs
+++ b/autumn-harvest-cli/src/lib.rs
@@ -874,6 +874,40 @@ enum WorkflowCommand {
         /// Registered workflow name.
         workflow_name: String,
     },
+    /// Reset a cohort of workflow executions to a shared semantic point (issue #538).
+    ///
+    /// Selects candidates via the filter grammar, resolves the logical anchor
+    /// per execution, and returns a per-execution outcome list. Use
+    /// `--preview` to resolve without forking.
+    BatchReset {
+        /// Inline JSON filter (e.g. `'{"states":["FAILED"],"workflow_name":"my_flow"}'`).
+        #[arg(long, conflicts_with = "filter_file")]
+        filter_json: Option<String>,
+        /// File containing the JSON filter. Use `-` for stdin.
+        #[arg(long, value_name = "PATH", conflicts_with = "filter_json")]
+        filter_file: Option<PathBuf>,
+        /// Reset to a specific event ID (preserved for each execution individually).
+        #[arg(long, conflicts_with_all = ["first_activity", "last_workflow_task"])]
+        event_id: Option<i64>,
+        /// Reset each execution just before the first scheduling of this activity name.
+        #[arg(long, value_name = "ACTIVITY_NAME", conflicts_with_all = ["event_id", "last_workflow_task"])]
+        first_activity: Option<String>,
+        /// Reset each execution to the most-recent clean workflow-task boundary.
+        #[arg(long, conflicts_with_all = ["event_id", "first_activity"])]
+        last_workflow_task: bool,
+        /// Recovery reason recorded in reset marker events.
+        #[arg(long)]
+        reason: String,
+        /// Operator identity recorded in reset marker events.
+        #[arg(long, default_value = "cli")]
+        operator_id: String,
+        /// How to handle undelivered source signals.
+        #[arg(long, value_enum, default_value = "drop")]
+        signal_reapply: ResetSignalReapply,
+        /// Resolve the semantic point per execution but do not fork any execution.
+        #[arg(long)]
+        preview: bool,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -1111,10 +1145,10 @@ enum ScheduleCommand {
     Runs {
         /// Schedule row ID (UUID).
         id: String,
-        /// Filter by execution state (repeatable), e.g. --state FAILED --state TIMED_OUT.
+        /// Filter by execution state (repeatable), e.g. --state FAILED --state `TIMED_OUT`.
         #[arg(long = "state")]
         state: Vec<String>,
-        /// Filter by dispatch origin (repeatable): scheduled, backfill, manual_trigger.
+        /// Filter by dispatch origin (repeatable): scheduled, backfill, `manual_trigger`.
         #[arg(long = "origin")]
         origin: Vec<String>,
         /// Only runs started at/after this RFC 3339 time or relative duration (e.g. 24h).
@@ -3507,6 +3541,57 @@ fn workflow_request(command: &WorkflowCommand) -> Result<ApiRequest, CliError> {
             "/workflows/types/{}/handlers",
             path_segment(workflow_name),
         ))),
+        WorkflowCommand::BatchReset {
+            filter_json,
+            filter_file,
+            event_id,
+            first_activity,
+            last_workflow_task,
+            reason,
+            operator_id,
+            signal_reapply,
+            preview,
+        } => {
+            let filter = parse_json_source(
+                filter_json.as_deref(),
+                filter_file.as_deref(),
+                "batch reset filter",
+            )?
+            .ok_or_else(|| {
+                CliError::InvalidInput(
+                    "one of --filter-json or --filter-file is required".to_string(),
+                )
+            })?;
+            let reset_point = if let Some(id) = event_id {
+                json!({"type": "event_id", "event_id": id})
+            } else if let Some(name) = first_activity {
+                json!({"type": "first_activity_run", "activity_name": name})
+            } else if *last_workflow_task {
+                json!({"type": "last_workflow_task"})
+            } else {
+                return Err(CliError::InvalidInput(
+                    "one of --event-id, --first-activity, or --last-workflow-task is required"
+                        .to_string(),
+                ));
+            };
+            let mut body = serde_json::Map::new();
+            body.insert("filter".to_string(), filter);
+            body.insert("reset_point".to_string(), reset_point);
+            body.insert("reason".to_string(), Value::String(reason.clone()));
+            body.insert(
+                "operator_id".to_string(),
+                Value::String(operator_id.clone()),
+            );
+            body.insert(
+                "signal_reapply".to_string(),
+                Value::String(signal_reapply.as_wire().to_string()),
+            );
+            body.insert("preview".to_string(), Value::Bool(*preview));
+            Ok(ApiRequest::post(
+                "/workflows/batch_reset".to_string(),
+                Some(Value::Object(body)),
+            ))
+        }
     }
 }
 
@@ -3778,6 +3863,7 @@ fn dag_request(command: &DagCommand, actor: Option<&str>) -> Result<ApiRequest, 
     }
 }
 
+#[allow(clippy::too_many_lines)]
 fn schedule_request(command: &ScheduleCommand) -> Result<ApiRequest, CliError> {
     match command {
         ScheduleCommand::List => Ok(ApiRequest::get("/admin/schedules")),

--- a/autumn-harvest-cli/tests/request_mapping.rs
+++ b/autumn-harvest-cli/tests/request_mapping.rs
@@ -1283,3 +1283,154 @@ fn workflow_retry_activity_maps_to_post_retry_now_route() {
     );
     assert_eq!(request.body, None, "retry-activity sends no body");
 }
+
+// ── batch-reset subcommand (issue #538) ───────────────────────────────────────
+
+#[test]
+fn workflow_batch_reset_first_activity_maps_to_batch_reset_route() {
+    let cli = Cli::try_parse_from([
+        "harvest",
+        "workflow",
+        "batch-reset",
+        "--filter-json",
+        r#"{"states":["FAILED"],"workflow_name":"subscription_flow"}"#,
+        "--first-activity",
+        "activity_x",
+        "--reason",
+        "post-deploy fix #1234",
+        "--operator-id",
+        "oncall-jane",
+    ])
+    .expect("batch-reset args should parse");
+    let request = cli.api_request().expect("batch-reset request should build");
+
+    assert_eq!(request.method, ApiMethod::Post);
+    assert_eq!(request.path, "/workflows/batch_reset");
+
+    let body = request.body.unwrap();
+    assert_eq!(body["filter"]["states"][0], "FAILED");
+    assert_eq!(body["filter"]["workflow_name"], "subscription_flow");
+    assert_eq!(body["reset_point"]["type"], "first_activity_run");
+    assert_eq!(body["reset_point"]["activity_name"], "activity_x");
+    assert_eq!(body["reason"], "post-deploy fix #1234");
+    assert_eq!(body["operator_id"], "oncall-jane");
+    assert_eq!(body["signal_reapply"], "drop");
+    assert_eq!(body["preview"], false);
+}
+
+#[test]
+fn workflow_batch_reset_event_id_maps_correctly() {
+    let cli = Cli::try_parse_from([
+        "harvest",
+        "workflow",
+        "batch-reset",
+        "--filter-json",
+        r#"{"states":["FAILED"]}"#,
+        "--event-id",
+        "42",
+        "--reason",
+        "manual fix",
+    ])
+    .expect("batch-reset --event-id args should parse");
+    let request = cli
+        .api_request()
+        .expect("batch-reset --event-id request should build");
+
+    assert_eq!(request.method, ApiMethod::Post);
+    assert_eq!(request.path, "/workflows/batch_reset");
+
+    let body = request.body.unwrap();
+    assert_eq!(body["reset_point"]["type"], "event_id");
+    assert_eq!(body["reset_point"]["event_id"], 42);
+    assert_eq!(body["operator_id"], "cli");
+}
+
+#[test]
+fn workflow_batch_reset_last_workflow_task_maps_correctly() {
+    let cli = Cli::try_parse_from([
+        "harvest",
+        "workflow",
+        "batch-reset",
+        "--filter-json",
+        r#"{"states":["FAILED"]}"#,
+        "--last-workflow-task",
+        "--reason",
+        "recover from stuck state",
+    ])
+    .expect("batch-reset --last-workflow-task args should parse");
+    let request = cli
+        .api_request()
+        .expect("batch-reset --last-workflow-task request should build");
+
+    assert_eq!(request.method, ApiMethod::Post);
+    assert_eq!(request.path, "/workflows/batch_reset");
+
+    let body = request.body.unwrap();
+    assert_eq!(body["reset_point"]["type"], "last_workflow_task");
+}
+
+#[test]
+fn workflow_batch_reset_preview_flag_sets_preview_true() {
+    let cli = Cli::try_parse_from([
+        "harvest",
+        "workflow",
+        "batch-reset",
+        "--filter-json",
+        r#"{"states":["FAILED"]}"#,
+        "--first-activity",
+        "my_activity",
+        "--reason",
+        "dry run check",
+        "--preview",
+    ])
+    .expect("batch-reset --preview args should parse");
+    let request = cli
+        .api_request()
+        .expect("batch-reset --preview request should build");
+
+    let body = request.body.unwrap();
+    assert_eq!(body["preview"], true);
+}
+
+#[test]
+fn workflow_batch_reset_signal_reapply_buffer_maps_correctly() {
+    let cli = Cli::try_parse_from([
+        "harvest",
+        "workflow",
+        "batch-reset",
+        "--filter-json",
+        r#"{"states":["FAILED"]}"#,
+        "--first-activity",
+        "my_activity",
+        "--reason",
+        "fix",
+        "--signal-reapply",
+        "buffer",
+    ])
+    .expect("batch-reset --signal-reapply buffer args should parse");
+    let request = cli
+        .api_request()
+        .expect("batch-reset --signal-reapply buffer request should build");
+
+    let body = request.body.unwrap();
+    assert_eq!(body["signal_reapply"], "buffer");
+}
+
+#[test]
+fn workflow_batch_reset_no_point_flag_returns_error() {
+    let cli = Cli::try_parse_from([
+        "harvest",
+        "workflow",
+        "batch-reset",
+        "--filter-json",
+        r#"{"states":["FAILED"]}"#,
+        "--reason",
+        "fix",
+    ])
+    .expect("batch-reset parse should succeed (missing point is a runtime error)");
+    let result = cli.api_request();
+    assert!(
+        result.is_err(),
+        "batch-reset without a reset-point flag should return an error"
+    );
+}

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -3642,7 +3642,15 @@ pub const fn management_api_response_fields()
         (
             "POST",
             "/workflows/batch_reset",
-            Some(&["preview", "total", "reset_count", "skipped_count", "items"]),
+            Some(&[
+                "status",
+                "preview",
+                "total",
+                "reset_count",
+                "skipped_count",
+                "items",
+                "unavailable_shards",
+            ]),
         ),
         // ── batch operations ──────────────────────────────────────────────────
         ("GET", "/batch-operations", None), // Vec<BatchJobView> (external model)
@@ -8615,11 +8623,15 @@ struct BatchResetRequest {
 /// Response for `POST /workflows/batch_reset`.
 #[derive(Debug, Serialize)]
 struct BatchResetResponse {
+    /// `"complete"` when all shards were reachable, `"partial"` otherwise.
+    status: &'static str,
     preview: bool,
     total: usize,
     reset_count: usize,
     skipped_count: usize,
     items: Vec<BatchResetItem>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    unavailable_shards: Vec<UnavailableShard>,
 }
 
 #[allow(clippy::too_many_lines)]
@@ -8660,11 +8672,18 @@ async fn batch_reset_workflows(
     // ── Collect candidate exec_ids across all shards ───────────────────────
     // Collect (exec_id, shard_id) pairs for the per-exec resolve+reset phase.
     let mut shard_items: Vec<(uuid::Uuid, ShardId)> = Vec::new();
+    let mut unavailable_shards: Vec<UnavailableShard> = Vec::new();
 
     for (shard_id, shard_pool) in pool.iter_shards() {
         let mut conn = match acquire_conn(shard_pool).await {
             Ok(c) => c,
-            Err(_e) => continue,
+            Err(e) => {
+                unavailable_shards.push(UnavailableShard {
+                    shard_id: shard_id.as_i32(),
+                    reason: format!("connection unavailable: {e}"),
+                });
+                continue;
+            }
         };
 
         // Build a shard-local query using the BatchFilter (mirror batch.rs pattern).
@@ -8693,9 +8712,15 @@ async fn batch_reset_workflows(
             query = query.filter(harvest_workflow_executions::workflow_name.eq(name));
         }
 
-        // search_attrs filtering is intentionally not applied at the DB level
-        // for batch_reset (consistent with submit_batch_operation) — the
-        // cohort cap guards against runaway selects.
+        // Apply search_attrs JSONB containment predicates.
+        {
+            use diesel::dsl::sql;
+            use diesel::sql_types::{Bool, Jsonb};
+            for predicate in &request.filter.search_attrs {
+                query = query
+                    .filter(sql::<Bool>("search_attrs @> ").bind::<Jsonb, _>(predicate.clone()));
+            }
+        }
 
         let ids: Vec<uuid::Uuid> = match query
             .limit(i64::try_from(DEFAULT_BATCH_RESET_MAX_COHORT + 1).unwrap_or(i64::MAX))
@@ -8703,7 +8728,13 @@ async fn batch_reset_workflows(
             .await
         {
             Ok(ids) => ids,
-            Err(_e) => continue,
+            Err(e) => {
+                unavailable_shards.push(UnavailableShard {
+                    shard_id: shard_id.as_i32(),
+                    reason: format!("query failed: {e}"),
+                });
+                continue;
+            }
         };
 
         for id in ids {
@@ -8736,13 +8767,15 @@ async fn batch_reset_workflows(
         let exec_id_str = exec_uuid.to_string();
         let exec_id = match exec_id_str.parse::<ExecutionId>() {
             Ok(id) => id,
-            Err(_) => {
+            Err(e) => {
                 items.push(BatchResetItem {
                     exec_id: exec_id_str,
                     outcome: BatchResetOutcome::Skipped,
                     resolved_event_id: None,
                     new_exec_id: None,
-                    skip_reason: Some(ResetSkipReason::EmptyHistory),
+                    skip_reason: Some(ResetSkipReason::InfrastructureError {
+                        message: format!("invalid execution UUID: {e}"),
+                    }),
                 });
                 skipped_count += 1;
                 continue;
@@ -8751,13 +8784,15 @@ async fn batch_reset_workflows(
 
         let mut conn = match acquire_conn(pool.pool_for(*shard_id)).await {
             Ok(c) => c,
-            Err(_e) => {
+            Err(e) => {
                 items.push(BatchResetItem {
                     exec_id: exec_id_str.clone(),
                     outcome: BatchResetOutcome::Skipped,
                     resolved_event_id: None,
                     new_exec_id: None,
-                    skip_reason: Some(ResetSkipReason::EmptyHistory),
+                    skip_reason: Some(ResetSkipReason::InfrastructureError {
+                        message: format!("DB connection unavailable: {e}"),
+                    }),
                 });
                 skipped_count += 1;
                 continue;
@@ -8772,7 +8807,7 @@ async fn batch_reset_workflows(
         )
         .await
         {
-            Err(_db_err) => {
+            Err(db_err) => {
                 // DB errors are propagated as skips in batch context to
                 // keep the 100% account-for invariant.
                 items.push(BatchResetItem {
@@ -8780,7 +8815,9 @@ async fn batch_reset_workflows(
                     outcome: BatchResetOutcome::Skipped,
                     resolved_event_id: None,
                     new_exec_id: None,
-                    skip_reason: Some(ResetSkipReason::EmptyHistory),
+                    skip_reason: Some(ResetSkipReason::InfrastructureError {
+                        message: format!("resolve failed: {db_err}"),
+                    }),
                 });
                 skipped_count += 1;
             }
@@ -8803,7 +8840,6 @@ async fn batch_reset_workflows(
                         new_exec_id: None,
                         skip_reason: None,
                     });
-                    reset_count += 1;
                 } else {
                     // Perform the actual reset.
                     let reset_req = WorkflowResetRequest {
@@ -8832,13 +8868,15 @@ async fn batch_reset_workflows(
                             });
                             reset_count += 1;
                         }
-                        Err(_reset_err) => {
+                        Err(reset_err) => {
                             items.push(BatchResetItem {
                                 exec_id: exec_id_str,
                                 outcome: BatchResetOutcome::Skipped,
                                 resolved_event_id: Some(resolved_event_id),
                                 new_exec_id: None,
-                                skip_reason: Some(ResetSkipReason::EmptyHistory),
+                                skip_reason: Some(ResetSkipReason::InfrastructureError {
+                                    message: format!("reset failed: {reset_err}"),
+                                }),
                             });
                             skipped_count += 1;
                         }
@@ -8879,14 +8917,21 @@ async fn batch_reset_workflows(
         let _ = audit::insert_audit(&mut conn, &ar).await;
     }
 
+    let status = if unavailable_shards.is_empty() {
+        "complete"
+    } else {
+        "partial"
+    };
     (
         StatusCode::OK,
         Json(BatchResetResponse {
+            status,
             preview: request.preview,
             total,
             reset_count,
             skipped_count,
             items,
+            unavailable_shards,
         }),
     )
         .into_response()

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -8829,21 +8829,18 @@ async fn batch_reset_workflows(
 
         // If the shard's connection failed on a prior item, skip remaining
         // items on that shard without re-attempting acquisition.
-        let conn = match active_conn.as_mut() {
-            Some(c) => c,
-            None => {
-                items.push(BatchResetItem {
-                    exec_id: exec_id_str,
-                    outcome: BatchResetOutcome::Skipped,
-                    resolved_event_id: None,
-                    new_exec_id: None,
-                    skip_reason: Some(ResetSkipReason::InfrastructureError {
-                        message: "DB connection unavailable".to_string(),
-                    }),
-                });
-                skipped_count += 1;
-                continue;
-            }
+        let Some(conn) = active_conn.as_mut() else {
+            items.push(BatchResetItem {
+                exec_id: exec_id_str,
+                outcome: BatchResetOutcome::Skipped,
+                resolved_event_id: None,
+                new_exec_id: None,
+                skip_reason: Some(ResetSkipReason::InfrastructureError {
+                    message: "DB connection unavailable".to_string(),
+                }),
+            });
+            skipped_count += 1;
+            continue;
         };
 
         match resolve_batch_reset_one(conn, exec_id, &request.reset_point, request.signal_reapply)

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -3115,6 +3115,7 @@ pub const fn management_api_request_fields()
             "/workflows/{id}/reset",
             Some(&[
                 "reset_to_event_id",
+                "reset_point",
                 "reason",
                 "operator_id",
                 "signal_reapply",

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -8675,6 +8675,12 @@ async fn batch_reset_workflows(
     let mut unavailable_shards: Vec<UnavailableShard> = Vec::new();
 
     for (shard_id, shard_pool) in pool.iter_shards() {
+        // Break early once we already know the cohort is too large — no point
+        // querying additional shards when the request will be rejected anyway.
+        if shard_items.len() > DEFAULT_BATCH_RESET_MAX_COHORT {
+            break;
+        }
+
         let mut conn = match acquire_conn(shard_pool).await {
             Ok(c) => c,
             Err(e) => {
@@ -8722,8 +8728,11 @@ async fn batch_reset_workflows(
             }
         }
 
+        // Adjust per-shard limit so we never fetch more than one over the cap
+        // across all shards combined, saving a round-trip on subsequent shards.
+        let remaining_cap = DEFAULT_BATCH_RESET_MAX_COHORT + 1 - shard_items.len();
         let ids: Vec<uuid::Uuid> = match query
-            .limit(i64::try_from(DEFAULT_BATCH_RESET_MAX_COHORT + 1).unwrap_or(i64::MAX))
+            .limit(i64::try_from(remaining_cap).unwrap_or(i64::MAX))
             .load::<uuid::Uuid>(&mut conn)
             .await
         {
@@ -8763,6 +8772,12 @@ async fn batch_reset_workflows(
     let mut reset_count = 0usize;
     let mut skipped_count = 0usize;
 
+    // Reuse connections across contiguous same-shard items — shard_items is
+    // already shard-ordered from the collection phase above, so this reduces
+    // pool acquisitions from O(items) to O(shards).
+    let mut active_conn: Option<PoolConn> = None;
+    let mut active_shard_id: Option<ShardId> = None;
+
     for (exec_uuid, shard_id) in &shard_items {
         let exec_id_str = exec_uuid.to_string();
         let exec_id = match exec_id_str.parse::<ExecutionId>() {
@@ -8782,16 +8797,42 @@ async fn batch_reset_workflows(
             }
         };
 
-        let mut conn = match acquire_conn(pool.pool_for(*shard_id)).await {
-            Ok(c) => c,
-            Err(e) => {
+        // Acquire a new connection only when the shard changes.
+        if active_shard_id != Some(*shard_id) {
+            active_shard_id = Some(*shard_id);
+            match acquire_conn(pool.pool_for(*shard_id)).await {
+                Ok(c) => {
+                    active_conn = Some(c);
+                }
+                Err(e) => {
+                    active_conn = None;
+                    items.push(BatchResetItem {
+                        exec_id: exec_id_str,
+                        outcome: BatchResetOutcome::Skipped,
+                        resolved_event_id: None,
+                        new_exec_id: None,
+                        skip_reason: Some(ResetSkipReason::InfrastructureError {
+                            message: format!("DB connection unavailable: {e}"),
+                        }),
+                    });
+                    skipped_count += 1;
+                    continue;
+                }
+            }
+        }
+
+        // If the shard's connection failed on a prior item, skip remaining
+        // items on that shard without re-attempting acquisition.
+        let conn = match active_conn.as_mut() {
+            Some(c) => c,
+            None => {
                 items.push(BatchResetItem {
-                    exec_id: exec_id_str.clone(),
+                    exec_id: exec_id_str,
                     outcome: BatchResetOutcome::Skipped,
                     resolved_event_id: None,
                     new_exec_id: None,
                     skip_reason: Some(ResetSkipReason::InfrastructureError {
-                        message: format!("DB connection unavailable: {e}"),
+                        message: "DB connection unavailable".to_string(),
                     }),
                 });
                 skipped_count += 1;
@@ -8800,7 +8841,7 @@ async fn batch_reset_workflows(
         };
 
         match resolve_batch_reset_one(
-            &mut conn,
+            conn,
             exec_id,
             &request.reset_point,
             request.signal_reapply,
@@ -8851,7 +8892,7 @@ async fn batch_reset_workflows(
                         allow_terminal_source: true,
                     };
                     match reset_workflow_execution(
-                        &mut conn,
+                        conn,
                         exec_id,
                         reset_req,
                         Some(&runtime.registry),
@@ -10710,6 +10751,21 @@ async fn reset_workflow(
             return e.into_response();
         }
     };
+    // Validate that the caller specified at least one reset anchor.  With
+    // #[serde(default)] on reset_to_event_id, a body such as {"reason":"…"}
+    // would deserialize as reset_to_event_id=0 and reset_point=None, which
+    // silently resets the workflow to its very beginning — an unintentional
+    // destructive operation.
+    if request.reset_to_event_id == 0 && request.reset_point.is_none() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "error": "one of reset_to_event_id (non-zero) or reset_point must be provided"
+            })),
+        )
+            .into_response();
+    }
+
     let mut conn = match db_conn_for_execution(&api_state, exec_id).await {
         Ok(conn) => conn,
         Err(e) => return e.into_response(),

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -8846,13 +8846,8 @@ async fn batch_reset_workflows(
             }
         };
 
-        match resolve_batch_reset_one(
-            conn,
-            exec_id,
-            &request.reset_point,
-            request.signal_reapply,
-        )
-        .await
+        match resolve_batch_reset_one(conn, exec_id, &request.reset_point, request.signal_reapply)
+            .await
         {
             Err(db_err) => {
                 // DB errors are propagated as skips in batch context to

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -31,7 +31,6 @@ use serde_json::Value;
 
 use autumn_harvest::admission_gate::db as admission_gate_db;
 use autumn_harvest::admission_gate::{AdmissionGateView, GateScope};
-use autumn_harvest::audit::OP_BATCH_START;
 use autumn_harvest::audit::{
     self, AuditFilters, HEADER_ACTOR, HEADER_IDEMPOTENCY_KEY, HEADER_REQUEST_ID, HEADER_SOURCE,
     OP_ACTIVITY_RETRY_NOW, OP_BATCH_SUBMIT, OP_BUILD_COMPAT_DECLARE, OP_BUILD_COMPAT_REVOKE,
@@ -47,6 +46,7 @@ use autumn_harvest::audit::{
     TARGET_CIRCUIT, TARGET_DAG, TARGET_DEAD_LETTER, TARGET_EXTERNAL_ACTIVITY, TARGET_GATE,
     TARGET_RETENTION, TARGET_SCHEDULE, TARGET_TASK, TARGET_WORKER, TARGET_WORKFLOW,
 };
+use autumn_harvest::audit::{OP_BATCH_RESET, OP_BATCH_START};
 use autumn_harvest::batch::{
     self, BatchAction, BatchExecutorConfig, BatchFilter, BatchJobStatus, BatchJobView,
     BatchSubmission,
@@ -79,8 +79,9 @@ use autumn_harvest::policy::{
 };
 use autumn_harvest::queue::{self, ConcurrencyKeyStats};
 use autumn_harvest::reset::{
-    ResetInvalidPoint, ResetResult, WorkflowResetError, WorkflowResetRequest,
-    preview_workflow_reset, reset_workflow_execution,
+    BatchResetItem, BatchResetOutcome, ResetInvalidPoint, ResetPoint, ResetResult,
+    ResetSignalReapplyPolicy, ResetSkipReason, WorkflowResetError, WorkflowResetRequest,
+    preview_workflow_reset, reset_workflow_execution, resolve_batch_reset_one,
 };
 use autumn_harvest::retention::{RetentionConfig, RetentionMonitor, RetentionStatus};
 use autumn_harvest::scheduler::{
@@ -2494,6 +2495,12 @@ pub fn harvest_api_router(api_state: HarvestApiState) -> Router<AppState> {
                     usize::try_from(BATCH_START_BODY_HARD_LIMIT).unwrap_or(usize::MAX),
                 )),
         )
+        // Static /workflows/batch_reset must be registered before any /workflows/{param}
+        // routes so axum does not capture "batch_reset" as a path parameter (issue #538).
+        .route(
+            "/workflows/batch_reset",
+            post(batch_reset_workflows).route_layer(require_admin.clone()),
+        )
         // issue #373: static /workflows/registered must be registered before any
         // /workflows/{param} routes so axum does not capture "registered" as a path param.
         .route("/workflows/registered", get(list_registered_workflows))
@@ -2936,6 +2943,8 @@ pub const fn management_api_routes() -> &'static [(&'static str, &'static str)] 
         ("GET", "/workers/{worker_id}/pinned"),
         // ── batch workflow start (issue #357) ─────────────────────────────────
         ("POST", "/workflows/batch_start"),
+        // ── batch reset by semantic point (issue #538) ────────────────────────
+        ("POST", "/workflows/batch_reset"),
         ("GET", "/batches/pending"),
         // ── batch operations (issue #102) ─────────────────────────────────────
         ("GET", "/batch-operations"),
@@ -3078,6 +3087,19 @@ pub const fn management_api_request_fields()
         ),
         // ── batch workflow start (issue #357) ─────────────────────────────────
         ("POST", "/workflows/batch_start", Some(&["items", "atomic"])),
+        // ── batch reset by semantic point (issue #538) ────────────────────────
+        (
+            "POST",
+            "/workflows/batch_reset",
+            Some(&[
+                "filter",
+                "reset_point",
+                "reason",
+                "operator_id",
+                "signal_reapply",
+                "preview",
+            ]),
+        ),
         ("POST", "/workflows/{id}/cancel", Some(&["reason"])),
         ("POST", "/workflows/{id}/terminate", Some(&["reason"])),
         ("POST", "/workflows/{id}/pause", Some(&["reason"])),
@@ -3615,6 +3637,12 @@ pub const fn management_api_response_fields()
                 "shard_ids",
                 "unavailable_shards",
             ]),
+        ),
+        // ── batch reset by semantic point (issue #538) ────────────────────────
+        (
+            "POST",
+            "/workflows/batch_reset",
+            Some(&["preview", "total", "reset_count", "skipped_count", "items"]),
         ),
         // ── batch operations ──────────────────────────────────────────────────
         ("GET", "/batch-operations", None), // Vec<BatchJobView> (external model)
@@ -8558,6 +8586,312 @@ async fn batch_start_workflows(
     (StatusCode::OK, Json(BatchStartResponse { results })).into_response()
 }
 
+// ── batch_reset ────────────────────────────────────────────────────────────────
+
+/// Hard cohort cap for `POST /workflows/batch_reset` (issue #538).
+/// Requests selecting more than this many executions are rejected with 400.
+const DEFAULT_BATCH_RESET_MAX_COHORT: usize = 1000;
+
+/// Request body for `POST /workflows/batch_reset`.
+#[derive(Debug, Deserialize)]
+struct BatchResetRequest {
+    /// Filter identifying the cohort to reset.
+    filter: BatchFilter,
+    /// Logical anchor to reset to — resolved per execution at reset time.
+    reset_point: ResetPoint,
+    /// Human-readable reason stamped on every forked execution and in the
+    /// audit log.
+    reason: String,
+    /// Operator identity (e.g. "oncall-jane").
+    operator_id: String,
+    /// Signal re-apply policy for forked executions.
+    #[serde(default)]
+    signal_reapply: ResetSignalReapplyPolicy,
+    /// `true` = dry-run: resolve points but do not fork executions.
+    #[serde(default)]
+    preview: bool,
+}
+
+/// Response for `POST /workflows/batch_reset`.
+#[derive(Debug, Serialize)]
+struct BatchResetResponse {
+    preview: bool,
+    total: usize,
+    reset_count: usize,
+    skipped_count: usize,
+    items: Vec<BatchResetItem>,
+}
+
+#[allow(clippy::too_many_lines)]
+async fn batch_reset_workflows(
+    Extension(api_state): Extension<HarvestApiState>,
+    maybe_session: Option<Extension<Session>>,
+    headers: axum::http::HeaderMap,
+    Json(request): Json<BatchResetRequest>,
+) -> axum::response::Response {
+    use axum::response::IntoResponse as _;
+
+    if !has_harvest_admin_access(&api_state, maybe_session.map(|Extension(s)| s)).await {
+        return AutumnError::unauthorized_msg("authentication required").into_response();
+    }
+
+    let (actor, source, request_id) = audit_context(&headers, &api_state);
+    let route = "POST /workflows/batch_reset";
+
+    // Reject an empty filter — the caller must explicitly scope the cohort.
+    if request.filter.is_empty() {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({"error": "filter must not be empty — specify at least one of states, workflow_name, or search_attrs"})),
+        )
+            .into_response();
+    }
+
+    let pool = match api_state.storage_pool() {
+        Ok(p) => p,
+        Err(e) => return map_error(e).into_response(),
+    };
+
+    let runtime = match api_state.runtime() {
+        Ok(r) => r,
+        Err(e) => return map_error(e).into_response(),
+    };
+
+    // ── Collect candidate exec_ids across all shards ───────────────────────
+    // Collect (exec_id, shard_id) pairs for the per-exec resolve+reset phase.
+    let mut shard_items: Vec<(uuid::Uuid, ShardId)> = Vec::new();
+
+    for (shard_id, shard_pool) in pool.iter_shards() {
+        let mut conn = match acquire_conn(shard_pool).await {
+            Ok(c) => c,
+            Err(_e) => continue,
+        };
+
+        // Build a shard-local query using the BatchFilter (mirror batch.rs pattern).
+        let mut query = harvest_workflow_executions::table
+            .select(harvest_workflow_executions::id)
+            .into_boxed();
+
+        // Default to admissible reset states when the filter has none.
+        let reset_admissible = ["RUNNING", "PAUSED", "FAILED", "CANCELLED", "TIMED_OUT"];
+        if request.filter.states.is_empty() {
+            query = query.filter(harvest_workflow_executions::state.eq_any(reset_admissible));
+        } else {
+            query = query.filter(
+                harvest_workflow_executions::state.eq_any(
+                    request
+                        .filter
+                        .states
+                        .iter()
+                        .map(String::as_str)
+                        .collect::<Vec<_>>(),
+                ),
+            );
+        }
+
+        if let Some(ref name) = request.filter.workflow_name {
+            query = query.filter(harvest_workflow_executions::workflow_name.eq(name));
+        }
+
+        // search_attrs filtering is intentionally not applied at the DB level
+        // for batch_reset (consistent with submit_batch_operation) — the
+        // cohort cap guards against runaway selects.
+
+        let ids: Vec<uuid::Uuid> = match query
+            .limit(i64::try_from(DEFAULT_BATCH_RESET_MAX_COHORT + 1).unwrap_or(i64::MAX))
+            .load::<uuid::Uuid>(&mut conn)
+            .await
+        {
+            Ok(ids) => ids,
+            Err(_e) => continue,
+        };
+
+        for id in ids {
+            shard_items.push((id, shard_id));
+        }
+    }
+
+    // ── Cohort cap guard ──────────────────────────────────────────────────
+    if shard_items.len() > DEFAULT_BATCH_RESET_MAX_COHORT {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "error": format!(
+                    "cohort size ({}) exceeds DEFAULT_BATCH_RESET_MAX_COHORT ({}); \
+                     narrow the filter or use a streaming API",
+                    shard_items.len(),
+                    DEFAULT_BATCH_RESET_MAX_COHORT
+                )
+            })),
+        )
+            .into_response();
+    }
+
+    // ── Per-execution resolve + optional reset ─────────────────────────────
+    let mut items: Vec<BatchResetItem> = Vec::with_capacity(shard_items.len());
+    let mut reset_count = 0usize;
+    let mut skipped_count = 0usize;
+
+    for (exec_uuid, shard_id) in &shard_items {
+        let exec_id_str = exec_uuid.to_string();
+        let exec_id = match exec_id_str.parse::<ExecutionId>() {
+            Ok(id) => id,
+            Err(_) => {
+                items.push(BatchResetItem {
+                    exec_id: exec_id_str,
+                    outcome: BatchResetOutcome::Skipped,
+                    resolved_event_id: None,
+                    new_exec_id: None,
+                    skip_reason: Some(ResetSkipReason::EmptyHistory),
+                });
+                skipped_count += 1;
+                continue;
+            }
+        };
+
+        let mut conn = match acquire_conn(pool.pool_for(*shard_id)).await {
+            Ok(c) => c,
+            Err(_e) => {
+                items.push(BatchResetItem {
+                    exec_id: exec_id_str.clone(),
+                    outcome: BatchResetOutcome::Skipped,
+                    resolved_event_id: None,
+                    new_exec_id: None,
+                    skip_reason: Some(ResetSkipReason::EmptyHistory),
+                });
+                skipped_count += 1;
+                continue;
+            }
+        };
+
+        match resolve_batch_reset_one(
+            &mut conn,
+            exec_id,
+            &request.reset_point,
+            request.signal_reapply,
+        )
+        .await
+        {
+            Err(_db_err) => {
+                // DB errors are propagated as skips in batch context to
+                // keep the 100% account-for invariant.
+                items.push(BatchResetItem {
+                    exec_id: exec_id_str,
+                    outcome: BatchResetOutcome::Skipped,
+                    resolved_event_id: None,
+                    new_exec_id: None,
+                    skip_reason: Some(ResetSkipReason::EmptyHistory),
+                });
+                skipped_count += 1;
+            }
+            Ok(Err(skip_reason)) => {
+                items.push(BatchResetItem {
+                    exec_id: exec_id_str,
+                    outcome: BatchResetOutcome::Skipped,
+                    resolved_event_id: None,
+                    new_exec_id: None,
+                    skip_reason: Some(skip_reason),
+                });
+                skipped_count += 1;
+            }
+            Ok(Ok((resolved_event_id, _plan))) => {
+                if request.preview {
+                    items.push(BatchResetItem {
+                        exec_id: exec_id_str,
+                        outcome: BatchResetOutcome::Previewed,
+                        resolved_event_id: Some(resolved_event_id),
+                        new_exec_id: None,
+                        skip_reason: None,
+                    });
+                    reset_count += 1;
+                } else {
+                    // Perform the actual reset.
+                    let reset_req = WorkflowResetRequest {
+                        reset_to_event_id: resolved_event_id,
+                        reset_point: None,
+                        reason: request.reason.clone(),
+                        operator_id: request.operator_id.clone(),
+                        signal_reapply: request.signal_reapply,
+                        allow_terminal_source: true,
+                    };
+                    match reset_workflow_execution(
+                        &mut conn,
+                        exec_id,
+                        reset_req,
+                        Some(&runtime.registry),
+                    )
+                    .await
+                    {
+                        Ok(result) => {
+                            items.push(BatchResetItem {
+                                exec_id: exec_id_str,
+                                outcome: BatchResetOutcome::Reset,
+                                resolved_event_id: Some(resolved_event_id),
+                                new_exec_id: Some(result.new_exec_id.to_string()),
+                                skip_reason: None,
+                            });
+                            reset_count += 1;
+                        }
+                        Err(_reset_err) => {
+                            items.push(BatchResetItem {
+                                exec_id: exec_id_str,
+                                outcome: BatchResetOutcome::Skipped,
+                                resolved_event_id: Some(resolved_event_id),
+                                new_exec_id: None,
+                                skip_reason: Some(ResetSkipReason::EmptyHistory),
+                            });
+                            skipped_count += 1;
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // ── Audit ─────────────────────────────────────────────────────────────
+    let total = items.len();
+    let audit_status = if request.preview || skipped_count == 0 {
+        STATUS_SUCCEEDED
+    } else if reset_count == 0 {
+        STATUS_FAILED
+    } else {
+        STATUS_SUCCEEDED
+    };
+    let error_summary = if skipped_count > 0 && reset_count == 0 {
+        Some(format!("all {skipped_count} executions skipped"))
+    } else {
+        None
+    };
+    if let Ok(mut conn) = acquire_conn(pool.default_pool()).await {
+        let ar = NewAuditRecord {
+            actor: &actor,
+            operation: OP_BATCH_RESET,
+            target_type: TARGET_BATCH,
+            target_id: None,
+            route_or_command: route,
+            request_id: request_id.as_deref(),
+            idempotency_key: None,
+            status: audit_status,
+            error_summary: error_summary.as_deref(),
+            shard_id: None,
+            source: &source,
+        };
+        let _ = audit::insert_audit(&mut conn, &ar).await;
+    }
+
+    (
+        StatusCode::OK,
+        Json(BatchResetResponse {
+            preview: request.preview,
+            total,
+            reset_count,
+            skipped_count,
+            items,
+        }),
+    )
+        .into_response()
+}
+
 /// Helper: write a failed audit record for an atomic batch-start rejection.
 async fn audit_batch_start_failure(
     api_state: &HarvestApiState,
@@ -10689,6 +11023,7 @@ async fn retry_dag_run(
     );
     let reset_request = WorkflowResetRequest {
         reset_to_event_id: plan.reset_to_event_id,
+        reset_point: None,
         reason: augmented_reason,
         operator_id: request.operator_id.trim().to_string(),
         signal_reapply: autumn_harvest::reset::ResetSignalReapplyPolicy::default(),

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -8888,10 +8888,13 @@ async fn batch_reset_workflows(
                         skip_reason: None,
                     });
                 } else {
-                    // Perform the actual reset.
+                    // Perform the actual reset. Pass the original `reset_point` so
+                    // `reset_workflow_execution` re-resolves it to a concrete event id
+                    // under its `FOR UPDATE` row lock, eliminating the TOCTOU window
+                    // between `resolve_batch_reset_one` and the actual fork transaction.
                     let reset_req = WorkflowResetRequest {
-                        reset_to_event_id: Some(resolved_event_id),
-                        reset_point: None,
+                        reset_to_event_id: None,
+                        reset_point: Some(request.reset_point.clone()),
                         reason: request.reason.clone(),
                         operator_id: request.operator_id.clone(),
                         signal_reapply: request.signal_reapply,
@@ -8909,7 +8912,9 @@ async fn batch_reset_workflows(
                             items.push(BatchResetItem {
                                 exec_id: exec_id_str,
                                 outcome: BatchResetOutcome::Reset,
-                                resolved_event_id: Some(resolved_event_id),
+                                // Use the engine's authoritatively-resolved event id (under lock),
+                                // not the speculative value from resolve_batch_reset_one.
+                                resolved_event_id: Some(result.reset_to_event_id),
                                 new_exec_id: Some(result.new_exec_id.to_string()),
                                 skip_reason: None,
                             });

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -8806,6 +8806,12 @@ async fn batch_reset_workflows(
                 }
                 Err(e) => {
                     active_conn = None;
+                    // Record the shard as unavailable so the response status
+                    // is "partial" rather than "complete".
+                    unavailable_shards.push(UnavailableShard {
+                        shard_id: shard_id.as_i32(),
+                        reason: format!("DB connection unavailable during reset phase: {e}"),
+                    });
                     items.push(BatchResetItem {
                         exec_id: exec_id_str,
                         outcome: BatchResetOutcome::Skipped,
@@ -8884,7 +8890,7 @@ async fn batch_reset_workflows(
                 } else {
                     // Perform the actual reset.
                     let reset_req = WorkflowResetRequest {
-                        reset_to_event_id: resolved_event_id,
+                        reset_to_event_id: Some(resolved_event_id),
                         reset_point: None,
                         reason: request.reason.clone(),
                         operator_id: request.operator_id.clone(),
@@ -10751,16 +10757,17 @@ async fn reset_workflow(
             return e.into_response();
         }
     };
-    // Validate that the caller specified at least one reset anchor.  With
-    // #[serde(default)] on reset_to_event_id, a body such as {"reason":"…"}
-    // would deserialize as reset_to_event_id=0 and reset_point=None, which
-    // silently resets the workflow to its very beginning — an unintentional
-    // destructive operation.
-    if request.reset_to_event_id == 0 && request.reset_point.is_none() {
+    // Validate that the caller specified at least one reset anchor.  With both
+    // fields defaulting to None/absent, a body such as {"reason":"…"} would
+    // silently resolve to event 0 (WorkflowStarted) — an unintentional
+    // destructive operation.  The explicit value `reset_to_event_id: 0` is
+    // intentional (fork at WorkflowStarted) and is accepted; only the
+    // all-absent case is rejected here.
+    if request.reset_to_event_id.is_none() && request.reset_point.is_none() {
         return (
             StatusCode::BAD_REQUEST,
             Json(serde_json::json!({
-                "error": "one of reset_to_event_id (non-zero) or reset_point must be provided"
+                "error": "one of reset_to_event_id or reset_point must be provided"
             })),
         )
             .into_response();
@@ -11123,7 +11130,7 @@ async fn retry_dag_run(
         request.from_nodes.join(",")
     );
     let reset_request = WorkflowResetRequest {
-        reset_to_event_id: plan.reset_to_event_id,
+        reset_to_event_id: Some(plan.reset_to_event_id),
         reset_point: None,
         reason: augmented_reason,
         operator_id: request.operator_id.trim().to_string(),

--- a/autumn-harvest-plugin/src/ui.rs
+++ b/autumn-harvest-plugin/src/ui.rs
@@ -1506,7 +1506,7 @@ async fn reset_workflow_ui(
     let reset_to_event_id = form.reset_to_event_id.saturating_sub(1);
 
     let request = WorkflowResetRequest {
-        reset_to_event_id,
+        reset_to_event_id: Some(reset_to_event_id),
         reset_point: None,
         reason,
         operator_id: actor.clone(),

--- a/autumn-harvest-plugin/src/ui.rs
+++ b/autumn-harvest-plugin/src/ui.rs
@@ -1507,6 +1507,7 @@ async fn reset_workflow_ui(
 
     let request = WorkflowResetRequest {
         reset_to_event_id,
+        reset_point: None,
         reason,
         operator_id: actor.clone(),
         signal_reapply: ResetSignalReapplyPolicy::default(),

--- a/autumn-harvest/src/audit.rs
+++ b/autumn-harvest/src/audit.rs
@@ -117,6 +117,8 @@ pub const OP_WORKFLOW_ERASE_PAYLOADS: &str = "workflow.erase_payloads";
 pub const OP_WORKFLOW_REPLAY_CANARY: &str = "workflow.replay_canary";
 /// Audit operation: Force-retried a backing-off activity task (issue #516).
 pub const OP_ACTIVITY_RETRY_NOW: &str = "activity.retry_now";
+/// Audit operation: Batch-reset workflow executions to a semantic point (issue #538).
+pub const OP_BATCH_RESET: &str = "batch.reset";
 
 // ── Target type constants ─────────────────────────────────────────────────────
 
@@ -374,6 +376,8 @@ pub const CLASSIFIED_ROUTES: &[(&str, RouteClass)] = &[
         "POST /workflows/{id}/activities/{activity_exec_id}/retry-now",
         RouteClass::Mutating,
     ),
+    // Batch reset by semantic point (issue #538): admin-only.
+    ("POST /workflows/batch_reset", RouteClass::Mutating),
 ];
 
 // ── Declarative route manifest ────────────────────────────────────────────────
@@ -424,6 +428,8 @@ pub const AUDITED_OPERATIONS: &[&str] = &[
     OP_WORKFLOW_REPLAY_CANARY,
     // Force-retry backing-off activity (issue #516)
     OP_ACTIVITY_RETRY_NOW,
+    // Batch reset by semantic point (issue #538)
+    OP_BATCH_RESET,
 ];
 
 /// Routes explicitly excluded from audit.
@@ -636,6 +642,8 @@ pub const ALL_MUTATION_ROUTES: &[(&str, Option<&str>)] = &[
         "POST /workflows/{id}/activities/{activity_exec_id}/retry-now",
         Some(OP_ACTIVITY_RETRY_NOW),
     ),
+    // Batch reset by semantic point (issue #538)
+    ("POST /workflows/batch_reset", Some(OP_BATCH_RESET)),
 ];
 
 // ── Query filters ─────────────────────────────────────────────────────────────

--- a/autumn-harvest/src/lib.rs
+++ b/autumn-harvest/src/lib.rs
@@ -276,9 +276,10 @@ pub use query::QueryRegistry;
 pub use replay::{HistoryMatch, HistoryMatcher, SignalOrTimerMatch};
 #[cfg(feature = "db")]
 pub use reset::{
-    ResetInvalidPoint, ResetPlan, ResetResult, ResetSignalReapplyPolicy, ResetUnresolvedSideEffect,
-    WorkflowResetError, WorkflowResetRequest, preview_workflow_reset, reset_workflow_execution,
-    validate_reset_point,
+    BatchResetItem, BatchResetOutcome, ResetInvalidPoint, ResetPlan, ResetPoint, ResetResult,
+    ResetSignalReapplyPolicy, ResetSkipReason, ResetUnresolvedSideEffect, WorkflowResetError,
+    WorkflowResetRequest, preview_workflow_reset, reset_workflow_execution,
+    resolve_batch_reset_one, resolve_reset_point, validate_reset_point,
 };
 pub use retention::{ArchiverFuture, HistoryArchiver, RetentionConfig};
 #[cfg(feature = "db")]

--- a/autumn-harvest/src/reset.rs
+++ b/autumn-harvest/src/reset.rs
@@ -204,14 +204,36 @@ pub fn resolve_reset_point(
             {
                 return Err(ResetSkipReason::ContinueAsNew);
             }
-            // Walk the full history and pick the highest valid boundary.
+            // Walk the full history and pick the highest valid decision boundary,
+            // skipping terminal and operational lifecycle events. Including a
+            // terminal event (WorkflowFailed, WorkflowCancelled, WorkflowExecutionTimedOut,
+            // WorkflowCompleted) in the fork history causes the replayer to hit that
+            // event and terminate immediately rather than re-running the workflow body.
             let last = events.len().saturating_sub(1);
             let (valid, _) = boundary_validity(events, last);
             let highest = valid
                 .iter()
+                .zip(events.iter())
                 .enumerate()
                 .rev()
-                .find_map(|(idx, ok)| ok.then_some(idx));
+                .find_map(|(idx, (ok, event))| {
+                    if !ok {
+                        return None;
+                    }
+                    // Exclude terminal lifecycle events: including them in the
+                    // fork history causes replay to terminate immediately rather
+                    // than re-running the workflow body.
+                    if matches!(
+                        event,
+                        WorkflowEvent::WorkflowCompleted { .. }
+                            | WorkflowEvent::WorkflowFailed { .. }
+                            | WorkflowEvent::WorkflowCancelled { .. }
+                            | WorkflowEvent::WorkflowExecutionTimedOut { .. }
+                    ) {
+                        return None;
+                    }
+                    Some(idx)
+                });
             let idx = highest.ok_or(ResetSkipReason::EmptyHistory)?;
             Ok(i64::try_from(idx).unwrap_or(0))
         }
@@ -1918,6 +1940,75 @@ mod tests {
         assert_eq!(
             resolve_reset_point(&[], &ResetPoint::EventId { event_id: 0 }),
             Err(ResetSkipReason::EmptyHistory)
+        );
+    }
+
+    // ── LastWorkflowTask terminal-event exclusion (issue #538 / Codex P1) ───
+
+    #[test]
+    fn last_workflow_task_skips_workflow_failed_at_tail() {
+        // History: started(0), scheduled(1), completed(2), failed(3).
+        // Index 3 (WorkflowFailed) must be skipped; highest valid non-terminal
+        // boundary is index 2 (ActivityCompleted, pending=empty).
+        let act_id = crate::types::ActivityExecId::new();
+        let events = vec![
+            started(),
+            WorkflowEvent::ActivityScheduled {
+                activity_id: act_id,
+                name: "a".to_string(),
+                input: Value::Null,
+                queue: "default".to_string(),
+            },
+            activity_completed(act_id),
+            WorkflowEvent::WorkflowFailed {
+                error: "oops".to_string(),
+            },
+        ];
+        assert_eq!(
+            resolve_reset_point(&events, &ResetPoint::LastWorkflowTask),
+            Ok(2),
+            "LastWorkflowTask must skip WorkflowFailed and return the prior clean boundary"
+        );
+    }
+
+    #[test]
+    fn last_workflow_task_skips_workflow_cancelled_at_tail() {
+        // History: started(0), cancelled(1).  Only valid non-terminal boundary
+        // is index 0 (WorkflowStarted).
+        let events = vec![
+            started(),
+            WorkflowEvent::WorkflowCancelled {
+                reason: "operator cancel".to_string(),
+            },
+        ];
+        assert_eq!(
+            resolve_reset_point(&events, &ResetPoint::LastWorkflowTask),
+            Ok(0),
+            "LastWorkflowTask must skip WorkflowCancelled and fall back to WorkflowStarted"
+        );
+    }
+
+    #[test]
+    fn last_workflow_task_skips_workflow_execution_timed_out_at_tail() {
+        let act_id = crate::types::ActivityExecId::new();
+        let events = vec![
+            started(),
+            WorkflowEvent::ActivityScheduled {
+                activity_id: act_id,
+                name: "b".to_string(),
+                input: Value::Null,
+                queue: "default".to_string(),
+            },
+            activity_completed(act_id),
+            WorkflowEvent::WorkflowExecutionTimedOut {
+                deadline: Utc::now(),
+                timed_out_at: Utc::now(),
+            },
+        ];
+        assert_eq!(
+            resolve_reset_point(&events, &ResetPoint::LastWorkflowTask),
+            Ok(2),
+            "LastWorkflowTask must skip WorkflowExecutionTimedOut and return the prior clean boundary"
         );
     }
 

--- a/autumn-harvest/src/reset.rs
+++ b/autumn-harvest/src/reset.rs
@@ -243,8 +243,11 @@ pub fn resolve_reset_point(
 /// Request body for resetting one workflow execution.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WorkflowResetRequest {
-    #[serde(default)]
-    pub reset_to_event_id: i64,
+    /// Raw event id to fork at. `None` means unspecified (backward-compatible
+    /// default for requests that only supply `reset_point`). When both are
+    /// `None` the API layer returns a 400 before this struct reaches the engine.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reset_to_event_id: Option<i64>,
     /// Optional logical reset anchor (issue #538). When `Some`, the anchor is
     /// resolved against the execution's event history *before* `validate_reset_point`
     /// so the caller does not need to know the per-execution raw event id.
@@ -701,10 +704,12 @@ pub async fn preview_workflow_reset(
     let events = decode_events(&rows)?;
     // If a logical ResetPoint was specified, resolve it to a raw event id now.
     if let Some(ref point) = request.reset_point.clone() {
-        request.reset_to_event_id = resolve_reset_point(&events, point)
+        let resolved = resolve_reset_point(&events, point)
             .map_err(|reason| skip_reason_to_error(exec_id, reason))?;
+        request.reset_to_event_id = Some(resolved);
     }
-    let mut plan = validate_reset_point(&events, request.reset_to_event_id)?;
+    let raw_event_id = request.reset_to_event_id.unwrap_or(0);
+    let mut plan = validate_reset_point(&events, raw_event_id)?;
     attach_side_effect_counts(conn, exec_id, request.signal_reapply, &mut plan).await?;
     Ok(plan)
 }
@@ -734,10 +739,12 @@ pub async fn reset_workflow_execution(
                 let events = decode_events(&rows)?;
                 // Resolve a logical ResetPoint to a raw event id before validation.
                 if let Some(ref point) = request.reset_point.clone() {
-                    request.reset_to_event_id = resolve_reset_point(&events, point)
+                    let resolved = resolve_reset_point(&events, point)
                         .map_err(|reason| skip_reason_to_error(exec_id, reason))?;
+                    request.reset_to_event_id = Some(resolved);
                 }
-                let plan = validate_reset_point(&events, request.reset_to_event_id)?;
+                let reset_event_id = request.reset_to_event_id.unwrap_or(0);
+                let plan = validate_reset_point(&events, reset_event_id)?;
 
                 let new_exec_id = ExecutionId::new_for_shard(ShardId::new(source.shard_id));
                 let source_next_event_id =
@@ -752,7 +759,7 @@ pub async fn reset_workflow_execution(
                 )
                 .await?;
                 let fork = insert_fork_execution(conn, &source, new_exec_id).await?;
-                copy_carried_events(conn, new_exec_id, &rows, request.reset_to_event_id).await?;
+                copy_carried_events(conn, new_exec_id, &rows, reset_event_id).await?;
                 append_fork_marker(conn, new_exec_id, exec_id, &request, &plan).await?;
 
                 let source_tasks_cancelled = queue::cancel_open_tasks_for_execution(
@@ -774,7 +781,7 @@ pub async fn reset_workflow_execution(
                     ResetResult {
                         new_exec_id,
                         reset_from_exec_id: exec_id,
-                        reset_to_event_id: request.reset_to_event_id,
+                        reset_to_event_id: reset_event_id,
                         events_carried_over: plan.events_carried_over,
                         source_tasks_cancelled: source_tasks_cancelled + source_external_cancelled,
                         source_timers_removed,
@@ -1256,7 +1263,7 @@ async fn append_fork_marker(
         new_exec_id,
         &[WorkflowEvent::WorkflowResetFork {
             reset_from_exec_id: source_exec_id,
-            reset_to_event_id: request.reset_to_event_id,
+            reset_to_event_id: request.reset_to_event_id.unwrap_or(0),
             reason: request.reason.clone(),
             operator_id: request.operator_id.clone(),
         }],

--- a/autumn-harvest/src/reset.rs
+++ b/autumn-harvest/src/reset.rs
@@ -220,15 +220,27 @@ pub fn resolve_reset_point(
                     if !ok {
                         return None;
                     }
-                    // Exclude terminal lifecycle events: including them in the
-                    // fork history causes replay to terminate immediately rather
-                    // than re-running the workflow body.
+                    // Exclude terminal and post-terminal tail events: including
+                    // them in the fork history causes replay to terminate
+                    // immediately or execute stale lifecycle side effects rather
+                    // than re-running the workflow body from a clean boundary.
+                    //
+                    // * WorkflowFailed / WorkflowCancelled / WorkflowCompleted /
+                    //   WorkflowExecutionTimedOut — direct terminal events.
+                    // * WorkflowRetryScheduled — appended *after* WorkflowFailed
+                    //   on sealed runs; carrying it into a fork puts WorkflowFailed
+                    //   inside the forked history, which terminates replay.
+                    // * ChildWorkflowCascadeApplied — post-terminal operational
+                    //   tail emitted when the parent close cascade fires; including
+                    //   it would re-trigger the cascade on replay.
                     if matches!(
                         event,
                         WorkflowEvent::WorkflowCompleted { .. }
                             | WorkflowEvent::WorkflowFailed { .. }
                             | WorkflowEvent::WorkflowCancelled { .. }
                             | WorkflowEvent::WorkflowExecutionTimedOut { .. }
+                            | WorkflowEvent::WorkflowRetryScheduled { .. }
+                            | WorkflowEvent::ChildWorkflowCascadeApplied { .. }
                     ) {
                         return None;
                     }
@@ -2016,6 +2028,65 @@ mod tests {
             resolve_reset_point(&events, &ResetPoint::LastWorkflowTask),
             Ok(2),
             "LastWorkflowTask must skip WorkflowExecutionTimedOut and return the prior clean boundary"
+        );
+    }
+
+    #[test]
+    fn last_workflow_task_skips_workflow_retry_scheduled_at_tail() {
+        // A FAILED run with an auto-retry linkage appended afterwards:
+        //   started(0), scheduled(1), completed(2), failed(3), retry_scheduled(4).
+        // After completed(2) the pending set is empty, so boundary_validity[4] would
+        // be true — WorkflowRetryScheduled must be explicitly excluded, otherwise the
+        // fork carries WorkflowFailed at index 3 and replay terminates immediately.
+        let act_id = crate::types::ActivityExecId::new();
+        let retry_exec_id = ExecutionId::new();
+        let events = vec![
+            started(),
+            WorkflowEvent::ActivityScheduled {
+                activity_id: act_id,
+                name: "a".to_string(),
+                input: Value::Null,
+                queue: "default".to_string(),
+            },
+            activity_completed(act_id),
+            WorkflowEvent::WorkflowFailed {
+                error: "transient".to_string(),
+            },
+            WorkflowEvent::WorkflowRetryScheduled {
+                retry_exec_id,
+                attempt: 2,
+                fire_at: Utc::now(),
+            },
+        ];
+        assert_eq!(
+            resolve_reset_point(&events, &ResetPoint::LastWorkflowTask),
+            Ok(2),
+            "LastWorkflowTask must skip WorkflowRetryScheduled (and the preceding \
+             WorkflowFailed) and return the prior clean boundary"
+        );
+    }
+
+    #[test]
+    fn last_workflow_task_skips_child_workflow_cascade_applied_at_tail() {
+        // A CANCELLED execution where a parent-close cascade tail event follows:
+        //   started(0), cancelled(1), cascade(2).
+        // WorkflowCancelled is already excluded; ChildWorkflowCascadeApplied must
+        // also be excluded so the cascade is not re-triggered by the fork.
+        let events = vec![
+            started(),
+            WorkflowEvent::WorkflowCancelled {
+                reason: "parent closed".to_string(),
+            },
+            WorkflowEvent::ChildWorkflowCascadeApplied {
+                child_id: ExecutionId::new(),
+                policy: crate::types::ParentClosePolicy::RequestCancel,
+                action: "request_cancel".to_string(),
+            },
+        ];
+        assert_eq!(
+            resolve_reset_point(&events, &ResetPoint::LastWorkflowTask),
+            Ok(0),
+            "LastWorkflowTask must skip ChildWorkflowCascadeApplied and return WorkflowStarted"
         );
     }
 

--- a/autumn-harvest/src/reset.rs
+++ b/autumn-harvest/src/reset.rs
@@ -211,41 +211,42 @@ pub fn resolve_reset_point(
             // event and terminate immediately rather than re-running the workflow body.
             let last = events.len().saturating_sub(1);
             let (valid, _) = boundary_validity(events, last);
-            let highest = valid
-                .iter()
-                .zip(events.iter())
-                .enumerate()
-                .rev()
-                .find_map(|(idx, (ok, event))| {
-                    if !ok {
-                        return None;
-                    }
-                    // Exclude terminal and post-terminal tail events: including
-                    // them in the fork history causes replay to terminate
-                    // immediately or execute stale lifecycle side effects rather
-                    // than re-running the workflow body from a clean boundary.
-                    //
-                    // * WorkflowFailed / WorkflowCancelled / WorkflowCompleted /
-                    //   WorkflowExecutionTimedOut — direct terminal events.
-                    // * WorkflowRetryScheduled — appended *after* WorkflowFailed
-                    //   on sealed runs; carrying it into a fork puts WorkflowFailed
-                    //   inside the forked history, which terminates replay.
-                    // * ChildWorkflowCascadeApplied — post-terminal operational
-                    //   tail emitted when the parent close cascade fires; including
-                    //   it would re-trigger the cascade on replay.
-                    if matches!(
-                        event,
-                        WorkflowEvent::WorkflowCompleted { .. }
-                            | WorkflowEvent::WorkflowFailed { .. }
-                            | WorkflowEvent::WorkflowCancelled { .. }
-                            | WorkflowEvent::WorkflowExecutionTimedOut { .. }
-                            | WorkflowEvent::WorkflowRetryScheduled { .. }
-                            | WorkflowEvent::ChildWorkflowCascadeApplied { .. }
-                    ) {
-                        return None;
-                    }
-                    Some(idx)
-                });
+            let highest =
+                valid
+                    .iter()
+                    .zip(events.iter())
+                    .enumerate()
+                    .rev()
+                    .find_map(|(idx, (ok, event))| {
+                        if !ok {
+                            return None;
+                        }
+                        // Exclude terminal and post-terminal tail events: including
+                        // them in the fork history causes replay to terminate
+                        // immediately or execute stale lifecycle side effects rather
+                        // than re-running the workflow body from a clean boundary.
+                        //
+                        // * WorkflowFailed / WorkflowCancelled / WorkflowCompleted /
+                        //   WorkflowExecutionTimedOut — direct terminal events.
+                        // * WorkflowRetryScheduled — appended *after* WorkflowFailed
+                        //   on sealed runs; carrying it into a fork puts WorkflowFailed
+                        //   inside the forked history, which terminates replay.
+                        // * ChildWorkflowCascadeApplied — post-terminal operational
+                        //   tail emitted when the parent close cascade fires; including
+                        //   it would re-trigger the cascade on replay.
+                        if matches!(
+                            event,
+                            WorkflowEvent::WorkflowCompleted { .. }
+                                | WorkflowEvent::WorkflowFailed { .. }
+                                | WorkflowEvent::WorkflowCancelled { .. }
+                                | WorkflowEvent::WorkflowExecutionTimedOut { .. }
+                                | WorkflowEvent::WorkflowRetryScheduled { .. }
+                                | WorkflowEvent::ChildWorkflowCascadeApplied { .. }
+                        ) {
+                            return None;
+                        }
+                        Some(idx)
+                    });
             let idx = highest.ok_or(ResetSkipReason::EmptyHistory)?;
             Ok(i64::try_from(idx).unwrap_or(0))
         }

--- a/autumn-harvest/src/reset.rs
+++ b/autumn-harvest/src/reset.rs
@@ -118,6 +118,11 @@ pub enum ResetSkipReason {
     ChildWorkflow,
     /// The execution has no history at all (no `WorkflowStarted` event).
     EmptyHistory,
+    /// An infrastructure failure (UUID parse, DB connection, or reset engine
+    /// error) prevented the execution from being processed. This is distinct
+    /// from a domain skip — the execution was not examined and should be
+    /// retried once the underlying issue is resolved.
+    InfrastructureError { message: String },
 }
 
 /// Per-execution outcome in a batch reset response.
@@ -216,6 +221,7 @@ pub fn resolve_reset_point(
 /// Request body for resetting one workflow execution.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WorkflowResetRequest {
+    #[serde(default)]
     pub reset_to_event_id: i64,
     /// Optional logical reset anchor (issue #538). When `Some`, the anchor is
     /// resolved against the execution's event history *before* `validate_reset_point`
@@ -862,6 +868,16 @@ fn skip_reason_to_error(exec_id: ExecutionId, reason: ResetSkipReason) -> Workfl
             nearest_valid_before,
             nearest_valid_after,
         }),
+        ResetSkipReason::InfrastructureError { message } => {
+            WorkflowResetError::InvalidPoint(ResetInvalidPoint {
+                message,
+                reset_to_event_id: -1,
+                last_event_id: -1,
+                unresolved_side_effects: Vec::new(),
+                nearest_valid_before: None,
+                nearest_valid_after: None,
+            })
+        }
     }
 }
 
@@ -874,7 +890,14 @@ fn skip_reason_to_error(exec_id: ExecutionId, reason: ResetSkipReason) -> Workfl
 /// - `Ok(Ok((event_id, plan)))` — boundary resolved and valid; ready to fork.
 /// - `Ok(Err(reason))` — batch-skip (CAN, child, terminal, no-match, invalid
 ///   boundary, empty history). Never an error; caller records `Skipped`.
-/// - `Err(e)` — storage or DB error; propagated to the caller.
+///
+/// # Errors
+///
+/// Returns `Err(WorkflowResetError)` only for storage or DB failures that
+/// prevent the execution from being examined. Domain-level skips (CAN, child,
+/// terminal state, no matching activity, invalid boundary, empty history) are
+/// returned as `Ok(Err(ResetSkipReason))` so the batch handler can record them
+/// as skipped items without aborting the rest of the cohort.
 pub async fn resolve_batch_reset_one(
     conn: &mut AsyncPgConnection,
     exec_id: ExecutionId,
@@ -882,20 +905,17 @@ pub async fn resolve_batch_reset_one(
     signal_reapply: ResetSignalReapplyPolicy,
 ) -> Result<Result<(i64, ResetPlan), ResetSkipReason>, WorkflowResetError> {
     // Load without locking — preview only.
-    let execution = match harvest_workflow_executions::table
+    let Some(execution) = harvest_workflow_executions::table
         .find(exec_id.as_uuid())
         .select(WorkflowExecution::as_select())
         .first(conn)
         .await
         .optional()
         .map_err(database_error)?
-    {
-        Some(e) => e,
-        None => {
-            return Ok(Err(ResetSkipReason::TerminalSource {
-                state: "NOT_FOUND".to_string(),
-            }));
-        }
+    else {
+        return Ok(Err(ResetSkipReason::TerminalSource {
+            state: "NOT_FOUND".to_string(),
+        }));
     };
 
     // State gate: batch admits RUNNING|PAUSED|FAILED|CANCELLED|TIMED_OUT;

--- a/autumn-harvest/src/reset.rs
+++ b/autumn-harvest/src/reset.rs
@@ -70,10 +70,159 @@ impl<'de> Deserialize<'de> for ResetSignalReapplyPolicy {
     }
 }
 
+/// Logical anchor for resolving a reset boundary per-execution (issue #538).
+///
+/// `EventId` preserves the existing raw-id path. The other variants are
+/// resolved against the execution's live event history at reset time, so the
+/// same `ResetPoint` produces the correct — and possibly different — event id
+/// for every execution in a batch.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ResetPoint {
+    /// Raw event id — today's behavior, preserved for backward compatibility.
+    EventId { event_id: i64 },
+    /// Fork just before the **first** `ActivityScheduled` event whose `name`
+    /// matches `activity_name`. Resolved id = (first-schedule-index − 1).
+    FirstActivityRun { activity_name: String },
+    /// Fork at the **most-recent** clean decision boundary (highest index where
+    /// `boundary_validity` returns `true`). Index 0 (`WorkflowStarted`) is
+    /// always valid and acts as the floor.
+    LastWorkflowTask,
+}
+
+/// Machine-readable reason an individual execution was skipped during batch reset.
+///
+/// Skips are not errors: every candidate execution appears in the batch
+/// response with either `outcome = reset` or `outcome = skipped` plus this
+/// reason. The batch never silently drops an execution.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum ResetSkipReason {
+    /// `FirstActivityRun` found no `ActivityScheduled` event with that name.
+    NoMatchingActivity { activity_name: String },
+    /// The execution has a `WorkflowContinuedAsNew` in its history; CAN chains
+    /// are out of scope for v1 batch reset.
+    ContinueAsNew,
+    /// The resolved event id is not a valid decision boundary (unresolved side
+    /// effects at that point).
+    InvalidBoundary {
+        resolved_event_id: i64,
+        nearest_valid_before: Option<i64>,
+        nearest_valid_after: Option<i64>,
+    },
+    /// The execution is in a terminal state that is never admissible for batch
+    /// reset (`COMPLETED` or `TERMINATED`).
+    TerminalSource { state: String },
+    /// The execution is a child workflow. Batch reset skips child workflows
+    /// in v1; reset the root parent directly.
+    ChildWorkflow,
+    /// The execution has no history at all (no `WorkflowStarted` event).
+    EmptyHistory,
+}
+
+/// Per-execution outcome in a batch reset response.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum BatchResetOutcome {
+    /// The execution was forked at the resolved boundary.
+    Reset,
+    /// The execution was skipped (not an error); see `skip_reason`.
+    Skipped,
+    /// Dry-run: the boundary was resolved but no fork was created.
+    Previewed,
+}
+
+/// One item in the `POST /workflows/batch_reset` response.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BatchResetItem {
+    pub exec_id: String,
+    pub outcome: BatchResetOutcome,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resolved_event_id: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub new_exec_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub skip_reason: Option<ResetSkipReason>,
+}
+
+/// Resolve a logical `ResetPoint` to a raw `reset_to_event_id` for one execution.
+///
+/// This is a **pure function** — it only reads `events` and performs no I/O.
+/// The batch handler calls it on the already-loaded event history for each
+/// candidate execution.
+///
+/// # Errors
+///
+/// Returns `Err(ResetSkipReason)` when the point cannot be resolved for this
+/// history. The batch handler records these as `outcome = skipped`; the single
+/// reset path maps them to a `WorkflowResetError`.
+pub fn resolve_reset_point(
+    events: &[WorkflowEvent],
+    point: &ResetPoint,
+) -> Result<i64, ResetSkipReason> {
+    if events.is_empty() {
+        // EmptyHistory is a skip for any logical point.
+        return Err(ResetSkipReason::EmptyHistory);
+    }
+
+    match point {
+        ResetPoint::EventId { event_id } => Ok(*event_id),
+
+        ResetPoint::FirstActivityRun { activity_name } => {
+            // CAN histories are out of scope; detect them before searching.
+            if events
+                .iter()
+                .any(|e| matches!(e, WorkflowEvent::WorkflowContinuedAsNew { .. }))
+            {
+                return Err(ResetSkipReason::ContinueAsNew);
+            }
+            // Find the first ActivityScheduled whose name matches.
+            let idx = events
+                .iter()
+                .position(|e| match e {
+                    WorkflowEvent::ActivityScheduled { name, .. } => name == activity_name,
+                    _ => false,
+                })
+                .ok_or_else(|| ResetSkipReason::NoMatchingActivity {
+                    activity_name: activity_name.clone(),
+                })?;
+            // Carry over everything *before* the schedule: resolved id = idx - 1.
+            // idx == 0 is impossible in a well-formed history (WorkflowStarted is
+            // always first), but saturating_sub is correct and safe here.
+            Ok(i64::try_from(idx).unwrap_or(0).saturating_sub(1))
+        }
+
+        ResetPoint::LastWorkflowTask => {
+            if events
+                .iter()
+                .any(|e| matches!(e, WorkflowEvent::WorkflowContinuedAsNew { .. }))
+            {
+                return Err(ResetSkipReason::ContinueAsNew);
+            }
+            // Walk the full history and pick the highest valid boundary.
+            let last = events.len().saturating_sub(1);
+            let (valid, _) = boundary_validity(events, last);
+            let highest = valid
+                .iter()
+                .enumerate()
+                .rev()
+                .find_map(|(idx, ok)| ok.then_some(idx));
+            let idx = highest.ok_or(ResetSkipReason::EmptyHistory)?;
+            Ok(i64::try_from(idx).unwrap_or(0))
+        }
+    }
+}
+
 /// Request body for resetting one workflow execution.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct WorkflowResetRequest {
     pub reset_to_event_id: i64,
+    /// Optional logical reset anchor (issue #538). When `Some`, the anchor is
+    /// resolved against the execution's event history *before* `validate_reset_point`
+    /// so the caller does not need to know the per-execution raw event id.
+    /// When `None`, `reset_to_event_id` is used directly (backward-compatible).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reset_point: Option<ResetPoint>,
     pub reason: String,
     pub operator_id: String,
     #[serde(default)]
@@ -517,11 +666,16 @@ pub async fn preview_workflow_reset(
     exec_id: ExecutionId,
     request: WorkflowResetRequest,
 ) -> Result<ResetPlan, WorkflowResetError> {
-    let request = request.normalized();
+    let mut request = request.normalized();
     let execution = load_source_execution(conn, exec_id, false).await?;
     validate_source_execution(exec_id, &execution, request.allow_terminal_source)?;
     let rows = load_event_rows(conn, exec_id).await?;
     let events = decode_events(&rows)?;
+    // If a logical ResetPoint was specified, resolve it to a raw event id now.
+    if let Some(ref point) = request.reset_point.clone() {
+        request.reset_to_event_id = resolve_reset_point(&events, point)
+            .map_err(|reason| skip_reason_to_error(exec_id, reason))?;
+    }
     let mut plan = validate_reset_point(&events, request.reset_to_event_id)?;
     attach_side_effect_counts(conn, exec_id, request.signal_reapply, &mut plan).await?;
     Ok(plan)
@@ -541,7 +695,7 @@ pub async fn reset_workflow_execution(
     request: WorkflowResetRequest,
     registry: Option<&HandlerRegistry>,
 ) -> Result<ResetResult, WorkflowResetError> {
-    let request = request.normalized();
+    let mut request = request.normalized();
     let (res, deferred_starts) = conn
         .transaction::<(ResetResult, Vec<DeferredTriggerStart>), WorkflowResetError, _>(|conn| {
             async move {
@@ -550,6 +704,11 @@ pub async fn reset_workflow_execution(
 
                 let rows = load_event_rows(conn, exec_id).await?;
                 let events = decode_events(&rows)?;
+                // Resolve a logical ResetPoint to a raw event id before validation.
+                if let Some(ref point) = request.reset_point.clone() {
+                    request.reset_to_event_id = resolve_reset_point(&events, point)
+                        .map_err(|reason| skip_reason_to_error(exec_id, reason))?;
+                }
                 let plan = validate_reset_point(&events, request.reset_to_event_id)?;
 
                 let new_exec_id = ExecutionId::new_for_shard(ShardId::new(source.shard_id));
@@ -657,6 +816,129 @@ fn validate_source_execution(
         return Err(WorkflowResetError::ChildWorkflow { exec_id, parent_id });
     }
     Ok(())
+}
+
+/// Map a `ResetSkipReason` (batch path) to a `WorkflowResetError` (single path).
+///
+/// The single-execution reset/preview endpoints treat skip reasons as hard
+/// errors; the batch endpoint uses the raw `ResetSkipReason` directly.
+fn skip_reason_to_error(exec_id: ExecutionId, reason: ResetSkipReason) -> WorkflowResetError {
+    match reason {
+        ResetSkipReason::ContinueAsNew => WorkflowResetError::ContinueAsNew,
+        ResetSkipReason::TerminalSource { state } => {
+            WorkflowResetError::TerminalSource { exec_id, state }
+        }
+        ResetSkipReason::ChildWorkflow => WorkflowResetError::ChildWorkflow {
+            exec_id,
+            parent_id: uuid::Uuid::nil(),
+        },
+        ResetSkipReason::NoMatchingActivity { activity_name } => {
+            WorkflowResetError::InvalidPoint(ResetInvalidPoint {
+                message: format!("no ActivityScheduled event found for activity '{activity_name}'"),
+                reset_to_event_id: -1,
+                last_event_id: -1,
+                unresolved_side_effects: Vec::new(),
+                nearest_valid_before: None,
+                nearest_valid_after: None,
+            })
+        }
+        ResetSkipReason::EmptyHistory => WorkflowResetError::InvalidPoint(ResetInvalidPoint {
+            message: "execution has no recorded history".to_string(),
+            reset_to_event_id: -1,
+            last_event_id: -1,
+            unresolved_side_effects: Vec::new(),
+            nearest_valid_before: None,
+            nearest_valid_after: None,
+        }),
+        ResetSkipReason::InvalidBoundary {
+            resolved_event_id,
+            nearest_valid_before,
+            nearest_valid_after,
+        } => WorkflowResetError::InvalidPoint(ResetInvalidPoint {
+            message: format!("event {resolved_event_id} is not a valid reset boundary"),
+            reset_to_event_id: resolved_event_id,
+            last_event_id: resolved_event_id,
+            unresolved_side_effects: Vec::new(),
+            nearest_valid_before,
+            nearest_valid_after,
+        }),
+    }
+}
+
+/// Read-only per-execution resolver for batch reset.
+///
+/// Gates source state, resolves the `ResetPoint`, and validates the boundary
+/// for ONE execution. Never mutates any row.
+///
+/// Returns:
+/// - `Ok(Ok((event_id, plan)))` — boundary resolved and valid; ready to fork.
+/// - `Ok(Err(reason))` — batch-skip (CAN, child, terminal, no-match, invalid
+///   boundary, empty history). Never an error; caller records `Skipped`.
+/// - `Err(e)` — storage or DB error; propagated to the caller.
+pub async fn resolve_batch_reset_one(
+    conn: &mut AsyncPgConnection,
+    exec_id: ExecutionId,
+    point: &ResetPoint,
+    signal_reapply: ResetSignalReapplyPolicy,
+) -> Result<Result<(i64, ResetPlan), ResetSkipReason>, WorkflowResetError> {
+    // Load without locking — preview only.
+    let execution = match harvest_workflow_executions::table
+        .find(exec_id.as_uuid())
+        .select(WorkflowExecution::as_select())
+        .first(conn)
+        .await
+        .optional()
+        .map_err(database_error)?
+    {
+        Some(e) => e,
+        None => {
+            return Ok(Err(ResetSkipReason::TerminalSource {
+                state: "NOT_FOUND".to_string(),
+            }));
+        }
+    };
+
+    // State gate: batch admits RUNNING|PAUSED|FAILED|CANCELLED|TIMED_OUT;
+    // skips COMPLETED and TERMINATED.
+    match execution.state.as_str() {
+        "RUNNING" | "PAUSED" | "FAILED" | "CANCELLED" | "TIMED_OUT" => {}
+        other => {
+            return Ok(Err(ResetSkipReason::TerminalSource {
+                state: other.to_string(),
+            }));
+        }
+    }
+
+    // Skip child workflows in v1.
+    if execution.parent_id.is_some() {
+        return Ok(Err(ResetSkipReason::ChildWorkflow));
+    }
+
+    let rows = load_event_rows(conn, exec_id).await?;
+    let events = decode_events(&rows)?;
+
+    // Resolve logical point to a raw event id.
+    let resolved_id = match resolve_reset_point(&events, point) {
+        Ok(id) => id,
+        Err(reason) => return Ok(Err(reason)),
+    };
+
+    // Validate the boundary.
+    let mut plan = match validate_reset_point(&events, resolved_id) {
+        Ok(p) => p,
+        Err(invalid) => {
+            return Ok(Err(ResetSkipReason::InvalidBoundary {
+                resolved_event_id: resolved_id,
+                nearest_valid_before: invalid.nearest_valid_before,
+                nearest_valid_after: invalid.nearest_valid_after,
+            }));
+        }
+    };
+
+    // Attach DB counts (tasks/timers/signals) for the preview plan.
+    attach_side_effect_counts(conn, exec_id, signal_reapply, &mut plan).await?;
+
+    Ok(Ok((resolved_id, plan)))
 }
 
 async fn load_source_execution(
@@ -1466,5 +1748,218 @@ mod tests {
             !request.allow_terminal_source,
             "allow_terminal_source must remain false when set via the request body"
         );
+    }
+
+    // ── ResetPoint resolver unit tests (issue #538, pure / no-DB) ────────────
+
+    use super::{BatchResetOutcome, ResetPoint, ResetSkipReason, resolve_reset_point};
+
+    fn started() -> WorkflowEvent {
+        WorkflowEvent::WorkflowStarted {
+            input: Value::Null,
+            timestamp: Utc::now(),
+            last_completion_result: None,
+            last_error: None,
+            scheduled_time: None,
+        }
+    }
+
+    fn activity_scheduled(name: &str) -> WorkflowEvent {
+        WorkflowEvent::ActivityScheduled {
+            activity_id: crate::types::ActivityExecId::new(),
+            name: name.to_string(),
+            input: Value::Null,
+            queue: "default".to_string(),
+        }
+    }
+
+    fn activity_completed(id: crate::types::ActivityExecId) -> WorkflowEvent {
+        WorkflowEvent::ActivityCompleted {
+            activity_id: id,
+            output: Value::Null,
+        }
+    }
+
+    #[test]
+    fn resolve_event_id_passthrough() {
+        let events = vec![started(), activity_scheduled("a")];
+        let result = resolve_reset_point(&events, &ResetPoint::EventId { event_id: 1 });
+        assert_eq!(result, Ok(1));
+    }
+
+    #[test]
+    fn first_activity_run_resolves_to_before_first_schedule() {
+        // History: started(0) + other_activity(1) + target_activity(2)
+        let events = vec![
+            started(),
+            activity_scheduled("other"),
+            activity_scheduled("target"),
+        ];
+        let result = resolve_reset_point(
+            &events,
+            &ResetPoint::FirstActivityRun {
+                activity_name: "target".to_string(),
+            },
+        );
+        // First "target" ActivityScheduled is at index 2 → resolved = 2 - 1 = 1
+        assert_eq!(result, Ok(1));
+    }
+
+    #[test]
+    fn first_activity_run_resolves_to_zero_when_at_index_one() {
+        // History: started(0) + target_activity(1)
+        let events = vec![started(), activity_scheduled("target")];
+        let result = resolve_reset_point(
+            &events,
+            &ResetPoint::FirstActivityRun {
+                activity_name: "target".to_string(),
+            },
+        );
+        // First "target" at index 1 → resolved = 1 - 1 = 0
+        assert_eq!(result, Ok(0));
+    }
+
+    #[test]
+    fn first_activity_run_no_match_returns_skip() {
+        let events = vec![started(), activity_scheduled("other")];
+        let result = resolve_reset_point(
+            &events,
+            &ResetPoint::FirstActivityRun {
+                activity_name: "missing".to_string(),
+            },
+        );
+        assert_eq!(
+            result,
+            Err(ResetSkipReason::NoMatchingActivity {
+                activity_name: "missing".to_string(),
+            })
+        );
+    }
+
+    #[test]
+    fn last_workflow_task_returns_highest_valid_boundary() {
+        let act_id = crate::types::ActivityExecId::new();
+        // History: started(0) + scheduled(1) + completed(2)
+        // After completed(2) the pending set is empty → index 2 is valid.
+        let events = vec![
+            started(),
+            WorkflowEvent::ActivityScheduled {
+                activity_id: act_id,
+                name: "a".to_string(),
+                input: Value::Null,
+                queue: "default".to_string(),
+            },
+            activity_completed(act_id),
+        ];
+        let result = resolve_reset_point(&events, &ResetPoint::LastWorkflowTask);
+        // index 2 is valid (all side effects resolved)
+        assert_eq!(result, Ok(2));
+    }
+
+    #[test]
+    fn last_workflow_task_with_open_side_effect_falls_back_to_lower_boundary() {
+        // History: started(0) + scheduled(1) — pending activity never completed.
+        // Index 0 is always valid (WorkflowStarted); index 1 is invalid (pending).
+        let events = vec![started(), activity_scheduled("a")];
+        let result = resolve_reset_point(&events, &ResetPoint::LastWorkflowTask);
+        assert_eq!(result, Ok(0));
+    }
+
+    #[test]
+    fn can_history_returns_continue_as_new_skip() {
+        let events = vec![
+            started(),
+            WorkflowEvent::WorkflowContinuedAsNew {
+                new_exec_id: ExecutionId::new(),
+                input: Value::Null,
+            },
+        ];
+        assert_eq!(
+            resolve_reset_point(
+                &events,
+                &ResetPoint::FirstActivityRun {
+                    activity_name: "x".to_string()
+                }
+            ),
+            Err(ResetSkipReason::ContinueAsNew)
+        );
+        assert_eq!(
+            resolve_reset_point(&events, &ResetPoint::LastWorkflowTask),
+            Err(ResetSkipReason::ContinueAsNew)
+        );
+    }
+
+    #[test]
+    fn empty_history_returns_empty_history_skip() {
+        assert_eq!(
+            resolve_reset_point(&[], &ResetPoint::LastWorkflowTask),
+            Err(ResetSkipReason::EmptyHistory)
+        );
+        assert_eq!(
+            resolve_reset_point(&[], &ResetPoint::EventId { event_id: 0 }),
+            Err(ResetSkipReason::EmptyHistory)
+        );
+    }
+
+    #[test]
+    fn reset_point_field_is_backward_compatible_on_wire() {
+        // A legacy body without `reset_point` must deserialize with reset_point = None
+        // and a legacy serialized form must NOT include the field.
+        let legacy_body = serde_json::json!({
+            "reset_to_event_id": 5,
+            "reason": "fix",
+            "operator_id": "ops"
+        });
+        let request: super::WorkflowResetRequest =
+            serde_json::from_value(legacy_body).expect("deserializes");
+        assert!(
+            request.reset_point.is_none(),
+            "legacy body without reset_point must deserialize as None"
+        );
+
+        // Serializing a request with reset_point = None must not include the field.
+        let serialized = serde_json::to_value(&request).expect("serializes");
+        assert!(
+            serialized.get("reset_point").is_none(),
+            "reset_point must be absent in serialized form when None"
+        );
+    }
+
+    #[test]
+    fn batch_reset_outcome_serde_roundtrip() {
+        for outcome in [
+            BatchResetOutcome::Reset,
+            BatchResetOutcome::Skipped,
+            BatchResetOutcome::Previewed,
+        ] {
+            let json = serde_json::to_string(&outcome).expect("serialize");
+            let back: BatchResetOutcome = serde_json::from_str(&json).expect("deserialize");
+            assert_eq!(outcome, back);
+        }
+    }
+
+    #[test]
+    fn reset_skip_reason_serde_roundtrip() {
+        let reasons = vec![
+            ResetSkipReason::ContinueAsNew,
+            ResetSkipReason::EmptyHistory,
+            ResetSkipReason::ChildWorkflow,
+            ResetSkipReason::TerminalSource {
+                state: "COMPLETED".to_string(),
+            },
+            ResetSkipReason::NoMatchingActivity {
+                activity_name: "act_x".to_string(),
+            },
+            ResetSkipReason::InvalidBoundary {
+                resolved_event_id: 3,
+                nearest_valid_before: Some(2),
+                nearest_valid_after: Some(5),
+            },
+        ];
+        for reason in reasons {
+            let json = serde_json::to_string(&reason).expect("serialize");
+            let back: ResetSkipReason = serde_json::from_str(&json).expect("deserialize");
+            assert_eq!(reason, back, "round-trip failed for {json}");
+        }
     }
 }

--- a/autumn-harvest/tests/child_policy_tests.rs
+++ b/autumn-harvest/tests/child_policy_tests.rs
@@ -1239,6 +1239,7 @@ async fn workflow_reset_cascades_detached_children() {
         parent_exec_id,
         WorkflowResetRequest {
             reset_to_event_id: 0,
+            reset_point: None,
             reason: "operator reset".to_string(),
             operator_id: "test-operator".to_string(),
             signal_reapply: autumn_harvest::ResetSignalReapplyPolicy::default(),

--- a/autumn-harvest/tests/child_policy_tests.rs
+++ b/autumn-harvest/tests/child_policy_tests.rs
@@ -1238,7 +1238,7 @@ async fn workflow_reset_cascades_detached_children() {
         &mut conn,
         parent_exec_id,
         WorkflowResetRequest {
-            reset_to_event_id: 0,
+            reset_to_event_id: Some(0),
             reset_point: None,
             reason: "operator reset".to_string(),
             operator_id: "test-operator".to_string(),

--- a/docs/api-contract.json
+++ b/docs/api-contract.json
@@ -1124,8 +1124,13 @@
         "fields": [
           {
             "name": "reset_to_event_id",
-            "required": true,
-            "description": "Event sequence number to reset to."
+            "required": false,
+            "description": "Event sequence number to reset to. Required when reset_point is absent; mutually exclusive with reset_point."
+          },
+          {
+            "name": "reset_point",
+            "required": false,
+            "description": "Logical reset anchor resolved per-execution at reset time. One of: {\"type\":\"event_id\",\"event_id\":N}, {\"type\":\"first_activity_run\",\"activity_name\":\"name\"}, {\"type\":\"last_workflow_task\"}. Required when reset_to_event_id is absent; mutually exclusive with reset_to_event_id."
           },
           {
             "name": "reason",

--- a/docs/api-contract.json
+++ b/docs/api-contract.json
@@ -2684,6 +2684,75 @@
       ]
     },
     {
+      "method": "POST",
+      "path": "/workflows/batch_reset",
+      "category": "batch",
+      "read_only": false,
+      "description": "Reset a cohort of workflow executions to a shared semantic point. Resolves the logical anchor per execution and returns a per-execution outcome list. preview=true resolves points without forking (issue #538).",
+      "idempotency": "Not idempotent. Each call forks the matched cohort. Use preview=true to plan first.",
+      "params": [],
+      "request_body": {
+        "required": true,
+        "free_form": false,
+        "fields": [
+          {
+            "name": "filter",
+            "required": true,
+            "description": "BatchFilter identifying the cohort. Must not be empty."
+          },
+          {
+            "name": "reset_point",
+            "required": true,
+            "description": "Logical anchor: {type: event_id, event_id: N} | {type: first_activity_run, activity_name: S} | {type: last_workflow_task}."
+          },
+          {
+            "name": "reason",
+            "required": true,
+            "description": "Human-readable recovery reason stamped on each fork."
+          },
+          {
+            "name": "operator_id",
+            "required": true,
+            "description": "Operator identity recorded in the audit log."
+          },
+          {
+            "name": "signal_reapply",
+            "required": false,
+            "description": "Signal re-apply policy for forked executions: drop (default) | buffer."
+          },
+          {
+            "name": "preview",
+            "required": false,
+            "description": "true = dry-run: resolve per-execution points without forking."
+          }
+        ]
+      },
+      "success_response": {
+        "status": 200,
+        "fields": [
+          "preview",
+          "total",
+          "reset_count",
+          "skipped_count",
+          "items"
+        ]
+      },
+      "error_responses": [
+        {
+          "status": 400,
+          "description": "Empty filter or cohort exceeds DEFAULT_BATCH_RESET_MAX_COHORT (1000)."
+        },
+        {
+          "status": 401,
+          "description": "Missing or invalid admin credentials."
+        },
+        {
+          "status": 500,
+          "description": "Database error."
+        }
+      ]
+    },
+    {
       "method": "GET",
       "path": "/health",
       "category": "health",

--- a/docs/api-contract.json
+++ b/docs/api-contract.json
@@ -2730,11 +2730,13 @@
       "success_response": {
         "status": 200,
         "fields": [
+          "status",
           "preview",
           "total",
           "reset_count",
           "skipped_count",
-          "items"
+          "items",
+          "unavailable_shards"
         ]
       },
       "error_responses": [


### PR DESCRIPTION
## Summary

Implements `POST /workflows/batch_reset` endpoint to reset a cohort of workflow executions to a shared logical anchor point, with per-execution resolution. Adds three semantic reset point types (`EventId`, `FirstActivityRun`, `LastWorkflowTask`) that resolve to raw event IDs based on each execution's event history, enabling operators to reset multiple executions without knowing individual event IDs in advance.

## Key Changes

**Core reset logic (`autumn-harvest/src/reset.rs`)**
- Added `ResetPoint` enum with three variants:
  - `EventId { event_id }`: raw event ID (backward compatible)
  - `FirstActivityRun { activity_name }`: resolves to index before first `ActivityScheduled` event matching the name
  - `LastWorkflowTask`: resolves to highest valid decision boundary (index where all side effects are resolved)
- Added `ResetSkipReason` enum for machine-readable batch skip reasons (no matching activity, CAN chains, invalid boundary, terminal state, child workflow, empty history, infrastructure error)
- Added `BatchResetOutcome` enum (`Reset`, `Skipped`, `Previewed`) and `BatchResetItem` struct for per-execution response items
- Implemented `resolve_reset_point()` pure function to resolve logical points to raw event IDs given an event history
- Implemented `resolve_batch_reset_one()` async function for per-execution resolution + validation (read-only, no mutations)
- Added `skip_reason_to_error()` to map batch skip reasons to single-execution `WorkflowResetError` variants
- Updated `WorkflowResetRequest` to include optional `reset_point` field; when present, it is resolved before validation
- Updated `preview_workflow_reset()` and `reset_workflow_execution()` to resolve logical points before validation
- Added comprehensive unit tests for `resolve_reset_point()` covering all variants, edge cases (empty history, CAN chains, no matches), and boundary resolution

**API handler (`autumn-harvest-plugin/src/api.rs`)**
- Implemented `batch_reset_workflows()` handler for `POST /workflows/batch_reset`
- Collects candidate execution IDs across all shards using `BatchFilter` (states, workflow_name, search_attrs)
- Enforces cohort cap (`DEFAULT_BATCH_RESET_MAX_COHORT = 1000`) with 400 error if exceeded
- Per-execution flow: resolve logical point → validate boundary → optionally fork (or preview)
- Returns `BatchResetResponse` with status, counts, per-execution items, and unavailable shards
- Registered route before parameterized `/workflows/{param}` routes to prevent path capture collision
- Added audit operation constant `OP_BATCH_RESET` and audit logging

**CLI support (`autumn-harvest-cli/src/lib.rs`)**
- Added `WorkflowCommand::BatchReset` variant with flags:
  - `--filter-json` / `--filter-file`: cohort selection
  - `--event-id`, `--first-activity`, `--last-workflow-task`: mutually exclusive reset point selection
  - `--reason`, `--operator-id`, `--signal-reapply`, `--preview`
- Builds `BatchResetRequest` JSON body with resolved `reset_point` structure
- Added 6 integration tests covering all reset point types, preview flag, signal reapply policy, and error cases

**Documentation**
- Updated `docs/api-contract.json` with `/workflows/batch_reset` endpoint definition
- Documented request fields (filter, reset_point, reason, operator_id, signal_reapply, preview)
- Documented response fields and error conditions (400 for empty filter/oversized cohort, 401 for auth, 500 for DB)

**Backward compatibility**
- `reset_point` field on `WorkflowResetRequest` is optional (defaults to `None`)
- Single-execution reset/preview endpoints continue to work with raw `reset_to_event_id`
- Logical point resolution only occurs when `reset_point` is `Some`
- Existing tests updated to include `reset_point: None` in request construction

## Notable

https://claude.ai/code/session_019KxdkzTCLQhp8weyuXQXSr