### PR TITLE
chore: changelog newsfragments to eliminate cross-PR merge conflicts

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,10 @@
 
 Postgres-backed durable workflow engine, companion to the Autumn web framework. Provides event-sourced workflow execution with activities, signals, timers, child workflows, and DAG scheduling.
 
+## Changelog entries
+
+Do not edit the `### Phase Status` list below (or `CHANGELOG.md`) in a feature PR — that shared list is what causes cross-PR merge conflicts. Instead add your changelog entry as a new fragment file `docs/changelog.d/pr-<number>-<slug>.md` (see `docs/changelog.d/README.md`). A periodic maintenance sweep folds fragments back into the phase list.
+
 ## Workspace Structure
 
 ```

--- a/autumn-harvest/tests/changelog_convention.rs
+++ b/autumn-harvest/tests/changelog_convention.rs
@@ -8,17 +8,26 @@ use std::path::PathBuf;
 #[test]
 fn changelog_fragments_readme_exists() {
     // Walk up from this crate's manifest dir to the workspace root so the test
-    // is robust to crate nesting depth.
+    // is robust to crate nesting depth. Only assert when we're clearly inside a
+    // git checkout: a packaged crates.io distribution ships the crate without the
+    // workspace-level `docs/` dir and must not fail the build there.
     let mut dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    let mut in_git_repo = false;
     loop {
         if dir.join("docs/changelog.d/README.md").exists() {
             return;
         }
+        if dir.join(".git").exists() {
+            in_git_repo = true;
+        }
         if !dir.pop() {
-            panic!(
+            assert!(
+                !in_git_repo,
                 "docs/changelog.d/README.md not found walking up from CARGO_MANIFEST_DIR; \
                  see docs/changelog.d/README.md for the changelog-fragment convention"
             );
+            // No workspace docs and no .git — a packaged distribution; skip.
+            return;
         }
     }
 }

--- a/autumn-harvest/tests/changelog_convention.rs
+++ b/autumn-harvest/tests/changelog_convention.rs
@@ -1,0 +1,24 @@
+//! Guard for the changelog-fragment convention (`docs/changelog.d/`).
+//! See `docs/changelog.d/README.md`. This is a lightweight anchor, not tooling:
+//! it just asserts the convention doc still exists so the fragment directory
+//! can't silently disappear.
+
+use std::path::PathBuf;
+
+#[test]
+fn changelog_fragments_readme_exists() {
+    // Walk up from this crate's manifest dir to the workspace root so the test
+    // is robust to crate nesting depth.
+    let mut dir = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    loop {
+        if dir.join("docs/changelog.d/README.md").exists() {
+            return;
+        }
+        if !dir.pop() {
+            panic!(
+                "docs/changelog.d/README.md not found walking up from CARGO_MANIFEST_DIR; \
+                 see docs/changelog.d/README.md for the changelog-fragment convention"
+            );
+        }
+    }
+}

--- a/docs/changelog.d/README.md
+++ b/docs/changelog.d/README.md
@@ -1,0 +1,36 @@
+# Changelog fragments (`docs/changelog.d/`)
+
+This directory holds **changelog fragments** (newsfragments), one per pull request. It exists to eliminate the merge conflicts that arise when many parallel PRs each edit a shared changelog list.
+
+## Why
+
+Historically every PR appended a `Phase N` entry to the phase list in `CLAUDE.md` (and to `CHANGELOG.md`). With multiple PR waves in flight at once, nearly every PR conflicted on those shared, append-only lists. Fragments move each PR's entry into its own file, so two PRs never touch the same file.
+
+## The rule
+
+- **Every substantive PR adds exactly one new file:** `docs/changelog.d/pr-<number>-<slug>.md`
+  - `<number>` = the PR number (or the issue number if the PR number isn't known yet — rename on push if needed).
+  - `<slug>` = a short kebab-case description, e.g. `pr-812-schedule-update`.
+- The file contains the **full changelog entry** that previously went into the `CLAUDE.md` phase list: the issue number, what shipped, key design decisions, invariant/append-only notes (new `WorkflowEvent` variant? migration?), and test evidence. Same content, new home.
+- **Do NOT edit the `### Phase Status` list in `CLAUDE.md` or `CHANGELOG.md` directly in a feature PR.** Those files are now updated only by a periodic collation sweep.
+
+## Collation
+
+A dedicated maintenance session periodically:
+
+1. Folds all accumulated fragments into `CLAUDE.md`'s phase list and `CHANGELOG.md`, in one PR.
+2. Deletes the collated fragment files.
+
+Because collation is a single, isolated PR, it conflicts with nothing.
+
+## Fragment template
+
+```markdown
+## Phase X.Y — <short title> (issue #NNN)
+
+<What shipped: the same prose you'd have written in the CLAUDE.md phase entry —
+design decisions, invariant notes (new WorkflowEvent variant? migration?),
+and test evidence.>
+```
+
+Keep the heading style consistent with the existing phase entries so collation is a straight copy-paste.

