### PR TITLE
Add built-in Prometheus scrape endpoint for Harvest metrics (issue #355)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,6 +32,8 @@ jobs:
         run: cargo clippy -p autumn-harvest-plugin --all-targets -- -D warnings
       - name: Clippy autumn-harvest-plugin (mcp feature)
         run: cargo clippy -p autumn-harvest-plugin --all-targets --features mcp,unified-dag-execution -- -D warnings
+      - name: Clippy autumn-harvest-plugin (metrics feature)
+        run: cargo clippy -p autumn-harvest-plugin --all-targets --features metrics -- -D warnings
       - name: Clippy autumn-harvest-macros
         run: cargo clippy -p autumn-harvest-macros -- -D warnings
 
@@ -63,6 +65,10 @@ jobs:
         run: cargo test -p autumn-harvest-plugin --features mcp,unified-dag-execution --lib --test mcp_tools_http_tests
       - name: Compile plugin MCP integration tests
         run: cargo test -p autumn-harvest-plugin --features mcp,unified-dag-execution --test mcp_tools_integration --no-run
+      - name: Run plugin metrics scrape tests (issue #355)
+        run: cargo test -p autumn-harvest-plugin --features metrics --lib --test metrics_scrape_http_tests
+      - name: Compile plugin metrics scrape example
+        run: cargo build -p autumn-harvest-plugin --example metrics_scrape_quickstart --features metrics
       - name: Run macros tests
         run: cargo test -p autumn-harvest-macros
       - name: Compile plugin integration tests

--- a/autumn-harvest-plugin/Cargo.toml
+++ b/autumn-harvest-plugin/Cargo.toml
@@ -18,6 +18,11 @@ webhooks = ["autumn-harvest/db"]
 # autumn-web's MCP layer so HarvestPlugin::mcp_tools() can project workflows
 # as start/status/signal/update/watch tools via AppBuilder::mount_mcp.
 mcp = ["autumn-web/mcp"]
+# Built-in Prometheus scrape endpoint (issue #355). Registers Harvest's nine
+# ADR-0001 catalogue metrics as an autumn-web MetricsSource feeding the
+# app's shared /actuator/prometheus endpoint. No new dependency: rendering
+# is done entirely through autumn-web's existing MetricsSource contract.
+metrics = []
 
 
 [dependencies]
@@ -60,3 +65,7 @@ required-features = ["mcp"]
 [[example]]
 name = "webhook_receiver_quickstart"
 required-features = ["webhooks"]
+
+[[example]]
+name = "metrics_scrape_quickstart"
+required-features = ["metrics"]

--- a/autumn-harvest-plugin/examples/metrics_scrape_quickstart.rs
+++ b/autumn-harvest-plugin/examples/metrics_scrape_quickstart.rs
@@ -1,0 +1,136 @@
+//! Curl the built-in Prometheus scrape endpoint after a single workflow run
+//! (issue #355).
+//!
+//! Run with:
+//! ```bash
+//! export AUTUMN_DATABASE__URL=postgres://localhost/harvest_demo
+//! cargo run -p autumn-harvest-plugin --example metrics_scrape_quickstart --features metrics
+//! ```
+//!
+//! Wait a few seconds for the app to boot and the workflow below to run
+//! once, then in another terminal:
+//! ```bash
+//! curl http://localhost:3000/actuator/prometheus | grep ^harvest_
+//! ```
+//!
+//! `HarvestPlugin::with_metrics_scrape()` is the only line needed to make
+//! Harvest's nine ADR-0001 §7 catalogue metrics appear on the app's shared
+//! `/actuator/prometheus` endpoint -- no exporter to install, no route to
+//! wire, no new dependency. This example drives every one of the nine
+//! within a few seconds of boot:
+//!
+//! - `harvest_workflow_started_total` / `harvest_workflow_duration_{count,sum}`
+//!   -- the `onboarding` workflow below is started once, right after boot.
+//! - `harvest_activity_duration_{count,sum}` -- `onboarding` calls one activity.
+//! - `harvest_timer_started_total` -- `onboarding` also waits on a durable timer.
+//! - `harvest_queue_depth` / `harvest_dlq_entries` -- sampled every
+//!   `poll_interval` (500ms by default) regardless of whether either is
+//!   nonzero, so both appear within about a second of boot with no
+//!   dedicated setup.
+//! - `harvest_schedule_runs_total` / `harvest_schedule_skipped_total` -- the
+//!   `every_3_seconds` DAG below fires every 3s; its activity intentionally
+//!   takes ~4s, so every other fire collides with the still-running
+//!   previous one and is skipped (observed reason: `max_active_runs_reached`,
+//!   a DAG's default concurrency cap of 1).
+//! - `harvest_retention_deleted_total` -- retention is configured with a 1s
+//!   `max_age`/tick interval so the family appears quickly. Verified against
+//!   a live run: the family and its `# HELP`/`# TYPE` lines are always
+//!   present once retention is configured, but the *count* can legitimately
+//!   stay at 0 for a while -- a completed execution keeps its last-processed
+//!   worker's id stamped on it, which the retention candidate query
+//!   deliberately excludes, so deletion only proceeds once that stamp is
+//!   cleared through normal fleet churn. Present-but-zero is still a
+//!   correctly emitted sample (the same is true of `harvest_dlq_entries` and
+//!   `harvest_queue_depth` above whenever nothing is backlogged).
+//!
+//! None of this is meant as production retention/schedule tuning advice --
+//! the intervals here are deliberately short so the demo is observable in
+//! seconds rather than hours.
+
+use std::time::Duration;
+
+use autumn_harvest::prelude::*;
+use autumn_harvest::retention::RetentionConfig;
+use autumn_harvest_plugin::HarvestPlugin;
+
+#[activity]
+#[allow(clippy::unused_async)] // #[activity] handlers must be async fn
+async fn send_email(_ctx: &ActivityContext, addr: String) -> Result<(), String> {
+    tracing::info!(%addr, "sent email");
+    Ok(())
+}
+
+/// The workflow this example starts once, right after boot -- drives
+/// `harvest_workflow_started_total`, `harvest_workflow_duration_{count,sum}`,
+/// `harvest_activity_duration_{count,sum}`, and `harvest_timer_started_total`.
+#[workflow]
+async fn onboarding(ctx: &WorkflowContext, user_id: i64) -> Result<(), String> {
+    ctx.execute_activity::<_, ()>(&send_email_info(), format!("user-{user_id}@example.com"))
+        .await
+        .map_err(|e| e.to_string())?;
+    ctx.timer("welcome_followup", 1)
+        .await
+        .map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+#[activity]
+async fn slow_background_task(_ctx: &ActivityContext) -> Result<(), String> {
+    // Deliberately outlasts the schedule's 3s interval so every other fire
+    // collides with this one and is skipped -- this is what drives
+    // `harvest_schedule_skipped_total` in this demo.
+    tokio::time::sleep(Duration::from_secs(4)).await;
+    Ok(())
+}
+
+/// A unified DAG (issue #256) scheduled to fire every 3 seconds -- drives
+/// `harvest_schedule_runs_total` and, via the slow activity above,
+/// `harvest_schedule_skipped_total`.
+#[dag(schedule = "*/3 * * * * *")]
+fn every_3_seconds(dag: &mut DagBuilder) {
+    let _ = dag.activity(slow_background_task);
+}
+
+/// autumn-web requires at least one top-level `.routes(...)` registration
+/// (unrelated to Harvest); this is that one route for the app.
+#[autumn_web::get("/")]
+async fn index() -> &'static str {
+    "metrics_scrape_quickstart is running -- see /actuator/prometheus"
+}
+
+#[autumn_web::main]
+async fn main() {
+    let app = autumn_web::app().routes(autumn_web::routes![index]).plugin(
+        HarvestPlugin::new()
+            .workflows(workflows![onboarding])
+            .activities(activities![send_email, slow_background_task])
+            .dags(dags![every_3_seconds])
+            .worker(WorkerConfig::default())
+            .retention(RetentionConfig {
+                max_age_secs: Some(1),
+                tick_interval_secs: 1,
+                ..RetentionConfig::default()
+            })
+            .api("/api/harvest")
+            .with_metrics_scrape(),
+    );
+
+    tokio::spawn(async move {
+        // Give the plugin's on_startup hook time to install the runtime
+        // before dispatching the demo's single workflow run, over the same
+        // HTTP API a real caller would use.
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        let resp = reqwest::Client::new()
+            .post("http://localhost:3000/api/harvest/workflows/onboarding/start")
+            .json(&serde_json::json!({ "input": 42 }))
+            .send()
+            .await
+            .expect("start the demo workflow over HTTP");
+        tracing::info!(
+            status = %resp.status(),
+            "started the onboarding workflow -- curl /actuator/prometheus in a few seconds"
+        );
+    });
+
+    app.run().await;
+}

--- a/autumn-harvest-plugin/src/lib.rs
+++ b/autumn-harvest-plugin/src/lib.rs
@@ -34,6 +34,13 @@ pub mod webhook_receiver;
 #[cfg(feature = "mcp")]
 pub mod mcp_tools;
 
+/// Built-in Prometheus scrape endpoint (issue #355).
+///
+/// Registers the nine ADR-0001 §7 catalogue metrics as an autumn-web
+/// `MetricsSource` feeding the app's shared `/actuator/prometheus` endpoint.
+#[cfg(feature = "metrics")]
+pub mod metrics_scrape;
+
 pub use api::{
     HarvestApiRuntime, HarvestApiState, HarvestRetentionRuntime, harvest_api_router,
     management_api_request_fields, management_api_response_fields, management_api_routes,

--- a/autumn-harvest-plugin/src/metrics_scrape.rs
+++ b/autumn-harvest-plugin/src/metrics_scrape.rs
@@ -1,0 +1,610 @@
+//! Built-in Prometheus scrape endpoint for `HarvestPlugin` (issue #355).
+//!
+//! [`HarvestMetricsRecorder`] is an in-process aggregator that implements
+//! both `autumn_harvest::telemetry::MetricsRecorder` (so the core engine can
+//! record samples into it) and `autumn_web::actuator::MetricsSource` (so
+//! autumn-web's already-shared `/actuator/prometheus` endpoint can render
+//! those samples alongside the app's own `autumn_http_*` families and any
+//! other plugin's metrics).
+//!
+//! This deliberately does **not** touch the global `metrics`-crate registry
+//! (unlike the `metrics-rs` adapter/escape hatch documented in
+//! `docs/telemetry.md`) — there is nothing to double-register, and no new
+//! dependency is pulled in. `HarvestPlugin::with_metrics_scrape()` wires one
+//! shared instance into both the core `HarvestBuilder::telemetry(..)` slot
+//! and `AppBuilder::metrics_source("harvest", ..)`.
+//!
+//! Only the nine ADR-0001 §7 catalogue metrics are aggregated here. Every
+//! other `MetricsRecorder` method keeps the trait's no-op default — an
+//! embedder who needs the full metric surface (or OTLP) still reaches for
+//! the `metrics-rs` adapter escape hatch.
+//!
+//! A `MetricFamily` is only emitted once at least one sample has been
+//! recorded for it — there is no way to synthesize a meaningful zero-value
+//! default for a labeled series before its label values are known.
+
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+use autumn_harvest::telemetry::{
+    ActivityStatus, METRIC_LABEL_ACTIVITY, METRIC_LABEL_KIND, METRIC_LABEL_NAME,
+    METRIC_LABEL_QUEUE, METRIC_LABEL_REASON, METRIC_LABEL_SHARD, METRIC_LABEL_STATUS,
+    METRIC_LABEL_WORKFLOW, MetricsRecorder, WorkflowStatus,
+};
+use autumn_web::actuator::{MetricFamily, MetricKind, MetricSample, MetricsSource};
+
+/// Label values keyed to a stable position; label *names* are supplied by
+/// the caller at render time (see [`push_counter`]/[`push_gauge`]/[`push_histogram`]),
+/// since every call site always records labels in the same declared order.
+type LabelValues = Vec<String>;
+
+#[derive(Default)]
+struct Counter(RwLock<HashMap<LabelValues, u64>>);
+
+impl Counter {
+    fn incr(&self, labels: LabelValues, delta: u64) {
+        let mut map = self
+            .0
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        *map.entry(labels).or_insert(0) += delta;
+    }
+
+    fn snapshot(&self) -> Vec<(LabelValues, u64)> {
+        self.0
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .iter()
+            .map(|(k, v)| (k.clone(), *v))
+            .collect()
+    }
+}
+
+#[derive(Default)]
+struct Gauge(RwLock<HashMap<LabelValues, f64>>);
+
+impl Gauge {
+    fn set(&self, labels: LabelValues, value: f64) {
+        let mut map = self
+            .0
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        map.insert(labels, value);
+    }
+
+    fn snapshot(&self) -> Vec<(LabelValues, f64)> {
+        self.0
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .iter()
+            .map(|(k, v)| (k.clone(), *v))
+            .collect()
+    }
+}
+
+/// `(count, sum)` per label combination — the Prometheus histogram/summary
+/// decomposition without bucket boundaries. `autumn_web::actuator::MetricKind`
+/// only supports `Counter`/`Gauge` (no `Histogram` variant), so a duration
+/// metric is rendered as a `_count` and a `_sum` counter pair; a caller can
+/// still chart an average via `rate(x_sum[5m]) / rate(x_count[5m])`. Full
+/// bucketed histograms remain available via the `metrics-rs` adapter escape
+/// hatch documented in `docs/telemetry.md`.
+#[derive(Default)]
+struct Histogram(RwLock<HashMap<LabelValues, (u64, f64)>>);
+
+impl Histogram {
+    // The write guard is held only for the two-statement bump below (bounded,
+    // uncontended in-process work); the lint's general "hold locks briefly"
+    // advice doesn't apply cleanly to `HashMap::entry`'s borrow shape here.
+    #[allow(clippy::significant_drop_tightening)]
+    fn observe(&self, labels: LabelValues, value: f64) {
+        let mut map = self
+            .0
+            .write()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+        let entry = map.entry(labels).or_insert((0, 0.0));
+        entry.0 += 1;
+        entry.1 += value;
+    }
+
+    fn snapshot(&self) -> Vec<(LabelValues, (u64, f64))> {
+        self.0
+            .read()
+            .unwrap_or_else(std::sync::PoisonError::into_inner)
+            .iter()
+            .map(|(k, v)| (k.clone(), *v))
+            .collect()
+    }
+}
+
+#[derive(Default)]
+struct Inner {
+    workflow_started: Counter,
+    workflow_duration: Histogram,
+    activity_duration: Histogram,
+    timer_started: Counter,
+    queue_depth: Gauge,
+    dlq_entries: Gauge,
+    schedule_runs: Counter,
+    schedule_skipped: Counter,
+    retention_deleted: Counter,
+}
+
+/// In-process aggregator for the nine ADR-0001 §7 catalogue metrics.
+///
+/// Implements both `MetricsRecorder` (recording side, installed via
+/// `HarvestBuilder::telemetry`) and `MetricsSource` (rendering side,
+/// registered via `AppBuilder::metrics_source`) over one shared
+/// `Arc<Inner>`, so `.clone()` is cheap and every clone observes the same
+/// underlying counters/gauges/histograms.
+#[derive(Clone, Default)]
+pub struct HarvestMetricsRecorder(Arc<Inner>);
+
+impl HarvestMetricsRecorder {
+    /// Create a fresh, empty aggregator.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl MetricsRecorder for HarvestMetricsRecorder {
+    fn is_enabled(&self) -> bool {
+        true
+    }
+
+    fn record_workflow_started(&self, workflow_name: &str, queue: &str) {
+        self.0
+            .workflow_started
+            .incr(vec![workflow_name.to_owned(), queue.to_owned()], 1);
+    }
+
+    fn record_workflow_completed(
+        &self,
+        workflow_name: &str,
+        queue: &str,
+        duration_secs: f64,
+        status: WorkflowStatus,
+    ) {
+        self.0.workflow_duration.observe(
+            vec![
+                workflow_name.to_owned(),
+                queue.to_owned(),
+                status.as_str().to_owned(),
+            ],
+            duration_secs,
+        );
+    }
+
+    fn record_activity_completed(
+        &self,
+        activity_name: &str,
+        queue: &str,
+        duration_secs: f64,
+        status: ActivityStatus,
+    ) {
+        self.0.activity_duration.observe(
+            vec![
+                activity_name.to_owned(),
+                queue.to_owned(),
+                status.as_str().to_owned(),
+            ],
+            duration_secs,
+        );
+    }
+
+    fn record_timer_started(&self, _duration_secs: f64) {
+        self.0.timer_started.incr(Vec::new(), 1);
+    }
+
+    #[allow(clippy::cast_precision_loss)]
+    fn record_queue_depth(&self, queue_name: &str, depth: u64) {
+        self.0
+            .queue_depth
+            .set(vec![queue_name.to_owned()], depth as f64);
+    }
+
+    #[allow(clippy::cast_precision_loss)]
+    fn record_dlq_entries(&self, shard: u16, depth: u64) {
+        self.0
+            .dlq_entries
+            .set(vec![shard.to_string()], depth as f64);
+    }
+
+    fn record_schedule_run(&self, kind: &str, name: &str) {
+        self.0
+            .schedule_runs
+            .incr(vec![kind.to_owned(), name.to_owned()], 1);
+    }
+
+    fn record_schedule_skipped(&self, kind: &str, name: &str, reason: &str) {
+        self.0
+            .schedule_skipped
+            .incr(vec![kind.to_owned(), name.to_owned(), reason.to_owned()], 1);
+    }
+
+    fn record_schedule_skipped_n(&self, kind: &str, name: &str, reason: &str, count: u64) {
+        self.0.schedule_skipped.incr(
+            vec![kind.to_owned(), name.to_owned(), reason.to_owned()],
+            count,
+        );
+    }
+
+    fn record_retention_tick(
+        &self,
+        shard: u16,
+        _candidate_count: u64,
+        deleted_count: u64,
+        _duration_secs: f64,
+    ) {
+        self.0
+            .retention_deleted
+            .incr(vec![shard.to_string()], deleted_count);
+    }
+}
+
+fn zip_labels(label_names: &[&str], values: LabelValues) -> Vec<(String, String)> {
+    label_names
+        .iter()
+        .map(|s| (*s).to_string())
+        .zip(values)
+        .collect()
+}
+
+fn push_counter(
+    out: &mut Vec<MetricFamily>,
+    name: &str,
+    help: &str,
+    label_names: &[&str],
+    data: Vec<(LabelValues, u64)>,
+) {
+    if data.is_empty() {
+        return;
+    }
+    #[allow(clippy::cast_precision_loss)]
+    let samples = data
+        .into_iter()
+        .map(|(vals, v)| MetricSample {
+            labels: zip_labels(label_names, vals),
+            value: v as f64,
+        })
+        .collect();
+    out.push(MetricFamily {
+        name: name.to_string(),
+        help: help.to_string(),
+        kind: MetricKind::Counter,
+        samples,
+    });
+}
+
+fn push_gauge(
+    out: &mut Vec<MetricFamily>,
+    name: &str,
+    help: &str,
+    label_names: &[&str],
+    data: Vec<(LabelValues, f64)>,
+) {
+    if data.is_empty() {
+        return;
+    }
+    let samples = data
+        .into_iter()
+        .map(|(vals, value)| MetricSample {
+            labels: zip_labels(label_names, vals),
+            value,
+        })
+        .collect();
+    out.push(MetricFamily {
+        name: name.to_string(),
+        help: help.to_string(),
+        kind: MetricKind::Gauge,
+        samples,
+    });
+}
+
+#[allow(clippy::cast_precision_loss)]
+fn push_histogram(
+    out: &mut Vec<MetricFamily>,
+    name: &str,
+    help: &str,
+    label_names: &[&str],
+    data: Vec<(LabelValues, (u64, f64))>,
+) {
+    if data.is_empty() {
+        return;
+    }
+    let mut count_samples = Vec::with_capacity(data.len());
+    let mut sum_samples = Vec::with_capacity(data.len());
+    for (vals, (count, sum)) in data {
+        let labels = zip_labels(label_names, vals);
+        count_samples.push(MetricSample {
+            labels: labels.clone(),
+            value: count as f64,
+        });
+        sum_samples.push(MetricSample { labels, value: sum });
+    }
+    out.push(MetricFamily {
+        name: format!("{name}_count"),
+        help: format!("{help} (sample count)"),
+        kind: MetricKind::Counter,
+        samples: count_samples,
+    });
+    out.push(MetricFamily {
+        name: format!("{name}_sum"),
+        help: format!("{help} (sum)"),
+        kind: MetricKind::Counter,
+        samples: sum_samples,
+    });
+}
+
+impl MetricsSource for HarvestMetricsRecorder {
+    fn collect(&self) -> Vec<MetricFamily> {
+        let mut families = Vec::new();
+        push_counter(
+            &mut families,
+            "harvest_workflow_started_total",
+            "Total number of workflow executions started",
+            &[METRIC_LABEL_WORKFLOW, METRIC_LABEL_QUEUE],
+            self.0.workflow_started.snapshot(),
+        );
+        push_histogram(
+            &mut families,
+            "harvest_workflow_duration",
+            "Workflow execution duration in seconds",
+            &[
+                METRIC_LABEL_WORKFLOW,
+                METRIC_LABEL_QUEUE,
+                METRIC_LABEL_STATUS,
+            ],
+            self.0.workflow_duration.snapshot(),
+        );
+        push_histogram(
+            &mut families,
+            "harvest_activity_duration",
+            "Activity execution duration in seconds",
+            &[
+                METRIC_LABEL_ACTIVITY,
+                METRIC_LABEL_QUEUE,
+                METRIC_LABEL_STATUS,
+            ],
+            self.0.activity_duration.snapshot(),
+        );
+        push_counter(
+            &mut families,
+            "harvest_timer_started_total",
+            "Total number of durable timers started",
+            &[],
+            self.0.timer_started.snapshot(),
+        );
+        push_gauge(
+            &mut families,
+            "harvest_queue_depth",
+            "Current pending task count per queue",
+            &[METRIC_LABEL_QUEUE],
+            self.0.queue_depth.snapshot(),
+        );
+        push_gauge(
+            &mut families,
+            "harvest_dlq_entries",
+            "Current dead-letter queue entry count per shard",
+            &[METRIC_LABEL_SHARD],
+            self.0.dlq_entries.snapshot(),
+        );
+        push_counter(
+            &mut families,
+            "harvest_schedule_runs_total",
+            "Total number of schedule firings",
+            &[METRIC_LABEL_KIND, METRIC_LABEL_NAME],
+            self.0.schedule_runs.snapshot(),
+        );
+        push_counter(
+            &mut families,
+            "harvest_schedule_skipped_total",
+            "Total number of skipped schedule firings",
+            &[METRIC_LABEL_KIND, METRIC_LABEL_NAME, METRIC_LABEL_REASON],
+            self.0.schedule_skipped.snapshot(),
+        );
+        push_counter(
+            &mut families,
+            "harvest_retention_deleted_total",
+            "Total number of records deleted by the retention sweep",
+            &[METRIC_LABEL_SHARD],
+            self.0.retention_deleted.snapshot(),
+        );
+        families
+    }
+}
+
+#[cfg(test)]
+// Every assertion compares an exactly-representable whole-number count/sum
+// (small integers, safe well below f64's 2^53 exact-integer bound) against a
+// literal -- intentional exact equality, not a precision-sensitive float
+// comparison.
+#[allow(clippy::float_cmp)]
+mod tests {
+    use super::*;
+
+    fn family<'a>(families: &'a [MetricFamily], name: &str) -> &'a MetricFamily {
+        families
+            .iter()
+            .find(|f| f.name == name)
+            .unwrap_or_else(|| panic!("missing family {name} in {families:?}"))
+    }
+
+    fn sample_value(family: &MetricFamily, labels: &[(&str, &str)]) -> f64 {
+        family
+            .samples
+            .iter()
+            .find(|s| {
+                s.labels.len() == labels.len()
+                    && labels
+                        .iter()
+                        .all(|(k, v)| s.labels.iter().any(|(sk, sv)| sk == k && sv == v))
+            })
+            .unwrap_or_else(|| panic!("missing sample {labels:?} in family {family:?}"))
+            .value
+    }
+
+    #[test]
+    fn no_families_emitted_before_any_recording() {
+        let recorder = HarvestMetricsRecorder::new();
+        assert!(recorder.collect().is_empty());
+    }
+
+    #[test]
+    fn workflow_started_is_a_counter_with_workflow_and_queue_labels() {
+        let recorder = HarvestMetricsRecorder::new();
+        recorder.record_workflow_started("onboarding", "default");
+        recorder.record_workflow_started("onboarding", "default");
+        recorder.record_workflow_started("billing", "priority");
+
+        let families = recorder.collect();
+        let f = family(&families, "harvest_workflow_started_total");
+        assert_eq!(f.kind, MetricKind::Counter);
+        assert_eq!(
+            sample_value(f, &[("workflow", "onboarding"), ("queue", "default")]),
+            2.0
+        );
+        assert_eq!(
+            sample_value(f, &[("workflow", "billing"), ("queue", "priority")]),
+            1.0
+        );
+    }
+
+    #[test]
+    fn workflow_duration_decomposes_into_count_and_sum_counters() {
+        let recorder = HarvestMetricsRecorder::new();
+        recorder.record_workflow_completed("onboarding", "default", 1.5, WorkflowStatus::Completed);
+        recorder.record_workflow_completed("onboarding", "default", 2.5, WorkflowStatus::Completed);
+
+        let families = recorder.collect();
+        let count_f = family(&families, "harvest_workflow_duration_count");
+        let sum_f = family(&families, "harvest_workflow_duration_sum");
+        assert_eq!(count_f.kind, MetricKind::Counter);
+        assert_eq!(sum_f.kind, MetricKind::Counter);
+        let labels = [
+            ("workflow", "onboarding"),
+            ("queue", "default"),
+            ("status", "completed"),
+        ];
+        assert_eq!(sample_value(count_f, &labels), 2.0);
+        assert_eq!(sample_value(sum_f, &labels), 4.0);
+    }
+
+    #[test]
+    fn activity_duration_decomposes_into_count_and_sum_counters() {
+        let recorder = HarvestMetricsRecorder::new();
+        recorder.record_activity_completed(
+            "send_email",
+            "email-workers",
+            0.25,
+            ActivityStatus::Completed,
+        );
+
+        let families = recorder.collect();
+        let count_f = family(&families, "harvest_activity_duration_count");
+        let sum_f = family(&families, "harvest_activity_duration_sum");
+        let labels = [
+            ("activity", "send_email"),
+            ("queue", "email-workers"),
+            ("status", "completed"),
+        ];
+        assert_eq!(sample_value(count_f, &labels), 1.0);
+        assert_eq!(sample_value(sum_f, &labels), 0.25);
+    }
+
+    #[test]
+    fn timer_started_is_an_unlabeled_counter() {
+        let recorder = HarvestMetricsRecorder::new();
+        recorder.record_timer_started(30.0);
+        recorder.record_timer_started(60.0);
+
+        let families = recorder.collect();
+        let f = family(&families, "harvest_timer_started_total");
+        assert_eq!(f.kind, MetricKind::Counter);
+        assert_eq!(f.samples.len(), 1);
+        assert_eq!(f.samples[0].labels.len(), 0);
+        assert_eq!(f.samples[0].value, 2.0);
+    }
+
+    #[test]
+    fn queue_depth_is_a_last_write_wins_gauge() {
+        let recorder = HarvestMetricsRecorder::new();
+        recorder.record_queue_depth("default", 5);
+        recorder.record_queue_depth("default", 3);
+
+        let families = recorder.collect();
+        let f = family(&families, "harvest_queue_depth");
+        assert_eq!(f.kind, MetricKind::Gauge);
+        assert_eq!(sample_value(f, &[("queue", "default")]), 3.0);
+    }
+
+    #[test]
+    fn dlq_entries_is_a_gauge_labeled_by_shard() {
+        let recorder = HarvestMetricsRecorder::new();
+        recorder.record_dlq_entries(0, 7);
+
+        let families = recorder.collect();
+        let f = family(&families, "harvest_dlq_entries");
+        assert_eq!(f.kind, MetricKind::Gauge);
+        assert_eq!(sample_value(f, &[("shard", "0")]), 7.0);
+    }
+
+    #[test]
+    fn schedule_runs_is_a_counter_labeled_by_kind_and_name() {
+        let recorder = HarvestMetricsRecorder::new();
+        recorder.record_schedule_run("cron", "nightly_report");
+
+        let families = recorder.collect();
+        let f = family(&families, "harvest_schedule_runs_total");
+        assert_eq!(
+            sample_value(f, &[("kind", "cron"), ("name", "nightly_report")]),
+            1.0
+        );
+    }
+
+    #[test]
+    fn schedule_skipped_batches_via_record_schedule_skipped_n() {
+        let recorder = HarvestMetricsRecorder::new();
+        recorder.record_schedule_skipped("cron", "nightly_report", "overlap");
+        recorder.record_schedule_skipped_n("cron", "nightly_report", "overlap", 4);
+
+        let families = recorder.collect();
+        let f = family(&families, "harvest_schedule_skipped_total");
+        assert_eq!(
+            sample_value(
+                f,
+                &[
+                    ("kind", "cron"),
+                    ("name", "nightly_report"),
+                    ("reason", "overlap")
+                ]
+            ),
+            5.0
+        );
+    }
+
+    #[test]
+    fn retention_deleted_is_a_counter_labeled_by_shard() {
+        let recorder = HarvestMetricsRecorder::new();
+        recorder.record_retention_tick(0, 100, 42, 0.5);
+
+        let families = recorder.collect();
+        let f = family(&families, "harvest_retention_deleted_total");
+        assert_eq!(sample_value(f, &[("shard", "0")]), 42.0);
+    }
+
+    #[test]
+    fn clones_share_the_same_underlying_state() {
+        let recorder = HarvestMetricsRecorder::new();
+        let clone = recorder.clone();
+        clone.record_workflow_started("onboarding", "default");
+
+        let families = recorder.collect();
+        let f = family(&families, "harvest_workflow_started_total");
+        assert_eq!(
+            sample_value(f, &[("workflow", "onboarding"), ("queue", "default")]),
+            1.0
+        );
+    }
+}

--- a/autumn-harvest-plugin/src/metrics_scrape.rs
+++ b/autumn-harvest-plugin/src/metrics_scrape.rs
@@ -14,10 +14,20 @@
 //! shared instance into both the core `HarvestBuilder::telemetry(..)` slot
 //! and `AppBuilder::metrics_source("harvest", ..)`.
 //!
-//! Only the nine ADR-0001 §7 catalogue metrics are aggregated here. Every
-//! other `MetricsRecorder` method keeps the trait's no-op default — an
-//! embedder who needs the full metric surface (or OTLP) still reaches for
-//! the `metrics-rs` adapter escape hatch.
+//! This aggregates the nine ADR-0001 §7 catalogue metrics named in issue
+//! #355, plus `harvest.queue.oldest_pending_age`, `harvest.worker.slots_*`,
+//! and `harvest.shard.stranded_pending` — the engine's own background
+//! samplers already compute these under the same `MetricsRecorder::is_enabled()`
+//! gate (see `HarvestMetricsRecorder::is_enabled`, which reports `true`
+//! unconditionally so the nine required metrics are actually sampled), so
+//! leaving them unimplemented would mean the sampler's DB queries still ran
+//! on every tick with their results silently discarded. Every other
+//! `MetricsRecorder` method keeps the trait's no-op default — an embedder
+//! who needs the full metric surface (e.g. `harvest.workflow.terminal`,
+//! `harvest.activity.attempts`/`.retries`, `harvest.schedule.fire_attempts`,
+//! and the rest of the starter alert pack in `docs/alerts/`) or OTLP export
+//! still reaches for the `metrics-rs` adapter escape hatch — this endpoint
+//! does **not** back the full starter alert pack.
 //!
 //! A `MetricFamily` is only emitted once at least one sample has been
 //! recorded for it — there is no way to synthesize a meaningful zero-value
@@ -28,8 +38,8 @@ use std::sync::{Arc, RwLock};
 
 use autumn_harvest::telemetry::{
     ActivityStatus, METRIC_LABEL_ACTIVITY, METRIC_LABEL_KIND, METRIC_LABEL_NAME,
-    METRIC_LABEL_QUEUE, METRIC_LABEL_REASON, METRIC_LABEL_SHARD, METRIC_LABEL_STATUS,
-    METRIC_LABEL_WORKFLOW, MetricsRecorder, WorkflowStatus,
+    METRIC_LABEL_QUEUE, METRIC_LABEL_REASON, METRIC_LABEL_SHARD, METRIC_LABEL_SLOT_TYPE,
+    METRIC_LABEL_STATUS, METRIC_LABEL_WORKFLOW, MetricsRecorder, SlotType, WorkflowStatus,
 };
 use autumn_web::actuator::{MetricFamily, MetricKind, MetricSample, MetricsSource};
 
@@ -128,9 +138,23 @@ struct Inner {
     schedule_runs: Counter,
     schedule_skipped: Counter,
     retention_deleted: Counter,
+    // These four back-fill metrics that the engine's own is_enabled()-gated
+    // background samplers already compute (queue-depth sampler's oldest-age
+    // query, the stranded-work scanner, the worker-slot sampler): once
+    // `.with_metrics_scrape()` flips `is_enabled()` to true, those samplers
+    // run regardless of whether this recorder was going to use the result.
+    // Implementing them turns already-paid-for sampler work into real
+    // series instead of a discarded read.
+    queue_oldest_pending_age: Gauge,
+    worker_slots_in_use: Gauge,
+    worker_slots_available: Gauge,
+    worker_slot_target: Gauge,
+    shard_stranded_pending: Gauge,
 }
 
-/// In-process aggregator for the nine ADR-0001 §7 catalogue metrics.
+/// In-process aggregator for the built-in Prometheus scrape endpoint
+/// (issue #355) — see the module docs above for exactly which metrics are
+/// covered.
 ///
 /// Implements both `MetricsRecorder` (recording side, installed via
 /// `HarvestBuilder::telemetry`) and `MetricsSource` (rendering side,
@@ -149,6 +173,11 @@ impl HarvestMetricsRecorder {
 }
 
 impl MetricsRecorder for HarvestMetricsRecorder {
+    // Must be `true` for the engine's own is_enabled()-gated background
+    // samplers (queue depth, DLQ depth, worker slots, stranded-work) to run
+    // at all -- the required nine catalogue metrics live behind those same
+    // samplers. Every metric those samplers compute is implemented below so
+    // none of that gated work goes to waste.
     fn is_enabled(&self) -> bool {
         true
     }
@@ -240,6 +269,36 @@ impl MetricsRecorder for HarvestMetricsRecorder {
         self.0
             .retention_deleted
             .incr(vec![shard.to_string()], deleted_count);
+    }
+
+    fn record_queue_oldest_pending_age(&self, queue_name: &str, age_secs: f64) {
+        self.0
+            .queue_oldest_pending_age
+            .set(vec![queue_name.to_owned()], age_secs);
+    }
+
+    #[allow(clippy::cast_precision_loss)]
+    fn record_worker_slots(&self, slot_type: SlotType, in_use: u64, available: u64) {
+        self.0
+            .worker_slots_in_use
+            .set(vec![slot_type.as_str().to_owned()], in_use as f64);
+        self.0
+            .worker_slots_available
+            .set(vec![slot_type.as_str().to_owned()], available as f64);
+    }
+
+    #[allow(clippy::cast_precision_loss)]
+    fn record_worker_slot_target(&self, slot_type: SlotType, target: u64) {
+        self.0
+            .worker_slot_target
+            .set(vec![slot_type.as_str().to_owned()], target as f64);
+    }
+
+    #[allow(clippy::cast_precision_loss)]
+    fn record_shard_stranded_pending(&self, shard: u16, count: u64) {
+        self.0
+            .shard_stranded_pending
+            .set(vec![shard.to_string()], count as f64);
     }
 }
 
@@ -337,80 +396,127 @@ fn push_histogram(
     });
 }
 
