### PR TITLE
⚡ Bolt: Remove unnecessary `.clone()` on Copy types

### DIFF
--- a/autumn-harvest-plugin/src/plugin.rs
+++ b/autumn-harvest-plugin/src/plugin.rs
@@ -435,8 +435,8 @@ async fn start_harvest_runtime(
                     .and_then(|registry| {
                         registry.workflows.get("webhook_delivery").map(|wf| {
                             (
-                                wf.owner.clone(),
-                                wf.runbook_url.clone(),
+                                wf.owner,
+                                wf.runbook_url,
                                 wf.severity,
                                 wf.sla,
                                 wf.retry_policy.clone(),


### PR DESCRIPTION
💡 What: Removed unnecessary `.clone()` calls on `Option<&str>` types inside `autumn-harvest-plugin/src/plugin.rs`.

🎯 Why: In Rust, `&str` and `Option<&str>` implement the `Copy` trait. Calling `.clone()` on them is redundant and unnecessary because it merely copies the reference, rather than duplicating any string data. The `clippy` linter flags this as `clippy::clone_on_copy` which is triggered when `cargo clippy` is run with `-D warnings`.

📊 Impact: Reduces visual noise, conforms to idiomatic Rust, and appeases clippy rules enforced in CI. Resolves a `clippy::clone_on_copy` error during build verification.

🔭 Measurement: Verified the removal compiles successfully using `cargo check -p autumn-harvest-plugin --lib` and passes all formatting and clippy rules locally via `cargo fmt --all` and `cargo clippy --all-targets --all-features -- -D warnings`.

---
*PR created automatically by Jules for task [15704749594020997534](https://jules.google.com/task/15704749594020997534) started by @madmax983*