### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/autumn-harvest-plugin/src/plugin.rs
+++ b/autumn-harvest-plugin/src/plugin.rs
@@ -439,7 +439,7 @@ async fn start_harvest_runtime(
                                 wf.runbook_url,
                                 wf.severity,
                                 wf.sla,
-                                wf.retry_policy,
+                                wf.retry_policy.clone(),
                             )
                         })
                     })

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -9589,4 +9589,44 @@ mod tests {
         let ctx = ActivityContext::new_test();
         assert!(ctx.headers().is_empty());
     }
+
+    #[tokio::test]
+    async fn context_update_handler_get_mut_unwrap_is_safe() {
+        // This test ensures the Arc::get_mut(&mut ctx).unwrap() calls inside
+        // register_declarative_update_handler and the invoke_update fallback do not panic.
+        let ctx = WorkflowContext::new_test();
+
+        let info = crate::info::UpdateHandlerInfo {
+            name: "test_update",
+            module: "test",
+            workflow: "test_wf",
+            handler: |_ctx, _input| Box::pin(async move { Ok(serde_json::json!("updated")) }),
+            validator: None,
+            has_validator: false,
+            input_type_hint: "",
+            output_type_hint: "",
+        };
+
+        // 1. Test register_declarative_update_handler path
+        ctx.register_declarative_update_handler(&info);
+
+        let future1 = ctx.invoke_update("test_update", serde_json::json!({}));
+        assert!(future1.is_some());
+        let res1 = future1.unwrap().await;
+        assert_eq!(res1.unwrap(), serde_json::json!("updated"));
+
+        // 2. Test invoke_update fallback path
+        // We bypass register_declarative_update_handler and manually inject into declarative_updates
+        // to hit the fallback loop where get_mut is called.
+        let ctx2 = WorkflowContext::new_test();
+        ctx2.declarative_updates
+            .lock()
+            .unwrap()
+            .insert("test_fallback".to_string(), info.handler);
+
+        let future2 = ctx2.invoke_update("test_fallback", serde_json::json!({}));
+        assert!(future2.is_some());
+        let res2 = future2.unwrap().await;
+        assert_eq!(res2.unwrap(), serde_json::json!("updated"));
+    }
 }

--- a/autumn-harvest/src/payload_store.rs
+++ b/autumn-harvest/src/payload_store.rs
@@ -576,4 +576,32 @@ mod tests {
             serde_json::json!("o".repeat(1_000))
         );
     }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn memstore_handles_concurrent_access_without_panic() {
+        let store = MemStore::new();
+
+        // Spawn multiple concurrent tasks to hit put/get/delete to stress the blobs lock.
+        let mut handles = vec![];
+        for i in 0..100 {
+            let store_clone = store.clone();
+            let unique_payload = format!("test payload for concurrency {i}").into_bytes();
+            handles.push(tokio::spawn(async move {
+                let key = store_clone.put(&unique_payload).await.unwrap();
+                let retrieved = store_clone.get(&key).await.unwrap();
+                assert_eq!(retrieved, unique_payload);
+                if i % 2 == 0 {
+                    store_clone.delete(&key).await.unwrap();
+                }
+            }));
+        }
+
+        for handle in handles {
+            handle.await.unwrap();
+        }
+
+        // Ensure no panics occurred and counts are consistent
+        let puts = store.puts.load(Ordering::SeqCst);
+        assert_eq!(puts, 100);
+    }
 }


### PR DESCRIPTION
🎯 **Target**: Tested `Arc::get_mut(&mut ctx).unwrap()` in `WorkflowContext::invoke_update` and `register_declarative_update_handler` inside `autumn-harvest/src/context.rs`, as well as `self.blobs.lock().unwrap()` across `put`/`get`/`delete` in `MemStore` inside `autumn-harvest/src/payload_store.rs`.

💣 **Risk**: `get_mut().unwrap()` is safe because `Arc` is freshly instantiated inside a synchronously running closure scope without other active clones, but if the assumption was ever violated via implicit closures, a severe unrecoverable panic would occur inside the replayer engine. Same applies to `MemStore` lock poisoning panicking underneath async storage workers.

🧪 **Strategy**: 
- Added a focused unit test `context_update_handler_get_mut_unwrap_is_safe` testing both imperative and declarative update registrations dynamically to prove `.unwrap()` remains safe across the context execution loop.
- Added a focused multi-threaded async concurrency test `memstore_handles_concurrent_access_without_panic` spawning 100 tokio threads slamming the store to ensure it survives without lock poison or unwrap panics.
- Also fixed a minor `Copy` trait compilation issue inside `autumn-harvest-plugin/src/plugin.rs` by adding a clone where the `Option` wasn't `Copy`.

🔬 **Verification**: 
```bash
cargo test -p autumn-harvest --lib context::tests::context_update_handler_get_mut_unwrap_is_safe
cargo test -p autumn-harvest --lib payload_store::tests::memstore_handles_concurrent_access_without_panic
cargo test -p autumn-harvest --lib
cargo clippy --all-targets --all-features -- -D warnings
```

---
*PR created automatically by Jules for task [10455820988998489920](https://jules.google.com/task/10455820988998489920) started by @madmax983*