+/// The nine ADR-0001 §7 catalogue metrics named in issue #355.
+fn push_catalogue_metrics(families: &mut Vec<MetricFamily>, inner: &Inner) {
+    push_counter(
+        families,
+        "harvest_workflow_started_total",
+        "Total number of workflow executions started",
+        &[METRIC_LABEL_WORKFLOW, METRIC_LABEL_QUEUE],
+        inner.workflow_started.snapshot(),
+    );
+    push_histogram(
+        families,
+        "harvest_workflow_duration",
+        "Workflow execution duration in seconds",
+        &[
+            METRIC_LABEL_WORKFLOW,
+            METRIC_LABEL_QUEUE,
+            METRIC_LABEL_STATUS,
+        ],
+        inner.workflow_duration.snapshot(),
+    );
+    push_histogram(
+        families,
+        "harvest_activity_duration",
+        "Activity execution duration in seconds",
+        &[
+            METRIC_LABEL_ACTIVITY,
+            METRIC_LABEL_QUEUE,
+            METRIC_LABEL_STATUS,
+        ],
+        inner.activity_duration.snapshot(),
+    );
+    push_counter(
+        families,
+        "harvest_timer_started_total",
+        "Total number of durable timers started",
+        &[],
+        inner.timer_started.snapshot(),
+    );
+    push_gauge(
+        families,
+        "harvest_queue_depth",
+        "Current pending task count per queue",
+        &[METRIC_LABEL_QUEUE],
+        inner.queue_depth.snapshot(),
+    );
+    push_gauge(
+        families,
+        "harvest_dlq_entries",
+        "Current dead-letter queue entry count per shard",
+        &[METRIC_LABEL_SHARD],
+        inner.dlq_entries.snapshot(),
+    );
+    push_counter(
+        families,
+        "harvest_schedule_runs_total",
+        "Total number of schedule firings",
+        &[METRIC_LABEL_KIND, METRIC_LABEL_NAME],
+        inner.schedule_runs.snapshot(),
+    );
+    push_counter(
+        families,
+        "harvest_schedule_skipped_total",
+        "Total number of skipped schedule firings",
+        &[METRIC_LABEL_KIND, METRIC_LABEL_NAME, METRIC_LABEL_REASON],
+        inner.schedule_skipped.snapshot(),
+    );
+    push_counter(
+        families,
+        "harvest_retention_deleted_total",
+        "Total number of records deleted by the retention sweep",
+        &[METRIC_LABEL_SHARD],
+        inner.retention_deleted.snapshot(),
+    );
+}
+
+/// Metrics the engine's own `is_enabled()`-gated background samplers already
+/// compute alongside the nine catalogue metrics above -- implemented so that
+/// sampler work isn't silently discarded (see the module docs).
+fn push_sampler_adjacent_metrics(families: &mut Vec<MetricFamily>, inner: &Inner) {
+    push_gauge(
+        families,
+        "harvest_queue_oldest_pending_age",
+        "Age in seconds of the oldest claimable pending task per queue",
+        &[METRIC_LABEL_QUEUE],
+        inner.queue_oldest_pending_age.snapshot(),
+    );
+    push_gauge(
+        families,
+        "harvest_worker_slots_in_use",
+        "Currently occupied dispatch slots per slot type",
+        &[METRIC_LABEL_SLOT_TYPE],
+        inner.worker_slots_in_use.snapshot(),
+    );
+    push_gauge(
+        families,
+        "harvest_worker_slots_available",
+        "Currently free dispatch slots per slot type",
+        &[METRIC_LABEL_SLOT_TYPE],
+        inner.worker_slots_available.snapshot(),
+    );
+    push_gauge(
+        families,
+        "harvest_worker_slot_target",
+        "Adaptive slot tuner's current resize target per slot type",
+        &[METRIC_LABEL_SLOT_TYPE],
+        inner.worker_slot_target.snapshot(),
+    );
+    push_gauge(
+        families,
+        "harvest_shard_stranded_pending",
+        "Claimable pending task demand per shard with no compatible worker",
+        &[METRIC_LABEL_SHARD],
+        inner.shard_stranded_pending.snapshot(),
+    );
+}
+
 impl MetricsSource for HarvestMetricsRecorder {
     fn collect(&self) -> Vec<MetricFamily> {
         let mut families = Vec::new();
-        push_counter(
-            &mut families,
-            "harvest_workflow_started_total",
-            "Total number of workflow executions started",
-            &[METRIC_LABEL_WORKFLOW, METRIC_LABEL_QUEUE],
-            self.0.workflow_started.snapshot(),
-        );
-        push_histogram(
-            &mut families,
-            "harvest_workflow_duration",
-            "Workflow execution duration in seconds",
-            &[
-                METRIC_LABEL_WORKFLOW,
-                METRIC_LABEL_QUEUE,
-                METRIC_LABEL_STATUS,
-            ],
-            self.0.workflow_duration.snapshot(),
-        );
-        push_histogram(
-            &mut families,
-            "harvest_activity_duration",
-            "Activity execution duration in seconds",
-            &[
-                METRIC_LABEL_ACTIVITY,
-                METRIC_LABEL_QUEUE,
-                METRIC_LABEL_STATUS,
-            ],
-            self.0.activity_duration.snapshot(),
-        );
-        push_counter(
-            &mut families,
-            "harvest_timer_started_total",
-            "Total number of durable timers started",
-            &[],
-            self.0.timer_started.snapshot(),
-        );
-        push_gauge(
-            &mut families,
-            "harvest_queue_depth",
-            "Current pending task count per queue",
-            &[METRIC_LABEL_QUEUE],
-            self.0.queue_depth.snapshot(),
-        );
-        push_gauge(
-            &mut families,
-            "harvest_dlq_entries",
-            "Current dead-letter queue entry count per shard",
-            &[METRIC_LABEL_SHARD],
-            self.0.dlq_entries.snapshot(),
-        );
-        push_counter(
-            &mut families,
-            "harvest_schedule_runs_total",
-            "Total number of schedule firings",
-            &[METRIC_LABEL_KIND, METRIC_LABEL_NAME],
-            self.0.schedule_runs.snapshot(),
-        );
-        push_counter(
-            &mut families,
-            "harvest_schedule_skipped_total",
-            "Total number of skipped schedule firings",
-            &[METRIC_LABEL_KIND, METRIC_LABEL_NAME, METRIC_LABEL_REASON],
-            self.0.schedule_skipped.snapshot(),
-        );
-        push_counter(
-            &mut families,
-            "harvest_retention_deleted_total",
-            "Total number of records deleted by the retention sweep",
-            &[METRIC_LABEL_SHARD],
-            self.0.retention_deleted.snapshot(),
-        );
+        push_catalogue_metrics(&mut families, &self.0);
+        push_sampler_adjacent_metrics(&mut families, &self.0);
         families
     }
 }
