### PR TITLE
fix: gate current_details_status example tests on the testing feature

### DIFF
--- a/autumn-harvest/examples/current_details_status.rs
+++ b/autumn-harvest/examples/current_details_status.rs
@@ -152,7 +152,11 @@ fn main() {
     );
 }
 
-#[cfg(test)]
+// Gated on the `testing` feature as well as `test`: the example itself must
+// keep building under `--no-default-features` (which CI exercises), while
+// `autumn_harvest::testing` only exists for external consumers when the
+// `testing` feature is enabled.
+#[cfg(all(test, feature = "testing"))]
 mod tests {
     use super::*;
     use autumn_harvest::event::WorkflowEvent;


### PR DESCRIPTION
Post-merge cleanup pass after #933, #935, and #936 landed (the manual "accept both" conflict resolutions were audited for duplicated blocks in CLAUDE.md / CHANGELOG.md / docs/api-contract.json and the overlapping source files — none found — and the full CI lint/test matrix was re-run on trunk-dev: fmt, all clippy variants, no-db + all-features lib + plugin + CLI + macros test suites, and the db-backed test compile all pass).

The one genuine fix: `autumn-harvest/examples/current_details_status.rs` gated its test module with a plain `#[cfg(test)]` while importing `autumn_harvest::testing`, which only exists behind the `testing` feature — so `cargo test -p autumn-harvest --no-default-features --example current_details_status` failed to compile. This mirrors the `#[cfg(all(test, feature = "testing"))]` gating `examples/patched_workflow.rs` (#933) already uses for the same pattern. Verified: compiles under `--no-default-features` and both tests pass under `--features testing`.

Note: the multiple "Phase 3.47" headings in CLAUDE.md are left as-is — duplicate phase numbers are established convention in this file (e.g. "Phase 3.46" appears four times).

---
_Generated by [Claude Code](https://claude.ai/code/session_01BNfkXwuozGS6jpWofDJwXa)_