### PR TITLE
⚡ Bolt: [performance improvement] optimize DlqRawGroup collect

### DIFF
--- a/autumn-harvest/src/dlq.rs
+++ b/autumn-harvest/src/dlq.rs
@@ -1637,10 +1637,7 @@ pub fn merge_dlq_aggregates(
         }
     }
 
-    let groups: Vec<(Vec<Option<String>>, DlqRawGroup)> = merged
-        .into_values()
-        .map(|group| (group.key.clone(), group))
-        .collect();
+    let groups: Vec<(Vec<Option<String>>, DlqRawGroup)> = merged.into_iter().collect();
     let limit = params.limit_groups as usize;
 
     let (groups, truncated) = rollup_top_n(


### PR DESCRIPTION
💡 What:
Replaced `.into_values().map(|group| (group.key.clone(), group))` with `.into_iter().collect()` when collecting rolled-up DLQ groups into a vector.

🎯 Why:
The original implementation needlessly cloned the `group.key` (a `Vec<Option<String>>`) when the hash map iteration via `into_iter` perfectly returns the owned `(K, V)` tuples.

📊 Impact:
Removes one redundant heap allocation (`.clone()` on a nested `Vec`) per group during Dead Letter Queue aggregate rollups.

🔬 Measurement:
Run `cargo test -p autumn-harvest dlq` to ensure DLQ aggregations and rollup behavior remain correct.

---
*PR created automatically by Jules for task [13217601101728126706](https://jules.google.com/task/13217601101728126706) started by @madmax983*