### PR TITLE
👹 Havoc: [TypedWorkflowHandle Clone bound]

### DIFF
--- a/autumn-harvest-macros/src/determinism_lint.rs
+++ b/autumn-harvest-macros/src/determinism_lint.rs
@@ -508,7 +508,7 @@ impl<'ast> Visit<'ast> for DeterminismVisitor {
 
     fn visit_expr_for_loop(&mut self, i: &'ast syn::ExprForLoop) {
         // HVG011: NonDeterministicIteration (issue #785; the issue proposed
-        // HVG010, permanently taken by SelectMacro/#600, hence HVG011).
+        // HVG010, permanently taken by `SelectMacro`/#600, hence HVG011).
         // Command-aware severity: a loop body that schedules commands on the
         // context param is a HardBlocker (the recorded command order would
         // follow the randomized hash order and diverge on replay); a
@@ -755,7 +755,7 @@ impl<'ast> Visit<'ast> for DeterminismVisitor {
     }
 
     fn visit_macro(&mut self, i: &'ast syn::Macro) {
-        // HVG010: SelectMacro (issue #600) -- tokio::select!/futures::select!/
+        // HVG010: `SelectMacro` (issue #600) -- tokio::select!/futures::select!/
         // futures::select_biased! racing ctx-managed awaitables is a double
         // footgun (non-deterministic winner on replay, no durable loser
         // cancellation). Checked at the generic `visit_macro` level (rather
@@ -858,7 +858,7 @@ pub fn load_catalog_metadata() -> HashMap<String, RuleInfo> {
             alternative: "Use ctx.race() (WorkflowContext), the deterministic race/select primitive (issue #600). It records the winning branch durably via a MarkerRecorded event so replay always resolves the same winner, and durably cancels every losing branch (activity task rows, child-workflow executions, or a losing durable timer) so no leaked in-flight work remains. For a single signal bounded by a deadline, ctx.receive_signal_timeout()/wait_for_signal_timeout() is the direct primitive ctx.race()'s timer-plus-signal shape wraps.".to_string(),
         },
         // HVG011 (issue #785; the issue proposed HVG010, permanently taken by
-        // SelectMacro/#600 — IDs are never reused). Text must stay
+        // `SelectMacro`/#600 — IDs are never reused). Text must stay
         // byte-identical to the guardrail.rs CATALOG entry.
         RuleInfo {
             id: "HVG011".to_string(),
@@ -882,7 +882,7 @@ mod hvg011_tests {
     //! iteration-order determinism.
     //!
     //! NOTE on the rule ID: issue #785's text proposed HVG010, but HVG010 was
-    //! already permanently assigned to SelectMacro (issue #600) and rule IDs
+    //! already permanently assigned to `SelectMacro` (issue #600) and rule IDs
     //! are never reused, so the iteration-order rule ships as HVG011.
 
     use super::{DeterminismVisitor, LinterFinding, load_catalog_metadata};

--- a/autumn-harvest/src/handle_typed.rs
+++ b/autumn-harvest/src/handle_typed.rs
@@ -27,10 +27,19 @@ pub struct TypedWorkflowResult<T> {
 }
 
 /// Type-safe awaitable handle for one workflow execution.
-#[derive(Debug, Clone)]
+#[derive(Debug)]
 pub struct TypedWorkflowHandle<T> {
     inner: WorkflowHandle,
     _marker: PhantomData<T>,
+}
+
+impl<T> Clone for TypedWorkflowHandle<T> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            _marker: PhantomData,
+        }
+    }
 }
 
 unsafe impl<T> Send for TypedWorkflowHandle<T> {}

--- a/autumn-harvest/tests/havoc_typed_handle_clone.rs
+++ b/autumn-harvest/tests/havoc_typed_handle_clone.rs
@@ -1,0 +1,10 @@
+use autumn_harvest::handle_typed::TypedWorkflowHandle;
+
+struct NotCloneable;
+
+#[test]
+fn test_clone() {
+    fn assert_clone<T: Clone>() {}
+
+    assert_clone::<TypedWorkflowHandle<NotCloneable>>();
+}


### PR DESCRIPTION
🧨 **The Trigger:** Invoking `clone()` on a `TypedWorkflowHandle<T>` where `T` does not implement `Clone` failed to compile.
📉 **The Stack Trace:** 
```rust
error[E0277]: the trait bound `NotCloneable: Clone` is not satisfied
  --> autumn-harvest/tests/havoc_typed_handle_clone.rs:9:20
   |
 9 |     assert_clone::<TypedWorkflowHandle<NotCloneable>>();
   |                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Clone` is not implemented for `NotCloneable`
```
🧪 **Reproduction:** Run `cargo test -p autumn-harvest --test havoc_typed_handle_clone`.
😈 **Comment:** You trusted a `derive` macro implicitly on a generic wrapper containing only `PhantomData`. You assumed users wouldn't use exotic, non-cloneable return types for typed workflows. You were wrong. I removed the generic bound. You're welcome.

---
*PR created automatically by Jules for task [17934187873908077134](https://jules.google.com/task/17934187873908077134) started by @madmax983*