### PR TITLE
⚒️ Forge: Extract tokenize_requirements

### DIFF
--- a/autumn-harvest/src/eligibility.rs
+++ b/autumn-harvest/src/eligibility.rs
@@ -33,6 +33,13 @@ pub fn parse_requirements(s: &str) -> Result<Vec<Requirement>, String> {
         return Ok(Vec::new());
     }
 
+    tokenize_requirements(s)?
+        .into_iter()
+        .map(|token| parse_single_requirement(&token))
+        .collect()
+}
+
+fn tokenize_requirements(s: &str) -> Result<Vec<String>, String> {
     let mut tokens = Vec::new();
     let mut current = String::new();
     let mut in_brackets = false;
@@ -79,12 +86,7 @@ pub fn parse_requirements(s: &str) -> Result<Vec<Requirement>, String> {
         tokens.push(trimmed.to_string());
     }
 
-    let mut requirements = Vec::new();
-    for token in tokens {
-        requirements.push(parse_single_requirement(&token)?);
-    }
-
-    Ok(requirements)
+    Ok(tokens)
 }
 
 fn find_operator_indices(token: &str) -> (Option<usize>, Option<usize>) {

--- a/autumn-harvest/tests/integration/query_terminal_tests.rs
+++ b/autumn-harvest/tests/integration/query_terminal_tests.rs
@@ -159,7 +159,9 @@ fn await_condition_workflow<'a>(
 
         // Park forever on a predicate that never holds. `await_condition` pushes
         // no command and never wakes — during a query drive nothing re-polls it.
-        ctx.await_condition(|| false).await.map_err(|e| e.to_string())?;
+        ctx.await_condition(|| false)
+            .await
+            .map_err(|e| e.to_string())?;
         // Unreachable: the predicate is always false.
         Ok(Value::Null)
     })
@@ -696,9 +698,13 @@ async fn async_driver_in_runtime_yield_now_spin_drives_to_deadline() {
     // A small budget bounds the spin; the driver re-checks the deadline at the
     // top of each cycle and yields the runtime between polls, so it never hangs
     // or starves other tasks.
-    let outcome =
-        drive_query_replay_async(&ctx, spinning_query_workflow, input, Duration::from_millis(50))
-            .await;
+    let outcome = drive_query_replay_async(
+        &ctx,
+        spinning_query_workflow,
+        input,
+        Duration::from_millis(50),
+    )
+    .await;
     assert_eq!(
         outcome,
         QueryReplayOutcome::TimedOut,


### PR DESCRIPTION
🚮 Smell
The `parse_requirements` function in `autumn-harvest/src/eligibility.rs` was a "God Function" (>50 lines) that contained a pyramid of doom and mixed multiple concerns. It manually iterated through characters to tokenize a string, handled brackets and quotes, and simultaneously parsed the tokens. The result was aggregated manually using a `for` loop pushing to a `Vec`.

✨ Solution
I applied the Extract refactoring to pull the string tokenization logic (handling brackets, quotes, and commas) into a new private helper function called `tokenize_requirements(s: &str) -> Result<Vec<String>, String>`. I then updated the main `parse_requirements` function to call this helper and process the tokens using a clean, idiomatic iterator pipeline: `.into_iter().map(|token| parse_single_requirement(&token)).collect()`.

🧼 Benefit
Reduces cognitive load by separating the tokenization concern from the parsing concern. The main function is now extremely short and clearly demonstrates the pipeline flow. Replaces a manual `for` loop with a declarative `.collect()` that automatically handles `Result` short-circuiting natively, making it more idiomatic Rust.

🛡️ Verification
Tests passed. No logic changed. Verified via `cargo test -p autumn-harvest --lib eligibility`.

---
*PR created automatically by Jules for task [16995077174580399277](https://jules.google.com/task/16995077174580399277) started by @madmax983*