### PR TITLE
👺 Havoc: Add fuzzing and loom tests for throttle, dlq, and admission gates

### DIFF
--- a/autumn-harvest-macros/src/determinism_lint.rs
+++ b/autumn-harvest-macros/src/determinism_lint.rs
@@ -929,7 +929,7 @@ mod hvg011_tests {
     //! iteration-order determinism.
     //!
     //! NOTE on the rule ID: issue #785's text proposed HVG010, but HVG010 was
-    //! already permanently assigned to SelectMacro (issue #600) and rule IDs
+    //! already permanently assigned to `SelectMacro` (issue #600) and rule IDs
     //! are never reused, so the iteration-order rule ships as HVG011.
 
     use super::{DeterminismVisitor, LinterFinding, load_catalog_metadata};
@@ -1603,7 +1603,7 @@ mod hvg010_combinator_tests {
     //! The select-macro positive case is covered by the
     //! `hvg010_select_macro.rs` compile-fail fixture; the activity-body
     //! negative case (AC6) is covered by the `#[activity]` macro never running
-    //! this visitor (see `suppressed_guardrails.rs` and the det_check
+    //! this visitor (see `suppressed_guardrails.rs` and the `det_check`
     //! `det011_activity_bodies_are_never_flagged` test) — the visitor lints
     //! whatever `fn` it is handed, so an "activity" negative cannot be
     //! expressed at this layer.

--- a/autumn-harvest/tests/loom_models.rs
+++ b/autumn-harvest/tests/loom_models.rs
@@ -291,3 +291,39 @@ fn session_slot_acquire_release_balances_and_never_underflows() {
         );
     });
 }
+
+/// Model 5: AdmissionGateCache check while refresh is occurring never panics or deadlocks.
+#[test]
+fn admission_gate_cache_concurrent_refresh_and_check() {
+    use autumn_harvest::admission_gate::{AdmissionGate, AdmissionGateCache, GateScope};
+    use chrono::Utc;
+    use uuid::Uuid;
+
+    loom::model(|| {
+        let cache = std::sync::Arc::new(AdmissionGateCache::default());
+
+        // Setup some dummy gates
+        let gates = vec![AdmissionGate {
+            id: autumn_harvest::admission_gate::AdmissionGateId(Uuid::nil()),
+            scope: GateScope::Fleet,
+            reason: "dummy".to_string(),
+            created_at: Utc::now(),
+            created_by: "test".to_string(),
+            message: Some("test".to_string()),
+            expires_at: None,
+        }];
+
+        let c1 = std::sync::Arc::clone(&cache);
+        let t1 = loom::thread::spawn(move || {
+            c1.refresh(gates.clone());
+        });
+
+        let c2 = std::sync::Arc::clone(&cache);
+        let t2 = loom::thread::spawn(move || {
+            let _ = c2.check("wf", "q", 0, None);
+        });
+
+        t1.join().unwrap();
+        t2.join().unwrap();
+    });
+}

--- a/fuzz/Cargo.toml
+++ b/fuzz/Cargo.toml
@@ -64,3 +64,17 @@ path = "fuzz_targets/fuzz_failure_signature.rs"
 test = false
 doc = false
 bench = false
+
+[[bin]]
+name = "fuzz_parse_rate"
+path = "fuzz_targets/fuzz_parse_rate.rs"
+test = false
+doc = false
+bench = false
+
+[[bin]]
+name = "fuzz_from_wire"
+path = "fuzz_targets/fuzz_from_wire.rs"
+test = false
+doc = false
+bench = false

--- a/fuzz/fuzz_targets/fuzz_from_wire.rs
+++ b/fuzz/fuzz_targets/fuzz_from_wire.rs
@@ -1,0 +1,9 @@
+#![no_main]
+
+use autumn_harvest::dlq::DlqGroupDimension;
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let raw = String::from_utf8_lossy(data);
+    let _ = DlqGroupDimension::from_wire(&raw);
+});

--- a/fuzz/fuzz_targets/fuzz_parse_rate.rs
+++ b/fuzz/fuzz_targets/fuzz_parse_rate.rs
@@ -1,0 +1,9 @@
+#![no_main]
+
+use autumn_harvest::throttle::parse_rate;
+use libfuzzer_sys::fuzz_target;
+
+fuzz_target!(|data: &[u8]| {
+    let raw = String::from_utf8_lossy(data);
+    let _ = parse_rate(&raw);
+});

--- a/patch_loom.py
+++ b/patch_loom.py
@@ -1,0 +1,41 @@
+import sys
+
+with open("autumn-harvest/tests/loom_models.rs", "r") as f:
+    lines = f.readlines()
+
+new_lines = []
+in_test = False
+for line in lines:
+    if line.strip() == "fn admission_gate_cache_concurrent_refresh_and_check() {":
+        in_test = True
+        new_lines.append(line)
+        new_lines.append("    use autumn_harvest::admission_gate::{AdmissionGateCache, AdmissionGate, GateScope};\n")
+        new_lines.append("    use uuid::Uuid;\n")
+        new_lines.append("    use chrono::Utc;\n")
+        continue
+
+    if in_test and line.strip().startswith("use autumn_harvest::"):
+        if "AdmissionGateCache" in line or "loom_sync" in line:
+            pass # skip these from old implementation
+        else:
+            new_lines.append(line)
+    elif in_test and line.strip() == "id: autumn_harvest::admission_gate::AdmissionGateId(Uuid::nil()),":
+        new_lines.append(line)
+    elif in_test and line.strip() == "created_by: \"test\".to_string(),":
+        new_lines.append(line)
+        new_lines.append("            message: \"test\".to_string(),\n")
+    elif in_test and "loom_sync::Arc" in line:
+        pass # Handle Arc manually later
+    elif in_test and "let c1 = Arc::clone" in line:
+        new_lines.append("        let c1 = std::sync::Arc::clone(&cache);\n")
+    elif in_test and "let c2 = Arc::clone" in line:
+        new_lines.append("        let c2 = std::sync::Arc::clone(&cache);\n")
+    elif in_test and "let cache = Arc::new" in line:
+        new_lines.append("        let cache = std::sync::Arc::new(AdmissionGateCache::default());\n")
+    else:
+        new_lines.append(line)
+        if in_test and line.strip() == "}":
+            in_test = False
+
+with open("autumn-harvest/tests/loom_models.rs", "w") as f:
+    f.writelines(new_lines)


### PR DESCRIPTION
🧨 **The Trigger:** Testing malformed strings in `parse_rate`/`from_wire` and concurrency in `AdmissionGateCache`.
📉 **The Stack Trace:** No crashes yet, but chaos is waiting.
🧪 **Reproduction:** Run `cargo +nightly fuzz run fuzz_parse_rate` and `RUSTFLAGS="--cfg loom" cargo test -p autumn-harvest --no-default-features --test loom_models --release`.
😈 **Comment:** "You thought parsing strings and RwLocking cache was safe. Prove it."

---
*PR created automatically by Jules for task [10795129907284169051](https://jules.google.com/task/10795129907284169051) started by @madmax983*