@@ -592,6 +698,51 @@ mod tests {
         let families = recorder.collect();
         let f = family(&families, "harvest_retention_deleted_total");
         assert_eq!(sample_value(f, &[("shard", "0")]), 42.0);
+    }
+
+    #[test]
+    fn queue_oldest_pending_age_is_a_gauge_labeled_by_queue() {
+        let recorder = HarvestMetricsRecorder::new();
+        recorder.record_queue_oldest_pending_age("default", 12.5);
+
+        let families = recorder.collect();
+        let f = family(&families, "harvest_queue_oldest_pending_age");
+        assert_eq!(f.kind, MetricKind::Gauge);
+        assert_eq!(sample_value(f, &[("queue", "default")]), 12.5);
+    }
+
+    #[test]
+    fn worker_slots_are_gauges_labeled_by_slot_type() {
+        let recorder = HarvestMetricsRecorder::new();
+        recorder.record_worker_slots(SlotType::Workflow, 3, 7);
+
+        let families = recorder.collect();
+        let in_use = family(&families, "harvest_worker_slots_in_use");
+        let available = family(&families, "harvest_worker_slots_available");
+        assert_eq!(in_use.kind, MetricKind::Gauge);
+        assert_eq!(available.kind, MetricKind::Gauge);
+        assert_eq!(sample_value(in_use, &[("slot_type", "workflow")]), 3.0);
+        assert_eq!(sample_value(available, &[("slot_type", "workflow")]), 7.0);
+    }
+
+    #[test]
+    fn worker_slot_target_is_a_gauge_labeled_by_slot_type() {
+        let recorder = HarvestMetricsRecorder::new();
+        recorder.record_worker_slot_target(SlotType::Activity, 10);
+
+        let families = recorder.collect();
+        let f = family(&families, "harvest_worker_slot_target");
+        assert_eq!(sample_value(f, &[("slot_type", "activity")]), 10.0);
+    }
+
+    #[test]
+    fn shard_stranded_pending_is_a_gauge_labeled_by_shard() {
+        let recorder = HarvestMetricsRecorder::new();
+        recorder.record_shard_stranded_pending(2, 9);
+
+        let families = recorder.collect();
+        let f = family(&families, "harvest_shard_stranded_pending");
+        assert_eq!(sample_value(f, &[("shard", "2")]), 9.0);
     }
 
     #[test]

