### PR TITLE
🌟 Nova: [PlantUML Sequence Exporter]

### DIFF
--- a/autumn-harvest-cli/src/lib.rs
+++ b/autumn-harvest-cli/src/lib.rs
@@ -651,6 +651,14 @@ enum HistoryCommand {
         #[arg(long, value_name = "PATH")]
         output_file: Option<PathBuf>,
     },
+    /// Generate a `PlantUML` sequence diagram for a single execution.
+    PlantumlSequence {
+        /// Workflow execution ID.
+        execution_id: String,
+        /// Write the `PlantUML` diagram to a file instead of stdout.
+        #[arg(long, value_name = "PATH")]
+        output_file: Option<PathBuf>,
+    },
 }
 
 #[derive(Debug, Subcommand)]
@@ -1797,7 +1805,8 @@ fn history_output_file(cli: &Cli) -> Option<&Path> {
         Commands::History {
             command:
                 HistoryCommand::Export { output_file, .. }
-                | HistoryCommand::ExportBatch { output_file, .. },
+                | HistoryCommand::ExportBatch { output_file, .. }
+                | HistoryCommand::PlantumlSequence { output_file, .. },
         } => output_file.as_deref(),
         _ => None,
     }
@@ -2040,6 +2049,28 @@ pub fn format_output(value: &Value, output: OutputFormat) -> Result<String, CliE
 }
 
 fn render_response(cli: &Cli, value: &Value) -> Result<String, CliError> {
+    if let Commands::History {
+        command: HistoryCommand::PlantumlSequence { .. },
+    } = &cli.command
+    {
+        if let Some(events_val) = value.get("events") {
+            let events: Vec<autumn_harvest::event::WorkflowEvent> = serde_json::from_value(events_val.clone()).map_err(|e| CliError::ReadJson {
+                label: "parse history events",
+                path: "history.events".into(),
+                source: std::io::Error::new(std::io::ErrorKind::InvalidData, e),
+            })?;
+            return autumn_harvest::history_export::export_plantuml_sequence(&events).map_err(|e| CliError::ReadJson {
+                label: "export plantuml sequence",
+                path: "history.events".into(),
+                source: std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()),
+            });
+        }
+        return Err(CliError::ReadJson {
+            label: "parse history export",
+            path: "events".into(),
+            source: std::io::Error::new(std::io::ErrorKind::InvalidData, "missing events array"),
+        });
+    }
     let state_filtered = completion_delivery_list_state_filter(cli)
         .map(|state| filter_completion_deliveries_by_state(value, state));
     let value = state_filtered.as_ref().unwrap_or(value);
@@ -3850,6 +3881,13 @@ fn history_request(command: &HistoryCommand) -> ApiRequest {
                 "/workflows/{}/history/export?{}",
                 path_segment(execution_id),
                 encode_query_params(&params)
+            ))
+        }
+        HistoryCommand::PlantumlSequence { execution_id, .. } => {
+            // We fetch the history in redacted form, which is safe for sharing diagrams
+            ApiRequest::get(format!(
+                "/workflows/{}/history/export?payload_policy=redacted",
+                path_segment(execution_id)
             ))
         }
         HistoryCommand::ExportBatch {

--- a/autumn-harvest/src/history_export.rs
+++ b/autumn-harvest/src/history_export.rs
@@ -883,6 +883,525 @@ impl MermaidExporter {
     }
 }
 
