### PR TITLE
⚡ Bolt: [Replace Vec::new with Vec::with_capacity]

### DIFF
--- a/autumn-harvest-plugin/src/plugin.rs
+++ b/autumn-harvest-plugin/src/plugin.rs
@@ -435,8 +435,8 @@ async fn start_harvest_runtime(
                     .and_then(|registry| {
                         registry.workflows.get("webhook_delivery").map(|wf| {
                             (
-                                wf.owner.clone(),
-                                wf.runbook_url.clone(),
+                                wf.owner,
+                                wf.runbook_url,
                                 wf.severity,
                                 wf.sla,
                                 wf.retry_policy.clone(),

--- a/autumn-harvest/src/dlq.rs
+++ b/autumn-harvest/src/dlq.rs
@@ -1645,7 +1645,7 @@ pub async fn aggregate_dead_letters(
         HashMap::new()
     };
 
-    let mut groups: HashMap<Vec<Option<String>>, DlqRawGroup> = HashMap::new();
+    let mut groups: HashMap<Vec<Option<String>>, DlqRawGroup> = HashMap::with_capacity(rows.len());
     for (id, exec_id, activity_name, queue_name, task_type, failed_at, error) in rows {
         let key: Vec<Option<String>> = params
             .group_by

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -890,7 +890,7 @@ fn extract_single_command<T>(
 fn extract_all_scheduled_activities(
     commands: &[WorkflowCommand],
 ) -> Option<Vec<ScheduledActivityCommand>> {
-    let mut scheduled = Vec::new();
+    let mut scheduled = Vec::with_capacity(commands.len());
 
     for cmd in commands {
         match cmd {
@@ -930,7 +930,7 @@ fn extract_all_scheduled_activities(
 }
 
 fn extract_all_activity_waits(commands: &[WorkflowCommand]) -> Option<Vec<ActivityExecId>> {
-    let mut activity_ids = Vec::new();
+    let mut activity_ids = Vec::with_capacity(commands.len());
 
     for cmd in commands {
         match cmd {
@@ -1317,8 +1317,8 @@ fn extract_signal_external_workflow(commands: Vec<WorkflowCommand>) -> Vec<Signa
 fn split_mixed_signal_batch(
     commands: Vec<WorkflowCommand>,
 ) -> (Vec<SignalBatchItem>, Vec<WorkflowCommand>) {
-    let mut signal_items = Vec::new();
-    let mut remaining = Vec::new();
+    let mut signal_items = Vec::with_capacity(commands.len());
+    let mut remaining = Vec::with_capacity(commands.len());
     for cmd in commands {
         match cmd {
             WorkflowCommand::SignalExternalWorkflow {


### PR DESCRIPTION
💡 What: Switched `Vec::new()` to `Vec::with_capacity(size)` and `HashMap::new()` to `HashMap::with_capacity(size)` in hot code paths where the size is known or upper bounded. Also fixed two instances of `clone_on_copy` warnings.
🎯 Why: Minimizing allocations by pre-allocating the underlying buffer capacity helps avoiding intermediate resizes and allocations in collections and improves overall performance.
📊 Impact: Reduces heap re-allocations while building vectors or maps when extracting commands or batch signals inside `worker.rs` and while aggregating dead letters.
🔬 Measurement: Run `cargo bench` and observe improvements in throughput and reduced latency for commands extraction metrics.

---
*PR created automatically by Jules for task [15961689862145973245](https://jules.google.com/task/15961689862145973245) started by @madmax983*