### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/autumn-harvest-macros/src/determinism_lint.rs
+++ b/autumn-harvest-macros/src/determinism_lint.rs
@@ -929,7 +929,7 @@ mod hvg011_tests {
     //! iteration-order determinism.
     //!
     //! NOTE on the rule ID: issue #785's text proposed HVG010, but HVG010 was
-    //! already permanently assigned to SelectMacro (issue #600) and rule IDs
+    //! already permanently assigned to `SelectMacro` (issue #600) and rule IDs
     //! are never reused, so the iteration-order rule ships as HVG011.
 
     use super::{DeterminismVisitor, LinterFinding, load_catalog_metadata};
@@ -1603,7 +1603,7 @@ mod hvg010_combinator_tests {
     //! The select-macro positive case is covered by the
     //! `hvg010_select_macro.rs` compile-fail fixture; the activity-body
     //! negative case (AC6) is covered by the `#[activity]` macro never running
-    //! this visitor (see `suppressed_guardrails.rs` and the det_check
+    //! this visitor (see `suppressed_guardrails.rs` and the `det_check`
     //! `det011_activity_bodies_are_never_flagged` test) — the visitor lints
     //! whatever `fn` it is handed, so an "activity" negative cannot be
     //! expressed at this layer.

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -17799,6 +17799,47 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn invoke_update_handler_inherits_context_properties() {
+        let ctx = WorkflowContext::new_test()
+            .with_workflow_id("test-wfid")
+            .with_workflow_name("test-wfname")
+            .with_execution_timeout(Some(chrono::Duration::seconds(100)));
+
+        let mut headers = std::collections::HashMap::new();
+        headers.insert("trace-id".to_string(), "123".to_string());
+        let ctx = ctx.with_context_headers(headers);
+
+        let info = crate::info::UpdateHandlerInfo {
+            name: "test_update",
+            module: "test",
+            workflow: "test_wfname",
+            validator: None,
+            mcp: false,
+            input_type_hint: "()",
+            output_type_hint: "()",
+            has_validator: false,
+            handler: |update_ctx, _input| {
+                Box::pin(async move {
+                    assert_eq!(update_ctx.workflow_id(), "test-wfid");
+                    assert_eq!(update_ctx.workflow_name, "test-wfname");
+                    assert_eq!(update_ctx.header("trace-id"), Some("123"));
+                    // Inherits parent execution timeout
+                    assert!(update_ctx.execution_timeout.is_some());
+                    Ok(serde_json::Value::Null)
+                })
+            },
+        };
+
+        ctx.register_declarative_update_handler(&info);
+
+        let future = ctx
+            .invoke_update("test_update", serde_json::Value::Null)
+            .unwrap();
+        let result = future.await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
     async fn test_await_all_handlers_finished() {
         let update_id = UpdateId::new();
         let events = vec![

--- a/autumn-harvest/tests/integration/query_terminal_tests.rs
+++ b/autumn-harvest/tests/integration/query_terminal_tests.rs
@@ -159,7 +159,9 @@ fn await_condition_workflow<'a>(
 
         // Park forever on a predicate that never holds. `await_condition` pushes
         // no command and never wakes — during a query drive nothing re-polls it.
-        ctx.await_condition(|| false).await.map_err(|e| e.to_string())?;
+        ctx.await_condition(|| false)
+            .await
+            .map_err(|e| e.to_string())?;
         // Unreachable: the predicate is always false.
         Ok(Value::Null)
     })
@@ -696,9 +698,13 @@ async fn async_driver_in_runtime_yield_now_spin_drives_to_deadline() {
     // A small budget bounds the spin; the driver re-checks the deadline at the
     // top of each cycle and yields the runtime between polls, so it never hangs
     // or starves other tasks.
-    let outcome =
-        drive_query_replay_async(&ctx, spinning_query_workflow, input, Duration::from_millis(50))
-            .await;
+    let outcome = drive_query_replay_async(
+        &ctx,
+        spinning_query_workflow,
+        input,
+        Duration::from_millis(50),
+    )
+    .await;
     assert_eq!(
         outcome,
         QueryReplayOutcome::TimedOut,


### PR DESCRIPTION
🎯 Target: `register_declarative_update_handler` and `invoke_update` inside `autumn-harvest/src/context.rs`.
💣 Risk: `Arc::get_mut(&mut ctx).unwrap()` relies on the internal property that there are absolutely no other concurrent references mapped to the same context yet. If parent properties were not correctly passed to this extracted macro or inherited incorrectly, the handler logic or the unwrap could silently fail or panic.
🧪 Strategy: Mocked a `WorkflowContext` with specific properties and headers set, registered an update handler with an inner assertion logic loop checking all identical context attributes, and dispatched the future manually.
🔬 Verification: Run `cargo test -p autumn-harvest --lib context` for the entire context module unit test block.

---
*PR created automatically by Jules for task [14429700250081839699](https://jules.google.com/task/14429700250081839699) started by @madmax983*