### PR TITLE
⚡ Bolt: Remove intermediate Vec allocations in load_stalled_workflows

### DIFF
--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -18067,11 +18067,9 @@ pub(crate) async fn load_stalled_workflows(
     // ── Step 3: any runnable task queue row (activity or workflow type) ────────
     // Checking all task_type values mirrors the sleeping-filter predicate so that
     // an execution with a stuck workflow task is not mislabelled no_pending_work.
+    // Optimized: Avoiding intermediate Vec allocations by passing `&exec_ids` slice directly to `.eq_any()`.
     let has_activity: HashSet<uuid::Uuid> = harvest_task_queue::table
-        .filter(
-            harvest_task_queue::workflow_exec_id
-                .eq_any(exec_ids.iter().map(|id| Some(*id)).collect::<Vec<_>>()),
-        )
+        .filter(harvest_task_queue::workflow_exec_id.eq_any(&exec_ids))
         .filter(harvest_task_queue::state.eq_any(["PENDING", "CLAIMED", "RUNNING", "BACKOFF"]))
         .select(harvest_task_queue::workflow_exec_id)
         .distinct()
@@ -18083,11 +18081,9 @@ pub(crate) async fn load_stalled_workflows(
         .collect();
 
     // ── Step 4: non-terminal child workflows ────────────────────────────────
+    // Optimized: Avoiding intermediate Vec allocations by passing `&exec_ids` slice directly to `.eq_any()`.
     let has_child: HashSet<uuid::Uuid> = harvest_workflow_executions::table
-        .filter(
-            harvest_workflow_executions::parent_id
-                .eq_any(exec_ids.iter().map(|id| Some(*id)).collect::<Vec<_>>()),
-        )
+        .filter(harvest_workflow_executions::parent_id.eq_any(&exec_ids))
         .filter(harvest_workflow_executions::state.ne_all([
             "COMPLETED",
             "FAILED",


### PR DESCRIPTION
💡 **What:**  
Replaced `exec_ids.iter().map(|id| Some(*id)).collect::<Vec<_>>()` with a direct slice reference `&exec_ids` when building Diesel `.eq_any` database queries inside `autumn-harvest-plugin/src/api.rs::load_stalled_workflows`. I also added inline doc comments explaining the optimization.

🎯 **Why:**  
Diesel's `.eq_any()` automatically handles comparing non-nullable elements to nullable database columns by generating the correct SQL `IN` bounds. The original code defensively (and redundantly) mapped `Uuid` elements to `Some(Uuid)` and `.collect()`'d them into intermediate vectors on every query execution. This forced unnecessary heap allocations on a path that queries for stalled workflows.

📊 **Impact:**  
Removes two intermediate heap vector allocations per call to `load_stalled_workflows`. The `&exec_ids` reference borrows existing data with zero-cost abstraction, speeding up query preparation slightly.

🔬 **Measurement:**  
Run `cargo test -p autumn-harvest-plugin --lib` to verify the original logic and bindings compile and pass correctly. Run `cargo clippy` to verify no warnings on lifetimes or formatting.

---
*PR created automatically by Jules for task [11447645029020717041](https://jules.google.com/task/11447645029020717041) started by @madmax983*