### PR TITLE
🎻 Bard: [documentation update]

### DIFF
--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -4688,7 +4688,7 @@ async fn usage_report(
 /// `GET /workflows/registered` — list all registered workflow types with
 /// their optional JSON Schema, description, and type information (issue #373).
 ///
-/// Returns an array of [`RegisteredWorkflowRecord`] objects sorted by name.
+/// Returns an array of [`autumn_harvest::info::RegisteredWorkflowRecord`] objects sorted by name.
 /// Workflows that have not opted into schema publishing return `null` for
 /// `input_schema`, `output_schema`, and `error_schema`.
 async fn list_registered_workflows(
@@ -4708,7 +4708,7 @@ async fn list_registered_workflows(
 /// `GET /workflows/registered/{name}/schema` — return the schema record for a
 /// single registered workflow type (issue #373).
 ///
-/// Returns `200` with the [`RegisteredWorkflowRecord`] when the workflow is
+/// Returns `200` with the [`autumn_harvest::info::RegisteredWorkflowRecord`] when the workflow is
 /// known, or `404` when the name is not registered.
 async fn get_registered_workflow_schema(
     Extension(api_state): Extension<HarvestApiState>,

--- a/autumn-harvest-plugin/src/mcp_tools.rs
+++ b/autumn-harvest-plugin/src/mcp_tools.rs
@@ -521,7 +521,7 @@ fn permissive_object_schema(description: &str) -> serde_json::Value {
 /// Record the descriptors' schemas into the process-global schema map.
 ///
 /// Covers each workflow's input schema plus the fixed response/payload
-/// schemas, consumed by [`register_harvest_mcp_schemas`]. Idempotent,
+/// schemas, consumed by `register_harvest_mcp_schemas`. Idempotent,
 /// name-keyed: re-recording the same workflow overwrites with identical
 /// content.
 pub fn record_schemas(descriptors: &[McpWorkflowDescriptor]) {
@@ -673,7 +673,7 @@ fn leak(s: String) -> &'static str {
 /// Each route carries an `ApiDoc` with `mcp_tool: true` (and `mcp_stream` for
 /// watch) so autumn-web's `mount_mcp` projects it into the tool catalog; the
 /// handlers delegate to the same primitives the management API uses, reading
-/// runtime state from the given [`HarvestApiState`] (fail-closed 503 before
+/// runtime state from the given [`crate::api::HarvestApiState`] (fail-closed 503 before
 /// `on_startup` installs the runtime).
 #[must_use]
 pub fn build_mcp_tool_routes(

--- a/autumn-harvest-plugin/src/ui.rs
+++ b/autumn-harvest-plugin/src/ui.rs
@@ -4489,7 +4489,7 @@ enum DagNodeState {
     /// Skipped because a trigger rule evaluated to false over upstream statuses.
     Skipped,
     /// Skipped because a data-dependent condition predicate evaluated to false
-    /// (issue #482).  Distinct from [`Skipped`] so the UI can show a different
+    /// (issue #482).  Distinct from [`DagNodeState::Skipped`] so the UI can show a different
     /// label ("Skipped (condition)").
     SkippedByCondition,
     Unknown,

--- a/autumn-harvest-plugin/src/workflow_count.rs
+++ b/autumn-harvest-plugin/src/workflow_count.rs
@@ -6,7 +6,7 @@
 //! or hand-querying every shard database. `GET /workflows/count` groups
 //! `harvest_workflow_executions` rows by `state` and/or `workflow_name` with a
 //! real per-shard SQL `GROUP BY … COUNT(*)`
-//! ([`count_workflow_executions_grouped`](autumn_harvest::execution::count_workflow_executions_grouped))
+//! ([`count_workflow_executions_grouped`])
 //! and sums the per-group counts across shards here.
 //!
 //! ## Response shape
@@ -21,7 +21,7 @@
 //! (default [`DEFAULT_LIMIT_GROUPS`], max [`MAX_LIMIT_GROUPS`]); the long tail
 //! is rolled into a single `{"other": true}` group so a pathological number of
 //! workflow types can never produce an unbounded payload, via the same
-//! [`rollup_top_n`](autumn_harvest::dlq::rollup_top_n) helper the DLQ
+//! [`rollup_top_n`] helper the DLQ
 //! aggregation endpoint's `_other` rollup (issue #385) uses.
 //!
 //! ## Partial answers

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -6326,7 +6326,7 @@ impl WorkflowContext {
     /// `UpdateFailed` event and is therefore skipped on replay),  a signal
     /// handler has no persisted "already delivered" marker. Every recorded
     /// `SignalReceived` event for `name` is drained and dispatched exactly
-    /// once **per [`HistoryMatcher`](crate::replay::HistoryMatcher) instance**
+    /// once **per [`HistoryMatcher`] instance**
     /// -- i.e. once per registration call within a single workflow-task
     /// cycle -- but a *new* cycle (the next activity/timer/signal
     /// completion, a worker restart, a warm-cache eviction) rebuilds the

--- a/autumn-harvest/src/dlq.rs
+++ b/autumn-harvest/src/dlq.rs
@@ -794,7 +794,7 @@ async fn query_dead_letters_for_redrive(
 /// Re-enqueues the dead-lettered task onto its original queue with a fresh
 /// retry budget. Unlike [`replay_dead_letter`], a redrive **reactivates** an
 /// owning execution that was sealed `FAILED` at quarantine time (`FAILED →
-/// RUNNING`, appending a [`WorkflowEvent::WorkflowRedriven`] event so replay
+/// RUNNING`, appending a [`crate::event::WorkflowEvent::WorkflowRedriven`] event so replay
 /// resumes from existing history append-only). The whole operation is one
 /// transaction.
 ///

--- a/autumn-harvest/src/replay.rs
+++ b/autumn-harvest/src/replay.rs
@@ -3608,7 +3608,7 @@ impl HistoryMatcher {
     /// `race_winner:1` marker. Those tolerated event kinds are scanned past
     /// (tracked, not consumed) rather than treated as an immediate miss; on
     /// a match, the cursor rewinds to the first such tolerated event (like
-    /// [`Self::settle_terminal`]) so a sibling's own later scan still finds
+    /// `Self::settle_terminal`) so a sibling's own later scan still finds
     /// it. On a genuine miss (scan exhausted, or an event outside the
     /// tolerated set is encountered) the cursor is left unchanged if nothing
     /// was skipped, or parked at the first tolerated event otherwise — in

--- a/autumn-harvest/src/schedule_decision.rs
+++ b/autumn-harvest/src/schedule_decision.rs
@@ -53,7 +53,7 @@ pub async fn record_decision_graceful(
 ///
 /// # Errors
 ///
-/// Returns a [`database_error`] if the database query execution fails.
+/// Returns a [`crate::error::database_error`] if the database query execution fails.
 pub async fn purge_old_schedule_decisions(
     conn: &mut AsyncPgConnection,
     retention_days: i64,

--- a/autumn-harvest/src/scheduler.rs
+++ b/autumn-harvest/src/scheduler.rs
@@ -3188,7 +3188,7 @@ pub(crate) struct CatchupPlan {
     pub dropped: u64,
 }
 
-/// Compute the set of fire slots and the dropped count given a [`CatchupPolicy`].
+/// Compute the set of fire slots and the dropped count given a [`crate::policy::CatchupPolicy`].
 ///
 /// This is the policy-aware replacement for the internal `due_run_plan` helper.
 /// The old function is preserved as a thin wrapper for backward-compat so that

--- a/autumn-harvest/src/slot_tuner.rs
+++ b/autumn-harvest/src/slot_tuner.rs
@@ -8,15 +8,15 @@
 //! climbs.
 //!
 //! This module is the opt-in *act* half of issue #531 (slot-utilization
-//! gauges, the *observe* half): a [`SlotTuner`] resizes a worker's live
+//! gauges, the *observe* half): a [`crate::slot_tuner::SlotTuner`] resizes a worker's live
 //! dispatch semaphore within an operator-configured `[min_slots, max_slots]`
 //! band, driven only by in-process signals the worker already owns — slot
 //! utilization, worker DB-pool acquisition pressure, and recent
 //! claim-to-dispatch permit-wait latency. No new external dependency, no
 //! `execution.id` sampling.
 //!
-//! This module is pure / no-DB except for [`TunedSlotRuntime`] and
-//! [`spawn_slot_tuner_loop`], which operate on an in-memory `Semaphore` and a
+//! This module is pure / no-DB except for [`crate::slot_tuner::TunedSlotRuntime`] and
+//! [`crate::slot_tuner::spawn_slot_tuner_loop`], which operate on an in-memory `Semaphore` and a
 //! caller-supplied pool-pressure closure — there is still no direct database
 //! dependency here (the closure and the DB connection live in `worker.rs`).
 //!
@@ -505,9 +505,9 @@ impl TunedSlotRuntime {
     /// [`Self::desired_target`] independent of what this call achieves.
     ///
     /// Async (issue #548 review, round 4) only to reap an already-finished
-    /// background shrink-acquire (see [`Self::pending_shrink`]) — that
+    /// background shrink-acquire (see `Self::pending_shrink`) — that
     /// `.await` never actually suspends, since it is only reached after
-    /// confirming the task [`JoinHandle::is_finished`]. This does not make
+    /// confirming the task [`tokio::task::JoinHandle::is_finished`]. This does not make
     /// `resize_toward` itself block on the semaphore.
     pub async fn resize_toward(&mut self, desired: usize) -> usize {
         let desired = desired.clamp(self.min_slots, self.max_slots);

--- a/autumn-harvest/src/store.rs
+++ b/autumn-harvest/src/store.rs
@@ -833,7 +833,7 @@ pub struct HistoryPage {
 
 /// Returns `true` when a workflow execution with `exec_id` exists in the database.
 ///
-/// Cheaper than [`load_execution`] when only presence needs to be confirmed
+/// Cheaper than [`crate::execution::load_execution`] when only presence needs to be confirmed
 /// because it projects only the primary key column.
 #[cfg(feature = "db")]
 pub async fn check_execution_exists(

--- a/autumn-harvest/src/types.rs
+++ b/autumn-harvest/src/types.rs
@@ -817,7 +817,7 @@ impl fmt::Display for IdempotencyKey {
 /// execution-timeout).
 ///
 /// This is only relevant for children spawned via
-/// [`WorkflowContext::spawn_child_workflow_detached_raw`]. Children spawned via
+/// [`crate::context::WorkflowContext::spawn_child_workflow_detached_raw`]. Children spawned via
 /// the await path (`spawn_child_workflow_raw`) pin the parent alive until the
 /// child terminates — no cascade policy is needed.
 ///

--- a/autumn-harvest/src/usage.rs
+++ b/autumn-harvest/src/usage.rs
@@ -74,7 +74,7 @@
 //! ## Known limitation: `search_attr` value collision with the sentinel
 //!
 //! An execution whose `search_attrs` value for the requested key literally
-//! equals [`UNATTRIBUTED_GROUP`] (`"(unattributed)"`) is indistinguishable
+//! equals [`crate::usage::UNATTRIBUTED_GROUP`] (`"(unattributed)"`) is indistinguishable
 //! from an execution that lacks the key entirely — both merge into the same
 //! `"(unattributed)"` group. This is an accepted, documented limitation, not
 //! a defect: issue #596's AC mandates this exact literal for missing-key
@@ -110,7 +110,7 @@ pub const fn default_usage_window_ceiling() -> std::time::Duration {
 /// Unlike `GET /workflows/count`'s top-N + `other` rollup, a chargeback
 /// report must never silently drop a low-volume tenant's data — so
 /// exceeding this cap is a hard error naming the ceiling rather than a
-/// silent rollup. The cap is enforced at two layers: [`usage_sql`] binds it
+/// silent rollup. The cap is enforced at two layers: `usage_sql` binds it
 /// (plus one) as a `LIMIT` so a single high-cardinality shard can't
 /// materialize an unbounded result set, and the plugin's
 /// `build_usage_response` checks the merged cross-shard count before
@@ -360,7 +360,7 @@ LIMIT $5
 /// Load grouped usage rows from a single shard without mutating state.
 ///
 /// `row_limit` bounds the number of grouped rows this single shard's query
-/// can return (a `LIMIT` clause in [`usage_sql`]) — callers should pass the
+/// can return (a `LIMIT` clause in `usage_sql`) — callers should pass the
 /// configured group cap plus one, so the plugin can still detect and report
 /// an over-cap condition without ever materializing an unbounded result set
 /// for a single high-cardinality shard.


### PR DESCRIPTION
📖 Chapter: Various modules including `replay`, `slot_tuner`, `types`, `usage`, `dlq`, `schedule_decision`, `scheduler`, `store`, `context`, `api`, `ui`, `mcp_tools`, and `workflow_count`.

🔦 Insight: Fixed numerous unresolved intra-doc links that were causing `cargo doc` warnings. Correctly updated paths to absolute module structures (e.g. `crate::slot_tuner::SlotTuner`), dropped explicit targets when redundant, and updated internal/private links (e.g. `Self::settle_terminal`) to standard backticks instead of documentation brackets.

🧪 Example: Ran `cargo doc --no-deps --document-private-items --all-features` and verified 0 warnings. 

🖼️ Preview: (n/a)

---
*PR created automatically by Jules for task [5763460072203548026](https://jules.google.com/task/5763460072203548026) started by @madmax983*