### PR TITLE
🌟 Nova: [Workflow Timeline Chrome Trace Export]

### DIFF
--- a/autumn-harvest-cli/src/lib.rs
+++ b/autumn-harvest-cli/src/lib.rs
@@ -828,6 +828,11 @@ enum WorkflowCommand {
         /// Workflow execution ID.
         execution_id: String,
     },
+    /// Export a workflow execution's timeline to Chrome Trace Event Format.
+    Trace {
+        /// Workflow execution ID.
+        execution_id: String,
+    },
     /// Reconstruct the ordered continue-as-new run chain a workflow execution
     /// belongs to, resolvable from any member (origin, middle, or tail).
     RunChain {
@@ -2234,6 +2239,23 @@ pub fn format_output(value: &Value, output: OutputFormat) -> Result<String, CliE
 }
 
 fn render_response(cli: &Cli, value: &Value) -> Result<String, CliError> {
+    if let Commands::Workflow {
+        command: WorkflowCommand::Trace { .. },
+    } = &cli.command
+    {
+        let timeline: autumn_harvest::timeline::Timeline = serde_json::from_value(value.clone())
+            .map_err(|e| CliError::ReadJson {
+                label: "parse timeline",
+                path: "api response".to_string(),
+                source: std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()),
+            })?;
+        let trace = autumn_harvest::export_timeline_chrome_trace(&timeline);
+        return serde_json::to_string_pretty(&trace).map_err(|e| CliError::ReadJson {
+            label: "serialize trace",
+            path: "in-memory".to_string(),
+            source: std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()),
+        });
+    }
     let state_filtered = completion_delivery_list_state_filter(cli)
         .map(|state| filter_completion_deliveries_by_state(value, state));
     let value = state_filtered.as_ref().unwrap_or(value);
@@ -3961,10 +3983,12 @@ fn workflow_request(command: &WorkflowCommand) -> Result<ApiRequest, CliError> {
             "/workflows/{}/stack",
             path_segment(execution_id)
         ))),
