### PR TITLE
🌟 Nova: [DAG Simulator Trace Exporter]

### DIFF
--- a/autumn-harvest/src/dag_export.rs
+++ b/autumn-harvest/src/dag_export.rs
@@ -91,6 +91,79 @@ pub fn export_dot(dag: &DagDefinition) -> Result<String, std::fmt::Error> {
     Ok(out)
 }
 
+/// Exports a simulated DAG definition to a Mermaid.js flowchart with nodes styled
+/// by their execution result.
+///
+/// # Examples
+///
+/// ```rust
+/// use autumn_harvest::dag::DagBuilder;
+/// use autumn_harvest::dag_simulator::DagSimulator;
+/// use autumn_harvest::dag_export::export_mermaid_with_simulation;
+///
+/// fn my_activity() {}
+/// fn my_other_activity() {}
+///
+/// let mut builder = DagBuilder::new();
+/// let a = builder.activity(my_activity);
+/// let b = builder.activity(my_other_activity).upstream(&a);
+/// let dag = builder.build().unwrap();
+/// let sim = DagSimulator::new(dag.clone()).run();
+///
+/// let mermaid = export_mermaid_with_simulation(&dag, &sim).unwrap();
+/// assert!(mermaid.contains("classDef succeeded"));
+/// assert!(mermaid.contains("class t0 succeeded;"));
+/// ```
+///
+/// # Errors
+/// Returns `std::fmt::Error` if string formatting fails.
+#[cfg(any(test, feature = "testing"))]
+pub fn export_mermaid_with_simulation(
+    dag: &DagDefinition,
+    sim: &crate::dag_simulator::DagSimulatorResult,
+) -> Result<String, std::fmt::Error> {
+    let mut out = String::new();
+    writeln!(out, "graph TD")?;
+
+    let tasks = dag.tasks();
+
+    for (i, task) in tasks.iter().enumerate() {
+        writeln!(out, "    t{i}[\"{}\"]", task.activity_name)?;
+    }
+
+    for (i, task) in tasks.iter().enumerate() {
+        for &upstream in &task.upstreams {
+            writeln!(out, "    t{upstream} --> t{i}")?;
+        }
+    }
+
+    writeln!(
+        out,
+        "    classDef succeeded fill:#4CAF50,color:white,stroke-width:2px,stroke:#388E3C;"
+    )?;
+    writeln!(
+        out,
+        "    classDef failed fill:#F44336,color:white,stroke-width:2px,stroke:#D32F2F;"
+    )?;
+    writeln!(
+        out,
+        "    classDef skipped fill:#E0E0E0,color:#9E9E9E,stroke-width:2px,stroke:#BDBDBD,stroke-dasharray: 5 5;"
+    )?;
+
+    for (i, _) in tasks.iter().enumerate() {
+        if let Some(status) = sim.get_status(i) {
+            let class_name = match status {
+                crate::policy::TaskStatus::Succeeded => "succeeded",
+                crate::policy::TaskStatus::Failed => "failed",
+                crate::policy::TaskStatus::Skipped => "skipped",
+            };
+            writeln!(out, "    class t{i} {class_name};")?;
+        }
+    }
+
+    Ok(out)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -153,5 +226,39 @@ digraph DAG {
 }
 ";
         assert_eq!(dot, expected_dot);
+    }
+
+    #[test]
+    fn test_export_mermaid_with_simulation() {
+        use crate::dag_simulator::DagSimulator;
+
+        let mut builder = DagBuilder::new();
+        let a = builder.activity(dummy_activity);
+        let _b = builder.activity(dummy_activity2).upstream(&a);
+        let dag = builder.build().unwrap();
+
+        // Simulate where A fails, causing B to be skipped (default behavior for upstream failures).
+        let sim = DagSimulator::new(dag.clone())
+            .mock_activity("dummy_activity", || Err("Fail".into()))
+            .run();
+
+        let mermaid = export_mermaid_with_simulation(&dag, &sim).unwrap();
+
+        // Assert base structures
+        assert!(mermaid.contains("graph TD"));
+        assert!(mermaid.contains("t0[\"dummy_activity\"]"));
+        assert!(mermaid.contains("t1[\"dummy_activity2\"]"));
+        assert!(mermaid.contains("t0 --> t1"));
+
+        // Assert class definitions
+        assert!(mermaid.contains("classDef succeeded fill:#4CAF50"));
+        assert!(mermaid.contains("classDef failed fill:#F44336"));
+        assert!(mermaid.contains("classDef skipped fill:#E0E0E0"));
+
+        // Assert assigned classes based on simulation result
+        // t0 (dummy_activity) should be failed
+        assert!(mermaid.contains("class t0 failed;"));
+        // t1 (dummy_activity2) should be skipped
+        assert!(mermaid.contains("class t1 skipped;"));
     }
 }


### PR DESCRIPTION
💡 **The Spark:** We have a great DAG Simulator (`dag_simulator.rs`) that evaluates workflow triggers, and we have a neat `MermaidExporter` (`dag_export.rs`) to visualize DAG definitions. But we lacked a visual way to debug DAG topologies after they've been simulated. What if we colored the Mermaid nodes based on their execution result?

🚀 **The Feature:** Implemented `export_mermaid_with_simulation` which maps a `DagSimulatorResult` onto a `DagDefinition`, styling nodes Green (Succeeded), Red (Failed), or Grey (Skipped).

🔮 **The Potential:** Makes debugging complex DAG structures, custom trigger policies, and upstream failures incredibly visual and intuitive without leaving the test environment.

⚠️ **Risk:** Extremely low. The feature is completely additive, safely tucked into `dag_export.rs`, and gated behind the `testing` feature.

---
*PR created automatically by Jules for task [5502205585464060902](https://jules.google.com/task/5502205585464060902) started by @madmax983*