### PR TITLE
⚒️ Forge: [Refactor `match` to `if let` in `WorkflowContext::for_replay_with_state_and_history_policy`]

### DIFF
--- a/autumn-harvest-macros/src/determinism_lint.rs
+++ b/autumn-harvest-macros/src/determinism_lint.rs
@@ -508,7 +508,7 @@ impl<'ast> Visit<'ast> for DeterminismVisitor {
 
     fn visit_expr_for_loop(&mut self, i: &'ast syn::ExprForLoop) {
         // HVG011: NonDeterministicIteration (issue #785; the issue proposed
-        // HVG010, permanently taken by SelectMacro/#600, hence HVG011).
+        // HVG010, permanently taken by `SelectMacro`/#600, hence HVG011).
         // Command-aware severity: a loop body that schedules commands on the
         // context param is a HardBlocker (the recorded command order would
         // follow the randomized hash order and diverge on replay); a
@@ -755,7 +755,7 @@ impl<'ast> Visit<'ast> for DeterminismVisitor {
     }
 
     fn visit_macro(&mut self, i: &'ast syn::Macro) {
-        // HVG010: SelectMacro (issue #600) -- tokio::select!/futures::select!/
+        // HVG010: `SelectMacro` (issue #600) -- tokio::select!/futures::select!/
         // futures::select_biased! racing ctx-managed awaitables is a double
         // footgun (non-deterministic winner on replay, no durable loser
         // cancellation). Checked at the generic `visit_macro` level (rather
@@ -858,7 +858,7 @@ pub fn load_catalog_metadata() -> HashMap<String, RuleInfo> {
             alternative: "Use ctx.race() (WorkflowContext), the deterministic race/select primitive (issue #600). It records the winning branch durably via a MarkerRecorded event so replay always resolves the same winner, and durably cancels every losing branch (activity task rows, child-workflow executions, or a losing durable timer) so no leaked in-flight work remains. For a single signal bounded by a deadline, ctx.receive_signal_timeout()/wait_for_signal_timeout() is the direct primitive ctx.race()'s timer-plus-signal shape wraps.".to_string(),
         },
         // HVG011 (issue #785; the issue proposed HVG010, permanently taken by
-        // SelectMacro/#600 — IDs are never reused). Text must stay
+        // `SelectMacro`/#600 — IDs are never reused). Text must stay
         // byte-identical to the guardrail.rs CATALOG entry.
         RuleInfo {
             id: "HVG011".to_string(),
@@ -882,7 +882,7 @@ mod hvg011_tests {
     //! iteration-order determinism.
     //!
     //! NOTE on the rule ID: issue #785's text proposed HVG010, but HVG010 was
-    //! already permanently assigned to SelectMacro (issue #600) and rule IDs
+    //! already permanently assigned to `SelectMacro` (issue #600) and rule IDs
     //! are never reused, so the iteration-order rule ships as HVG011.
 
     use super::{DeterminismVisitor, LinterFinding, load_catalog_metadata};

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -1734,28 +1734,35 @@ impl WorkflowContext {
         // Extract start_time, carryover, and scheduled slot from WorkflowStarted (first event).
         let (start_time, last_completion_result, last_error, scheduled_time) = events
             .first()
-            .and_then(|e| match e {
-                WorkflowEvent::WorkflowStarted {
+            .and_then(|e| {
+                if let WorkflowEvent::WorkflowStarted {
                     timestamp,
                     last_completion_result,
                     last_error,
                     scheduled_time,
                     ..
-                } => Some((
-                    *timestamp,
-                    last_completion_result.clone(),
-                    last_error.clone(),
-                    *scheduled_time,
-                )),
-                _ => None,
+                } = e
+                {
+                    Some((
+                        *timestamp,
+                        last_completion_result.clone(),
+                        last_error.clone(),
+                        *scheduled_time,
+                    ))
+                } else {
+                    None
+                }
             })
             .unwrap_or_else(|| (Utc::now(), None, None, None));
 
         // Capture any terminal cancellation event so workflow code can detect
         // it via `is_cancelled()` / `check_cancellation()` during replay.
-        let cancellation_reason = events.iter().find_map(|e| match e {
-            WorkflowEvent::WorkflowCancelled { reason } => Some(reason.clone()),
-            _ => None,
+        let cancellation_reason = events.iter().find_map(|e| {
+            if let WorkflowEvent::WorkflowCancelled { reason } = e {
+                Some(reason.clone())
+            } else {
+                None
+            }
         });
 
         let mut matcher = HistoryMatcher::new(events);


### PR DESCRIPTION
🚮 **Smell**: `match` statements were used inside closures (`and_then`, `find_map`) where a single arm and a catch-all `_ => None` were present, which slightly reduced readability when `if let` would suffice.

✨ **Solution**: Replaced the `match` blocks in `WorkflowContext::for_replay_with_state_and_history_policy` (`autumn-harvest/src/context.rs`) with `if let` statements to extract `start_time`, `last_completion_result`, `last_error`, `scheduled_time`, and `cancellation_reason`.

🧼 **Benefit**: Aligns with idiomatic Rust by avoiding overused `match` statements, flattening code structure, and slightly reducing cognitive load by explicitly highlighting the expected shape of the event.

🛡️ **Verification**: `cargo clippy` and `cargo test -p autumn-harvest context` passed cleanly, ensuring no logic or runtime behavior was changed.

---
*PR created automatically by Jules for task [8241217925170730388](https://jules.google.com/task/8241217925170730388) started by @madmax983*