### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/autumn-harvest/src/handle_typed.rs
+++ b/autumn-harvest/src/handle_typed.rs
@@ -246,3 +246,20 @@ pub struct TypedSignalWithStartOptions {
     /// without terminating it. Overrides `WorkflowInfo::sla`; clamped to `execution_timeout`.
     pub sla: Option<Duration>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::rc::Rc;
+
+    #[test]
+    fn typed_handle_is_send_sync() {
+        // Assert thread-safety of TypedWorkflowHandle regardless of T.
+        // T=std::rc::Rc<()> is deliberately neither Send nor Sync.
+        fn is_send<T: Send>() {}
+        fn is_sync<T: Sync>() {}
+
+        is_send::<TypedWorkflowHandle<Rc<()>>>();
+        is_sync::<TypedWorkflowHandle<Rc<()>>>();
+    }
+}


### PR DESCRIPTION
🎯 **Target**: `autumn-harvest/src/handle_typed.rs` -> `TypedWorkflowHandle`

💣 **Risk**: `TypedWorkflowHandle` uses an `unsafe impl Send` and `unsafe impl Sync` block to guarantee that the handle can be moved across await boundaries and shared between threads safely, regardless of its generic type parameter `T`. If structural changes are made in the future (e.g. adding a new field that isn't `Send`), or the `unsafe impl` blocks are accidentally removed, `TypedWorkflowHandle` could silently lose its thread safety.

🧪 **Strategy**: Added a compile-time unit test `typed_handle_is_send_sync` within a `#[cfg(test)] mod tests` block. This test forces the rust compiler to evaluate `TypedWorkflowHandle<Rc<()>>` against `Send` and `Sync` bounds. Since `std::rc::Rc` is explicitly neither `Send` nor `Sync`, the successful compilation of this test proves the effectiveness of the `unsafe impl` overrides and guards against regressions.

🔬 **Verification**: Run `cargo test --lib -p autumn-harvest handle_typed`

---
*PR created automatically by Jules for task [9147347211244143322](https://jules.google.com/task/9147347211244143322) started by @madmax983*