### PR TITLE
🌟 Nova: Chrome Trace Timeline Exporter

### DIFF
--- a/autumn-harvest-macros/src/determinism_lint.rs
+++ b/autumn-harvest-macros/src/determinism_lint.rs
@@ -929,7 +929,7 @@ mod hvg011_tests {
     //! iteration-order determinism.
     //!
     //! NOTE on the rule ID: issue #785's text proposed HVG010, but HVG010 was
-    //! already permanently assigned to SelectMacro (issue #600) and rule IDs
+    //! already permanently assigned to `SelectMacro` (issue #600) and rule IDs
     //! are never reused, so the iteration-order rule ships as HVG011.
 
     use super::{DeterminismVisitor, LinterFinding, load_catalog_metadata};
@@ -1603,7 +1603,7 @@ mod hvg010_combinator_tests {
     //! The select-macro positive case is covered by the
     //! `hvg010_select_macro.rs` compile-fail fixture; the activity-body
     //! negative case (AC6) is covered by the `#[activity]` macro never running
-    //! this visitor (see `suppressed_guardrails.rs` and the det_check
+    //! this visitor (see `suppressed_guardrails.rs` and the `det_check`
     //! `det011_activity_bodies_are_never_flagged` test) — the visitor lints
     //! whatever `fn` it is handed, so an "activity" negative cannot be
     //! expressed at this layer.

--- a/autumn-harvest/src/lib.rs
+++ b/autumn-harvest/src/lib.rs
@@ -394,7 +394,7 @@ pub use timeline::{
     derive_timeline,
 };
 #[cfg(any(test, feature = "testing"))]
-pub use trace_export::export_chrome_trace;
+pub use trace_export::{export_chrome_trace, export_timeline_chrome_trace};
 pub use types::{
     ActivityExecId, BuildId, DeploymentName, ExecutionId, ExternalActivityToken, ExternalCancelId,
     ExternalSignalId, ParentClosePolicy, Priority, SessionId, ShardId, TimerId, UpdateId, WorkerId,

--- a/autumn-harvest/src/trace_export.rs
+++ b/autumn-harvest/src/trace_export.rs
@@ -4,8 +4,51 @@
 //! like `chrome://tracing` or `ui.perfetto.dev`.
 
 use crate::dag_profiler::{DagProfile, ProfilerEventKind};
+use crate::timeline::Timeline;
 use serde_json::{Value, json};
 use std::collections::HashMap;
+
+/// Exports a `Timeline` to Chrome Trace Event Format.
+///
+/// Converts a real workflow execution timeline into a series of "Complete" (`"ph": "X"`)
+/// trace events. Each step is represented as a span with a start time (`ts`)
+/// and duration (`dur`) in microseconds, relative to the first recorded step's scheduling time.
+///
+/// # Returns
+/// A JSON `Value` representing the trace events array.
+#[must_use]
+pub fn export_timeline_chrome_trace(timeline: &Timeline) -> Value {
+    let mut events = Vec::new();
+
+    // Find the earliest timestamp to use as relative zero for tracing.
+    let base_ts = timeline.steps.iter().map(|s| s.scheduled_at).min();
+
+    if let Some(base_ts) = base_ts {
+        for (idx, step) in timeline.steps.iter().enumerate() {
+            let relative_ts = step.scheduled_at.signed_duration_since(base_ts);
+            // Ignore events scheduled before the base (shouldn't happen with min).
+            if relative_ts.num_microseconds().unwrap_or(-1) >= 0 {
+                let name = step.name.as_ref().map_or_else(|| format!("{:?}", step.step_kind), Clone::clone);
+
+                events.push(json!({
+                    "name": name,
+                    "cat": format!("{:?}", step.step_kind),
+                    "ph": "X",
+                    "ts": relative_ts.num_microseconds().unwrap_or(0),
+                    "dur": step.total_ms * 1000,
+                    "pid": timeline.exec_id,
+                    "tid": timeline.workflow_name,
+                    "args": {
+                        "step_index": idx,
+                        "outcome": format!("{:?}", step.outcome),
+                    }
+                }));
+            }
+        }
+    }
+
+    json!(events)
+}
 
 /// Exports a `DagProfile` to Chrome Trace Event Format.
 ///
@@ -52,7 +95,75 @@ pub fn export_chrome_trace(profile: &DagProfile) -> Value {
 mod tests {
     use super::*;
     use crate::dag_profiler::{ProfilerEvent, ProfilerEventKind};
+    use crate::timeline::{StepKind, StepOutcome, TimelineRollup, TimelineStep};
+    use chrono::{TimeZone, Utc};
+    use std::collections::BTreeMap;
     use std::time::Duration;
+
+    #[test]
+    fn test_export_timeline_chrome_trace() {
+        let ts_base = Utc.timestamp_opt(1_600_000_000, 0).unwrap();
+        let ts_offset1 = Utc.timestamp_opt(1_600_000_001, 500_000_000).unwrap();
+
+        let timeline = Timeline {
+            exec_id: "exec-1".to_string(),
+            workflow_id: "wf-1".to_string(),
+            workflow_name: "MyWorkflow".to_string(),
+            state: "COMPLETED".to_string(),
+            steps: vec![
+                TimelineStep {
+                    step_kind: StepKind::Activity,
+                    name: Some("activity_1".to_string()),
+                    scheduled_at: ts_base,
+                    ended_at: None,
+                    total_ms: 1000,
+                    wait_ms: None,
+                    exec_ms: None,
+                    outcome: StepOutcome::Completed,
+                    attempt: None,
+                },
+                TimelineStep {
+                    step_kind: StepKind::Timer,
+                    name: Some("timer_1".to_string()),
+                    scheduled_at: ts_offset1,
+                    ended_at: None,
+                    total_ms: 500,
+                    wait_ms: None,
+                    exec_ms: None,
+                    outcome: StepOutcome::Completed,
+                    attempt: None,
+                },
+            ],
+            rollup: TimelineRollup {
+                total_wall_clock_ms: 1500,
+                busy_ms: 1000,
+                wait_ms: 500,
+                slowest_step: None,
+                step_count_by_kind: BTreeMap::new(),
+            },
+        };
+
+        let trace = export_timeline_chrome_trace(&timeline);
+        let arr = trace.as_array().expect("Expected JSON array");
+        assert_eq!(arr.len(), 2);
+
+        let event1 = &arr[0];
+        assert_eq!(event1["name"], "activity_1");
+        assert_eq!(event1["cat"], "Activity");
+        assert_eq!(event1["ph"], "X");
+        assert_eq!(event1["ts"], 0);
+        assert_eq!(event1["dur"], 1_000_000);
+        assert_eq!(event1["pid"], "exec-1");
+        assert_eq!(event1["tid"], "MyWorkflow");
+        assert_eq!(event1["args"]["step_index"], 0);
+
+        let event2 = &arr[1];
+        assert_eq!(event2["name"], "timer_1");
+        assert_eq!(event2["cat"], "Timer");
+        assert_eq!(event2["ph"], "X");
+        assert_eq!(event2["ts"], 1_500_000); // 1.5 seconds later
+        assert_eq!(event2["dur"], 500_000);
+    }
 
     #[test]
     fn test_export_chrome_trace() {


### PR DESCRIPTION
💡 The Spark
I noticed we export our simulated `DagProfile` to Chrome Trace Event format, but our real execution history `Timeline` only generates standard structs and Mermaid sequences. Connecting the `Timeline` data to `export_chrome_trace` opens up powerful tracing visualizations for live executions.

🚀 The Feature
Implemented `export_timeline_chrome_trace` in `autumn-harvest/src/trace_export.rs`. This function takes a real `Timeline`, determines the earliest `scheduled_at` timestamp as a zero-point, and emits a compatible JSON trace array where each step is represented with relative microsecond timestamps and durations.

🔮 The Potential
Could be used in the `autumn-harvest-plugin` or an admin CLI to download `.json` traces of actual workflow runs for deep performance inspection and latency debugging in tools like `ui.perfetto.dev`.

⚠️ Risk
Low. Isolated entirely within `src/trace_export.rs` and safely exported under the `testing` or `test` feature flags. Does not modify core execution logic.

---
*PR created automatically by Jules for task [1663603743868190587](https://jules.google.com/task/1663603743868190587) started by @madmax983*