### PR TITLE
⚒️ Forge: Remove redundant clone on Copy types

### DIFF
--- a/autumn-harvest-plugin/src/plugin.rs
+++ b/autumn-harvest-plugin/src/plugin.rs
@@ -435,8 +435,8 @@ async fn start_harvest_runtime(
                     .and_then(|registry| {
                         registry.workflows.get("webhook_delivery").map(|wf| {
                             (
-                                wf.owner.clone(),
-                                wf.runbook_url.clone(),
+                                wf.owner,
+                                wf.runbook_url,
                                 wf.severity,
                                 wf.sla,
                                 wf.retry_policy.clone(),


### PR DESCRIPTION
**🚬 Smell**: The `owner` and `runbook_url` fields in `WorkflowInfo` are of type `Option<&'static str>`, which implements `Copy`. Calling `.clone()` on them is redundant and triggered `clippy::clone_on_copy` warnings.

**✨ Solution**: Removed `.clone()` calls from `wf.owner.clone()` and `wf.runbook_url.clone()` in `autumn-harvest-plugin/src/plugin.rs`.

**🧼 Benefit**: Eliminates redundant clone operations and resolves compiler warnings, making the code more idiomatic.

**🛡️ Verification**: Tests passed (`cargo test -p autumn-harvest-plugin --lib` and `cargo check -p autumn-harvest-plugin`) and no clippy warnings remain. No runtime logic was changed.

---
*PR created automatically by Jules for task [463117798741743581](https://jules.google.com/task/463117798741743581) started by @madmax983*