### PR TITLE
ci: reclaim runner disk before the heavy plugin integration compile step

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -197,6 +197,13 @@ jobs:
       # guard that keeps the manifest honest. Per-step `if:` gating is preserved
       # exactly (NOT hoisted to a job-level `if:` — see the note on the `test`
       # job above); `shell: bash` resolves to Git Bash on Windows.
+      - name: Free runner disk before heavy plugin link (Linux)
+        if: runner.os == 'Linux' && needs.changes.outputs.code == 'true'
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
+            /usr/local/share/boost /usr/lib/jvm "$AGENT_TOOLSDIRECTORY" || true
+          sudo docker image prune --all --force > /dev/null 2>&1 || true
+          df -h /
       - name: Compile plugin integration test suites (manifest, all OSes)
         if: needs.changes.outputs.code == 'true'
         shell: bash


### PR DESCRIPTION
## What & why

The `Test` (ubuntu-latest) job's **"Compile plugin integration test suites (manifest, all OSes)"** step (`.github/ci/run-suites.sh compile`) links **21 `*_integration` test binaries** (each ~200+ rlibs, `debuginfo=2`) in one `cargo test --no-run` invocation and exhausts the runner's ~14GB disk. The failure surfaces intermittently as:

- `rustc-LLVM ERROR: No space left on device`
- `ld: ... signal 7 [Bus error]` (SIGBUS in the linker — the classic symptom of the output file/mmap hitting a full filesystem mid-link)

This is a **runner disk-exhaustion flake, not a source/cross-PR compile error**: there are 0 rustc errors, and the suites compile clean locally with headroom. The job's existing `Free disk space` (`cargo clean`) step runs *early*, and many `target/`-repopulating steps execute between it and this peak-disk compile, so it provides no headroom by the time the 21-binary link runs.

## The fix

Reclaim ~25–30GB of unused **preinstalled** runner toolchains (dotnet, android SDK, ghc, boost, jvm, and the agent tools cache) plus dangling docker images, immediately before the heavy step:

```yaml
      - name: Free runner disk before heavy plugin link (Linux)
        if: runner.os == 'Linux' && needs.changes.outputs.code == 'true'
        run: |
          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc \
            /usr/local/share/boost /usr/lib/jvm "$AGENT_TOOLSDIRECTORY" || true
          sudo docker image prune --all --force > /dev/null 2>&1 || true
          df -h /
```

- **Linux-only + code-gated.** The `if:` is copied verbatim from the adjacent Linux Docker-backed manifest step (`runner.os == 'Linux' && needs.changes.outputs.code == 'true'`), so it matches the job's existing docs-only skip contract and never runs on macOS/Windows (which use different toolcache paths and don't hit this flake).
- **No `target/` touched** → no `Swatinem/rust-cache` invalidation; only preinstalled, build-unrelated toolchains are removed.
- **Never fails the job.** Every reclaim command is `|| true`; the step ends with `df -h /` for observability of the reclaimed headroom in the logs.

## Scope

CI-infra only. No source, test, or runtime-behavior change — a single 7-line step added to `.github/workflows/ci.yml`.

## Notes

- The proposed fix is per the earlier flake diagnosis (relayed by the coordinator; the diagnosis scratchpad is local-session-only and not linked here). The gate expression was verified directly against `ci.yml` rather than assumed — it is the same condition every code-gated step in the `test` job uses, copied verbatim from the adjacent Linux step.
- Referenced PR **#1074** could not be located in this repository (`404`), and no existing PR documents a "disk-mode" section, so no such cross-reference is made here.

## Related

Refs #1074 (CI flakiness tracker — disk-exhaustion sibling mode). #1074 is an **issue** (not a PR), which is why the earlier lookup 404'd; this disk-exhaustion flake on the plugin integration compile-link step is a sibling of the timing/timeout flakes tracked there.

_Draft — CI-infra only; not marked ready-for-review._

---
_Generated by [Claude Code](https://claude.ai/code/session_015EZry7sFuoQ7pzTXogESZa)_