### PR TITLE
🔒 Warden: [security fix] Remove unsafe blocks to resolve memory safety and UB risks

### DIFF
--- a/autumn-harvest-plugin/src/plugin.rs
+++ b/autumn-harvest-plugin/src/plugin.rs
@@ -439,7 +439,7 @@ async fn start_harvest_runtime(
                                 wf.runbook_url,
                                 wf.severity,
                                 wf.sla,
-                                wf.retry_policy,
+                                wf.retry_policy.clone(),
                             )
                         })
                     })

--- a/autumn-harvest-plugin/tests/webhook_durable_integration.rs
+++ b/autumn-harvest-plugin/tests/webhook_durable_integration.rs
@@ -17,9 +17,6 @@ async fn test_durable_signed_webhook_via_harvest_workflow() {
 
     // 1. Initialize TestDb and run pending migrations
     let db = TestDb::shared().await;
-    unsafe {
-        std::env::set_var("AUTUMN_DATABASE__URL", db.url());
-    }
     autumn_web::migrate::run_pending(db.url(), autumn_web::migrate::FRAMEWORK_MIGRATIONS)
         .expect("failed to run framework migrations");
     autumn_web::migrate::run_pending(db.url(), autumn_harvest::MIGRATIONS)
@@ -51,7 +48,11 @@ async fn test_durable_signed_webhook_via_harvest_workflow() {
         .plugin(webhook_plugin)
         .plugin(
             HarvestPlugin::new()
-                .worker(WorkerConfig::default().with_queues(["webhooks"]))
+                .worker(
+                    WorkerConfig::default()
+                        .with_queues(["webhooks"])
+                        .with_notification_database_url(db.url()),
+                )
                 .api("/api/harvest"),
         )
         .with_db(db.pool());

--- a/autumn-harvest/src/handle_typed.rs
+++ b/autumn-harvest/src/handle_typed.rs
@@ -30,11 +30,8 @@ pub struct TypedWorkflowResult<T> {
 #[derive(Debug, Clone)]
 pub struct TypedWorkflowHandle<T> {
     inner: WorkflowHandle,
-    _marker: PhantomData<T>,
+    _marker: PhantomData<fn() -> T>,
 }
-
-unsafe impl<T> Send for TypedWorkflowHandle<T> {}
-unsafe impl<T> Sync for TypedWorkflowHandle<T> {}
 
 impl<T> TypedWorkflowHandle<T> {
     /// Wrap an untyped [`WorkflowHandle`] with type parameter `T` representing


### PR DESCRIPTION
🦠 Threat: `unsafe { std::env::set_var(...) }` was used in `webhook_durable_integration.rs`, which can cause data races and undefined behavior in concurrent, multi-threaded test environments. Additionally, `TypedWorkflowHandle` manually implemented `unsafe impl Send` and `unsafe impl Sync`, circumventing the compiler's safety checks without formal proof.
🛡️ Defense: Replaced the unsafe environment variable mutation with explicit configuration parsing (`WorkerConfig::with_notification_database_url()`). Replaced `PhantomData<T>` with `PhantomData<fn() -> T>` on `TypedWorkflowHandle`, allowing the compiler to safely derive `Send` and `Sync` automatically.
💥 Severity: Critical - Undefined behavior and data races in test execution, plus potential unsound thread-safety guarantees on a core client handle.
🧪 Verification: Ran `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test`, and `cargo fmt --all` successfully. No regressions were introduced.

---
*PR created automatically by Jules for task [4531072530744235683](https://jules.google.com/task/4531072530744235683) started by @madmax983*