### PR TITLE
test(#1074): harden nd_blocked_cycle_does_not_emit_signal_unhandled against loaded-runner timeout

### DIFF
--- a/autumn-harvest/tests/integration/nd_block_tests.rs
+++ b/autumn-harvest/tests/integration/nd_block_tests.rs
@@ -480,7 +480,10 @@ async fn wait_for_nd_block(
     exec_id: ExecutionId,
     count: i32,
 ) -> (bool, Option<String>, i32, Option<Value>) {
-    for _ in 0..400 {
+    // ~40s budget (800 × 50ms): belt-and-braces against a loaded runner. Only
+    // affects how long a *failing* wait tolerates before panicking — a satisfied
+    // wait still returns early, so no passing test's timing semantics change.
+    for _ in 0..800 {
         let row = get_nd_block_row(conn, exec_id).await;
         if row.2 >= count && row.0 {
             return row;
@@ -1263,6 +1266,15 @@ async fn nd_blocked_cycle_does_not_emit_signal_unhandled() {
     // Phase 2: v2 diverges (schedules an activity where v1 recorded a timer) —
     // the cycle ND-blocks and must never reach the terminal-emit site.
     fire_timer_now(&mut conn, exec_b).await;
+    // Backdating `harvest_timers.fires_at` alone is not enough: the parked
+    // workflow task's `scheduled_at` was set to the timer's original `fires_at`
+    // (now + 300s) by `reschedule_task` at suspension, so the divergent worker
+    // cannot re-claim it within the poll window — the test then races worker2's
+    // own timer-scan → append `TimerFired` → re-pend chain against the
+    // `wait_for_nd_block` budget and times out on loaded runners. Make the task
+    // claimable now so worker2 replays the recorded history and blocks promptly
+    // (mirrors `divergent_replay_blocks_instead_of_failing`).
+    make_task_claimable_now(&mut conn, exec_b).await;
     let (worker2, handle2) = spawn_worker(
         make_worker(
             vec![wf_info("nd_wf", divergent_v2_handler)],

--- a/docs/changelog.d/pr-nd-block-flake-hardening.md
+++ b/docs/changelog.d/pr-nd-block-flake-hardening.md
@@ -1,0 +1,26 @@
+## Trunk hardening — de-flake `nd_blocked_cycle_does_not_emit_signal_unhandled` (Refs #1074)
+
+**Test-code-only.** The issue #603/#684 engine test
+`nd_block_tests::nd_blocked_cycle_does_not_emit_signal_unhandled` timed out
+intermittently on loaded CI runners. Its `wait_for_nd_block` poll helper
+(~20s budget) exhausted because the test relied on worker2's own
+timer-scan → append `TimerFired` → re-pend the parked task → claim →
+divergent-replay chain to complete inside the budget: the parked workflow
+task's `scheduled_at` had been set to the timer's original `fires_at`
+(`now + 300s`) at suspension, so backdating `harvest_timers.fires_at` alone
+(`fire_timer_now`) does not make the task re-claimable within the poll
+window.
+
+Fix (mirrors the already-passing sibling
+`divergent_replay_blocks_instead_of_failing`): call
+`make_task_claimable_now(&mut conn, exec_b)` immediately after
+`fire_timer_now(...)`, so the parked task becomes immediately claimable and
+worker2 replays the recorded history and ND-blocks promptly (the test now
+finishes in ~2s instead of racing the timer-scan chain against the 20s
+budget). Belt-and-braces: widen the local `wait_for_nd_block` loop bound
+from 400 to 800 iterations (~20s → ~40s) — this only extends how long a
+*failing* wait tolerates before panicking; a satisfied wait still returns
+early, so no passing test's timing semantics change.
+
+No production code touched. Verified 5×-green against a local Postgres 16
+via `HARVEST_TEST_DATABASE_URL` (no Docker in this sandbox). Refs #1074.


### PR DESCRIPTION
## What

**Test-code-only** trunk hardening. De-flakes the issue #603/#684 engine test `nd_block_tests::nd_blocked_cycle_does_not_emit_signal_unhandled`, which times out intermittently on loaded CI runners.

`Refs #1074` (that issue tracks both this test and the separate #601 wall-clock sibling — this PR fixes only the nd_block one, so no `Closes`).

## The flake

The test's `wait_for_nd_block` poll helper (~`for _ in 0..400 { sleep 50ms }` = ~20s budget) exhausts because the test relied on worker2's own timer-scan → append `TimerFired` → re-pend the parked task → claim → divergent-replay chain to finish inside the budget. The parked workflow task's `scheduled_at` was set to the timer's original `fires_at` (`now + 300s`) at suspension, so backdating `harvest_timers.fires_at` alone (`fire_timer_now`) does **not** make the task re-claimable within the poll window. On a loaded runner the timer-scan chain loses the race against the budget → timeout panic.

The **passing sibling** `divergent_replay_blocks_instead_of_failing` already documents and handles exactly this: it calls `make_task_claimable_now(...)` right after `fire_timer_now(...)`. The failing test simply never mirrored that step.

## The fix

- Add `make_task_claimable_now(&mut conn, exec_b).await;` immediately after `fire_timer_now(...)` in `nd_blocked_cycle_does_not_emit_signal_unhandled`, mirroring the passing sibling. The parked task becomes immediately claimable, so worker2 replays the recorded history and ND-blocks promptly (the test now finishes in **~2s** instead of racing the timer-scan chain against the ~20s budget).
- Belt-and-braces: widen the local `wait_for_nd_block` loop bound `400 → 800` (~20s → ~40s). This only extends how long a *failing* wait tolerates before panicking; a satisfied wait still returns early, so **no passing test's timing semantics change**.

**No production code touched. No SQLite spike files touched.** Diff is `nd_block_tests.rs` (2 hunks) + one changelog fragment.

```
 autumn-harvest/tests/integration/nd_block_tests.rs | 14 +++++++++++-
 docs/changelog.d/pr-nd-block-flake-hardening.md    | 26 ++++++++++++++++++++++
```

## Verification (local Postgres 16 — no Docker in this sandbox)

Ran against a real local PG16 via `HARVEST_TEST_DATABASE_URL` (the harness uses it when set, else testcontainers). The target test passed **5/5 consecutive runs**, each finishing in ~2s:

```
=== run 1..5 ===
test nd_block_tests::nd_blocked_cycle_does_not_emit_signal_unhandled ... ok
test result: ok. 1 passed; 0 failed; ...; finished in ~2.0s   (×5)
```

Full `nd_block` suite note: the other 8 `nd_block` tests use the **Docker-only** `setup()` path (a testcontainer `.start()` at `nd_block_tests.rs:218`) and cannot run in this no-Docker sandbox — they panic on `expect("failed to start Postgres container")` and fail **identically on unmodified `trunk-dev`** here. My change touches neither `setup()` nor those tests. Both nd_block tests that use the Docker-optional `setup_env_or_container()` path (my target + `genuine_terminal_with_undrained_signal_emits_signal_unhandled`) **pass**. The reference sibling I mirrored, `divergent_replay_blocks_instead_of_failing`, is itself Docker-only, so it was not executed here — but its proven pattern is what this PR copies.

## Guards

- `cargo fmt --all -- --check` → clean
- `cargo +1.97.0 clippy -p autumn-harvest --all-features --tests -- -D warnings` → clean (CI toolchain)
- `cargo test -p autumn-harvest --no-default-features --test changelog_convention` → ok


---
_Generated by [Claude Code](https://claude.ai/code/session_01GdtMcR6k4D2xVzbn29PhuT)_