-        WorkflowCommand::Timeline { execution_id } => Ok(ApiRequest::get(format!(
-            "/workflows/{}/timeline",
-            path_segment(execution_id)
-        ))),
+        WorkflowCommand::Timeline { execution_id } | WorkflowCommand::Trace { execution_id } => {
+            Ok(ApiRequest::get(format!(
+                "/workflows/{}/timeline",
+                path_segment(execution_id)
+            )))
+        }
         WorkflowCommand::RunChain {
             execution_id,
             json: _,

--- a/autumn-harvest-macros/src/determinism_lint.rs
+++ b/autumn-harvest-macros/src/determinism_lint.rs
@@ -929,7 +929,7 @@ mod hvg011_tests {
     //! iteration-order determinism.
     //!
     //! NOTE on the rule ID: issue #785's text proposed HVG010, but HVG010 was
-    //! already permanently assigned to SelectMacro (issue #600) and rule IDs
+    //! already permanently assigned to `SelectMacro` (issue #600) and rule IDs
     //! are never reused, so the iteration-order rule ships as HVG011.
 
     use super::{DeterminismVisitor, LinterFinding, load_catalog_metadata};
@@ -1603,7 +1603,7 @@ mod hvg010_combinator_tests {
     //! The select-macro positive case is covered by the
     //! `hvg010_select_macro.rs` compile-fail fixture; the activity-body
     //! negative case (AC6) is covered by the `#[activity]` macro never running
-    //! this visitor (see `suppressed_guardrails.rs` and the det_check
+    //! this visitor (see `suppressed_guardrails.rs` and the `det_check`
     //! `det011_activity_bodies_are_never_flagged` test) — the visitor lints
     //! whatever `fn` it is handed, so an "activity" negative cannot be
     //! expressed at this layer.

--- a/autumn-harvest/src/lib.rs
+++ b/autumn-harvest/src/lib.rs
@@ -394,7 +394,7 @@ pub use timeline::{
     derive_timeline,
 };
 #[cfg(any(test, feature = "testing"))]
-pub use trace_export::export_chrome_trace;
+pub use trace_export::{export_chrome_trace, export_timeline_chrome_trace};
 pub use types::{
     ActivityExecId, BuildId, DeploymentName, ExecutionId, ExternalActivityToken, ExternalCancelId,
     ExternalSignalId, ParentClosePolicy, Priority, SessionId, ShardId, TimerId, UpdateId, WorkerId,

--- a/autumn-harvest/src/trace_export.rs
+++ b/autumn-harvest/src/trace_export.rs
@@ -7,6 +7,8 @@ use crate::dag_profiler::{DagProfile, ProfilerEventKind};
 use serde_json::{Value, json};
 use std::collections::HashMap;
 
+use crate::timeline::{StepOutcome, Timeline};
+
 /// Exports a `DagProfile` to Chrome Trace Event Format.
 ///
 /// Converts the simulated DAG timeline into a series of "Complete" (`"ph": "X"`)
@@ -48,11 +50,112 @@ pub fn export_chrome_trace(profile: &DagProfile) -> Value {
     json!(events)
 }
 
+/// Exports a workflow `Timeline` to Chrome Trace Event Format.
+///
+/// Converts the reconstructed timeline of a workflow execution into a series of
+/// "Complete" (`"ph": "X"`) trace events.
+///
+/// # Returns
+/// A JSON `Value` representing the trace events array.
+#[must_use]
+pub fn export_timeline_chrome_trace(timeline: &Timeline) -> Value {
+    let mut events = Vec::new();
+
+    for (idx, step) in timeline.steps.iter().enumerate() {
+        let name = step
+            .name
+            .clone()
+            .unwrap_or_else(|| step.step_kind.as_str().to_string());
+        let cat = step.step_kind.as_str();
+        let ts = step.scheduled_at.timestamp_micros();
+        let dur = step.total_ms * 1000;
+
+        let mut args = serde_json::Map::new();
+        args.insert("step_index".to_string(), json!(idx));
+        if let Some(wait) = step.wait_ms {
+            args.insert("wait_ms".to_string(), json!(wait));
+        }
+        if let Some(exec) = step.exec_ms {
+            args.insert("exec_ms".to_string(), json!(exec));
+        }
+        if let Some(attempt) = step.attempt {
+            args.insert("attempt".to_string(), json!(attempt));
+        }
+        let outcome_str = match step.outcome {
+            StepOutcome::Completed => "Completed",
+            StepOutcome::Failed => "Failed",
+            StepOutcome::TimedOut => "TimedOut",
+            StepOutcome::Cancelled => "Cancelled",
+            StepOutcome::Fired => "Fired",
+            StepOutcome::Pending => "Pending",
+        };
+        args.insert("outcome".to_string(), json!(outcome_str));
+
+        events.push(json!({
+            "name": name,
+            "cat": cat,
+            "ph": "X",
+            "ts": ts,
+            "dur": dur,
+            "pid": 1,
+            "tid": 1,
+            "args": args
+        }));
+    }
+
+    json!(events)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::dag_profiler::{ProfilerEvent, ProfilerEventKind};
     use std::time::Duration;
+
+    #[test]
+    fn test_export_timeline_chrome_trace() {
+        use crate::timeline::{StepKind, StepOutcome, Timeline, TimelineRollup, TimelineStep};
+        use chrono::TimeZone;
+
+        let step1 = TimelineStep {
+            step_kind: StepKind::Activity,
+            name: Some("test_act".to_string()),
+            scheduled_at: chrono::Utc.timestamp_opt(1000, 0).unwrap(),
+            ended_at: Some(chrono::Utc.timestamp_opt(1001, 0).unwrap()),
+            total_ms: 1000,
+            wait_ms: Some(200),
+            exec_ms: Some(800),
+            attempt: Some(1),
+            outcome: StepOutcome::Completed,
+        };
+        let tl = Timeline {
+            exec_id: "exec-1".into(),
+            workflow_id: "wf-1".into(),
+            workflow_name: "my_wf".into(),
+            state: "COMPLETED".into(),
+            steps: vec![step1],
+            rollup: TimelineRollup {
+                total_wall_clock_ms: 1000,
+                busy_ms: 800,
+                wait_ms: 200,
+                step_count_by_kind: std::collections::BTreeMap::new(),
+                slowest_step: None,
+            },
+        };
+
+        let trace = export_timeline_chrome_trace(&tl);
+        let arr = trace.as_array().expect("Expected JSON array");
+        assert_eq!(arr.len(), 1);
+
+        let event = &arr[0];
+        assert_eq!(event["name"], "test_act");
+        assert_eq!(event["cat"], "activity");
+        assert_eq!(event["ph"], "X");
+        assert_eq!(event["ts"], 1_000_000_000);
+        assert_eq!(event["dur"], 1_000_000);
+        assert_eq!(event["args"]["wait_ms"], 200);
+        assert_eq!(event["args"]["outcome"], "Completed");
+    }
 
     #[test]
     fn test_export_chrome_trace() {


### PR DESCRIPTION
💡 **The Spark:** "I noticed we reconstruct an execution's full timeline but don't use it for external performance visualization tools."
🚀 **The Feature:** "Implemented `export_timeline_chrome_trace` which converts a `Timeline` into Chrome Trace JSON. Exposed it in the CLI as `harvest workflow trace <execution_id>`."
🔮 **The Potential:** "Could be used by operators to visualize actual workflow executions in Perfetto/Chrome Tracing to spot bottlenecks and optimize performance."
⚠️ **Risk:** "Low. Isolated in `src/trace_export.rs` and CLI routing. Completely read-only transformation of the timeline projection."

---
*PR created automatically by Jules for task [15130924099948121300](https://jules.google.com/task/15130924099948121300) started by @madmax983*