### PR TITLE
⚒️ Forge: refactor circuit breaker on_result

### DIFF
--- a/autumn-harvest-macros/src/determinism_lint.rs
+++ b/autumn-harvest-macros/src/determinism_lint.rs
@@ -542,7 +542,7 @@ impl<'ast> Visit<'ast> for DeterminismVisitor {
 
     fn visit_expr_for_loop(&mut self, i: &'ast syn::ExprForLoop) {
         // HVG011: NonDeterministicIteration (issue #785; the issue proposed
-        // HVG010, permanently taken by SelectMacro/#600, hence HVG011).
+        // HVG010, permanently taken by `SelectMacro`/#600, hence HVG011).
         // Command-aware severity: a loop body that schedules commands on the
         // context param is a HardBlocker (the recorded command order would
         // follow the randomized hash order and diverge on replay); a
@@ -682,7 +682,7 @@ impl<'ast> Visit<'ast> for DeterminismVisitor {
                 );
             }
 
-            // HVG010: SelectMacro (issue #799) — the futures combinator
+            // HVG010: `SelectMacro` (issue #799) — the futures combinator
             // FUNCTIONS are the function-call siblings of tokio::select!/
             // futures::select! and carry the identical non-deterministic-winner
             // + no-durable-loser-cancellation footgun (the select MACROS are
@@ -802,7 +802,7 @@ impl<'ast> Visit<'ast> for DeterminismVisitor {
     }
 
     fn visit_macro(&mut self, i: &'ast syn::Macro) {
-        // HVG010: SelectMacro (issue #600) -- tokio::select!/futures::select!/
+        // HVG010: `SelectMacro` (issue #600) -- tokio::select!/futures::select!/
         // futures::select_biased! racing ctx-managed awaitables is a double
         // footgun (non-deterministic winner on replay, no durable loser
         // cancellation). Checked at the generic `visit_macro` level (rather
@@ -905,7 +905,7 @@ pub fn load_catalog_metadata() -> HashMap<String, RuleInfo> {
             alternative: "Use ctx.race() (WorkflowContext), the deterministic race/select primitive (issue #600). It records the winning branch durably via a MarkerRecorded event so replay always resolves the same winner, and durably cancels every losing branch (activity task rows, child-workflow executions, or a losing durable timer) so no leaked in-flight work remains. For a single signal bounded by a deadline, ctx.receive_signal_timeout()/wait_for_signal_timeout() is the direct primitive ctx.race()'s timer-plus-signal shape wraps. To fan out many activities in parallel and collect their results in a deterministic order, use ctx.execute_activity_fan_out* instead of racing them; to block until a workflow-local predicate holds (optionally bounded by a deadline), use ctx.await_condition_timeout().".to_string(),
         },
         // HVG011 (issue #785; the issue proposed HVG010, permanently taken by
-        // SelectMacro/#600 — IDs are never reused). Text must stay
+        // `SelectMacro`/#600 — IDs are never reused). Text must stay
         // byte-identical to the guardrail.rs CATALOG entry.
         RuleInfo {
             id: "HVG011".to_string(),
@@ -929,7 +929,7 @@ mod hvg011_tests {
     //! iteration-order determinism.
     //!
     //! NOTE on the rule ID: issue #785's text proposed HVG010, but HVG010 was
-    //! already permanently assigned to SelectMacro (issue #600) and rule IDs
+    //! already permanently assigned to `SelectMacro` (issue #600) and rule IDs
     //! are never reused, so the iteration-order rule ships as HVG011.
 
     use super::{DeterminismVisitor, LinterFinding, load_catalog_metadata};
@@ -1603,7 +1603,7 @@ mod hvg010_combinator_tests {
     //! The select-macro positive case is covered by the
     //! `hvg010_select_macro.rs` compile-fail fixture; the activity-body
     //! negative case (AC6) is covered by the `#[activity]` macro never running
-    //! this visitor (see `suppressed_guardrails.rs` and the det_check
+    //! this visitor (see `suppressed_guardrails.rs` and the `det_check`
     //! `det011_activity_bodies_are_never_flagged` test) — the visitor lints
     //! whatever `fn` it is handed, so an "activity" negative cannot be
     //! expressed at this layer.

--- a/autumn-harvest/src/circuit_breaker.rs
+++ b/autumn-harvest/src/circuit_breaker.rs
@@ -244,6 +244,71 @@ impl BreakerState {
         self.probe_in_flight = false;
         self.bump_generation();
     }
+
+    fn handle_closed_phase_result(
+        &mut self,
+        outcome: AttemptOutcome,
+        now: Instant,
+        policy: &CircuitBreakerPolicy,
+    ) -> Option<CircuitTransition> {
+        match outcome {
+            // A success clears the rolling failure window.
+            AttemptOutcome::Success => {
+                self.failures.clear();
+                None
+            }
+            // A non-retryable (permanent per-request) error is excluded from
+            // trip counts entirely: it is neither downstream sickness nor
+            // proof of health, so it leaves the rolling window untouched.
+            AttemptOutcome::NonRetryableFailure => None,
+            AttemptOutcome::RetryableFailure => {
+                self.failures.push_back(now);
+                self.prune(now, policy.window);
+                if self.failures.len() >= policy.failure_threshold as usize {
+                    self.trip(now);
+                    Some(CircuitTransition::Tripped)
+                } else {
+                    None
+                }
+            }
+        }
+    }
+
+    fn handle_half_open_phase_result(
+        &mut self,
+        outcome: AttemptOutcome,
+        token: DispatchToken,
+        now: Instant,
+    ) -> Option<CircuitTransition> {
+        // Only the admitted probe decides the half-open outcome. A
+        // same-generation non-probe (shouldn't normally happen, but be
+        // defensive) must not close the breaker early or restart cooldown.
+        if !token.is_probe {
+            return None;
+        }
+        match outcome {
+            // The probe reached the downstream and it answered: recovered.
+            AttemptOutcome::Success => {
+                self.close();
+                Some(CircuitTransition::Closed)
+            }
+            // The probe failed transiently: the downstream is still down.
+            AttemptOutcome::RetryableFailure => {
+                self.trip(now);
+                Some(CircuitTransition::Tripped)
+            }
+            // A non-retryable per-request error (e.g. bad input) does NOT
+            // prove the downstream recovered — the error may have been
+            // produced before the dependency was even touched. Treat the
+            // probe as inconclusive: release the probe slot and re-arm the
+            // cooldown so a fresh probe is admitted later, but emit no
+            // transition (it is neither a recovery nor a downstream trip).
+            AttemptOutcome::NonRetryableFailure => {
+                self.trip(now);
+                None
+            }
+        }
+    }
 }
 
 /// In-process registry of per-activity circuit breakers.
@@ -420,57 +485,8 @@ impl CircuitBreakerRegistry {
         }
 
         match st.phase {
-            CircuitPhase::Closed => match outcome {
-                // A success clears the rolling failure window.
-                AttemptOutcome::Success => {
-                    st.failures.clear();
-                    None
-                }
-                // A non-retryable (permanent per-request) error is excluded from
-                // trip counts entirely: it is neither downstream sickness nor
-                // proof of health, so it leaves the rolling window untouched.
-                AttemptOutcome::NonRetryableFailure => None,
-                AttemptOutcome::RetryableFailure => {
-                    st.failures.push_back(now);
-                    st.prune(now, policy.window);
-                    if st.failures.len() >= policy.failure_threshold as usize {
-                        st.trip(now);
-                        Some(CircuitTransition::Tripped)
-                    } else {
-                        None
-                    }
-                }
-            },
-            CircuitPhase::HalfOpen => {
-                // Only the admitted probe decides the half-open outcome. A
-                // same-generation non-probe (shouldn't normally happen, but be
-                // defensive) must not close the breaker early or restart cooldown.
-                if !token.is_probe {
-                    return None;
-                }
-                match outcome {
-                    // The probe reached the downstream and it answered: recovered.
-                    AttemptOutcome::Success => {
-                        st.close();
-                        Some(CircuitTransition::Closed)
-                    }
-                    // The probe failed transiently: the downstream is still down.
-                    AttemptOutcome::RetryableFailure => {
-                        st.trip(now);
-                        Some(CircuitTransition::Tripped)
-                    }
-                    // A non-retryable per-request error (e.g. bad input) does NOT
-                    // prove the downstream recovered — the error may have been
-                    // produced before the dependency was even touched. Treat the
-                    // probe as inconclusive: release the probe slot and re-arm the
-                    // cooldown so a fresh probe is admitted later, but emit no
-                    // transition (it is neither a recovery nor a downstream trip).
-                    AttemptOutcome::NonRetryableFailure => {
-                        st.trip(now);
-                        None
-                    }
-                }
-            }
+            CircuitPhase::Closed => st.handle_closed_phase_result(outcome, now, &policy),
+            CircuitPhase::HalfOpen => st.handle_half_open_phase_result(outcome, token, now),
             // A result arriving while fully open (no probe admitted) is a
             // stale straggler; leave the breaker untouched.
             CircuitPhase::Open => None,

--- a/plan.md
+++ b/plan.md
@@ -1,0 +1,7 @@
+1. **Refactor `on_result` in `autumn-harvest/src/circuit_breaker.rs`:**
+   - Extract the nested logic within `match st.phase` into smaller helper methods on `BreakerState`.
+   - Create `handle_closed_phase_result` and `handle_half_open_phase_result` methods to handle the respective phases.
+   - This directly targets a "Pyramid of Doom" readability smell identified in Forge's guidelines by reducing nesting and extracting logic into named helpers.
+2. **Complete pre-commit steps to ensure proper testing, verification, review, and reflection are done.**
+3. **Submit the PR:**
+   - Follow Forge's required PR formatting.


### PR DESCRIPTION
🚮 Smell
The `on_result` method in `circuit_breaker.rs` contained deeply nested `match` statements ("Pyramid of Doom"). It first matched on `st.phase`, and then inside the `Closed` and `HalfOpen` arms, it matched again on `outcome`. This made the function long and difficult to follow, hiding the core state transitions.

✨ Solution
Extracted the inner `match outcome` logic for the `Closed` and `HalfOpen` phases into two new private helper methods on `BreakerState`: `handle_closed_phase_result` and `handle_half_open_phase_result`. The original `on_result` method now delegates directly to these cleanly named helpers. 

🧼 Benefit
Dramatically improves readability by reducing nesting and flattening the control flow. The `on_result` function is now much shorter and its primary dispatch logic based on the circuit phase is immediately obvious. The complex retry/probe logic is neatly encapsulated in the helper methods. Zero logic or behavior was changed.

🛡️ Verification
Tests passed. No logic changed. Compiled successfully and passed all 21 tests in `circuit_breaker.rs`. Full workspace formatting and linting (clippy) also pass (including a minor fix for a `doc_markdown` lint in `determinism_lint.rs`).

---
*PR created automatically by Jules for task [17497283362583777369](https://jules.google.com/task/17497283362583777369) started by @madmax983*