--- a/autumn-harvest-plugin/src/plugin.rs
+++ b/autumn-harvest-plugin/src/plugin.rs
@@ -117,6 +117,10 @@ pub struct HarvestPlugin {
     /// (issue #344). Set via [`Self::webhooks`] (feature `webhooks`).
     #[cfg(feature = "webhooks")]
     webhook_triggers: Vec<autumn_harvest::webhook_trigger::WebhookTriggerInfo>,
+    /// Built-in Prometheus scrape endpoint (issue #355). Set via
+    /// [`Self::with_metrics_scrape`] (feature `metrics`).
+    #[cfg(feature = "metrics")]
+    metrics_scrape_enabled: bool,
 }
 
 impl Default for HarvestPlugin {
@@ -138,6 +142,8 @@ impl HarvestPlugin {
             mcp_tools_prefix: None,
             #[cfg(feature = "webhooks")]
             webhook_triggers: Vec::new(),
+            #[cfg(feature = "metrics")]
+            metrics_scrape_enabled: false,
         }
     }
 
@@ -187,6 +193,13 @@ impl HarvestPlugin {
     #[must_use]
     pub fn worker(mut self, config: WorkerConfig) -> Self {
         self.builder = self.builder.worker(config);
+        self
+    }
+
+    /// Configure the background retention job (history/audit pruning).
+    #[must_use]
+    pub fn retention(mut self, config: autumn_harvest::retention::RetentionConfig) -> Self {
+        self.builder = self.builder.retention(config);
         self
     }
 
@@ -301,6 +314,39 @@ impl HarvestPlugin {
         self.webhook_triggers.extend(triggers);
         self
     }
+
+    /// Expose the nine ADR-0001 §7 catalogue metrics on the app's shared
+    /// `/actuator/prometheus` scrape endpoint (issue #355).
+    ///
+    /// Installs a `HarvestMetricsRecorder` as both the engine's
+    /// `MetricsRecorder` (via `HarvestBuilder::telemetry`) and an
+    /// `autumn_web::actuator::MetricsSource` registered under the name
+    /// `"harvest"`. There is exactly **one** metrics scrape endpoint for the
+    /// whole app — Harvest's samples appear alongside the app's own
+    /// `autumn_http_*` families and any other plugin's `MetricsSource`, not on
+    /// a second, Harvest-owned route. Auth posture is therefore governed
+    /// entirely by the app's own `[actuator]` config (`actuator.prometheus`,
+    /// profile-aware sensitive-endpoint gating) rather than a
+    /// Harvest-specific toggle.
+    ///
+    /// Opt-in and additive: without this call, telemetry stays wired to the
+    /// zero-cost `NoOpMetrics` default exactly as before. Calling it a second
+    /// time is idempotent (autumn-web's `MetricsSourceRegistry` rejects the
+    /// duplicate `"harvest"` registration with a `tracing::warn!` and keeps
+    /// the first).
+    ///
+    /// For OTLP export, a custom `MetricsRecorder`, or a full bucketed
+    /// histogram (this endpoint renders `harvest.workflow.duration` /
+    /// `harvest.activity.duration` as `_count`/`_sum` counter pairs, since
+    /// `MetricsSource`'s `MetricKind` has no histogram variant), use the
+    /// `metrics-rs` adapter escape hatch documented in `docs/telemetry.md`
+    /// instead.
+    #[cfg(feature = "metrics")]
+    #[must_use]
+    pub const fn with_metrics_scrape(mut self) -> Self {
+        self.metrics_scrape_enabled = true;
+        self
+    }
 }
 
 /// Whether the generated MCP tool routes are about to be registered with no
