### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -5130,8 +5130,11 @@ impl WorkflowContext {
         // pushing any command yet, so a branch that already has a terminal
         // recorded (the common case on any replay after the race resolves)
         // never re-emits a stray dispatch/wait command for a cancelled sibling.
-        let mut resolved: Vec<(usize, HarvestResult<Value>)> = Vec::new();
-        let mut to_dispatch: Vec<RaceDispatch> = Vec::new();
+        //
+        // ⚡ Bolt: Pre-allocate vectors using the number of branches to prevent
+        // intermediate heap allocations during branch evaluation.
+        let mut resolved: Vec<(usize, HarvestResult<Value>)> = Vec::with_capacity(branches.len());
+        let mut to_dispatch: Vec<RaceDispatch> = Vec::with_capacity(branches.len());
 
         for (index, branch) in branches.iter().enumerate() {
             match &branch.kind {
@@ -5459,8 +5462,11 @@ impl WorkflowContext {
                 details: Value::from(winner_index as u64),
             });
 
-            let mut activities = Vec::new();
-            let mut children = Vec::new();
+            // ⚡ Bolt: Pre-allocate cancellation tracking vectors based on the number
+            // of spawned branches (minus the winner) to prevent reallocations.
+            let losers_count = to_dispatch.len().saturating_sub(1);
+            let mut activities = Vec::with_capacity(losers_count);
+            let mut children = Vec::with_capacity(losers_count);
             for dispatch in to_dispatch {
                 if dispatch.index == winner_index {
                     continue;


### PR DESCRIPTION
💡 What: Replaced `Vec::new()` with `Vec::with_capacity()` for branch evaluation and cancellation vectors during workflow race conditions.
🎯 Why: When dispatching a `Race` operation (with `N` branches), intermediate vectors were dynamically reallocating because their size is upper-bounded by `branches.len()`.
📊 Impact: Removes up to 4 dynamic heap reallocations per `ctx.race()` operation on the hot workflow execution path.
🔬 Measurement: Run `cargo bench` and observe allocations or inspect workflow execution times for heavy race conditions.

---
*PR created automatically by Jules for task [9411813627032246179](https://jules.google.com/task/9411813627032246179) started by @madmax983*