+/// Export a slice of workflow events into a `PlantUML` sequence diagram.
+///
+/// Converts a workflow history into a standard `PlantUML` format sequence diagram,
+/// mapping events (like `ActivityScheduled`, `ChildWorkflowStarted`) into lifelines
+/// and messages.
+///
+/// # Errors
+/// Returns `std::fmt::Error` if string formatting fails.
+pub fn export_plantuml_sequence(events: &[WorkflowEvent]) -> Result<String, std::fmt::Error> {
+    let mut exporter = PlantumlExporter::new();
+    exporter.export(events)?;
+    Ok(exporter.out)
+}
+
+struct PlantumlExporter {
+    out: String,
+    participants: std::collections::HashSet<String>,
+}
+
+impl PlantumlExporter {
+    fn new() -> Self {
+        Self {
+            out: String::new(),
+            participants: std::collections::HashSet::new(),
+        }
+    }
+
+    #[allow(clippy::too_many_lines)]
+    fn export(&mut self, events: &[WorkflowEvent]) -> Result<(), std::fmt::Error> {
+        writeln!(self.out, "@startuml")?;
+        writeln!(self.out, "autonumber")?;
+        writeln!(self.out, "participant WF as \"Workflow\"")?;
+
+        self.participants.insert("WF".to_string());
+
+        for event in events {
+            match event {
+                WorkflowEvent::WorkflowStarted { .. }
+                | WorkflowEvent::WorkflowCompleted { .. }
+                | WorkflowEvent::WorkflowFailed { .. }
+                | WorkflowEvent::WorkflowCancelled { .. }
+                | WorkflowEvent::WorkflowContinuedAsNew { .. }
+                | WorkflowEvent::WorkflowResetFork { .. }
+                | WorkflowEvent::WorkflowResetTerminated { .. }
+                | WorkflowEvent::WorkflowExecutionTimedOut { .. }
+                | WorkflowEvent::WorkflowExecutionPaused { .. }
+                | WorkflowEvent::WorkflowExecutionResumed { .. }
+                | WorkflowEvent::WorkflowRedriven { .. }
+                | WorkflowEvent::WorkflowRetryScheduled { .. } => {
+                    self.handle_workflow_event(event)?;
+                }
+                WorkflowEvent::ActivityScheduled { .. }
+                | WorkflowEvent::ActivityStarted { .. }
+                | WorkflowEvent::ActivityCompleted { .. }
+                | WorkflowEvent::ActivityFailed { .. }
+                | WorkflowEvent::ActivityTimedOut { .. }
+                | WorkflowEvent::ActivityHeartbeat { .. } => {
+                    self.handle_activity_event(event)?;
+                }
+                WorkflowEvent::TimerStarted { .. } | WorkflowEvent::TimerFired { .. } => {
+                    self.handle_timer_event(event)?;
+                }
+                WorkflowEvent::ChildWorkflowStarted { .. }
+                | WorkflowEvent::ChildWorkflowCompleted { .. }
+                | WorkflowEvent::ChildWorkflowFailed { .. }
+                | WorkflowEvent::ChildWorkflowSpawnedDetached { .. }
+                | WorkflowEvent::ChildWorkflowCascadeApplied { .. } => {
+                    self.handle_child_workflow_event(event)?;
+                }
+                WorkflowEvent::SignalReceived { .. }
+                | WorkflowEvent::MarkerRecorded { .. }
+                | WorkflowEvent::SideEffectRecorded { .. } => {
+                    self.handle_misc_event(event)?;
+                }
+                WorkflowEvent::ActivityAwaitingExternal { .. }
+                | WorkflowEvent::ActivityCompletedExternally { .. }
+                | WorkflowEvent::ActivityFailedExternally { .. }
+                | WorkflowEvent::ActivityExternalDeadlineExtended { .. } => {
+                    self.handle_external_activity_event(event)?;
+                }
+                WorkflowEvent::LocalActivityScheduled { .. }
+                | WorkflowEvent::LocalActivityCompleted { .. }
+                | WorkflowEvent::LocalActivityFailed { .. }
+                | WorkflowEvent::LocalActivityExhausted { .. } => {
+                    self.handle_local_activity_event(event)?;
+                }
+                WorkflowEvent::UpdateAdmitted { .. }
+                | WorkflowEvent::UpdateCompleted { .. }
+                | WorkflowEvent::UpdateFailed { .. } => {
+                    self.handle_update_event(event)?;
+                }
+                WorkflowEvent::ExternalSignalRequested { .. }
+                | WorkflowEvent::ExternalSignalDelivered { .. }
+                | WorkflowEvent::ExternalSignalFailed { .. } => {
+                    self.handle_external_signal_event(event)?;
+                }
+                WorkflowEvent::ExternalCancelRequested { .. }
+                | WorkflowEvent::ExternalCancelDelivered { .. }
+                | WorkflowEvent::ExternalCancelFailed { .. } => {
+                    self.handle_external_cancel_event(event)?;
+                }
+            }
+        }
+        writeln!(self.out, "@enduml")?;
+        Ok(())
+    }
+
+    fn handle_workflow_event(&mut self, event: &WorkflowEvent) -> Result<(), std::fmt::Error> {
+        match event {
+            WorkflowEvent::WorkflowStarted { .. } => {
+                writeln!(self.out, "hnote over WF : Workflow Started")?;
+            }
+            WorkflowEvent::WorkflowCompleted { .. } => {
+                writeln!(self.out, "hnote over WF : Workflow Completed")?;
+            }
+            WorkflowEvent::WorkflowFailed { error } => {
+                let safe_error = error.replace('\n', " ").replace('"', "'");
+                writeln!(self.out, "hnote over WF : Workflow Failed: {safe_error}")?;
+            }
+            WorkflowEvent::WorkflowCancelled { reason } => {
+                let safe_reason = reason.replace('\n', " ").replace('"', "'");
+                writeln!(
+                    self.out,
+                    "hnote over WF : Workflow Cancelled: {safe_reason}"
+                )?;
+            }
+            WorkflowEvent::WorkflowContinuedAsNew { new_exec_id, .. } => {
+                writeln!(
+                    self.out,
+                    "hnote over WF : Continued As New (next: {new_exec_id})"
+                )?;
+            }
+            WorkflowEvent::WorkflowResetFork {
+                reset_from_exec_id,
+                reset_to_event_id,
+                reason,
+                ..
+            } => {
+                let safe_reason = reason.replace('\n', " ").replace('"', "'");
+                writeln!(
+                    self.out,
+                    "hnote over WF : Reset Fork from {reset_from_exec_id} at event {reset_to_event_id}: {safe_reason}"
+                )?;
+            }
+            WorkflowEvent::WorkflowResetTerminated {
+                reset_to_exec_id,
+                reason,
+                ..
+            } => {
+                let safe_reason = reason.replace('\n', " ").replace('"', "'");
+                writeln!(
+                    self.out,
+                    "hnote over WF : Reset Terminated (forked to {reset_to_exec_id}): {safe_reason}"
+                )?;
+            }
+            WorkflowEvent::WorkflowExecutionTimedOut { deadline, .. } => {
+                writeln!(
+                    self.out,
+                    "hnote over WF : Workflow Execution Timed Out (deadline: {deadline})"
+                )?;
+            }
+            WorkflowEvent::WorkflowExecutionPaused { .. } => {
+                writeln!(self.out, "hnote over WF : Workflow Paused")?;
+            }
+            WorkflowEvent::WorkflowExecutionResumed { .. } => {
+                writeln!(self.out, "hnote over WF : Workflow Resumed")?;
+            }
+            WorkflowEvent::WorkflowRedriven { .. } => {
+                writeln!(self.out, "hnote over WF : Workflow Redriven")?;
+            }
+            WorkflowEvent::WorkflowRetryScheduled { attempt, .. } => {
+                writeln!(
+                    self.out,
+                    "hnote over WF : Retry Scheduled (attempt {attempt})"
+                )?;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn handle_activity_event(&mut self, event: &WorkflowEvent) -> Result<(), std::fmt::Error> {
+        match event {
+            WorkflowEvent::ActivityScheduled {
+                name, activity_id, ..
+            } => {
+                let participant = format!("Activity_{name}");
+                if self.participants.insert(participant.clone()) {
+                    writeln!(
+                        self.out,
+                        "participant {participant} as \"Activity: {name}\""
+                    )?;
+                }
+                writeln!(
+                    self.out,
+                    "WF -> {participant}: Schedule (ID: {activity_id})"
+                )?;
+                writeln!(self.out, "activate {participant}")?;
+            }
+            WorkflowEvent::ActivityStarted {
+                worker_id,
+                activity_id,
+                ..
+            } => {
+                writeln!(
+                    self.out,
+                    "note right of WF : Activity Started (ID: {activity_id}) on {worker_id}"
+                )?;
+            }
+            WorkflowEvent::ActivityCompleted { activity_id, .. } => {
+                writeln!(
+                    self.out,
+                    "note right of WF : Activity Completed (ID: {activity_id})"
+                )?;
+            }
+            WorkflowEvent::ActivityFailed {
+                activity_id,
+                error,
+                attempt,
+                ..
+            } => {
+                let safe_error = error.replace('\n', " ").replace('"', "'");
+                writeln!(
+                    self.out,
+                    "note right of WF : Activity Failed (ID: {activity_id}, attempt: {attempt}): {safe_error}"
+                )?;
+            }
+            WorkflowEvent::ActivityTimedOut {
+                activity_id,
+                timeout_type,
+            } => {
+                writeln!(
+                    self.out,
+                    "note right of WF : Activity Timed Out (ID: {activity_id}, type: {timeout_type:?})"
+                )?;
+            }
+            WorkflowEvent::ActivityHeartbeat { activity_id, .. } => {
+                writeln!(
+                    self.out,
+                    "note right of WF : Activity Heartbeat (ID: {activity_id})"
+                )?;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn handle_timer_event(&mut self, event: &WorkflowEvent) -> Result<(), std::fmt::Error> {
+        match event {
+            WorkflowEvent::TimerStarted { timer_id, .. } => {
+                writeln!(self.out, "WF -> WF: Start Timer (ID: {timer_id})")?;
+            }
+            WorkflowEvent::TimerFired { timer_id } => {
+                writeln!(self.out, "WF -> WF: Timer Fired (ID: {timer_id})")?;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn handle_child_workflow_event(
+        &mut self,
+        event: &WorkflowEvent,
+    ) -> Result<(), std::fmt::Error> {
+        match event {
+            WorkflowEvent::ChildWorkflowStarted {
+                child_id,
+                workflow_name,
+                ..
+            } => {
+                let participant = format!("Child_{workflow_name}");
+                if self.participants.insert(participant.clone()) {
+                    writeln!(
+                        self.out,
+                        "participant {participant} as \"Child WF: {workflow_name}\""
+                    )?;
+                }
+                writeln!(
+                    self.out,
+                    "WF -> {participant}: Start Child (ID: {child_id})"
+                )?;
+                writeln!(self.out, "activate {participant}")?;
+            }
+            WorkflowEvent::ChildWorkflowCompleted { child_id, .. } => {
+                writeln!(
+                    self.out,
+                    "note right of WF : Child Completed (ID: {child_id})"
+                )?;
+            }
+            WorkflowEvent::ChildWorkflowFailed { child_id, error } => {
+                let safe_error = error.replace('\n', " ").replace('"', "'");
+                writeln!(
+                    self.out,
+                    "note right of WF : Child Failed (ID: {child_id}): {safe_error}"
+                )?;
+            }
+            WorkflowEvent::ChildWorkflowSpawnedDetached {
+                child_id,
+                workflow_name,
+                ..
+            } => {
+                let participant = format!("Child_{workflow_name}");
+                if self.participants.insert(participant.clone()) {
+                    writeln!(
+                        self.out,
+                        "participant {participant} as \"Child WF: {workflow_name}\""
+                    )?;
+                }
+                writeln!(
+                    self.out,
+                    "WF ->> {participant}: Spawn Detached Child (ID: {child_id})"
+                )?;
+                writeln!(self.out, "activate {participant}")?;
+            }
+            WorkflowEvent::ChildWorkflowCascadeApplied {
+                child_id, action, ..
+            } => {
+                writeln!(
+                    self.out,
+                    "note right of WF : Child Cascade Applied (ID: {child_id}): {action}"
+                )?;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn handle_misc_event(&mut self, event: &WorkflowEvent) -> Result<(), std::fmt::Error> {
+        match event {
+            WorkflowEvent::SignalReceived { signal_name, .. } => {
+                writeln!(self.out, "-> WF: Signal Received: {signal_name}")?;
+            }
+            WorkflowEvent::MarkerRecorded { name, .. } => {
+                writeln!(self.out, "hnote over WF : Marker: {name}")?;
+            }
+            WorkflowEvent::SideEffectRecorded { kind, .. } => {
+                let kind_str = serde_json::to_string(kind).unwrap_or_else(|_| "Unknown".into());
+                writeln!(self.out, "hnote over WF : Side Effect: {kind_str}")?;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn handle_external_activity_event(
+        &mut self,
+        event: &WorkflowEvent,
+    ) -> Result<(), std::fmt::Error> {
+        match event {
+            WorkflowEvent::ActivityAwaitingExternal {
+                name, activity_id, ..
+            } => {
+                let participant = format!("ExtActivity_{name}");
+                if self.participants.insert(participant.clone()) {
+                    writeln!(
+                        self.out,
+                        "participant {participant} as \"Ext Activity: {name}\""
+                    )?;
+                }
+                writeln!(
+                    self.out,
+                    "WF -> {participant}: Await External (ID: {activity_id})"
+                )?;
+                writeln!(self.out, "activate {participant}")?;
+            }
+            WorkflowEvent::ActivityCompletedExternally { activity_id, .. } => {
+                writeln!(
+                    self.out,
+                    "note right of WF : External Activity Completed (ID: {activity_id})"
+                )?;
+            }
+            WorkflowEvent::ActivityFailedExternally {
+                activity_id, error, ..
+            } => {
+                let safe_error = error.replace('\n', " ").replace('"', "'");
+                writeln!(
+                    self.out,
+                    "note right of WF : External Activity Failed (ID: {activity_id}): {safe_error}"
+                )?;
+            }
+            WorkflowEvent::ActivityExternalDeadlineExtended { activity_id, .. } => {
+                writeln!(
+                    self.out,
+                    "note right of WF : External Activity Deadline Extended (ID: {activity_id})"
+                )?;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn handle_local_activity_event(
+        &mut self,
+        event: &WorkflowEvent,
+    ) -> Result<(), std::fmt::Error> {
+        match event {
+            WorkflowEvent::LocalActivityScheduled {
+                name, activity_id, ..
+            } => {
+                writeln!(
+                    self.out,
+                    "WF -> WF: Schedule Local Activity: {name} (ID: {activity_id})"
+                )?;
+            }
+            WorkflowEvent::LocalActivityCompleted { activity_id, .. } => {
+                writeln!(
+                    self.out,
+                    "note right of WF : Local Activity Completed (ID: {activity_id})"
+                )?;
+            }
+            WorkflowEvent::LocalActivityFailed {
+                activity_id, error, ..
+            } => {
+                let safe_error = error.replace('\n', " ").replace('"', "'");
+                writeln!(
+                    self.out,
+                    "note right of WF : Local Activity Failed (ID: {activity_id}): {safe_error}"
+                )?;
+            }
+            WorkflowEvent::LocalActivityExhausted { activity_id, .. } => {
+                writeln!(
+                    self.out,
+                    "note right of WF : Local Activity Exhausted (ID: {activity_id})"
+                )?;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn handle_update_event(&mut self, event: &WorkflowEvent) -> Result<(), std::fmt::Error> {
+        match event {
+            WorkflowEvent::UpdateAdmitted {
+                name, update_id, ..
+            } => {
+                writeln!(self.out, "-> WF: Update Admitted: {name} (ID: {update_id})")?;
+            }
+            WorkflowEvent::UpdateCompleted { update_id, .. } => {
+                writeln!(self.out, "WF -> WF: Update Completed (ID: {update_id})")?;
+            }
+            WorkflowEvent::UpdateFailed { update_id, error } => {
+                let safe_error = error.replace('\n', " ").replace('"', "'");
+                writeln!(
+                    self.out,
+                    "WF -> WF: Update Failed (ID: {update_id}): {safe_error}"
+                )?;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn handle_external_signal_event(
+        &mut self,
+        event: &WorkflowEvent,
+    ) -> Result<(), std::fmt::Error> {
+        match event {
+            WorkflowEvent::ExternalSignalRequested {
+                signal_name,
+                signal_id,
+                ..
+            } => {
+                writeln!(
+                    self.out,
+                    "WF -> WF: Request External Signal: {signal_name} (ID: {signal_id})"
+                )?;
+            }
+            WorkflowEvent::ExternalSignalDelivered { signal_id } => {
+                writeln!(
+                    self.out,
+                    "note right of WF : External Signal Delivered (ID: {signal_id})"
+                )?;
+            }
+            WorkflowEvent::ExternalSignalFailed {
+                signal_id,
+                reason_code,
+            } => {
+                writeln!(
+                    self.out,
+                    "note right of WF : External Signal Failed (ID: {signal_id}): {reason_code}"
+                )?;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    fn handle_external_cancel_event(
+        &mut self,
+        event: &WorkflowEvent,
+    ) -> Result<(), std::fmt::Error> {
+        match event {
+            WorkflowEvent::ExternalCancelRequested { cancel_id, .. } => {
+                writeln!(
+                    self.out,
+                    "WF -> WF: Request External Cancel (ID: {cancel_id})"
+                )?;
+            }
+            WorkflowEvent::ExternalCancelDelivered { cancel_id } => {
+                writeln!(
+                    self.out,
+                    "note right of WF : External Cancel Delivered (ID: {cancel_id})"
+                )?;
+            }
+            WorkflowEvent::ExternalCancelFailed {
+                cancel_id,
+                reason_code,
+            } => {
+                writeln!(
+                    self.out,
+                    "note right of WF : External Cancel Failed (ID: {cancel_id}): {reason_code}"
+                )?;
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -895,6 +1414,45 @@ mod tests {
         let diagram = export_mermaid_sequence(&events).expect("export should succeed");
         assert!(diagram.contains("sequenceDiagram"));
         assert!(diagram.contains("participant WF as Workflow"));
+    }
+
+    #[test]
+    fn test_export_plantuml_sequence_empty() {
+        let events = vec![];
+        let diagram = export_plantuml_sequence(&events).expect("export should succeed");
+        assert!(diagram.contains("@startuml"));
+        assert!(diagram.contains("participant WF as \"Workflow\""));
+        assert!(diagram.contains("@enduml"));
+    }
+
+    #[test]
+    fn test_export_plantuml_sequence_basic_workflow() {
+        let events = vec![
+            WorkflowEvent::WorkflowStarted {
+                input: serde_json::json!({}),
+                timestamp: Utc::now(),
+                last_completion_result: None,
+                last_error: None,
+                scheduled_time: None,
+            },
+            WorkflowEvent::ActivityScheduled {
+                activity_id: ActivityExecId::new(),
+                name: "download_file".to_string(),
+                input: serde_json::json!({}),
+                queue: "default".to_string(),
+            },
+            WorkflowEvent::WorkflowCompleted {
+                output: serde_json::json!({}),
+            },
+        ];
+
+        let diagram = export_plantuml_sequence(&events).unwrap();
+        assert!(diagram.contains("hnote over WF : Workflow Started"));
+        assert!(
+            diagram.contains("participant Activity_download_file as \"Activity: download_file\"")
+        );
+        assert!(diagram.contains("WF -> Activity_download_file: Schedule (ID: "));
+        assert!(diagram.contains("hnote over WF : Workflow Completed"));
     }
 
     #[test]

--- a/autumn-harvest/src/lib.rs
+++ b/autumn-harvest/src/lib.rs
@@ -282,6 +282,7 @@ pub use history_export::{
     DEFAULT_HISTORY_EXPORT_MAX_BYTES, HISTORY_EXPORT_SCHEMA, HISTORY_EXPORT_VERSION,
     HistoryExportDocument, HistoryExportError, HistoryExportRequest, HistoryExportSizeLimit,
     HistoryExportStatus, HistoryPayloadPolicy, export_history, export_mermaid_sequence,
+    export_plantuml_sequence,
 };
 pub use info::{
     ActivityHandlerFn, ActivityInfo, DagInfo, QueryHandlerFn, QueryHandlerInfo, UpdateHandlerFn,

--- a/fix_render.py
+++ b/fix_render.py
@@ -1,0 +1,36 @@
+import re
+
+with open("autumn-harvest-cli/src/lib.rs", "r") as f:
+    content = f.read()
+
+render_match = r'fn render_response\(cli: &Cli, value: &Value\) -> Result<String, CliError> \{\n'
+render_add = """fn render_response(cli: &Cli, value: &Value) -> Result<String, CliError> {
+    if let Commands::History {
+        command: HistoryCommand::PlantumlSequence { .. },
+    } = &cli.command
+    {
+        if let Some(events_val) = value.get("events") {
+            let events: Vec<autumn_harvest::event::WorkflowEvent> = serde_json::from_value(events_val.clone()).map_err(|e| CliError::ReadJson {
+                label: "parse history events",
+                path: "history.events".into(),
+                source: std::io::Error::new(std::io::ErrorKind::InvalidData, e),
+            })?;
+            return autumn_harvest::history_export::export_plantuml_sequence(&events).map_err(|e| CliError::ReadJson {
+                label: "export plantuml sequence",
+                path: "history.events".into(),
+                source: std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()),
+            });
+        }
+        return Err(CliError::ReadJson {
+            label: "parse history export",
+            path: "events".into(),
+            source: std::io::Error::new(std::io::ErrorKind::InvalidData, "missing events array"),
+        });
+    }
+"""
+
+content = re.sub(render_match, render_add, content)
+
+with open("autumn-harvest-cli/src/lib.rs", "w") as f:
+    f.write(content)
+print("Done")

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,15 @@
+1. **Add new feature `Export PlantUML Sequence Diagram` to `history_export.rs`**
+   - Use `run_in_bash_session` to execute a Python script that adds `export_plantuml_sequence` to `autumn-harvest/src/history_export.rs`.
+   - The function should take `&[WorkflowEvent]` and return `Result<String, std::fmt::Error>` containing a PlantUML sequence diagram, which works similarly to `export_mermaid_sequence` but outputs PlantUML (`@startuml` / `@enduml`).
+2. **Add unit tests for `export_plantuml_sequence`**
+   - Use `run_in_bash_session` with `sed` or `cat` to append tests checking the `export_plantuml_sequence` output to `autumn-harvest/src/history_export.rs`.
+3. **Expose `export_plantuml_sequence` in `lib.rs`**
+   - Use `run_in_bash_session` to use `sed` to update `autumn-harvest/src/lib.rs` by adding `export_plantuml_sequence` to the public exports.
+4. **Update `autumn-harvest-cli` to use the new feature**
+   - Use `run_in_bash_session` to run a Python script to update `autumn-harvest-cli/src/lib.rs` to support `--format plantuml-sequence` for the `history export` command. We can modify `HistoryCommand::Export` to accept a new output format or print it if a specific flag is passed (since `OutputFormat` only handles JSON, we'll probably add a new CLI command `harvest history plantuml-sequence <execution_id>` to match `HistoryCommand::Export`).
+5. **Verify changes to `history_export.rs`, `lib.rs`, and `autumn-harvest-cli/src/lib.rs`**
+   - Use `run_in_bash_session` to run `git diff` and verify all code modifications.
+6. **Ensure no regressions**
+   - Use `run_in_bash_session` to run `cargo fmt --all`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test`.
+7. **Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.**
+8. **Submit PR with the "🌟 Nova: [Feature Name]" title**


### PR DESCRIPTION
💡 **The Spark**: "We already support exporting workflow histories into Mermaid.js sequence diagrams, but Mermaid isn't always the best tool for massive workflows, and many engineering teams already standardize their documentation around PlantUML. I wondered if we could export the exact same sequence diagram in PlantUML format to serve those teams."

🚀 **The Feature**: "Added `export_plantuml_sequence` to the `history_export` core module. Updated the CLI to expose this via `harvest history plantuml-sequence <execution-id> [--output-file]`. The diagram renders workflows, activities, external activities, updates, and signals identically to the Mermaid version but using PlantUML syntax."

🔮 **The Potential**: "This allows users to pipe workflow executions straight into their existing PlantUML rendering pipelines or embed them in Confluence/Wiki pages that have native PlantUML macros, improving observability."

⚠️ **Risk**: "Low. The feature is completely isolated in `history_export.rs` and the CLI formatting step. The actual engine logic and state machine are untouched."

---
*PR created automatically by Jules for task [3975203226660751747](https://jules.google.com/task/3975203226660751747) started by @madmax983*