### PR TITLE
⚡ Bolt: [performance improvement]

### DIFF
--- a/autumn-harvest-macros/src/determinism_lint.rs
+++ b/autumn-harvest-macros/src/determinism_lint.rs
@@ -929,7 +929,7 @@ mod hvg011_tests {
     //! iteration-order determinism.
     //!
     //! NOTE on the rule ID: issue #785's text proposed HVG010, but HVG010 was
-    //! already permanently assigned to SelectMacro (issue #600) and rule IDs
+    //! already permanently assigned to `SelectMacro` (issue #600) and rule IDs
     //! are never reused, so the iteration-order rule ships as HVG011.
 
     use super::{DeterminismVisitor, LinterFinding, load_catalog_metadata};
@@ -1603,7 +1603,7 @@ mod hvg010_combinator_tests {
     //! The select-macro positive case is covered by the
     //! `hvg010_select_macro.rs` compile-fail fixture; the activity-body
     //! negative case (AC6) is covered by the `#[activity]` macro never running
-    //! this visitor (see `suppressed_guardrails.rs` and the det_check
+    //! this visitor (see `suppressed_guardrails.rs` and the `det_check`
     //! `det011_activity_bodies_are_never_flagged` test) — the visitor lints
     //! whatever `fn` it is handed, so an "activity" negative cannot be
     //! expressed at this layer.

--- a/autumn-harvest/src/trace_export.rs
+++ b/autumn-harvest/src/trace_export.rs
@@ -17,7 +17,7 @@ use std::collections::HashMap;
 /// A JSON `Value` representing the trace events array.
 #[must_use]
 pub fn export_chrome_trace(profile: &DagProfile) -> Value {
-    let mut events = Vec::new();
+    let mut events = Vec::with_capacity(profile.timeline.len());
     let mut start_times = HashMap::new();
 
     for event in &profile.timeline {

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -1088,7 +1088,7 @@ fn extract_single_command<T>(
 fn extract_all_scheduled_activities(
     commands: &[WorkflowCommand],
 ) -> Option<Vec<ScheduledActivityCommand>> {
-    let mut scheduled = Vec::new();
+    let mut scheduled = Vec::with_capacity(commands.len());
 
     for cmd in commands {
         match cmd {
@@ -1137,7 +1137,7 @@ fn extract_all_scheduled_activities(
 }
 
 fn extract_all_activity_waits(commands: &[WorkflowCommand]) -> Option<Vec<ActivityExecId>> {
-    let mut activity_ids = Vec::new();
+    let mut activity_ids = Vec::with_capacity(commands.len());
 
     for cmd in commands {
         match cmd {
@@ -1342,8 +1342,8 @@ fn local_activity_history_cap_reached(next_event_id: i32, cap: Option<u64>) -> O
 fn extract_run_local_activity(commands: Vec<WorkflowCommand>) -> LocalActivityCommandBatch {
     // ⚡ Bolt: Pre-allocate vector capacity to avoid intermediate allocations
     let mut pre_schedule_events = Vec::with_capacity(commands.len());
-    let mut post_schedule_events = Vec::new();
-    let mut detached_commands = Vec::new();
+    let mut post_schedule_events = Vec::with_capacity(commands.len());
+    let mut detached_commands = Vec::with_capacity(commands.len());
     let mut local_run = None;
     for cmd in commands {
         match cmd {
@@ -1533,8 +1533,8 @@ fn extract_signal_external_workflow(commands: Vec<WorkflowCommand>) -> Vec<Signa
 fn split_mixed_signal_batch(
     commands: Vec<WorkflowCommand>,
 ) -> (Vec<SignalBatchItem>, Vec<WorkflowCommand>) {
-    let mut signal_items = Vec::new();
-    let mut remaining = Vec::new();
+    let mut signal_items = Vec::with_capacity(commands.len());
+    let mut remaining = Vec::with_capacity(commands.len());
     for cmd in commands {
         match cmd {
             WorkflowCommand::SignalExternalWorkflow {


### PR DESCRIPTION
💡 What: Pre-allocate vectors using `Vec::with_capacity` in hot loops. Swapped `Vec::new()` for `Vec::with_capacity(len)` in multiple critical functions (like `extract_all_scheduled_activities`, `extract_run_local_activity`, `split_mixed_signal_batch`, and `export_chrome_trace`).
🎯 Why: Iterative pushes to vectors initialized with `Vec::new()` cause the vector to dynamically resize (0 -> 4 -> 8 -> 16), which requires intermediate heap allocations and memory copying. By pre-allocating the known required capacity, we eliminate these re-allocations on the hot path.
📊 Impact: Reduces intermediate heap allocations and memory copies during event extraction, signaling, and trace exports.
🔬 Measurement: Verify by running `cargo test -p autumn-harvest` and `cargo bench -p autumn-harvest` (if a workload bench exists for worker event extraction).

---
*PR created automatically by Jules for task [6900017169477837120](https://jules.google.com/task/6900017169477837120) started by @madmax983*