### PR TITLE
⚡ Bolt: Pre-allocate vectors in split_mixed_signal_batch

### DIFF
--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -1314,8 +1314,8 @@ fn extract_signal_external_workflow(commands: Vec<WorkflowCommand>) -> Vec<Signa
 fn split_mixed_signal_batch(
     commands: Vec<WorkflowCommand>,
 ) -> (Vec<SignalBatchItem>, Vec<WorkflowCommand>) {
-    let mut signal_items = Vec::new();
-    let mut remaining = Vec::new();
+    let mut signal_items = Vec::with_capacity(commands.len());
+    let mut remaining = Vec::with_capacity(commands.len());
     for cmd in commands {
         match cmd {
             WorkflowCommand::SignalExternalWorkflow {
@@ -1406,7 +1406,7 @@ async fn persist_external_signal_inline(
     let (new_events, final_next, deferred_starts, cancel_metrics): InlinePersistResult = conn
         .transaction::<InlinePersistResult, HarvestError, _>(|conn| {
             async move {
-                let mut new_events: Vec<WorkflowEvent> = Vec::new();
+                let mut new_events: Vec<WorkflowEvent> = Vec::with_capacity(items.len());
                 let mut next = start_next;
                 // Completion-trigger / cascade follow-up starts produced by
                 // same-shard cancellations. These must be spawned only *after*


### PR DESCRIPTION
💡 What: Replaced `Vec::new()` with `Vec::with_capacity(commands.len())` and `Vec::with_capacity(items.len())` in `split_mixed_signal_batch` and `persist_external_signal_inline` respectively within `autumn-harvest/src/worker.rs`.

🎯 Why: To eliminate unnecessary intermediate heap reallocations when processing batches of signals or commands in hot loops. The upper bound of elements is known beforehand (the length of the input batch).

📊 Impact: Removes `O(log N)` memory allocations per batch split/persist operation, making batch signal handling more efficient with zero-cost abstractions.

🔬 Measurement: Run bench tests on the worker signal handling or monitor memory allocation profiles during heavy batch signaling workloads. All unit tests via `cargo test -p autumn-harvest --lib worker` pass with this optimization.

---
*PR created automatically by Jules for task [13016140089122404776](https://jules.google.com/task/13016140089122404776) started by @madmax983*