--- a/docs/changelog.d/README.md
+++ b/docs/changelog.d/README.md
@@ -34,3 +34,14 @@ and test evidence.>
 ```
 
 Keep the heading style consistent with the existing phase entries so collation is a straight copy-paste.
+
+## Rebase policy (parallel waves)
+
+Same spirit as the fragments above — minimise churn across concurrent PRs. **Do not proactively rebase or force-push a PR branch every time `trunk-dev` moves.** Every push re-triggers the Codex auto-review and restarts the review tail, which is noisy for reviewers.
+
+Rebase / update a branch only when:
+
+1. GitHub actually reports the branch as **conflicted**, or
+2. **Immediately before** the branch is merged.
+
+If the branch is merge-clean, leave it alone even if it's behind trunk. Cosmetic force-pushes are the enemy.


### PR DESCRIPTION
## Problem

Parallel PR waves each append a `Phase N` entry to the shared `### Phase Status` list in `CLAUDE.md` (and to `CHANGELOG.md`). Because those are append-only shared lists, nearly every PR in flight merge-conflicts on them — the conflicts are purely about *where* an entry lands in one growing list, not about the content.

## Fix

Adopt a **changelog newsfragments** convention. Each PR now adds its changelog entry as its own file under `docs/changelog.d/pr-<number>-<slug>.md` instead of editing the shared list. Two PRs never touch the same file, so the conflicts disappear.

- `CLAUDE.md`'s `### Phase Status` list and `CHANGELOG.md` are now touched **only** by a periodic collation sweep — a single isolated PR that folds accumulated fragments back into those lists and deletes the fragment files. Because it's one isolated PR, it conflicts with nothing.
- This is a **convention bootstrap, not tooling** — no scripts, no CI wiring beyond a tiny guard test.

## What's in this PR

- `docs/changelog.d/README.md` — documents the convention (why, the one-file-per-PR rule, collation, and a fragment template).
- `CLAUDE.md` — a small `## Changelog entries` pointer section placed near the top (far from the `### Phase Status` list, to minimize conflicts with in-flight PRs). **No phase-list edit is made in this PR.**
- `autumn-harvest/tests/changelog_convention.rs` — a lightweight doc-existence test that walks up from `CARGO_MANIFEST_DIR` and asserts `docs/changelog.d/README.md` still exists, so the fragment directory can't silently disappear. Not tooling — just an anchor.

## Verification (local; GitHub Actions is throttled)

The only Rust touched is the one new test file.

- `cargo fmt --check` — clean (exit 0).
- `cargo test -p autumn-harvest --no-default-features --test changelog_convention` — `1 passed; 0 failed` (`--no-default-features` avoids the OpenSSL/Postgres dependency).

## Note

This PR intentionally makes **no** edit to the `### Phase Status` list — that's the whole point.

---
_Generated by [Claude Code](https://claude.ai/code/session_01HcJTrMHG8f2h5S263eaRb8)_