@@ -323,11 +369,41 @@ impl Plugin for HarvestPlugin {
             mcp_tools_prefix,
             #[cfg(feature = "webhooks")]
             webhook_triggers,
+            #[cfg(feature = "metrics")]
+            metrics_scrape_enabled,
         } = self;
         #[cfg(not(feature = "mcp"))]
         let _ = (mcp_tool_middleware, mcp_tools_enabled, mcp_tools_prefix);
 
         let api_state = HarvestApiState::new();
+
+        // Issue #355: one shared `HarvestMetricsRecorder` instance backs both
+        // the engine-side `MetricsRecorder` (installed on `builder` before it
+        // is stashed in the runtime slot -- `HarvestBuilder::telemetry(..)`
+        // must be applied before `try_build()` runs inside
+        // `start_harvest_runtime`) and the app-level `MetricsSource`
+        // registration, so the shared `/actuator/prometheus` endpoint always
+        // renders the exact samples the engine recorded. There is
+        // deliberately no separate Harvest-owned scrape route.
+        #[cfg(feature = "metrics")]
+        let metrics_recorder =
+            metrics_scrape_enabled.then(crate::metrics_scrape::HarvestMetricsRecorder::new);
+        #[cfg(feature = "metrics")]
+        let app = if let Some(recorder) = &metrics_recorder {
+            app.metrics_source("harvest", Arc::new(recorder.clone()))
+        } else {
+            app
+        };
+        #[cfg(feature = "metrics")]
+        let builder = if let Some(recorder) = metrics_recorder {
+            builder.telemetry(
+                autumn_harvest::telemetry::TelemetryConfig::builder()
+                    .metrics(Arc::new(recorder))
+                    .build(),
+            )
+        } else {
+            builder
+        };
 
         // Issue #344: generate the inbound webhook receiver routes before the
         // builder is stashed in the runtime slot (same ordering constraint as

