### PR TITLE
lint: heal trunk under clippy 1.97 — cfg-gate throttle const + doc_markdown backticks

### DIFF
--- a/autumn-harvest-macros/src/determinism_lint.rs
+++ b/autumn-harvest-macros/src/determinism_lint.rs
@@ -929,7 +929,7 @@ mod hvg011_tests {
     //! iteration-order determinism.
     //!
     //! NOTE on the rule ID: issue #785's text proposed HVG010, but HVG010 was
-    //! already permanently assigned to SelectMacro (issue #600) and rule IDs
+    //! already permanently assigned to `SelectMacro` (issue #600) and rule IDs
     //! are never reused, so the iteration-order rule ships as HVG011.
 
     use super::{DeterminismVisitor, LinterFinding, load_catalog_metadata};
@@ -1603,7 +1603,7 @@ mod hvg010_combinator_tests {
     //! The select-macro positive case is covered by the
     //! `hvg010_select_macro.rs` compile-fail fixture; the activity-body
     //! negative case (AC6) is covered by the `#[activity]` macro never running
-    //! this visitor (see `suppressed_guardrails.rs` and the det_check
+    //! this visitor (see `suppressed_guardrails.rs` and the `det_check`
     //! `det011_activity_bodies_are_never_flagged` test) — the visitor lints
     //! whatever `fn` it is handed, so an "activity" negative cannot be
     //! expressed at this layer.

--- a/autumn-harvest/src/throttle.rs
+++ b/autumn-harvest/src/throttle.rs
@@ -141,6 +141,11 @@ pub const THROTTLE_FIRE_PER_KEY_CAP: i64 = 10;
 /// candidate floor), so pushing `deferred_at` into the future never hides an
 /// expired row from its drop — `expires_at` is left untouched, so a gated row
 /// still times out at its original deadline.
+// Gated to match its sole user (the db-only throttle scanner path,
+// `redefer_throttle_row`/`fire_claimed_throttle_row`): without this the const is
+// dead code under narrow feature sets (e.g. the CLI Lint job, which compiles
+// `autumn-harvest` without `db`), surfaced by clippy 1.97 `-D warnings`.
+#[cfg(feature = "db")]
 const GATE_REDEFER_BACKOFF: Duration = Duration::from_secs(5);
 
 /// Maximum allowed byte length for a resolved throttle key.


### PR DESCRIPTION
## What

Two trivial lint heals for trunk-dev, both the same class: the **clippy 1.97 toolchain bump** newly rejects code that was clean on the prior toolchain. Each is independent of the feature work that authored the surrounding code.

### Heal 1 — cfg-gate `GATE_REDEFER_BACKOFF` (throttle const, from #1073)
`GATE_REDEFER_BACKOFF` is only referenced under the `db` feature, so the CLI Lint job (which builds a narrow feature set without `db`) flagged it as dead code. Fixed with `#[cfg(feature = "db")]` on the const so it only compiles for its db-only user. (commit `614beb0`)

### Heal 2 — doc_markdown backticks in `determinism_lint.rs` (macros Lint, #1055 det_check text)
The macros Lint job is red under clippy 1.97 on `clippy::doc_markdown` ("item in documentation is missing backticks") at `determinism_lint.rs:932:41` (`SelectMacro`) and `:1606:62` (`det_check`). Wrapped the flagged identifiers in backticks. No behavior change. (commit `9d35bf8`)

## Verification

All under `cargo +1.97.0`, all EXIT=0:
- `-p autumn-harvest --all-features --tests -- -D warnings`
- `-p autumn-harvest-plugin --all-targets -- -D warnings`
- `-p autumn-harvest-cli --all-targets -- -D warnings`
- `-p autumn-harvest-macros --all-targets -- -D warnings`
- `cargo +1.97.0 fmt --all -- --check`

Both are surgical, no-behavior-change heals that unblock the Lint job on every open PR.

Sources: #1073 (throttle const), #1055 (det_check text). Precedent: #1065 (prior clippy-1.97 Lint heal).

Kept as **draft** — do not merge.