### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/autumn-harvest-plugin/src/plugin.rs
+++ b/autumn-harvest-plugin/src/plugin.rs
@@ -435,8 +435,8 @@ async fn start_harvest_runtime(
                     .and_then(|registry| {
                         registry.workflows.get("webhook_delivery").map(|wf| {
                             (
-                                wf.owner.clone(),
-                                wf.runbook_url.clone(),
+                                wf.owner,
+                                wf.runbook_url,
                                 wf.severity,
                                 wf.sla,
                                 wf.retry_policy.clone(),

--- a/autumn-harvest/src/dlq.rs
+++ b/autumn-harvest/src/dlq.rs
@@ -2468,4 +2468,49 @@ mod tests {
         assert_eq!(back.queue_name, "billing");
         assert_eq!(back.attempts, 5);
     }
+
+    // ── Enums Parsing & Serialization ──────────────────────────────────────────
+
+    #[test]
+    fn time_bucket_granularity_parsing() {
+        let now = Utc::now();
+        let hour_params = DlqAggregateParams::from_query_pairs(
+            &pairs(&[("group_by", "time_bucket"), ("time_bucket", "hour")]),
+            now,
+        )
+        .unwrap();
+        assert_eq!(hour_params.time_bucket, TimeBucketGranularity::Hour);
+
+        let day_params = DlqAggregateParams::from_query_pairs(
+            &pairs(&[("group_by", "time_bucket"), ("time_bucket", "day")]),
+            now,
+        )
+        .unwrap();
+        assert_eq!(day_params.time_bucket, TimeBucketGranularity::Day);
+
+        let err = DlqAggregateParams::from_query_pairs(
+            &pairs(&[("group_by", "time_bucket"), ("time_bucket", "minute")]),
+            now,
+        )
+        .unwrap_err();
+        assert!(err.contains("invalid time_bucket"));
+    }
+
+    #[test]
+    fn dlq_group_dimension_wire_roundtrips() {
+        for dim in [
+            DlqGroupDimension::WorkflowName,
+            DlqGroupDimension::ActivityName,
+            DlqGroupDimension::QueueName,
+            DlqGroupDimension::TaskType,
+            DlqGroupDimension::TimeBucket,
+            DlqGroupDimension::FailureSignature,
+        ] {
+            let wire = dim.as_wire();
+            let parsed = DlqGroupDimension::from_wire(wire).unwrap();
+            assert_eq!(parsed, dim);
+        }
+
+        assert_eq!(DlqGroupDimension::from_wire("unknown_dim"), None);
+    }
 }

--- a/autumn-harvest/src/types.rs
+++ b/autumn-harvest/src/types.rs
@@ -1188,6 +1188,21 @@ mod tests {
         let ext_id_str = ext_uuid.to_string();
         let parsed_ext_id: ExternalActivityToken = ext_id_str.parse().unwrap();
         assert_eq!(parsed_ext_id.as_uuid(), ext_uuid);
+
+        let update_uuid = uuid::Uuid::new_v4();
+        let update_id_str = update_uuid.to_string();
+        let parsed_update_id: UpdateId = update_id_str.parse().unwrap();
+        assert_eq!(parsed_update_id.as_uuid(), update_uuid);
+
+        let ext_signal_uuid = uuid::Uuid::new_v4();
+        let ext_signal_str = ext_signal_uuid.to_string();
+        let parsed_ext_signal: ExternalSignalId = ext_signal_str.parse().unwrap();
+        assert_eq!(parsed_ext_signal.as_uuid(), ext_signal_uuid);
+
+        let ext_cancel_uuid = uuid::Uuid::new_v4();
+        let ext_cancel_str = ext_cancel_uuid.to_string();
+        let parsed_ext_cancel: ExternalCancelId = ext_cancel_str.parse().unwrap();
+        assert_eq!(parsed_ext_cancel.as_uuid(), ext_cancel_uuid);
     }
 
     #[test]
@@ -1196,6 +1211,9 @@ mod tests {
         assert!(invalid_uuid.parse::<ExecutionId>().is_err());
         assert!(invalid_uuid.parse::<ActivityExecId>().is_err());
         assert!(invalid_uuid.parse::<ExternalActivityToken>().is_err());
+        assert!(invalid_uuid.parse::<UpdateId>().is_err());
+        assert!(invalid_uuid.parse::<ExternalSignalId>().is_err());
+        assert!(invalid_uuid.parse::<ExternalCancelId>().is_err());
     }
 
     #[test]


### PR DESCRIPTION
🎯 Target: `autumn-harvest/src/types.rs` and `autumn-harvest/src/dlq.rs`
💣 Risk: Types lacking parsing tests for `FromStr` and enum parsers could be silently broken.
🧪 Strategy: Added table-driven round-trip UUID parsing tests and invalid UUID parse checks for `UpdateId`, `ExternalSignalId`, and `ExternalCancelId` in `types.rs`. Added tests for `TimeBucketGranularity` parameter parsing and `DlqGroupDimension` wire logic in `dlq.rs`.
🔬 Verification: Run `cargo test -p autumn-harvest --lib`.

Also fixed a `clippy::clone_on_copy` error in `autumn-harvest-plugin/src/plugin.rs` to ensure CI passes.

---
*PR created automatically by Jules for task [17318120649156318883](https://jules.google.com/task/17318120649156318883) started by @madmax983*