### PR TITLE
⚒️ Forge: Remove redundant `.clone()` on `Copy` types

### DIFF
--- a/autumn-harvest-plugin/src/plugin.rs
+++ b/autumn-harvest-plugin/src/plugin.rs
@@ -435,8 +435,8 @@ async fn start_harvest_runtime(
                     .and_then(|registry| {
                         registry.workflows.get("webhook_delivery").map(|wf| {
                             (
-                                wf.owner.clone(),
-                                wf.runbook_url.clone(),
+                                wf.owner,
+                                wf.runbook_url,
                                 wf.severity,
                                 wf.sla,
                                 wf.retry_policy.clone(),


### PR DESCRIPTION
🚮 Smell: `clippy::clone_on_copy` warned about calling `.clone()` on `Option<&str>` which already implements `Copy` inside `autumn-harvest-plugin/src/plugin.rs`.
✨ Solution: Removed the redundant `.clone()` method calls for `wf.owner` and `wf.runbook_url`.
🧼 Benefit: Resolves clippy warnings and idiomatic Rust enforcement.
🛡️ Verification: Tests passed. No logic changed. `cargo clippy --all-targets --all-features -- -D warnings` and `cargo test -p autumn-harvest-plugin --lib` passed successfully.

---
*PR created automatically by Jules for task [8618191287432817063](https://jules.google.com/task/8618191287432817063) started by @madmax983*