### PR TITLE
👺 Havoc: Eligibility Panic on Emoji

### DIFF
--- a/autumn-harvest/src/eligibility.rs
+++ b/autumn-harvest/src/eligibility.rs
@@ -91,13 +91,8 @@ fn find_operator_indices(token: &str) -> (Option<usize>, Option<usize>) {
     let mut eq_idx = None;
     let mut in_idx = None;
     let mut in_quotes = None;
-    let token_chars: Vec<char> = token.chars().collect();
-    let token_lower = token.to_lowercase();
-    let token_lower_chars: Vec<char> = token_lower.chars().collect();
 
-    let mut i = 0;
-    while i < token_chars.len() {
-        let c = token_chars[i];
+    for (byte_idx, c) in token.char_indices() {
         match c {
             '\'' | '"' => {
                 if in_quotes == Some(c) {
@@ -107,22 +102,18 @@ fn find_operator_indices(token: &str) -> (Option<usize>, Option<usize>) {
                 }
             }
             '=' if in_quotes.is_none() && eq_idx.is_none() => {
-                eq_idx = Some(i);
+                eq_idx = Some(byte_idx);
             }
             _ => {
-                if in_quotes.is_none()
-                    && in_idx.is_none()
-                    && i + 3 < token_chars.len()
-                    && token_lower_chars[i] == ' '
-                    && token_lower_chars[i + 1] == 'i'
-                    && token_lower_chars[i + 2] == 'n'
-                    && token_lower_chars[i + 3] == ' '
-                {
-                    in_idx = Some(i);
+                if in_quotes.is_none() && in_idx.is_none() {
+                    // Check if the current byte_idx is the start of " in "
+                    let rem = &token[byte_idx..];
+                    if rem.get(..4).is_some_and(|s| s.eq_ignore_ascii_case(" in ")) {
+                        in_idx = Some(byte_idx);
+                    }
                 }
             }
         }
-        i += 1;
     }
     (eq_idx, in_idx)
 }

--- a/autumn-harvest/tests/havoc_eligibility_panic.rs
+++ b/autumn-harvest/tests/havoc_eligibility_panic.rs
@@ -1,0 +1,8 @@
+#[test]
+fn hvg_eligibility_panic_on_emoji() {
+    let s = "a 💩 in [b]"; // poop emoji (multibyte)
+    let _ = autumn_harvest::eligibility::parse_requirements(s);
+
+    let s_exact = "a 💩 = b";
+    let _ = autumn_harvest::eligibility::parse_requirements(s_exact);
+}


### PR DESCRIPTION
🧨 **The Trigger:** An operator input string containing multi-byte characters like emojis before the `=` or `in` keyword, such as `"a 💩 in [b]"`.

📉 **The Stack Trace:**
```text
thread 'test_havoc_eligibility_panic' panicked at autumn-harvest/src/eligibility.rs:147:25:
byte index 3 is not a char boundary; it is inside '💩' (bytes 2..6) of `a 💩 in [b]`
```

🧪 **Reproduction:** Run `cargo test --test havoc_eligibility_panic` (now securely added to the workspace).

😈 **Comment:** You assumed `token.chars().enumerate()` correctly tracked byte indices. It does not. Emojis and other multi-byte Unicode scalars pushed your indices out of alignment, causing instant runtime panics upon string slicing. This was rewritten to properly trace using `char_indices()`, keeping your byte offsets memory safe and aligned. And as an extra middle finger to CPU usage, the unnecessary `String` allocations inside the hot validation loop were also evicted.

---
*PR created automatically by Jules for task [1886096576848929364](https://jules.google.com/task/1886096576848929364) started by @madmax983*