### PR TITLE
test: fix missing harvest_start_throttle migration in api_scheduler_integration

### DIFF
--- a/autumn-harvest-plugin/tests/api_scheduler_integration.rs
+++ b/autumn-harvest-plugin/tests/api_scheduler_integration.rs
@@ -200,6 +200,15 @@ const INIT_SQL: &str = concat!(
         "../../autumn-harvest/migrations/20260705000000_harvest_completion_deliveries/up.sql"
     ),
     include_str!("../../autumn-harvest/migrations/20260706000000_harvest_worker_sessions/up.sql"),
+    "\n",
+    // issue #607 / #688: workflow-start throttle table + its index follow-ups.
+    include_str!("../../autumn-harvest/migrations/20260706000001_harvest_start_throttle/up.sql"),
+    include_str!(
+        "../../autumn-harvest/migrations/20260707000000_harvest_start_throttle_bucket_deferred_idx/up.sql"
+    ),
+    include_str!(
+        "../../autumn-harvest/migrations/20260708000000_harvest_start_throttle_workflow_id_idx/up.sql"
+    ),
 );
 type HarvestApiApp = axum::Router;
 


### PR DESCRIPTION
## Summary

Fixes a deterministically-failing CI test introduced by merged PR #979 (issue #688): `backfill_release_on_oversized_input_leaves_budget_intact` in `autumn-harvest-plugin/tests/api_scheduler_integration.rs`.

Failing CI run: https://github.com/madmax983/autumn-harvest/actions/runs/29004895029/job/86125932019

## Root cause

That test is the only one in the binary that registers a `throttle`-policy workflow. The backfill throttle path issues an **unguarded** `SELECT` against `harvest_start_throttle` (`existing_pending_throttle_for_workflow_id` in `autumn-harvest/src/throttle.rs`). This test binary's `INIT_SQL` constant did not include migration `20260706000001_harvest_start_throttle` (nor its two index follow-ups), so the query errored with "relation does not exist" — sending both backfill slots to the `failed` bucket instead of `oversized_input`, and failing the assertion.

## Fix

Add the throttle base-table migration plus its two index follow-up migrations to the `INIT_SQL` concat, immediately after the `harvest_worker_sessions` include (matching the existing include-list style):

- `20260706000001_harvest_start_throttle` (CREATE TABLE)
- `20260707000000_harvest_start_throttle_bucket_deferred_idx`
- `20260708000000_harvest_start_throttle_workflow_id_idx`

All three reference only `harvest_start_throttle`, so they're self-contained.

## Before / After

- **Before:** the throttled-backfill test errored on a missing `harvest_start_throttle` table, mis-bucketing both slots as `failed`.
- **After:** the table (and its indexes) is created in the test schema, so the oversized-input path is exercised correctly and both slots land in `oversized_input` with the budget left intact.

## Verification

- `cargo test -p autumn-harvest-plugin --test api_scheduler_integration --no-run` — clean build (exit 0).
- `cargo fmt --check` — pass (exit 0).
- `cargo clippy -p autumn-harvest-plugin --all-targets -- -D warnings` (the exact CI invocation for this test target) — pass, no warnings (exit 0).
- **The DB test itself is compile-checked only locally** — Docker/testcontainers is unavailable in the authoring sandbox, so the test cannot be executed here. **CI runs it Docker-backed.**

No production code changed; test-schema only. No CLAUDE.md phase renumbering.

Refs: PR #979, issue #688.

---
_Generated by [Claude Code](https://claude.ai/code/session_01H78zNhmLvNv6n31bSGdFPQ)_