### PR TITLE
clippy: is_ok_and rewrite — heals inherited trunk Lint red

### DIFF
--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -17510,8 +17510,7 @@ async fn get_schedule(
             // Tick-exact shard-local basis (RUNNING/PAUSED + #607 pending throttle).
             at_capacity = autumn_harvest::scheduler::schedule_running_basis(&mut conn, name)
                 .await
-                .map(|basis| basis >= i64::from(sched.max_active_runs))
-                .unwrap_or(false);
+                .is_ok_and(|basis| basis >= i64::from(sched.max_active_runs));
             effective_fire_at = autumn_harvest::scheduler::resolve_effective_fire_at(
                 &mut conn,
                 sched.calendar_name.as_deref(),
@@ -18083,8 +18082,7 @@ async fn upsert_workflow_schedule_and_read_back(
         .unwrap_or("");
     let at_capacity = autumn_harvest::scheduler::schedule_running_basis(conn, name)
         .await
-        .map(|basis| basis >= i64::from(row.max_active_runs))
-        .unwrap_or(false);
+        .is_ok_and(|basis| basis >= i64::from(row.max_active_runs));
     // Calendar-adjusted fire time (Codex round 3), resolved on the same shard
     // conn, so a re-registered calendar-deferred schedule is not falsely flagged.
     let effective_fire_at = autumn_harvest::scheduler::resolve_effective_fire_at(


### PR DESCRIPTION
## What

Heals the pre-existing `clippy::map_unwrap_or` Lint failure on `trunk-dev` that every open PR (including docs PR #1062) inherits. The Lint job's `cargo clippy -p autumn-harvest-plugin --all-targets -- -D warnings` step fails on two `.map(<pred>).unwrap_or(false)` calls in `autumn-harvest-plugin/src/api.rs`.

## Why

`-D warnings` promotes `clippy::map_unwrap_or` to an error, so the Lint check is red on any branch cut from current trunk regardless of that branch's own changes. This is a minimal, isolated heal so unrelated PRs can go green.

## The fix — exactly two sites

Each `.map(<pred>).unwrap_or(false)` on a `Result` is rewritten to `.is_ok_and(<pred>)` — a semantically identical transform (`Result::is_ok_and` returns `false` on `Err`, else applies the predicate to the `Ok` value). The predicate closure is preserved verbatim in both cases.

- `get_schedule` (~L17513): `schedule_running_basis(...).await.map(|basis| basis >= i64::from(sched.max_active_runs)).unwrap_or(false)` → `.is_ok_and(|basis| basis >= i64::from(sched.max_active_runs))`
- `upsert_workflow_schedule_and_read_back` (~L18086): same transform against `row.max_active_runs`

No other changes — no additional cleanup, no behavior change.

## Verification

Ran the full `lint` job locally (`cargo fmt --all -- --check` + every clippy step) — all green, including the previously-failing `cargo clippy -p autumn-harvest-plugin --all-targets -- -D warnings`.

Precedent: identical `clippy::map_unwrap_or` heals in #1014 and #1060.

---
_Generated by [Claude Code](https://claude.ai/code/session_01L4F2aU2d1cSbJPjveJb66R)_