--- a/autumn-harvest-plugin/src/plugin.rs
+++ b/autumn-harvest-plugin/src/plugin.rs
@@ -315,7 +315,7 @@ impl HarvestPlugin {
         self
     }
 
-    /// Expose the nine ADR-0001 §7 catalogue metrics on the app's shared
+    /// Expose the ADR-0001 §7 catalogue metrics on the app's shared
     /// `/actuator/prometheus` scrape endpoint (issue #355).
     ///
     /// Installs a `HarvestMetricsRecorder` as both the engine's
@@ -335,12 +335,19 @@ impl HarvestPlugin {
     /// duplicate `"harvest"` registration with a `tracing::warn!` and keeps
     /// the first).
     ///
-    /// For OTLP export, a custom `MetricsRecorder`, or a full bucketed
-    /// histogram (this endpoint renders `harvest.workflow.duration` /
-    /// `harvest.activity.duration` as `_count`/`_sum` counter pairs, since
-    /// `MetricsSource`'s `MetricKind` has no histogram variant), use the
-    /// `metrics-rs` adapter escape hatch documented in `docs/telemetry.md`
-    /// instead.
+    /// This does **not** back the full starter alert pack
+    /// (`docs/alerts/starter-pack-v0.1.0.json`) — it covers the metrics
+    /// named in issue #355 plus a few more that the engine's own
+    /// background samplers already compute for free once enabled (queue
+    /// backlog age, worker slot occupancy, stranded-work demand), but not
+    /// the wider catalogue (e.g. `harvest.workflow.terminal`,
+    /// `harvest.activity.attempts`/`.retries`, `harvest.schedule.fire_attempts`).
+    /// For OTLP export, a custom `MetricsRecorder`, the full metric surface,
+    /// or a full bucketed histogram (this endpoint renders
+    /// `harvest.workflow.duration` / `harvest.activity.duration` as
+    /// `_count`/`_sum` counter pairs, since `MetricsSource`'s `MetricKind`
+    /// has no histogram variant), use the `metrics-rs` adapter escape hatch
+    /// documented in `docs/telemetry.md` instead.
     #[cfg(feature = "metrics")]
     #[must_use]
     pub const fn with_metrics_scrape(mut self) -> Self {
@@ -1449,5 +1456,25 @@ mod tests {
         assert!(plugin.builder.update_handlers()[0].mcp);
         assert_eq!(plugin.builder.query_handlers().len(), 1);
         assert_eq!(plugin.builder.query_handlers()[0].name, "progress");
+    }
+
+    #[test]
+    fn harvest_plugin_forwards_retention_to_builder() {
+        // Issue #355 review follow-up: `.retention(...)` had no dedicated
+        // coverage of its own -- only the metrics_scrape_quickstart example
+        // (Docker-requiring) exercised it. `try_build()` only validates
+        // config in-memory (no DB connection), so this stays a fast unit test.
+        let custom = autumn_harvest::retention::RetentionConfig {
+            max_age_secs: Some(42),
+            tick_interval_secs: 7,
+            ..autumn_harvest::retention::RetentionConfig::default()
+        };
+        let plugin = HarvestPlugin::new().retention(custom);
+        let built = plugin
+            .builder
+            .try_build()
+            .expect("valid retention config should build");
+        assert_eq!(built.retention().max_age_secs, Some(42));
+        assert_eq!(built.retention().tick_interval_secs, 7);
     }
 }

--- a/autumn-harvest-plugin/tests/metrics_scrape_http_tests.rs
+++ b/autumn-harvest-plugin/tests/metrics_scrape_http_tests.rs
@@ -1,0 +1,142 @@
+//! No-database HTTP tests for the built-in Prometheus scrape endpoint
+//! (issue #355).
+//!
+//! `HarvestPlugin::with_metrics_scrape()` registers a `HarvestMetricsRecorder`
+//! as both the engine's `MetricsRecorder` and an autumn-web `MetricsSource`
+//! feeding the shared `/actuator/prometheus` endpoint. That registration
+//! happens synchronously inside `Plugin::build` -- only the `on_startup`
+//! hook that installs the live Harvest runtime needs Postgres.
+//!
+//! NOTE: `TestApp::plugin(HarvestPlugin)` cannot be used here for the same
+//! reason `mcp_tools_http_tests.rs` cannot use it -- `TestApp` replays
+//! plugin startup hooks and `start_harvest_runtime` requires a live
+//! Postgres. This suite reproduces exactly the metrics-source-registration
+//! half of `HarvestPlugin::build` through a tiny local `Plugin`, so the real
+//! autumn-web rendering pipeline (HELP/TYPE lines, label sorting/escaping,
+//! dedup-by-family-name) is exercised end to end without a database. The
+//! full plugin-wired flow (a live workflow run driving the same recorder
+//! through `HarvestBuilder::telemetry`) is covered by the runnable example
+//! `examples/metrics_scrape_quickstart.rs`.
+
+#![cfg(feature = "metrics")]
+
+use std::sync::Arc;
+
+use autumn_harvest::telemetry::{ActivityStatus, MetricsRecorder, WorkflowStatus};
+use autumn_harvest_plugin::metrics_scrape::HarvestMetricsRecorder;
+use autumn_web::app::AppBuilder;
+use autumn_web::plugin::Plugin;
+use autumn_web::test::{TestApp, TestClient};
+
+/// Mirrors the metrics-source-registration half of `HarvestPlugin::build`
+/// without the DB-dependent `on_startup`/`nest` wiring.
+struct MetricsScrapeTestPlugin(HarvestMetricsRecorder);
+
+impl Plugin for MetricsScrapeTestPlugin {
+    fn build(self, app: AppBuilder) -> AppBuilder {
+        app.metrics_source("harvest", Arc::new(self.0))
+    }
+}
+
+async fn scrape(client: &TestClient) -> String {
+    let resp = client.get("/actuator/prometheus").send().await;
+    resp.assert_ok();
+    resp.text()
+}
+
+#[tokio::test]
+async fn scrape_endpoint_renders_all_nine_catalogue_metrics_after_recording() {
+    let recorder = HarvestMetricsRecorder::new();
+    recorder.record_workflow_started("onboarding", "default");
+    recorder.record_workflow_completed("onboarding", "default", 1.5, WorkflowStatus::Completed);
+    recorder.record_activity_completed(
+        "send_email",
+        "email-workers",
+        0.25,
+        ActivityStatus::Completed,
+    );
+    recorder.record_timer_started(30.0);
+    recorder.record_queue_depth("default", 3);
+    recorder.record_dlq_entries(0, 2);
+    recorder.record_schedule_run("cron", "nightly_report");
+    recorder.record_schedule_skipped("cron", "nightly_report", "overlap");
+    recorder.record_retention_tick(0, 100, 42, 0.5);
+
+    let client = TestApp::new()
+        .plugin(MetricsScrapeTestPlugin(recorder))
+        .build();
+    let body = scrape(&client).await;
+
+    // The nine ADR-0001 §7 catalogue metrics (issue #355 AC2). Duration
+    // histograms render as `_count`/`_sum` counter pairs since
+    // `autumn_web::actuator::MetricKind` has no histogram variant.
+    for expected in [
+        "# TYPE harvest_workflow_started_total counter",
+        "harvest_workflow_started_total{queue=\"default\",workflow=\"onboarding\"} 1",
+        "# TYPE harvest_workflow_duration_count counter",
+        "harvest_workflow_duration_count{queue=\"default\",status=\"completed\",workflow=\"onboarding\"} 1",
+        "# TYPE harvest_workflow_duration_sum counter",
+        "harvest_workflow_duration_sum{queue=\"default\",status=\"completed\",workflow=\"onboarding\"} 1.5",
+        "# TYPE harvest_activity_duration_count counter",
+        "harvest_activity_duration_count{activity=\"send_email\",queue=\"email-workers\",status=\"completed\"} 1",
+        "# TYPE harvest_activity_duration_sum counter",
+        "harvest_activity_duration_sum{activity=\"send_email\",queue=\"email-workers\",status=\"completed\"} 0.25",
+        "# TYPE harvest_timer_started_total counter",
+        "harvest_timer_started_total 1",
+        "# TYPE harvest_queue_depth gauge",
+        "harvest_queue_depth{queue=\"default\"} 3",
+        "# TYPE harvest_dlq_entries gauge",
+        "harvest_dlq_entries{shard=\"0\"} 2",
+        "# TYPE harvest_schedule_runs_total counter",
+        "harvest_schedule_runs_total{kind=\"cron\",name=\"nightly_report\"} 1",
+        "# TYPE harvest_schedule_skipped_total counter",
+        "harvest_schedule_skipped_total{kind=\"cron\",name=\"nightly_report\",reason=\"overlap\"} 1",
+        "# TYPE harvest_retention_deleted_total counter",
+        "harvest_retention_deleted_total{shard=\"0\"} 42",
+    ] {
+        assert!(body.contains(expected), "missing `{expected}` in:\n{body}");
+    }
+
+    // Cardinality rule (issue #355 AC2): no execution.id label ever appears
+    // -- the `MetricsRecorder` methods this recorder implements never
+    // accept one, so this also guards against a future accidental addition.
+    assert!(
+        !body.contains("execution.id") && !body.contains("execution_id"),
+        "execution.id leaked into scrape:\n{body}"
+    );
+
+    // Harvest's samples coexist with the app's own built-in families on the
+    // one shared endpoint (issue #355: "one endpoint for autumn web apps
+    // and its plugins like harvest").
+    assert!(body.contains("autumn_http_requests_total"));
+}
+
+#[tokio::test]
+async fn scrape_endpoint_omits_harvest_families_when_metrics_source_not_registered() {
+    // No plugin, no `metrics_source` registration -- mirrors an app that
+    // never calls `HarvestPlugin::with_metrics_scrape()`. `/actuator/prometheus`
+    // still exists (it's the app's own endpoint, always mounted by
+    // default) but carries no `harvest_*` family, and there is zero runtime
+    // cost paid for the unused aggregator (issue #355 AC3/AC8).
+    let client = TestApp::new().build();
+    let body = scrape(&client).await;
+    assert!(
+        !body.contains("harvest_"),
+        "unexpected harvest_* family with no HarvestMetricsRecorder registered:\n{body}"
+    );
+    assert!(body.contains("autumn_http_requests_total"));
+}
+
+#[tokio::test]
+async fn no_family_emitted_for_a_metric_that_was_never_recorded() {
+    // A cold aggregator contributes zero families -- there's no way to
+    // synthesize a meaningful zero-value default for a labeled series
+    // before its label values are known (see `metrics_scrape.rs` module
+    // docs).
+    let client = TestApp::new()
+        .plugin(MetricsScrapeTestPlugin(HarvestMetricsRecorder::new()))
+        .build();
+    let body = scrape(&client).await;
+    assert!(!body.contains("harvest_workflow_started_total"));
+    assert!(!body.contains("harvest_queue_depth"));
+}

--- a/autumn-harvest-plugin/tests/metrics_scrape_http_tests.rs
+++ b/autumn-harvest-plugin/tests/metrics_scrape_http_tests.rs
@@ -22,7 +22,7 @@
 
 use std::sync::Arc;
 
-use autumn_harvest::telemetry::{ActivityStatus, MetricsRecorder, WorkflowStatus};
+use autumn_harvest::telemetry::{ActivityStatus, MetricsRecorder, SlotType, WorkflowStatus};
 use autumn_harvest_plugin::metrics_scrape::HarvestMetricsRecorder;
 use autumn_web::app::AppBuilder;
 use autumn_web::plugin::Plugin;
@@ -45,7 +45,7 @@ async fn scrape(client: &TestClient) -> String {
 }
 
 #[tokio::test]
-async fn scrape_endpoint_renders_all_nine_catalogue_metrics_after_recording() {
+async fn scrape_endpoint_renders_all_catalogue_metrics_after_recording() {
     let recorder = HarvestMetricsRecorder::new();
     recorder.record_workflow_started("onboarding", "default");
     recorder.record_workflow_completed("onboarding", "default", 1.5, WorkflowStatus::Completed);
@@ -61,15 +61,25 @@ async fn scrape_endpoint_renders_all_nine_catalogue_metrics_after_recording() {
     recorder.record_schedule_run("cron", "nightly_report");
     recorder.record_schedule_skipped("cron", "nightly_report", "overlap");
     recorder.record_retention_tick(0, 100, 42, 0.5);
+    // These four back the engine's own is_enabled()-gated background
+    // samplers (queue depth/DLQ depth samplers' oldest-age query, the
+    // stranded-work scanner, the worker-slot sampler) -- implemented so
+    // that already-paid-for sampler work isn't silently discarded once
+    // .with_metrics_scrape() flips is_enabled() to true.
+    recorder.record_queue_oldest_pending_age("default", 12.5);
+    recorder.record_worker_slots(SlotType::Workflow, 3, 7);
+    recorder.record_worker_slot_target(SlotType::Activity, 10);
+    recorder.record_shard_stranded_pending(2, 9);
 
     let client = TestApp::new()
         .plugin(MetricsScrapeTestPlugin(recorder))
         .build();
     let body = scrape(&client).await;
 
-    // The nine ADR-0001 §7 catalogue metrics (issue #355 AC2). Duration
-    // histograms render as `_count`/`_sum` counter pairs since
-    // `autumn_web::actuator::MetricKind` has no histogram variant.
+    // The nine ADR-0001 §7 catalogue metrics (issue #355 AC2), plus the four
+    // sampler-adjacent metrics above. Duration histograms render as
+    // `_count`/`_sum` counter pairs since `autumn_web::actuator::MetricKind`
+    // has no histogram variant.
     for expected in [
         "# TYPE harvest_workflow_started_total counter",
         "harvest_workflow_started_total{queue=\"default\",workflow=\"onboarding\"} 1",
@@ -93,6 +103,16 @@ async fn scrape_endpoint_renders_all_nine_catalogue_metrics_after_recording() {
         "harvest_schedule_skipped_total{kind=\"cron\",name=\"nightly_report\",reason=\"overlap\"} 1",
         "# TYPE harvest_retention_deleted_total counter",
         "harvest_retention_deleted_total{shard=\"0\"} 42",
+        "# TYPE harvest_queue_oldest_pending_age gauge",
+        "harvest_queue_oldest_pending_age{queue=\"default\"} 12.5",
+        "# TYPE harvest_worker_slots_in_use gauge",
+        "harvest_worker_slots_in_use{slot_type=\"workflow\"} 3",
+        "# TYPE harvest_worker_slots_available gauge",
+        "harvest_worker_slots_available{slot_type=\"workflow\"} 7",
+        "# TYPE harvest_worker_slot_target gauge",
+        "harvest_worker_slot_target{slot_type=\"activity\"} 10",
+        "# TYPE harvest_shard_stranded_pending gauge",
+        "harvest_shard_stranded_pending{shard=\"2\"} 9",
     ] {
         assert!(body.contains(expected), "missing `{expected}` in:\n{body}");
     }

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -5,7 +5,69 @@ instruments that cover every production-observable aspect of the engine. The
 default implementation (`NoOpMetrics`) is zero-cost; no samples are emitted
 until you register a recorder.
 
-## Quick start with `metrics-exporter-prometheus`
+## Recommended: the built-in scrape endpoint (issue #355)
+
+If you're embedding Harvest via `autumn-harvest-plugin`'s `HarvestPlugin` in
+an autumn-web app, this is the fastest path to a working Prometheus scrape —
+one builder call, no exporter to install, no route to wire, and no new
+dependency (rendering is done entirely through autumn-web's existing
+`MetricsSource` contract):
+
+```toml
+[dependencies]
+autumn-harvest-plugin = { version = "0.4", features = ["metrics"] }
+```
+
+```rust
+let app = autumn_web::app().plugin(
+    HarvestPlugin::new()
+        .workflows(workflows![onboarding])
+        .activities(activities![send_email])
+        .api("/api/harvest")
+        .with_metrics_scrape(),
+);
+```
+
+`with_metrics_scrape()` registers a `HarvestMetricsRecorder` as both the
+engine's `MetricsRecorder` (via `HarvestBuilder::telemetry`) and an
+autumn-web `MetricsSource` (via `AppBuilder::metrics_source`). Harvest's nine
+ADR-0001 §7 catalogue metrics then appear on the app's **one, already-shared**
+`/actuator/prometheus` endpoint, alongside the app's own `autumn_http_*`
+families and any other plugin's metrics — there is deliberately no separate,
+Harvest-owned scrape route. This is the "one endpoint for autumn-web apps and
+their plugins" model: every plugin registers its metrics into the same
+scrape, instead of each mounting its own.
+
+```bash
+curl http://localhost:8080/actuator/prometheus
+```
+
+Auth posture is governed entirely by the app's own `[actuator]` config
+(`actuator.prometheus`, profile-aware sensitive-endpoint gating) — the same
+policy that already protects the app's other actuator endpoints, rather than
+a second, Harvest-specific toggle.
+
+**Trade-off:** `autumn_web::actuator::MetricsSource`'s `MetricKind` only
+supports `Counter`/`Gauge` (no histogram variant), so `harvest.workflow.duration`
+and `harvest.activity.duration` are rendered as `_count`/`_sum` counter pairs
+rather than a bucketed histogram. That's enough for an average-latency query
+(`rate(harvest_workflow_duration_sum[5m]) / rate(harvest_workflow_duration_count[5m])`)
+but not for `histogram_quantile(...)`. If you need full bucketed histograms
+(e.g. for the starter alert pack's `harvest_queue_schedule_to_start_high` p99
+alert), OTLP export, or a custom recorder, use the `metrics-rs` adapter
+escape hatch below instead — a fresh `HarvestBuilder::telemetry(...)` call
+(or a second `HarvestPlugin` that never calls `.with_metrics_scrape()`)
+overrides nothing else in your app.
+
+See `autumn-harvest-plugin/examples/metrics_scrape_quickstart.rs` for a
+complete runnable example: `cargo run`, `curl .../actuator/prometheus`, see
+all nine metrics after a single workflow run.
+
+## Escape hatch: `metrics-exporter-prometheus` for full histograms, OTLP, or a custom recorder
+
+Reach for this path if you need bucketed histogram `_bucket` series, OTLP
+push, or you already have a global `metrics`-crate recorder installed for
+app-level metrics.
 
 Enable the in-tree `metrics-rs` adapter in your application's `Cargo.toml`:
 

--- a/docs/telemetry.md
+++ b/docs/telemetry.md
@@ -30,13 +30,13 @@ let app = autumn_web::app().plugin(
 
 `with_metrics_scrape()` registers a `HarvestMetricsRecorder` as both the
 engine's `MetricsRecorder` (via `HarvestBuilder::telemetry`) and an
-autumn-web `MetricsSource` (via `AppBuilder::metrics_source`). Harvest's nine
-ADR-0001 §7 catalogue metrics then appear on the app's **one, already-shared**
-`/actuator/prometheus` endpoint, alongside the app's own `autumn_http_*`
-families and any other plugin's metrics — there is deliberately no separate,
-Harvest-owned scrape route. This is the "one endpoint for autumn-web apps and
-their plugins" model: every plugin registers its metrics into the same
-scrape, instead of each mounting its own.
+autumn-web `MetricsSource` (via `AppBuilder::metrics_source`). The metrics it
+covers then appear on the app's **one, already-shared** `/actuator/prometheus`
+endpoint, alongside the app's own `autumn_http_*` families and any other
+plugin's metrics — there is deliberately no separate, Harvest-owned scrape
+route. This is the "one endpoint for autumn-web apps and their plugins"
+model: every plugin registers its metrics into the same scrape, instead of
+each mounting its own.
 
 ```bash
 curl http://localhost:8080/actuator/prometheus
@@ -46,6 +46,24 @@ Auth posture is governed entirely by the app's own `[actuator]` config
 (`actuator.prometheus`, profile-aware sensitive-endpoint gating) — the same
 policy that already protects the app's other actuator endpoints, rather than
 a second, Harvest-specific toggle.
+
+**Coverage:** this endpoint aggregates the nine ADR-0001 §7 catalogue
+metrics named in issue #355 (`harvest.workflow.started`,
+`harvest.workflow.duration`, `harvest.activity.duration`,
+`harvest.timer.started`, `harvest.queue.depth`, `harvest.dlq.entries`,
+`harvest.schedule.runs`, `harvest.schedule.skipped`,
+`harvest.retention.deleted`), plus `harvest.queue.oldest_pending_age`,
+`harvest.worker.slots_in_use`/`slots_available`/`slot_target`, and
+`harvest.shard.stranded_pending` — the engine's own background samplers
+already compute these under the same `is_enabled()` gate the nine required
+metrics live behind, so they're implemented too rather than sampled and
+discarded. **It does not back the full starter alert pack**
+(`docs/alerts/starter-pack-v0.1.0.json`), which also references metrics this
+endpoint never emits (e.g. `harvest_workflow_terminal_total`,
+`harvest_activity_attempts_total`/`retries_total`,
+`harvest_schedule_fire_attempts_total`, `harvest_no_active_workers`). If you
+want the full starter alert pack to work, use the `metrics-rs` adapter
+escape hatch below, which bridges every `MetricsRecorder` method.
 
 **Trade-off:** `autumn_web::actuator::MetricsSource`'s `MetricKind` only
 supports `Counter`/`Gauge` (no histogram variant), so `harvest.workflow.duration`


### PR DESCRIPTION
## Summary

Implements a built-in Prometheus scrape endpoint for Harvest metrics via a new `HarvestMetricsRecorder` that aggregates the nine ADR-0001 §7 catalogue metrics plus four additional metrics the engine's background samplers already compute. This provides a zero-dependency, zero-cost way to expose Harvest telemetry on the app's shared `/actuator/prometheus` endpoint without requiring an external exporter.

## Key Changes

- **New `metrics_scrape.rs` module** (`autumn-harvest-plugin`): Implements `HarvestMetricsRecorder`, a thread-safe in-process aggregator that:
  - Implements `autumn_harvest::telemetry::MetricsRecorder` for recording samples from the core engine
  - Implements `autumn_web::actuator::MetricsSource` for rendering samples to Prometheus text format
  - Uses `Arc<Inner>` with `RwLock`-protected `Counter`/`Gauge`/`Histogram` collections for lock-free reads and minimal contention
  - Decomposes duration histograms into `_count`/`_sum` counter pairs (since `MetricKind` has no histogram variant)
  - Only emits `MetricFamily` entries once at least one sample has been recorded (no synthetic zero-value defaults)
  - Covers the nine catalogue metrics (`harvest_workflow_started_total`, `harvest_workflow_duration`, `harvest_activity_duration`, `harvest_timer_started_total`, `harvest_queue_depth`, `harvest_dlq_entries`, `harvest_schedule_runs_total`, `harvest_schedule_skipped_total`, `harvest_retention_deleted_total`) plus four sampler-adjacent metrics (`harvest_queue_oldest_pending_age`, `harvest_worker_slots_in_use/available/target`, `harvest_shard_stranded_pending`)

- **Plugin integration** (`HarvestPlugin`):
  - Added `with_metrics_scrape()` builder method (feature-gated on `metrics`)
  - Wires a shared `HarvestMetricsRecorder` instance into both `HarvestBuilder::telemetry()` and `AppBuilder::metrics_source("harvest", …)`
  - Auth posture governed entirely by the app's own `[actuator]` config, not a separate Harvest-specific toggle

- **Comprehensive test coverage**:
  - Unit tests in `metrics_scrape.rs` covering all metric types, label combinations, and aggregation semantics
  - HTTP integration tests in `metrics_scrape_http_tests.rs` verifying end-to-end rendering through autumn-web's Prometheus pipeline (HELP/TYPE lines, label sorting/escaping, dedup)
  - Runnable example `metrics_scrape_quickstart.rs` demonstrating the full flow with a live workflow run

- **Documentation**:
  - Updated `docs/telemetry.md` with recommended quick-start path for the built-in endpoint
  - Detailed module docs explaining coverage, trade-offs, and when to use the `metrics-rs` adapter escape hatch instead
  - Clarified that this endpoint does **not** back the full starter alert pack (which requires the `metrics-rs` adapter for metrics like `harvest_workflow_terminal_total`, `harvest_activity_attempts_total`, etc.)

- **Feature flag**: Added `metrics` feature to `autumn-harvest-plugin` (default off, no new dependencies)

## Notable Implementation Details

- **Zero-cost default**: Without calling `with_metrics_scrape()`, telemetry remains wired to the zero-cost `NoOpMetrics` default
- **Sampler efficiency**: By setting `is_enabled() = true`, the engine's own background samplers (queue depth, DLQ depth, worker slots, stranded-work scanner) run regardless; implementing all their computed metrics turns already-paid-for sampler work into real series instead of silently discarded reads
- **Label stability**: Label values are stored as `Vec<String>` keyed to a stable position; label *names* are supplied at render time, ensuring every call site records labels in the same declared order
- **Histogram decomposition**: Duration metrics render as `_count` and `_sum

https://claude.ai/code/session_01PCWbf8XrmLsR6hguPAww9f