### PR TITLE
feat(#620): builder-level default activity retry & timeout floor

### DIFF
--- a/.github/ci/integration-suites.txt
+++ b/.github/ci/integration-suites.txt
@@ -45,6 +45,7 @@ allos        autumn-harvest-plugin  contract_regression              -          
 allos        autumn-harvest-plugin  effective_config_http_tests      -                          -
 compileonly  autumn-harvest-plugin  mcp_tools_integration            mcp,unified-dag-execution  -
 compileonly  autumn-harvest-plugin  status_summary_localpg           -                          -
+linux        autumn-harvest         integration                      -                          activity_default_floor_tests
 linux        autumn-harvest         integration                      -                          activity_interceptor_tests
 linux        autumn-harvest         integration                      -                          admission_gate_authoritative
 linux        autumn-harvest         integration                      -                          child_timeout_tests

--- a/autumn-harvest-plugin/tests/read_path_decode_integration.rs
+++ b/autumn-harvest-plugin/tests/read_path_decode_integration.rs
@@ -1050,6 +1050,7 @@ async fn stack_pending_local_activity_surfaces_last_failure() {
                 activity_id,
                 name: "compute_checksum".to_string(),
                 input: json!({"blob": "abc"}),
+                retry_policy: None,
             },
             WorkflowEvent::LocalActivityFailed {
                 activity_id,
@@ -1107,6 +1108,7 @@ async fn stack_exhausted_local_activity_is_not_pending() {
                 activity_id,
                 name: "compute_checksum".to_string(),
                 input: json!({"blob": "abc"}),
+                retry_policy: None,
             },
             WorkflowEvent::LocalActivityFailed {
                 activity_id,
@@ -1163,6 +1165,7 @@ async fn stack_removed_local_activity_failure_is_not_decoded_or_audited() {
                 activity_id,
                 name: "compute_checksum".to_string(),
                 input: json!({"blob": "abc"}),
+                retry_policy: None,
             },
             WorkflowEvent::LocalActivityFailed {
                 activity_id,

--- a/autumn-harvest-plugin/tests/read_path_decode_integration.rs
+++ b/autumn-harvest-plugin/tests/read_path_decode_integration.rs
@@ -1051,6 +1051,8 @@ async fn stack_pending_local_activity_surfaces_last_failure() {
                 name: "compute_checksum".to_string(),
                 input: json!({"blob": "abc"}),
                 retry_policy: None,
+                resolved: false,
+                start_to_close_millis: None,
             },
             WorkflowEvent::LocalActivityFailed {
                 activity_id,
@@ -1109,6 +1111,8 @@ async fn stack_exhausted_local_activity_is_not_pending() {
                 name: "compute_checksum".to_string(),
                 input: json!({"blob": "abc"}),
                 retry_policy: None,
+                resolved: false,
+                start_to_close_millis: None,
             },
             WorkflowEvent::LocalActivityFailed {
                 activity_id,
@@ -1166,6 +1170,8 @@ async fn stack_removed_local_activity_failure_is_not_decoded_or_audited() {
                 name: "compute_checksum".to_string(),
                 input: json!({"blob": "abc"}),
                 retry_policy: None,
+                resolved: false,
+                start_to_close_millis: None,
             },
             WorkflowEvent::LocalActivityFailed {
                 activity_id,

--- a/autumn-harvest-plugin/tests/read_path_decode_integration.rs
+++ b/autumn-harvest-plugin/tests/read_path_decode_integration.rs
@@ -1052,7 +1052,7 @@ async fn stack_pending_local_activity_surfaces_last_failure() {
                 input: json!({"blob": "abc"}),
                 retry_policy: None,
                 resolved: false,
-                start_to_close_millis: None,
+                start_to_close_nanos: None,
             },
             WorkflowEvent::LocalActivityFailed {
                 activity_id,
@@ -1112,7 +1112,7 @@ async fn stack_exhausted_local_activity_is_not_pending() {
                 input: json!({"blob": "abc"}),
                 retry_policy: None,
                 resolved: false,
-                start_to_close_millis: None,
+                start_to_close_nanos: None,
             },
             WorkflowEvent::LocalActivityFailed {
                 activity_id,
@@ -1171,7 +1171,7 @@ async fn stack_removed_local_activity_failure_is_not_decoded_or_audited() {
                 input: json!({"blob": "abc"}),
                 retry_policy: None,
                 resolved: false,
-                start_to_close_millis: None,
+                start_to_close_nanos: None,
             },
             WorkflowEvent::LocalActivityFailed {
                 activity_id,

--- a/autumn-harvest-sqlite/src/runtime.rs
+++ b/autumn-harvest-sqlite/src/runtime.rs
@@ -1131,6 +1131,12 @@ impl SqliteRuntime {
             std::collections::HashMap::new(), // context headers (none)
             None,                             // payload offload threshold (none)
             std::sync::Arc::new(NoOpMetrics),
+            // Issue #620: builder-level default activity retry/timeout floor. This
+            // lightweight SQLite driver has no `HarvestBuilder` behind it, so there
+            // is no fleet-wide default to thread — `None`/`None` preserve today's
+            // "no floor" behavior (call-site/activity-level defaults still apply).
+            None,
+            None,
         )
         .await;
 

--- a/autumn-harvest/src/builder.rs
+++ b/autumn-harvest/src/builder.rs
@@ -3723,6 +3723,45 @@ mod tests {
         assert!(result.is_ok());
     }
 
+    // ── Builder-level activity default floor (issue #620) ─────────────────
+    //
+    // RED PHASE: the `default_activity_retry_policy` / `default_activity_start_to_close`
+    // fields and their `with_*` builder methods do not exist yet — this test
+    // fails to COMPILE against the missing `WorkerConfig` symbols until the
+    // green phase adds them. Both default to `None` so an unset config is
+    // byte-for-byte identical to today (opt-in, AC1/AC6).
+
+    #[test]
+    fn worker_config_activity_defaults_default_to_none() {
+        use crate::policy::RetryPolicy;
+
+        let config = WorkerConfig::default();
+        assert!(
+            config.default_activity_retry_policy.is_none(),
+            "default activity retry policy must be unset by default (opt-in)"
+        );
+        assert!(
+            config.default_activity_start_to_close.is_none(),
+            "default activity start_to_close must be unset by default (opt-in)"
+        );
+
+        // The two builder methods set the floors and are chainable.
+        let configured = WorkerConfig::default()
+            .with_default_activity_retry_policy(RetryPolicy::fixed(4, Duration::from_millis(50)))
+            .with_default_activity_start_to_close(Duration::from_secs(300));
+        assert_eq!(
+            configured
+                .default_activity_retry_policy
+                .as_ref()
+                .map(|p| p.max_attempts),
+            Some(4),
+        );
+        assert_eq!(
+            configured.default_activity_start_to_close,
+            Some(Duration::from_secs(300)),
+        );
+    }
+
     // ── Local activity cap tests ──────────────────────────────────────────
 
     #[test]

--- a/autumn-harvest/src/builder.rs
+++ b/autumn-harvest/src/builder.rs
@@ -909,7 +909,11 @@ impl BuiltHarvest {
         .with_current_details_cap(self.max_current_details_bytes)
         .with_max_workflow_attempts_ceiling(self.max_workflow_attempts)
         .with_payload_offloader(self.payload_offloader.clone())
-        .with_activity_interceptors(self.activity_interceptors.clone());
+        .with_activity_interceptors(self.activity_interceptors.clone())
+        .with_activity_defaults(
+            self.worker_config.default_activity_retry_policy.clone(),
+            self.worker_config.default_activity_start_to_close,
+        );
         #[cfg(feature = "wasm-activities")]
         if let Some(store) = self.wasm_store {
             registry = registry.with_wasm_activities(
@@ -966,7 +970,11 @@ impl BuiltHarvest {
         .with_current_details_cap(self.max_current_details_bytes)
         .with_max_workflow_attempts_ceiling(self.max_workflow_attempts)
         .with_payload_offloader(self.payload_offloader.clone())
-        .with_activity_interceptors(self.activity_interceptors.clone());
+        .with_activity_interceptors(self.activity_interceptors.clone())
+        .with_activity_defaults(
+            self.worker_config.default_activity_retry_policy.clone(),
+            self.worker_config.default_activity_start_to_close,
+        );
         #[cfg(feature = "wasm-activities")]
         if let Some(store) = self.wasm_store {
             registry = registry.with_wasm_activities(
@@ -2402,6 +2410,23 @@ pub struct WorkerConfig {
     /// Any local activity registered with `start_to_close > cap` is rejected
     /// at builder `try_build()` time.
     pub max_local_activity_start_to_close: Duration,
+    /// Builder-level default activity retry policy (issue #620).
+    ///
+    /// Applied at schedule time as the lowest-priority fallback in the
+    /// precedence chain: call-site override → activity `#[activity(retry = …)]`
+    /// default → this builder default → implicit fallback. `None` (the default)
+    /// is opt-in — an unset floor leaves today's behaviour byte-for-byte
+    /// unchanged. Set via [`WorkerConfig::with_default_activity_retry_policy`].
+    pub default_activity_retry_policy: Option<crate::policy::RetryPolicy>,
+    /// Builder-level default activity `start_to_close` timeout (issue #620).
+    ///
+    /// Same precedence as [`WorkerConfig::default_activity_retry_policy`]:
+    /// call-site override → activity default → this builder default → no
+    /// timeout. `None` (the default) is opt-in. For *local* activities the
+    /// resolved value is still clamped by
+    /// [`WorkerConfig::max_local_activity_start_to_close`]. Set via
+    /// [`WorkerConfig::with_default_activity_start_to_close`].
+    pub default_activity_start_to_close: Option<Duration>,
     /// How often the worker upserts its liveness row in `harvest_workers`.
     /// Defaults to **5 seconds**. The API classifies a worker as stale after
     /// `2 × worker_heartbeat_interval` without a heartbeat.
@@ -2559,6 +2584,8 @@ impl Default for WorkerConfig {
             cancellation_grace_period: Duration::from_secs(5),
             shard_assignments: vec![ShardId::new(0)],
             max_local_activity_start_to_close: Duration::from_secs(60),
+            default_activity_retry_policy: None,
+            default_activity_start_to_close: None,
             worker_heartbeat_interval: Duration::from_secs(5),
             build_id: String::new(),
             deployment_name: None,
@@ -2957,6 +2984,32 @@ impl WorkerConfig {
     #[must_use]
     pub const fn with_max_concurrent_sessions(mut self, n: i32) -> Self {
         self.max_concurrent_sessions = n;
+        self
+    }
+
+    /// Set the builder-level default activity retry policy (issue #620).
+    ///
+    /// Resolved at schedule time as the lowest-priority fallback: a call-site
+    /// override or an activity's own `#[activity(retry = …)]` default both win
+    /// over this floor. Unset (the default) leaves today's behaviour
+    /// byte-for-byte unchanged.
+    #[must_use]
+    pub fn with_default_activity_retry_policy(
+        mut self,
+        policy: crate::policy::RetryPolicy,
+    ) -> Self {
+        self.default_activity_retry_policy = Some(policy);
+        self
+    }
+
+    /// Set the builder-level default activity `start_to_close` timeout (issue #620).
+    ///
+    /// Same precedence as [`WorkerConfig::with_default_activity_retry_policy`].
+    /// For *local* activities the resolved value is still clamped by
+    /// [`WorkerConfig::max_local_activity_start_to_close`].
+    #[must_use]
+    pub const fn with_default_activity_start_to_close(mut self, timeout: Duration) -> Self {
+        self.default_activity_start_to_close = Some(timeout);
         self
     }
 }

--- a/autumn-harvest/src/builder.rs
+++ b/autumn-harvest/src/builder.rs
@@ -3315,6 +3315,82 @@ mod tests {
         assert_eq!(registry.history_policy().event_hard_cap(), Some(11));
     }
 
+    // Issue #620: the two `into_worker_parts*` hunks copy the builder-level
+    // activity defaults out of `WorkerConfig` and into the `HandlerRegistry`.
+    // Every other #620 test injects them via `HandlerRegistry::
+    // with_activity_defaults` directly, bypassing those hunks — so this test
+    // drives the REAL public entry point (`WorkerConfig::with_default_*` ->
+    // `.worker(..)` -> `.build()` -> `.into_worker_parts()`) and asserts the
+    // registry carries the configured floor. Without the wiring hunks the
+    // registry would report `None` and this test would fail.
+    #[cfg(feature = "db")]
+    #[test]
+    fn harvest_builder_wires_activity_defaults_into_worker_registry() {
+        use crate::policy::RetryPolicy;
+
+        let built = HarvestBuilder::new()
+            .worker(
+                WorkerConfig::default()
+                    .with_default_activity_retry_policy(RetryPolicy::fixed(
+                        7,
+                        Duration::from_millis(25),
+                    ))
+                    .with_default_activity_start_to_close(Duration::from_secs(42)),
+            )
+            .build();
+
+        let (registry, _dags, _workflow_schedules, _worker_config) = built.into_worker_parts();
+
+        assert_eq!(
+            registry
+                .default_activity_retry_policy()
+                .as_ref()
+                .map(|p| p.max_attempts),
+            Some(7),
+            "the builder-level default retry policy must be wired into the registry"
+        );
+        assert_eq!(
+            registry.default_activity_start_to_close(),
+            Some(Duration::from_secs(42)),
+            "the builder-level default start_to_close must be wired into the registry"
+        );
+    }
+
+    // Issue #620: the `into_worker_parts_with_extra_state` hunk is a distinct
+    // code path (used by the plugin's extra-state runner); assert it wires the
+    // same floor. An empty extra-state map is the minimal input.
+    #[cfg(feature = "db")]
+    #[test]
+    fn harvest_builder_extra_state_wires_activity_defaults_into_worker_registry() {
+        use crate::policy::RetryPolicy;
+
+        let built = HarvestBuilder::new()
+            .worker(
+                WorkerConfig::default()
+                    .with_default_activity_retry_policy(RetryPolicy::fixed(
+                        6,
+                        Duration::from_millis(15),
+                    ))
+                    .with_default_activity_start_to_close(Duration::from_secs(17)),
+            )
+            .build();
+
+        let (registry, _dags, _workflow_schedules, _worker_config) =
+            built.into_worker_parts_with_extra_state(crate::context::SharedStateMap::new());
+
+        assert_eq!(
+            registry
+                .default_activity_retry_policy()
+                .as_ref()
+                .map(|p| p.max_attempts),
+            Some(6),
+        );
+        assert_eq!(
+            registry.default_activity_start_to_close(),
+            Some(Duration::from_secs(17)),
+        );
+    }
+
     #[test]
     fn harvest_builder_telemetry_override_is_propagated() {
         use crate::telemetry::{TelemetryConfig, TraceContextCarrier, TraceContextPropagator};

--- a/autumn-harvest/src/builder.rs
+++ b/autumn-harvest/src/builder.rs
@@ -3304,6 +3304,14 @@ mod tests {
     #[cfg(feature = "db")]
     #[test]
     fn harvest_builder_passes_history_policy_to_worker_registry() {
+        // `into_worker_parts` unconditionally writes the process-global
+        // start-idempotency sweep window; serialize against the sibling
+        // `into_worker_parts_installs_configured_start_idempotency_purge_window`
+        // test, which reads that global back (issue #808 / #620).
+        let _guard = crate::start_idempotency::PURGE_WINDOW_TEST_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
         let built = HarvestBuilder::new()
             .history_continue_as_new_threshold(9)
             .history_event_hard_cap(11)
@@ -3327,6 +3335,14 @@ mod tests {
     #[test]
     fn harvest_builder_wires_activity_defaults_into_worker_registry() {
         use crate::policy::RetryPolicy;
+
+        // `into_worker_parts` unconditionally writes the process-global
+        // start-idempotency sweep window; serialize against the sibling
+        // `into_worker_parts_installs_configured_start_idempotency_purge_window`
+        // test, which reads that global back (issue #808 / #620).
+        let _guard = crate::start_idempotency::PURGE_WINDOW_TEST_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
 
         let built = HarvestBuilder::new()
             .worker(
@@ -3363,6 +3379,15 @@ mod tests {
     #[test]
     fn harvest_builder_extra_state_wires_activity_defaults_into_worker_registry() {
         use crate::policy::RetryPolicy;
+
+        // `into_worker_parts_with_extra_state` unconditionally writes the
+        // process-global start-idempotency sweep window; serialize against the
+        // sibling
+        // `into_worker_parts_installs_configured_start_idempotency_purge_window`
+        // test, which reads that global back (issue #808 / #620).
+        let _guard = crate::start_idempotency::PURGE_WINDOW_TEST_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
 
         let built = HarvestBuilder::new()
             .worker(
@@ -3424,6 +3449,14 @@ mod tests {
     #[cfg(feature = "db")]
     #[test]
     fn built_harvest_into_worker_parts_preserves_shared_state() {
+        // `into_worker_parts` unconditionally writes the process-global
+        // start-idempotency sweep window; serialize against the sibling
+        // `into_worker_parts_installs_configured_start_idempotency_purge_window`
+        // test, which reads that global back (issue #808 / #620).
+        let _guard = crate::start_idempotency::PURGE_WINDOW_TEST_LOCK
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner);
+
         let built = HarvestBuilder::new()
             .workflows(vec![fake_workflow_info()])
             .activities(vec![ActivityInfo {

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -4644,10 +4644,26 @@ impl WorkflowContext {
                     ));
                 }
 
+                // Issue #620 (AC8): the retry budget for an in-flight local
+                // activity must come from the policy it was ORIGINALLY scheduled
+                // with — frozen into the `LocalActivityScheduled` event — not a
+                // re-derivation from the current builder default, which may have
+                // changed during the crash-recovery window. Recorded (original)
+                // wins; `None` for a pre-#620 event falls back to today's
+                // re-derived `retry_policy`, preserving backward compatibility.
+                // A pure, cursor-independent read: lock the matcher directly
+                // rather than routing through `match_history` so the
+                // signal-handler pump is not triggered a second time here.
+                let recorded_retry = {
+                    let matcher = self.matcher.lock().expect("matcher lock poisoned");
+                    matcher.recorded_local_activity_retry(activity_id)
+                };
+                let effective_retry = recorded_retry.or(retry_policy);
+
                 // If the recorded failure count already covers all retry
                 // attempts, return the last error immediately — no handler
                 // execution is needed and no command should be pushed.
-                let max_attempts = retry_policy.as_ref().map_or(1, |p| p.max_attempts);
+                let max_attempts = effective_retry.as_ref().map_or(1, |p| p.max_attempts);
                 if failed_attempts >= max_attempts {
                     let error = last_error.unwrap_or_else(|| {
                         format!("local activity '{name}' failed after {failed_attempts} attempts")
@@ -4657,13 +4673,16 @@ impl WorkflowContext {
 
                 // Some retry attempts remain — push the command so the worker
                 // re-runs the handler starting from the next unrecorded attempt.
+                // Thread the ORIGINAL resolved policy so the worker's own
+                // `max_attempts`/backoff derivation stays consistent with the
+                // budget check above (issue #620 AC8).
                 let (tx, rx) = oneshot::channel();
                 self.push_command(WorkflowCommand::RunLocalActivity {
                     activity_id,
                     name: name.to_string(),
                     input,
                     start_to_close_secs,
-                    retry_policy,
+                    retry_policy: effective_retry,
                     result_tx: tx,
                     already_scheduled: true,
                     failed_attempts,
@@ -15778,6 +15797,7 @@ mod tests {
                 activity_id: id,
                 name: "format_data".into(),
                 input: Value::Null,
+                retry_policy: None,
             },
             WorkflowEvent::LocalActivityCompleted {
                 activity_id: id,
@@ -15808,6 +15828,7 @@ mod tests {
                 activity_id: id,
                 name: "format_data".into(),
                 input: Value::Null,
+                retry_policy: None,
             },
             WorkflowEvent::LocalActivityFailed {
                 activity_id: id,
@@ -17696,6 +17717,7 @@ mod tests {
                 activity_id,
                 name: "checksum".into(),
                 input: serde_json::json!("data"),
+                retry_policy: None,
             },
             WorkflowEvent::LocalActivityCompleted {
                 activity_id,

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -354,9 +354,13 @@ pub enum WorkflowCommand {
         name: String,
         /// JSON input for the handler.
         input: Value,
-        /// Optional start-to-close timeout in seconds. `None` defers to the
-        /// worker's `max_local_activity_start_to_close` cap.
-        start_to_close_secs: Option<u64>,
+        /// Optional start-to-close timeout in **milliseconds** (issue #620,
+        /// Codex P2). `None` defers to the worker's
+        /// `max_local_activity_start_to_close` cap. Millis (not seconds) so a
+        /// subsecond builder default / per-call override never truncates to `0`
+        /// and instantly times out — the worker builds the per-attempt timeout as
+        /// `Duration::from_millis(this).min(cap)`.
+        start_to_close_millis: Option<u64>,
         /// Optional retry policy. `None` = no retries (fail immediately).
         retry_policy: Option<crate::policy::RetryPolicy>,
         /// The worker sends the final result (success or exhausted retries) here.
@@ -643,13 +647,13 @@ impl std::fmt::Debug for WorkflowCommand {
             Self::RunLocalActivity {
                 activity_id,
                 name,
-                start_to_close_secs,
+                start_to_close_millis,
                 ..
             } => f
                 .debug_struct("RunLocalActivity")
                 .field("activity_id", activity_id)
                 .field("name", name)
-                .field("start_to_close_secs", start_to_close_secs)
+                .field("start_to_close_millis", start_to_close_millis)
                 .finish_non_exhaustive(),
             Self::UpsertSearchAttributes { patch } => f
                 .debug_struct("UpsertSearchAttributes")
@@ -4551,7 +4555,6 @@ impl WorkflowContext {
     /// # Panics
     ///
     /// Panics if the internal matcher or commands mutex is poisoned.
-    #[allow(clippy::too_many_lines)]
     pub async fn execute_local_activity_raw(
         &self,
         name: &str,
@@ -4559,9 +4562,49 @@ impl WorkflowContext {
         retry_policy: Option<crate::policy::RetryPolicy>,
         start_to_close_secs: Option<u64>,
     ) -> HarvestResult<Value> {
+        // Public seconds-granularity escape hatch (DAG/raw local dispatch). The
+        // whole-second value is exact; the subsecond-capable resolution (builder
+        // default and the typed `_with_opts` per-call/activity override) happens
+        // in `execute_local_activity_raw_resolved`, which preserves millisecond
+        // precision so a subsecond floor never truncates to `0` (issue #620,
+        // Codex P2).
+        self.execute_local_activity_raw_resolved(
+            name,
+            input,
+            retry_policy,
+            start_to_close_secs.map(std::time::Duration::from_secs),
+        )
+        .await
+    }
+
+    /// Core local-activity dispatch state machine underlying
+    /// [`execute_local_activity_raw`](Self::execute_local_activity_raw) and the
+    /// typed [`execute_local_activity_with_opts`](Self::execute_local_activity_with_opts).
+    ///
+    /// `start_to_close` is a full [`std::time::Duration`] so subsecond
+    /// precision survives all the way to the worker's per-attempt timeout
+    /// (issue #620, Codex P2) — the typed path passes a subsecond override/default
+    /// through here without the seconds truncation the public `_raw` escape hatch
+    /// still exposes.
+    ///
+    /// # Errors
+    ///
+    /// Same as [`execute_local_activity_raw`](Self::execute_local_activity_raw).
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal matcher or commands mutex is poisoned.
+    #[allow(clippy::too_many_lines)]
+    async fn execute_local_activity_raw_resolved(
+        &self,
+        name: &str,
+        input: Value,
+        retry_policy: Option<crate::policy::RetryPolicy>,
+        start_to_close: Option<std::time::Duration>,
+    ) -> HarvestResult<Value> {
         // Issue #620: builder-level default activity floor, applied as the
         // lowest-priority fallback. `_with_opts` has already resolved
-        // call-site → activity-level into `retry_policy`/`start_to_close_secs`,
+        // call-site → activity-level into `retry_policy`/`start_to_close`,
         // so appending the builder default here yields the full precedence
         // (call → activity → builder). A direct `_raw` caller with `None`
         // (e.g. a DAG/raw local dispatch) falls straight through to the builder
@@ -4569,8 +4612,14 @@ impl WorkflowContext {
         // regular/remote path resolves the same floor worker-side via the
         // shared `policy::resolve_effective_*` helpers.
         let retry_policy = retry_policy.or_else(|| self.default_activity_retry_policy.clone());
-        let start_to_close_secs = start_to_close_secs
-            .or_else(|| self.default_activity_start_to_close.map(|d| d.as_secs()));
+        let start_to_close = start_to_close.or(self.default_activity_start_to_close);
+        // Millis, not seconds — a subsecond floor (builder default OR per-call
+        // override) MUST NOT truncate to `0`, which would make the worker run
+        // `Duration::from_millis(0)` and instantly time out every attempt
+        // (issue #620, Codex P2). Clamp a pathologically large duration to
+        // `u64::MAX` millis rather than overflow.
+        let start_to_close_millis = start_to_close
+            .map(|d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX));
         let history_match = if self.strict_replay {
             self.match_history(|m| m.match_local_activity_strict(name, &input))
         } else {
@@ -4644,21 +4693,35 @@ impl WorkflowContext {
                     ));
                 }
 
-                // Issue #620 (AC8): the retry budget for an in-flight local
-                // activity must come from the policy it was ORIGINALLY scheduled
-                // with — frozen into the `LocalActivityScheduled` event — not a
-                // re-derivation from the current builder default, which may have
-                // changed during the crash-recovery window. Recorded (original)
-                // wins; `None` for a pre-#620 event falls back to today's
-                // re-derived `retry_policy`, preserving backward compatibility.
+                // Issue #620 (AC8): the retry budget AND per-attempt timeout for
+                // an in-flight local activity must come from the values it was
+                // ORIGINALLY scheduled with — frozen into the
+                // `LocalActivityScheduled` event — not a re-derivation from the
+                // current builder default, which may have changed during the
+                // crash-recovery window.
+                //
+                // The `resolved` marker (Codex P2) disambiguates a #620+ event —
+                // whose frozen retry/STC are authoritative even when `None`
+                // ("explicitly resolved to no floor") — from a genuine pre-#620
+                // legacy event, which has the marker absent and must fall back to
+                // today's live re-derivation for backward compatibility. Without
+                // the marker, a builder default ADDED from nothing after this
+                // activity was scheduled would wrongly apply on recovery.
+                //
                 // A pure, cursor-independent read: lock the matcher directly
                 // rather than routing through `match_history` so the
                 // signal-handler pump is not triggered a second time here.
-                let recorded_retry = {
+                let recorded = {
                     let matcher = self.matcher.lock().expect("matcher lock poisoned");
-                    matcher.recorded_local_activity_retry(activity_id)
+                    matcher.recorded_local_activity_resolution(activity_id)
                 };
-                let effective_retry = recorded_retry.or(retry_policy);
+                let (effective_retry, effective_stc_millis) = if recorded.resolved {
+                    // #620+ event: frozen values (Some OR None) are authoritative.
+                    (recorded.retry_policy, recorded.start_to_close_millis)
+                } else {
+                    // Legacy (pre-#620) event: re-derive from the live defaults.
+                    (retry_policy, start_to_close_millis)
+                };
 
                 // If the recorded failure count already covers all retry
                 // attempts, return the last error immediately — no handler
@@ -4673,15 +4736,15 @@ impl WorkflowContext {
 
                 // Some retry attempts remain — push the command so the worker
                 // re-runs the handler starting from the next unrecorded attempt.
-                // Thread the ORIGINAL resolved policy so the worker's own
-                // `max_attempts`/backoff derivation stays consistent with the
-                // budget check above (issue #620 AC8).
+                // Thread the ORIGINAL resolved policy AND timeout so the worker's
+                // own `max_attempts`/backoff/per-attempt-timeout derivation stays
+                // consistent with the budget check above (issue #620 AC8).
                 let (tx, rx) = oneshot::channel();
                 self.push_command(WorkflowCommand::RunLocalActivity {
                     activity_id,
                     name: name.to_string(),
                     input,
-                    start_to_close_secs,
+                    start_to_close_millis: effective_stc_millis,
                     retry_policy: effective_retry,
                     result_tx: tx,
                     already_scheduled: true,
@@ -4733,7 +4796,7 @@ impl WorkflowContext {
                     activity_id,
                     name: name.to_string(),
                     input,
-                    start_to_close_secs,
+                    start_to_close_millis,
                     retry_policy,
                     result_tx: tx,
                     already_scheduled: false,
@@ -5900,11 +5963,13 @@ impl WorkflowContext {
         }
         let json_input = serde_json::to_value(input)?;
         let retry = retry_override.or_else(|| info.default_retry_policy.clone());
-        let start_to_close_secs = timeout_override
-            .or(info.default_start_to_close)
-            .map(|d| d.as_secs());
+        // Preserve subsecond precision: pass the resolved call → activity
+        // `Duration` straight to the millis-carrying core (issue #620, Codex P2).
+        // The old `.as_secs()` truncated a subsecond override/default to `0`,
+        // instantly timing out every attempt.
+        let start_to_close = timeout_override.or(info.default_start_to_close);
         let raw = self
-            .execute_local_activity_raw(info.name, json_input, retry, start_to_close_secs)
+            .execute_local_activity_raw_resolved(info.name, json_input, retry, start_to_close)
             .await?;
         Ok(serde_json::from_value(raw)?)
     }
@@ -15798,6 +15863,8 @@ mod tests {
                 name: "format_data".into(),
                 input: Value::Null,
                 retry_policy: None,
+                resolved: false,
+                start_to_close_millis: None,
             },
             WorkflowEvent::LocalActivityCompleted {
                 activity_id: id,
@@ -15829,6 +15896,8 @@ mod tests {
                 name: "format_data".into(),
                 input: Value::Null,
                 retry_policy: None,
+                resolved: false,
+                start_to_close_millis: None,
             },
             WorkflowEvent::LocalActivityFailed {
                 activity_id: id,
@@ -17718,6 +17787,8 @@ mod tests {
                 name: "checksum".into(),
                 input: serde_json::json!("data"),
                 retry_policy: None,
+                resolved: false,
+                start_to_close_millis: None,
             },
             WorkflowEvent::LocalActivityCompleted {
                 activity_id,

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -1801,7 +1801,7 @@ pub struct WorkflowContext {
     default_activity_retry_policy: Option<crate::policy::RetryPolicy>,
     /// Builder-level default activity `start_to_close` (issue #620). Used by the
     /// LOCAL activity path (still clamped by the worker's local-STC cap). `None`.
-    default_activity_start_to_close: Option<Duration>,
+    default_activity_start_to_close: Option<std::time::Duration>,
     /// Per-activity input cap overrides: `activity_name → max_bytes`.
     /// When an entry exists, the effective cap is `max(global, override)`.
     activity_input_cap_overrides: HashMap<String, u64>,
@@ -2504,7 +2504,7 @@ impl WorkflowContext {
     pub fn with_activity_defaults(
         mut self,
         retry: Option<crate::policy::RetryPolicy>,
-        start_to_close: Option<Duration>,
+        start_to_close: Option<std::time::Duration>,
     ) -> Self {
         self.default_activity_retry_policy = retry;
         self.default_activity_start_to_close = start_to_close;

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -1796,6 +1796,12 @@ pub struct WorkflowContext {
     /// size cap is not tripped by it. `None` means no store registered — caps are
     /// enforced exactly as before.
     payload_offload_threshold: Option<u64>,
+    /// Builder-level default activity retry policy (issue #620). Used by the
+    /// LOCAL activity path as the lowest-priority fallback. `None` = no floor.
+    default_activity_retry_policy: Option<crate::policy::RetryPolicy>,
+    /// Builder-level default activity `start_to_close` (issue #620). Used by the
+    /// LOCAL activity path (still clamped by the worker's local-STC cap). `None`.
+    default_activity_start_to_close: Option<Duration>,
     /// Per-activity input cap overrides: `activity_name → max_bytes`.
     /// When an entry exists, the effective cap is `max(global, override)`.
     activity_input_cap_overrides: HashMap<String, u64>,
@@ -2193,6 +2199,8 @@ impl WorkflowContext {
             payload_max_side_effect: DEFAULT_MAX_WORKFLOW_INPUT_BYTES,
             payload_max_signal: DEFAULT_MAX_SIGNAL_PAYLOAD_BYTES,
             payload_offload_threshold: None,
+            default_activity_retry_policy: None,
+            default_activity_start_to_close: None,
             activity_input_cap_overrides: HashMap::new(),
             deferred_nd_error: Mutex::new(None),
             current_details_cap: DEFAULT_CURRENT_DETAILS_CAP_BYTES,
@@ -2335,6 +2343,8 @@ impl WorkflowContext {
             payload_max_side_effect: DEFAULT_MAX_WORKFLOW_INPUT_BYTES,
             payload_max_signal: DEFAULT_MAX_SIGNAL_PAYLOAD_BYTES,
             payload_offload_threshold: None,
+            default_activity_retry_policy: None,
+            default_activity_start_to_close: None,
             activity_input_cap_overrides: HashMap::new(),
             deferred_nd_error: Mutex::new(None),
             current_details_cap: DEFAULT_CURRENT_DETAILS_CAP_BYTES,
@@ -2392,6 +2402,8 @@ impl WorkflowContext {
             payload_max_side_effect: DEFAULT_MAX_WORKFLOW_INPUT_BYTES,
             payload_max_signal: DEFAULT_MAX_SIGNAL_PAYLOAD_BYTES,
             payload_offload_threshold: None,
+            default_activity_retry_policy: None,
+            default_activity_start_to_close: None,
             activity_input_cap_overrides: HashMap::new(),
             deferred_nd_error: Mutex::new(None),
             current_details_cap: DEFAULT_CURRENT_DETAILS_CAP_BYTES,
@@ -2479,6 +2491,23 @@ impl WorkflowContext {
     #[must_use]
     pub const fn with_payload_offload_threshold(mut self, threshold: Option<u64>) -> Self {
         self.payload_offload_threshold = threshold;
+        self
+    }
+
+    /// Install the builder-level default activity retry/timeout floor (issue #620).
+    ///
+    /// Consumed by the LOCAL activity path (`execute_local_activity_with_opts`)
+    /// as the lowest-priority fallback. Both `None` (the default) preserves
+    /// today's behaviour. The regular/DAG activity path resolves the same floor
+    /// worker-side in `persist_scheduled_activities`.
+    #[must_use]
+    pub fn with_activity_defaults(
+        mut self,
+        retry: Option<crate::policy::RetryPolicy>,
+        start_to_close: Option<Duration>,
+    ) -> Self {
+        self.default_activity_retry_policy = retry;
+        self.default_activity_start_to_close = start_to_close;
         self
     }
 
@@ -4530,6 +4559,18 @@ impl WorkflowContext {
         retry_policy: Option<crate::policy::RetryPolicy>,
         start_to_close_secs: Option<u64>,
     ) -> HarvestResult<Value> {
+        // Issue #620: builder-level default activity floor, applied as the
+        // lowest-priority fallback. `_with_opts` has already resolved
+        // call-site → activity-level into `retry_policy`/`start_to_close_secs`,
+        // so appending the builder default here yields the full precedence
+        // (call → activity → builder). A direct `_raw` caller with `None`
+        // (e.g. a DAG/raw local dispatch) falls straight through to the builder
+        // default. Both `None` = today's behaviour, byte-for-byte. The
+        // regular/remote path resolves the same floor worker-side via the
+        // shared `policy::resolve_effective_*` helpers.
+        let retry_policy = retry_policy.or_else(|| self.default_activity_retry_policy.clone());
+        let start_to_close_secs = start_to_close_secs
+            .or_else(|| self.default_activity_start_to_close.map(|d| d.as_secs()));
         let history_match = if self.strict_replay {
             self.match_history(|m| m.match_local_activity_strict(name, &input))
         } else {

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -354,13 +354,14 @@ pub enum WorkflowCommand {
         name: String,
         /// JSON input for the handler.
         input: Value,
-        /// Optional start-to-close timeout in **milliseconds** (issue #620,
-        /// Codex P2). `None` defers to the worker's
-        /// `max_local_activity_start_to_close` cap. Millis (not seconds) so a
-        /// subsecond builder default / per-call override never truncates to `0`
-        /// and instantly times out — the worker builds the per-attempt timeout as
-        /// `Duration::from_millis(this).min(cap)`.
-        start_to_close_millis: Option<u64>,
+        /// Optional per-attempt start-to-close timeout as a full
+        /// [`std::time::Duration`] (issue #620, Codex P2). `None` defers to the
+        /// worker's `max_local_activity_start_to_close` cap. A `Duration` (not
+        /// secs/millis) so NO floor — subsecond or sub-millisecond — is ever
+        /// truncated: the worker builds the per-attempt timeout as
+        /// `start_to_close.min(cap)` and feeds it straight to
+        /// `tokio::time::timeout`.
+        start_to_close: Option<std::time::Duration>,
         /// Optional retry policy. `None` = no retries (fail immediately).
         retry_policy: Option<crate::policy::RetryPolicy>,
         /// The worker sends the final result (success or exhausted retries) here.
@@ -647,13 +648,13 @@ impl std::fmt::Debug for WorkflowCommand {
             Self::RunLocalActivity {
                 activity_id,
                 name,
-                start_to_close_millis,
+                start_to_close,
                 ..
             } => f
                 .debug_struct("RunLocalActivity")
                 .field("activity_id", activity_id)
                 .field("name", name)
-                .field("start_to_close_millis", start_to_close_millis)
+                .field("start_to_close", start_to_close)
                 .finish_non_exhaustive(),
             Self::UpsertSearchAttributes { patch } => f
                 .debug_struct("UpsertSearchAttributes")
@@ -4612,14 +4613,11 @@ impl WorkflowContext {
         // regular/remote path resolves the same floor worker-side via the
         // shared `policy::resolve_effective_*` helpers.
         let retry_policy = retry_policy.or_else(|| self.default_activity_retry_policy.clone());
+        // Carry the FULL resolved `Duration` (issue #620, Codex P2) — no
+        // truncation at seconds OR milliseconds, so a subsecond floor
+        // (`from_millis(500)`) and a sub-millisecond floor (`from_micros(500)`)
+        // are both preserved end-to-end to the worker's `tokio::time::timeout`.
         let start_to_close = start_to_close.or(self.default_activity_start_to_close);
-        // Millis, not seconds — a subsecond floor (builder default OR per-call
-        // override) MUST NOT truncate to `0`, which would make the worker run
-        // `Duration::from_millis(0)` and instantly time out every attempt
-        // (issue #620, Codex P2). Clamp a pathologically large duration to
-        // `u64::MAX` millis rather than overflow.
-        let start_to_close_millis = start_to_close
-            .map(|d| u64::try_from(d.as_millis()).unwrap_or(u64::MAX));
         let history_match = if self.strict_replay {
             self.match_history(|m| m.match_local_activity_strict(name, &input))
         } else {
@@ -4715,12 +4713,19 @@ impl WorkflowContext {
                     let matcher = self.matcher.lock().expect("matcher lock poisoned");
                     matcher.recorded_local_activity_resolution(activity_id)
                 };
-                let (effective_retry, effective_stc_millis) = if recorded.resolved {
+                let (effective_retry, effective_stc) = if recorded.resolved {
                     // #620+ event: frozen values (Some OR None) are authoritative.
-                    (recorded.retry_policy, recorded.start_to_close_millis)
+                    // The frozen `start_to_close` is stored as nanos → restore the
+                    // exact `Duration` with no precision loss.
+                    (
+                        recorded.retry_policy,
+                        recorded
+                            .start_to_close_nanos
+                            .map(std::time::Duration::from_nanos),
+                    )
                 } else {
                     // Legacy (pre-#620) event: re-derive from the live defaults.
-                    (retry_policy, start_to_close_millis)
+                    (retry_policy, start_to_close)
                 };
 
                 // If the recorded failure count already covers all retry
@@ -4744,7 +4749,7 @@ impl WorkflowContext {
                     activity_id,
                     name: name.to_string(),
                     input,
-                    start_to_close_millis: effective_stc_millis,
+                    start_to_close: effective_stc,
                     retry_policy: effective_retry,
                     result_tx: tx,
                     already_scheduled: true,
@@ -4796,7 +4801,7 @@ impl WorkflowContext {
                     activity_id,
                     name: name.to_string(),
                     input,
-                    start_to_close_millis,
+                    start_to_close,
                     retry_policy,
                     result_tx: tx,
                     already_scheduled: false,
@@ -15864,7 +15869,7 @@ mod tests {
                 input: Value::Null,
                 retry_policy: None,
                 resolved: false,
-                start_to_close_millis: None,
+                start_to_close_nanos: None,
             },
             WorkflowEvent::LocalActivityCompleted {
                 activity_id: id,
@@ -15897,7 +15902,7 @@ mod tests {
                 input: Value::Null,
                 retry_policy: None,
                 resolved: false,
-                start_to_close_millis: None,
+                start_to_close_nanos: None,
             },
             WorkflowEvent::LocalActivityFailed {
                 activity_id: id,
@@ -17788,7 +17793,7 @@ mod tests {
                 input: serde_json::json!("data"),
                 retry_policy: None,
                 resolved: false,
-                start_to_close_millis: None,
+                start_to_close_nanos: None,
             },
             WorkflowEvent::LocalActivityCompleted {
                 activity_id,

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -4566,9 +4566,9 @@ impl WorkflowContext {
         // Public seconds-granularity escape hatch (DAG/raw local dispatch). The
         // whole-second value is exact; the subsecond-capable resolution (builder
         // default and the typed `_with_opts` per-call/activity override) happens
-        // in `execute_local_activity_raw_resolved`, which preserves millisecond
-        // precision so a subsecond floor never truncates to `0` (issue #620,
-        // Codex P2).
+        // in `execute_local_activity_raw_resolved`, which carries the full
+        // `Duration` so a subsecond OR sub-millisecond floor never truncates to
+        // `0` (issue #620, Codex P2).
         self.execute_local_activity_raw_resolved(
             name,
             input,

--- a/autumn-harvest/src/effective_config.rs
+++ b/autumn-harvest/src/effective_config.rs
@@ -118,6 +118,12 @@ pub struct WorkerConfigView {
     pub shard_assignments: Vec<i32>,
     /// Hard cap on local-activity `start_to_close`, milliseconds.
     pub max_local_activity_start_to_close_ms: u64,
+    /// Builder-level default activity retry `max_attempts` (issue #620);
+    /// `null` when no builder-default retry floor is configured.
+    pub default_activity_retry_max_attempts: Option<u32>,
+    /// Builder-level default activity `start_to_close`, milliseconds (issue #620);
+    /// `null` when no builder-default timeout floor is configured.
+    pub default_activity_start_to_close_ms: Option<u64>,
     /// Worker liveness heartbeat interval, milliseconds.
     pub worker_heartbeat_interval_ms: u64,
     /// Immutable build identifier (may be empty; not a secret).
@@ -246,6 +252,8 @@ impl WorkerConfigView {
             cancellation_grace_period,
             shard_assignments,
             max_local_activity_start_to_close,
+            default_activity_retry_policy,
+            default_activity_start_to_close,
             worker_heartbeat_interval,
             build_id,
             deployment_name,
@@ -280,6 +288,10 @@ impl WorkerConfigView {
             cancellation_grace_period_ms: dur_ms(*cancellation_grace_period),
             shard_assignments: shard_assignments.iter().map(|s| s.as_i32()).collect(),
             max_local_activity_start_to_close_ms: dur_ms(*max_local_activity_start_to_close),
+            default_activity_retry_max_attempts: default_activity_retry_policy
+                .as_ref()
+                .map(|p| p.max_attempts),
+            default_activity_start_to_close_ms: default_activity_start_to_close.map(dur_ms),
             worker_heartbeat_interval_ms: dur_ms(*worker_heartbeat_interval),
             build_id: build_id.clone(),
             deployment_name: deployment_name.clone(),

--- a/autumn-harvest/src/event.rs
+++ b/autumn-harvest/src/event.rs
@@ -323,20 +323,48 @@ pub enum WorkflowEvent {
         name: String,
         /// JSON input for the activity.
         input: serde_json::Value,
+        /// Disambiguation marker distinguishing a #620+ event whose defaults were
+        /// fully resolved at first schedule from a genuine pre-#620 legacy event
+        /// (issue #620, Codex P2). BOTH `retry_policy` and `start_to_close_millis`
+        /// below serialize as absent when they resolved to "no floor", so an
+        /// absent value alone cannot tell a resolved-to-nothing #620+ event apart
+        /// from a legacy event — the former MUST stay frozen (implicit 1-attempt /
+        /// no STC floor) on recovery, the latter MUST fall back to live
+        /// re-derivation for backward compat. This one marker covers both frozen
+        /// fields: every #620+ schedule writes it `true` at the same first-schedule
+        /// anchor; a pre-#620 event has the field absent → deserializes to `false`.
+        #[serde(default)]
+        resolved: bool,
         /// The fully-resolved retry policy this local activity was scheduled
         /// with (call-site → activity default → builder default; issue #620).
         ///
-        /// Additive/optional: pre-#620 events deserialize to `None` and fall
-        /// back to today's live re-derivation. Populated only when a retry
-        /// policy was resolved at first-schedule time. Frozen here so a local
-        /// activity mid-retry across a worker crash keeps its ORIGINAL retry
-        /// budget even if the builder-level default (`WorkerConfig::
-        /// with_default_activity_retry_policy`) is changed in the crash-recovery
-        /// window (AC8: an in-flight execution is unaffected by later default
-        /// changes). Recorded on the live frontier at first schedule; read on
-        /// crash-recovery replay — the established side-effect pattern.
+        /// Additive/optional: pre-#620 events deserialize to `None`. On a #620+
+        /// event (`resolved == true`), a recorded `None` means "explicitly
+        /// resolved to no retry floor" and MUST stay frozen (implicit 1 attempt);
+        /// a legacy event (`resolved == false`) with `None` falls back to today's
+        /// live re-derivation. Frozen here so a local activity mid-retry across a
+        /// worker crash keeps its ORIGINAL retry budget even if the builder-level
+        /// default (`WorkerConfig::with_default_activity_retry_policy`) is changed
+        /// in the crash-recovery window (AC8: an in-flight execution is unaffected
+        /// by later default changes). Recorded on the live frontier at first
+        /// schedule; read on crash-recovery replay — the established side-effect
+        /// pattern.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         retry_policy: Option<crate::policy::RetryPolicy>,
+        /// The fully-resolved `start_to_close` this local activity was scheduled
+        /// with, in **milliseconds** (call-site → activity default → builder
+        /// default; issue #620, Codex P2). Millis (not seconds) to preserve
+        /// subsecond precision — the local per-attempt timeout is
+        /// `Duration::from_millis(this).min(cap)`, so a seconds field would
+        /// truncate a subsecond floor to `0` and instantly time out every attempt.
+        ///
+        /// Additive/optional, same freeze semantics as `retry_policy`: on a #620+
+        /// event (`resolved == true`) a recorded value — `Some` OR `None` — is
+        /// authoritative on recovery (`None` = "explicitly resolved to no STC
+        /// floor", frozen); a legacy event (`resolved == false`) falls back to
+        /// live re-derivation.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        start_to_close_millis: Option<u64>,
     },
     /// A local activity finished executing successfully.
     LocalActivityCompleted {
@@ -1146,15 +1174,66 @@ mod tests {
 
     #[test]
     fn local_activity_scheduled_round_trips() -> Result<(), serde_json::Error> {
+        // Issue #620 (Codex P2): a #620+ event carrying the resolution marker
+        // plus frozen retry/STC must round-trip all three fields verbatim.
         let event = WorkflowEvent::LocalActivityScheduled {
             activity_id: ActivityExecId::new(),
             name: "format_data".into(),
             input: serde_json::json!({"x": 1}),
-            retry_policy: None,
+            resolved: true,
+            retry_policy: Some(crate::policy::RetryPolicy::fixed(
+                4,
+                std::time::Duration::from_millis(10),
+            )),
+            start_to_close_millis: Some(500),
         };
         let json = serde_json::to_string(&event)?;
         let back: WorkflowEvent = serde_json::from_str(&json)?;
-        assert!(matches!(back, WorkflowEvent::LocalActivityScheduled { .. }));
+        match back {
+            WorkflowEvent::LocalActivityScheduled {
+                resolved,
+                retry_policy,
+                start_to_close_millis,
+                ..
+            } => {
+                assert!(resolved, "resolution marker must round-trip as true");
+                assert_eq!(
+                    retry_policy.map(|p| p.max_attempts),
+                    Some(4),
+                    "frozen retry policy must round-trip"
+                );
+                assert_eq!(
+                    start_to_close_millis,
+                    Some(500),
+                    "frozen STC millis must round-trip"
+                );
+            }
+            other => panic!("expected LocalActivityScheduled, got {other:?}"),
+        }
+        Ok(())
+    }
+
+    #[test]
+    fn pre_620_local_activity_scheduled_deserializes_as_unresolved() -> Result<(), serde_json::Error>
+    {
+        // A pre-#620 stored event has none of the three additive fields. It must
+        // deserialize with `resolved = false` (legacy → re-derive on recovery)
+        // and both frozen fields `None`, preserving the append-only invariant.
+        let legacy = r#"{"type":"LocalActivityScheduled","data":{"activity_id":"00000000-0000-0000-0000-000000000001","name":"format_data","input":{"x":1}}}"#;
+        let back: WorkflowEvent = serde_json::from_str(legacy)?;
+        match back {
+            WorkflowEvent::LocalActivityScheduled {
+                resolved,
+                retry_policy,
+                start_to_close_millis,
+                ..
+            } => {
+                assert!(!resolved, "a legacy event must deserialize as unresolved");
+                assert!(retry_policy.is_none());
+                assert!(start_to_close_millis.is_none());
+            }
+            other => panic!("expected LocalActivityScheduled, got {other:?}"),
+        }
         Ok(())
     }
 
@@ -1317,7 +1396,9 @@ mod tests {
                 activity_id: ActivityExecId::new(),
                 name: "format_data".into(),
                 input: serde_json::Value::Null,
+                resolved: false,
                 retry_policy: None,
+                start_to_close_millis: None,
             },
             WorkflowEvent::LocalActivityCompleted {
                 activity_id: ActivityExecId::new(),

--- a/autumn-harvest/src/event.rs
+++ b/autumn-harvest/src/event.rs
@@ -323,6 +323,20 @@ pub enum WorkflowEvent {
         name: String,
         /// JSON input for the activity.
         input: serde_json::Value,
+        /// The fully-resolved retry policy this local activity was scheduled
+        /// with (call-site → activity default → builder default; issue #620).
+        ///
+        /// Additive/optional: pre-#620 events deserialize to `None` and fall
+        /// back to today's live re-derivation. Populated only when a retry
+        /// policy was resolved at first-schedule time. Frozen here so a local
+        /// activity mid-retry across a worker crash keeps its ORIGINAL retry
+        /// budget even if the builder-level default (`WorkerConfig::
+        /// with_default_activity_retry_policy`) is changed in the crash-recovery
+        /// window (AC8: an in-flight execution is unaffected by later default
+        /// changes). Recorded on the live frontier at first schedule; read on
+        /// crash-recovery replay — the established side-effect pattern.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        retry_policy: Option<crate::policy::RetryPolicy>,
     },
     /// A local activity finished executing successfully.
     LocalActivityCompleted {
@@ -1136,6 +1150,7 @@ mod tests {
             activity_id: ActivityExecId::new(),
             name: "format_data".into(),
             input: serde_json::json!({"x": 1}),
+            retry_policy: None,
         };
         let json = serde_json::to_string(&event)?;
         let back: WorkflowEvent = serde_json::from_str(&json)?;
@@ -1302,6 +1317,7 @@ mod tests {
                 activity_id: ActivityExecId::new(),
                 name: "format_data".into(),
                 input: serde_json::Value::Null,
+                retry_policy: None,
             },
             WorkflowEvent::LocalActivityCompleted {
                 activity_id: ActivityExecId::new(),

--- a/autumn-harvest/src/event.rs
+++ b/autumn-harvest/src/event.rs
@@ -325,7 +325,7 @@ pub enum WorkflowEvent {
         input: serde_json::Value,
         /// Disambiguation marker distinguishing a #620+ event whose defaults were
         /// fully resolved at first schedule from a genuine pre-#620 legacy event
-        /// (issue #620, Codex P2). BOTH `retry_policy` and `start_to_close_millis`
+        /// (issue #620, Codex P2). BOTH `retry_policy` and `start_to_close_nanos`
         /// below serialize as absent when they resolved to "no floor", so an
         /// absent value alone cannot tell a resolved-to-nothing #620+ event apart
         /// from a legacy event — the former MUST stay frozen (implicit 1-attempt /
@@ -352,11 +352,15 @@ pub enum WorkflowEvent {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         retry_policy: Option<crate::policy::RetryPolicy>,
         /// The fully-resolved `start_to_close` this local activity was scheduled
-        /// with, in **milliseconds** (call-site → activity default → builder
-        /// default; issue #620, Codex P2). Millis (not seconds) to preserve
-        /// subsecond precision — the local per-attempt timeout is
-        /// `Duration::from_millis(this).min(cap)`, so a seconds field would
-        /// truncate a subsecond floor to `0` and instantly time out every attempt.
+        /// with, in **nanoseconds** (call-site → activity default → builder
+        /// default; issue #620, Codex P2). Nanoseconds — the FULL `Duration`
+        /// precision — so no floor is ever truncated: the local per-attempt
+        /// timeout is `Duration::from_nanos(this).min(cap)`. Truncating at any
+        /// coarser unit is the same footgun one order down (a seconds field
+        /// zeroes a subsecond floor; a millis field zeroes a sub-millisecond
+        /// floor like `Duration::from_micros(500)`), so the full `Duration` is
+        /// carried end-to-end (`u64` nanos ≈ 584 years — never saturates for a
+        /// realistic timeout).
         ///
         /// Additive/optional, same freeze semantics as `retry_policy`: on a #620+
         /// event (`resolved == true`) a recorded value — `Some` OR `None` — is
@@ -364,7 +368,7 @@ pub enum WorkflowEvent {
         /// floor", frozen); a legacy event (`resolved == false`) falls back to
         /// live re-derivation.
         #[serde(default, skip_serializing_if = "Option::is_none")]
-        start_to_close_millis: Option<u64>,
+        start_to_close_nanos: Option<u64>,
     },
     /// A local activity finished executing successfully.
     LocalActivityCompleted {
@@ -1185,7 +1189,9 @@ mod tests {
                 4,
                 std::time::Duration::from_millis(10),
             )),
-            start_to_close_millis: Some(500),
+            // A sub-millisecond value (500µs = 500_000 ns): a millis field would
+            // have zeroed it — the full-nanos field round-trips it exactly.
+            start_to_close_nanos: Some(500_000),
         };
         let json = serde_json::to_string(&event)?;
         let back: WorkflowEvent = serde_json::from_str(&json)?;
@@ -1193,7 +1199,7 @@ mod tests {
             WorkflowEvent::LocalActivityScheduled {
                 resolved,
                 retry_policy,
-                start_to_close_millis,
+                start_to_close_nanos,
                 ..
             } => {
                 assert!(resolved, "resolution marker must round-trip as true");
@@ -1203,9 +1209,9 @@ mod tests {
                     "frozen retry policy must round-trip"
                 );
                 assert_eq!(
-                    start_to_close_millis,
-                    Some(500),
-                    "frozen STC millis must round-trip"
+                    start_to_close_nanos,
+                    Some(500_000),
+                    "frozen sub-millisecond STC nanos must round-trip exactly"
                 );
             }
             other => panic!("expected LocalActivityScheduled, got {other:?}"),
@@ -1225,12 +1231,12 @@ mod tests {
             WorkflowEvent::LocalActivityScheduled {
                 resolved,
                 retry_policy,
-                start_to_close_millis,
+                start_to_close_nanos,
                 ..
             } => {
                 assert!(!resolved, "a legacy event must deserialize as unresolved");
                 assert!(retry_policy.is_none());
-                assert!(start_to_close_millis.is_none());
+                assert!(start_to_close_nanos.is_none());
             }
             other => panic!("expected LocalActivityScheduled, got {other:?}"),
         }
@@ -1398,7 +1404,7 @@ mod tests {
                 input: serde_json::Value::Null,
                 resolved: false,
                 retry_policy: None,
-                start_to_close_millis: None,
+                start_to_close_nanos: None,
             },
             WorkflowEvent::LocalActivityCompleted {
                 activity_id: ActivityExecId::new(),

--- a/autumn-harvest/src/executor.rs
+++ b/autumn-harvest/src/executor.rs
@@ -1331,6 +1331,8 @@ pub async fn run_workflow_with_state_and_history_policy(
         std::collections::HashMap::new(),
         None,
         metrics,
+        None,
+        None,
     )
     .await
 }
@@ -1356,6 +1358,8 @@ pub async fn run_workflow_with_state_history_policy_and_caps(
     context_headers: std::collections::HashMap<String, String>,
     payload_offload_threshold: Option<u64>,
     metrics: std::sync::Arc<dyn MetricsRecorder>,
+    default_activity_retry_policy: Option<crate::policy::RetryPolicy>,
+    default_activity_start_to_close: Option<std::time::Duration>,
 ) -> (WorkflowOutcome, Vec<WorkflowCommand>, tracing::Span) {
     let ctx = WorkflowContext::for_replay_with_state_and_history_policy(
         exec_id,
@@ -1384,7 +1388,14 @@ pub async fn run_workflow_with_state_history_policy_and_caps(
     .with_current_details_cap(max_current_details_bytes)
     .with_payload_offload_threshold(payload_offload_threshold)
     .with_context_headers(context_headers)
-    .with_metrics(metrics);
+    .with_metrics(metrics)
+    // Issue #620: thread the builder-level default activity retry/timeout floor
+    // so LOCAL activities (resolved in `execute_local_activity_with_opts`) fall
+    // back to it when no call-site or activity-level default is set.
+    .with_activity_defaults(
+        default_activity_retry_policy,
+        default_activity_start_to_close,
+    );
 
     // Auto-register declarative handlers before any workflow code runs.
     // This satisfies the AC: "authors do not call ctx.register_*_handler in

--- a/autumn-harvest/src/policy.rs
+++ b/autumn-harvest/src/policy.rs
@@ -1274,6 +1274,38 @@ pub fn compute_jitter_offset(
     Duration::from_nanos(hash % jitter_nanos)
 }
 
+/// Resolve the effective activity retry policy at schedule time (issue #620).
+///
+/// Precedence, highest first:
+///   call-site override → activity `#[activity(retry = …)]` default →
+///   builder-level default (`WorkerConfig::with_default_activity_retry_policy`).
+///
+/// Returns `None` when nothing is set anywhere, preserving today's implicit
+/// fallback (the enqueue path's own `max_attempts` default). Opt-in: an unset
+/// builder default is a pure no-op via `.or(None)`.
+#[must_use]
+pub(crate) fn resolve_effective_retry(
+    call: Option<RetryPolicy>,
+    activity: Option<RetryPolicy>,
+    builder: Option<RetryPolicy>,
+) -> Option<RetryPolicy> {
+    call.or(activity).or(builder)
+}
+
+/// Resolve the effective activity `start_to_close` at schedule time (issue #620).
+///
+/// Same precedence as [`resolve_effective_retry`]: call-site override →
+/// activity default → builder default. `None` when unset (no timeout enforced),
+/// preserving today's behaviour.
+#[must_use]
+pub(crate) fn resolve_effective_start_to_close(
+    call: Option<Duration>,
+    activity: Option<Duration>,
+    builder: Option<Duration>,
+) -> Option<Duration> {
+    call.or(activity).or(builder)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/autumn-harvest/src/policy.rs
+++ b/autumn-harvest/src/policy.rs
@@ -1279,6 +1279,78 @@ mod tests {
     use super::*;
     use std::time::Duration;
 
+    // ── Builder-level activity default floor (issue #620) ─────────────────────
+    //
+    // RED PHASE: `resolve_effective_retry` / `resolve_effective_start_to_close`
+    // do not exist yet — these tests fail to COMPILE against the missing
+    // `crate::policy` symbols until the green phase adds them. The precedence
+    // the green phase must implement is:
+    //   call-site override  →  activity default  →  builder default  →  None
+    // i.e. `call.or(activity).or(builder)`.
+
+    #[test]
+    fn resolve_effective_retry_precedence() {
+        // Distinct policies so the returned identity is unambiguous.
+        let call = RetryPolicy::fixed(5, Duration::from_millis(10));
+        let activity = RetryPolicy::fixed(2, Duration::from_millis(10));
+        let builder = RetryPolicy::fixed(9, Duration::from_millis(10));
+
+        // All three present → call-site wins.
+        assert_eq!(
+            resolve_effective_retry(
+                Some(call.clone()),
+                Some(activity.clone()),
+                Some(builder.clone()),
+            )
+            .map(|p| p.max_attempts),
+            Some(5),
+        );
+
+        // No call-site → activity default wins over builder default.
+        assert_eq!(
+            resolve_effective_retry(None, Some(activity.clone()), Some(builder.clone()))
+                .map(|p| p.max_attempts),
+            Some(2),
+        );
+
+        // No call-site, no activity default → builder default applies.
+        assert_eq!(
+            resolve_effective_retry(None, None, Some(builder.clone())).map(|p| p.max_attempts),
+            Some(9),
+        );
+
+        // Nothing set anywhere → None (implicit fallback handled downstream).
+        assert!(resolve_effective_retry(None, None, None).is_none());
+    }
+
+    #[test]
+    fn resolve_effective_start_to_close_precedence() {
+        let call = Duration::from_secs(5);
+        let activity = Duration::from_secs(30);
+        let builder = Duration::from_secs(300);
+
+        // All three present → call-site wins.
+        assert_eq!(
+            resolve_effective_start_to_close(Some(call), Some(activity), Some(builder)),
+            Some(call),
+        );
+
+        // No call-site → activity default wins over builder default.
+        assert_eq!(
+            resolve_effective_start_to_close(None, Some(activity), Some(builder)),
+            Some(activity),
+        );
+
+        // No call-site, no activity default → builder default applies.
+        assert_eq!(
+            resolve_effective_start_to_close(None, None, Some(builder)),
+            Some(builder),
+        );
+
+        // Nothing set anywhere → None (no timeout enforced).
+        assert_eq!(resolve_effective_start_to_close(None, None, None), None);
+    }
+
     // ── Schedule jitter ───────────────────────────────────────────────────────
 
     #[test]

--- a/autumn-harvest/src/policy.rs
+++ b/autumn-harvest/src/policy.rs
@@ -1283,7 +1283,11 @@ pub fn compute_jitter_offset(
 /// Returns `None` when nothing is set anywhere, preserving today's implicit
 /// fallback (the enqueue path's own `max_attempts` default). Opt-in: an unset
 /// builder default is a pure no-op via `.or(None)`.
+///
+/// The sole non-test consumer is the `db`-gated worker dispatch path; unused
+/// under `--no-default-features` (the pure precedence is still test-covered).
 #[must_use]
+#[cfg_attr(not(feature = "db"), allow(dead_code))]
 pub(crate) fn resolve_effective_retry(
     call: Option<RetryPolicy>,
     activity: Option<RetryPolicy>,
@@ -1297,7 +1301,11 @@ pub(crate) fn resolve_effective_retry(
 /// Same precedence as [`resolve_effective_retry`]: call-site override →
 /// activity default → builder default. `None` when unset (no timeout enforced),
 /// preserving today's behaviour.
+///
+/// The sole non-test consumer is the `db`-gated worker dispatch path; unused
+/// under `--no-default-features` (the pure precedence is still test-covered).
 #[must_use]
+#[cfg_attr(not(feature = "db"), allow(dead_code))]
 pub(crate) fn resolve_effective_start_to_close(
     call: Option<Duration>,
     activity: Option<Duration>,
@@ -1329,25 +1337,21 @@ mod tests {
 
         // All three present → call-site wins.
         assert_eq!(
-            resolve_effective_retry(
-                Some(call.clone()),
-                Some(activity.clone()),
-                Some(builder.clone()),
-            )
-            .map(|p| p.max_attempts),
+            resolve_effective_retry(Some(call), Some(activity.clone()), Some(builder.clone()))
+                .map(|p| p.max_attempts),
             Some(5),
         );
 
         // No call-site → activity default wins over builder default.
         assert_eq!(
-            resolve_effective_retry(None, Some(activity.clone()), Some(builder.clone()))
+            resolve_effective_retry(None, Some(activity), Some(builder.clone()))
                 .map(|p| p.max_attempts),
             Some(2),
         );
 
         // No call-site, no activity default → builder default applies.
         assert_eq!(
-            resolve_effective_retry(None, None, Some(builder.clone())).map(|p| p.max_attempts),
+            resolve_effective_retry(None, None, Some(builder)).map(|p| p.max_attempts),
             Some(9),
         );
 

--- a/autumn-harvest/src/replay.rs
+++ b/autumn-harvest/src/replay.rs
@@ -535,8 +535,9 @@ pub(crate) struct LocalActivityResolution {
     pub(crate) resolved: bool,
     /// The frozen fully-resolved retry policy, or `None`.
     pub(crate) retry_policy: Option<crate::policy::RetryPolicy>,
-    /// The frozen fully-resolved `start_to_close` in milliseconds, or `None`.
-    pub(crate) start_to_close_millis: Option<u64>,
+    /// The frozen fully-resolved `start_to_close` in nanoseconds (full
+    /// `Duration` precision), or `None`.
+    pub(crate) start_to_close_nanos: Option<u64>,
 }
 
 /// Walks through recorded workflow events during replay, matching
@@ -5024,7 +5025,7 @@ impl HistoryMatcher {
     /// three additive fields in one pass.
     ///
     /// `resolved` is the disambiguation marker: `true` for a #620+ event whose
-    /// frozen `retry_policy`/`start_to_close_millis` are authoritative on
+    /// frozen `retry_policy`/`start_to_close_nanos` are authoritative on
     /// recovery even when `None` ("explicitly resolved to no floor"); `false`
     /// for a pre-#620 legacy event (all three fields absent → the marker
     /// deserializes to `false`), which the crash-recovery path in
@@ -5044,12 +5045,12 @@ impl HistoryMatcher {
                     activity_id: recorded_id,
                     resolved,
                     retry_policy,
-                    start_to_close_millis,
+                    start_to_close_nanos,
                     ..
                 } if *recorded_id == activity_id => Some(LocalActivityResolution {
                     resolved: *resolved,
                     retry_policy: retry_policy.clone(),
-                    start_to_close_millis: *start_to_close_millis,
+                    start_to_close_nanos: *start_to_close_nanos,
                 }),
                 _ => None,
             })
@@ -8646,7 +8647,7 @@ mod tests {
                 input: Value::Null,
                 retry_policy: None,
                 resolved: false,
-                start_to_close_millis: None,
+                start_to_close_nanos: None,
             },
             WorkflowEvent::LocalActivityCompleted {
                 activity_id: id,
@@ -8674,7 +8675,7 @@ mod tests {
                 input: Value::Null,
                 retry_policy: None,
                 resolved: false,
-                start_to_close_millis: None,
+                start_to_close_nanos: None,
             },
             WorkflowEvent::LocalActivityFailed {
                 activity_id: id,
@@ -8714,7 +8715,7 @@ mod tests {
                 input: Value::Null,
                 retry_policy: None,
                 resolved: false,
-                start_to_close_millis: None,
+                start_to_close_nanos: None,
             },
             WorkflowEvent::LocalActivityFailed {
                 activity_id: id,
@@ -8752,7 +8753,7 @@ mod tests {
                 input: Value::Null,
                 retry_policy: None,
                 resolved: false,
-                start_to_close_millis: None,
+                start_to_close_nanos: None,
             },
             WorkflowEvent::LocalActivityFailed {
                 activity_id: id,
@@ -8810,7 +8811,7 @@ mod tests {
             input: Value::Null,
             retry_policy: None,
             resolved: false,
-            start_to_close_millis: None,
+            start_to_close_nanos: None,
         }];
         let mut matcher = HistoryMatcher::new(events);
         let result = matcher.match_local_activity("format_data");
@@ -8835,7 +8836,7 @@ mod tests {
                 input: Value::Null,
                 retry_policy: None,
                 resolved: false,
-                start_to_close_millis: None,
+                start_to_close_nanos: None,
             },
             WorkflowEvent::LocalActivityFailed {
                 activity_id: id,
@@ -8878,7 +8879,7 @@ mod tests {
                 input: Value::Null,
                 retry_policy: None,
                 resolved: false,
-                start_to_close_millis: None,
+                start_to_close_nanos: None,
             },
             WorkflowEvent::LocalActivityCompleted {
                 activity_id: local_id,
@@ -9033,7 +9034,7 @@ mod tests {
                 input: Value::Null,
                 retry_policy: None,
                 resolved: false,
-                start_to_close_millis: None,
+                start_to_close_nanos: None,
             },
             WorkflowEvent::ChildWorkflowSpawnedDetached {
                 child_id,

--- a/autumn-harvest/src/replay.rs
+++ b/autumn-harvest/src/replay.rs
@@ -521,6 +521,24 @@ struct StashedExternalCancel {
     terminal: Option<StashedCancelTerminal>,
 }
 
+/// The frozen resolution recorded on a `LocalActivityScheduled` event
+/// (issue #620, AC8; Codex P2). Returned by
+/// [`HistoryMatcher::recorded_local_activity_resolution`].
+///
+/// `Default` yields the "unresolved legacy" shape (`resolved == false`, both
+/// frozen fields `None`) so a pre-#620 event or an absent `activity_id` falls
+/// back to live re-derivation on crash recovery.
+#[derive(Debug, Clone, Default)]
+pub(crate) struct LocalActivityResolution {
+    /// `true` for a #620+ event whose frozen fields below are authoritative
+    /// (even when `None`); `false` for a legacy event → re-derive live.
+    pub(crate) resolved: bool,
+    /// The frozen fully-resolved retry policy, or `None`.
+    pub(crate) retry_policy: Option<crate::policy::RetryPolicy>,
+    /// The frozen fully-resolved `start_to_close` in milliseconds, or `None`.
+    pub(crate) start_to_close_millis: Option<u64>,
+}
+
 /// Walks through recorded workflow events during replay, matching
 /// commands against what was previously recorded.
 ///
@@ -4999,30 +5017,43 @@ impl HistoryMatcher {
         }
     }
 
-    /// The retry policy a local activity was frozen with at first-schedule time
-    /// (issue #620, AC8). Read-only, cursor-independent: scans recorded history
-    /// for the `LocalActivityScheduled` event carrying `activity_id` and clones
-    /// its recorded `retry_policy`.
+    /// The frozen resolution (retry policy + `start_to_close`) a local activity
+    /// was scheduled with at first-schedule time (issue #620, AC8; Codex P2).
+    /// Read-only, cursor-independent: scans recorded history for the
+    /// `LocalActivityScheduled` event carrying `activity_id` and clones its
+    /// three additive fields in one pass.
     ///
-    /// Returns `None` for a pre-#620 event (the field is absent → deserializes
-    /// to `None`) or when no retry policy was resolved at schedule time. The
-    /// crash-recovery path in
+    /// `resolved` is the disambiguation marker: `true` for a #620+ event whose
+    /// frozen `retry_policy`/`start_to_close_millis` are authoritative on
+    /// recovery even when `None` ("explicitly resolved to no floor"); `false`
+    /// for a pre-#620 legacy event (all three fields absent → the marker
+    /// deserializes to `false`), which the crash-recovery path in
     /// [`WorkflowContext::execute_local_activity_raw`](crate::context::WorkflowContext::execute_local_activity_raw)
-    /// consults this so a builder-default change in the crash-recovery window
-    /// cannot shrink an in-flight local activity's retry budget.
+    /// treats as "re-derive from the live defaults" for backward compatibility.
+    /// A missing `activity_id` (no matching scheduled event) reports the same
+    /// unresolved default.
     #[must_use]
-    pub(crate) fn recorded_local_activity_retry(
+    pub(crate) fn recorded_local_activity_resolution(
         &self,
         activity_id: ActivityExecId,
-    ) -> Option<crate::policy::RetryPolicy> {
-        self.events.iter().find_map(|ev| match ev {
-            WorkflowEvent::LocalActivityScheduled {
-                activity_id: recorded_id,
-                retry_policy,
-                ..
-            } if *recorded_id == activity_id => retry_policy.clone(),
-            _ => None,
-        })
+    ) -> LocalActivityResolution {
+        self.events
+            .iter()
+            .find_map(|ev| match ev {
+                WorkflowEvent::LocalActivityScheduled {
+                    activity_id: recorded_id,
+                    resolved,
+                    retry_policy,
+                    start_to_close_millis,
+                    ..
+                } if *recorded_id == activity_id => Some(LocalActivityResolution {
+                    resolved: *resolved,
+                    retry_policy: retry_policy.clone(),
+                    start_to_close_millis: *start_to_close_millis,
+                }),
+                _ => None,
+            })
+            .unwrap_or_default()
     }
 
     /// Versioning mechanism for safe workflow code changes.
@@ -8614,6 +8645,8 @@ mod tests {
                 name: "format_data".into(),
                 input: Value::Null,
                 retry_policy: None,
+                resolved: false,
+                start_to_close_millis: None,
             },
             WorkflowEvent::LocalActivityCompleted {
                 activity_id: id,
@@ -8640,6 +8673,8 @@ mod tests {
                 name: "format_data".into(),
                 input: Value::Null,
                 retry_policy: None,
+                resolved: false,
+                start_to_close_millis: None,
             },
             WorkflowEvent::LocalActivityFailed {
                 activity_id: id,
@@ -8678,6 +8713,8 @@ mod tests {
                 name: "format_data".into(),
                 input: Value::Null,
                 retry_policy: None,
+                resolved: false,
+                start_to_close_millis: None,
             },
             WorkflowEvent::LocalActivityFailed {
                 activity_id: id,
@@ -8714,6 +8751,8 @@ mod tests {
                 name: "format_data".into(),
                 input: Value::Null,
                 retry_policy: None,
+                resolved: false,
+                start_to_close_millis: None,
             },
             WorkflowEvent::LocalActivityFailed {
                 activity_id: id,
@@ -8770,6 +8809,8 @@ mod tests {
             name: "other_activity".into(),
             input: Value::Null,
             retry_policy: None,
+            resolved: false,
+            start_to_close_millis: None,
         }];
         let mut matcher = HistoryMatcher::new(events);
         let result = matcher.match_local_activity("format_data");
@@ -8793,6 +8834,8 @@ mod tests {
                 name: "format_data".into(),
                 input: Value::Null,
                 retry_policy: None,
+                resolved: false,
+                start_to_close_millis: None,
             },
             WorkflowEvent::LocalActivityFailed {
                 activity_id: id,
@@ -8834,6 +8877,8 @@ mod tests {
                 name: "format_data".into(),
                 input: Value::Null,
                 retry_policy: None,
+                resolved: false,
+                start_to_close_millis: None,
             },
             WorkflowEvent::LocalActivityCompleted {
                 activity_id: local_id,
@@ -8987,6 +9032,8 @@ mod tests {
                 name: "format_data".into(),
                 input: Value::Null,
                 retry_policy: None,
+                resolved: false,
+                start_to_close_millis: None,
             },
             WorkflowEvent::ChildWorkflowSpawnedDetached {
                 child_id,

--- a/autumn-harvest/src/replay.rs
+++ b/autumn-harvest/src/replay.rs
@@ -4954,6 +4954,9 @@ impl HistoryMatcher {
                 activity_id,
                 name: recorded_name,
                 input: recorded_input,
+                // Issue #620: the recorded resolved retry policy is not part of
+                // strict-replay matching (name + input only), so ignore it here.
+                ..
             } => {
                 if recorded_name != activity_name {
                     return HistoryMatch::Diverged {
@@ -4994,6 +4997,32 @@ impl HistoryMatcher {
             } => HistoryMatch::NoMatch,
             other => other,
         }
+    }
+
+    /// The retry policy a local activity was frozen with at first-schedule time
+    /// (issue #620, AC8). Read-only, cursor-independent: scans recorded history
+    /// for the `LocalActivityScheduled` event carrying `activity_id` and clones
+    /// its recorded `retry_policy`.
+    ///
+    /// Returns `None` for a pre-#620 event (the field is absent → deserializes
+    /// to `None`) or when no retry policy was resolved at schedule time. The
+    /// crash-recovery path in
+    /// [`WorkflowContext::execute_local_activity_raw`](crate::context::WorkflowContext::execute_local_activity_raw)
+    /// consults this so a builder-default change in the crash-recovery window
+    /// cannot shrink an in-flight local activity's retry budget.
+    #[must_use]
+    pub(crate) fn recorded_local_activity_retry(
+        &self,
+        activity_id: ActivityExecId,
+    ) -> Option<crate::policy::RetryPolicy> {
+        self.events.iter().find_map(|ev| match ev {
+            WorkflowEvent::LocalActivityScheduled {
+                activity_id: recorded_id,
+                retry_policy,
+                ..
+            } if *recorded_id == activity_id => retry_policy.clone(),
+            _ => None,
+        })
     }
 
     /// Versioning mechanism for safe workflow code changes.
@@ -8584,6 +8613,7 @@ mod tests {
                 activity_id: id,
                 name: "format_data".into(),
                 input: Value::Null,
+                retry_policy: None,
             },
             WorkflowEvent::LocalActivityCompleted {
                 activity_id: id,
@@ -8609,6 +8639,7 @@ mod tests {
                 activity_id: id,
                 name: "format_data".into(),
                 input: Value::Null,
+                retry_policy: None,
             },
             WorkflowEvent::LocalActivityFailed {
                 activity_id: id,
@@ -8646,6 +8677,7 @@ mod tests {
                 activity_id: id,
                 name: "format_data".into(),
                 input: Value::Null,
+                retry_policy: None,
             },
             WorkflowEvent::LocalActivityFailed {
                 activity_id: id,
@@ -8681,6 +8713,7 @@ mod tests {
                 activity_id: id,
                 name: "format_data".into(),
                 input: Value::Null,
+                retry_policy: None,
             },
             WorkflowEvent::LocalActivityFailed {
                 activity_id: id,
@@ -8736,6 +8769,7 @@ mod tests {
             activity_id: id,
             name: "other_activity".into(),
             input: Value::Null,
+            retry_policy: None,
         }];
         let mut matcher = HistoryMatcher::new(events);
         let result = matcher.match_local_activity("format_data");
@@ -8758,6 +8792,7 @@ mod tests {
                 activity_id: id,
                 name: "format_data".into(),
                 input: Value::Null,
+                retry_policy: None,
             },
             WorkflowEvent::LocalActivityFailed {
                 activity_id: id,
@@ -8798,6 +8833,7 @@ mod tests {
                 activity_id: local_id,
                 name: "format_data".into(),
                 input: Value::Null,
+                retry_policy: None,
             },
             WorkflowEvent::LocalActivityCompleted {
                 activity_id: local_id,
@@ -8950,6 +8986,7 @@ mod tests {
                 activity_id,
                 name: "format_data".into(),
                 input: Value::Null,
+                retry_policy: None,
             },
             WorkflowEvent::ChildWorkflowSpawnedDetached {
                 child_id,

--- a/autumn-harvest/src/reset.rs
+++ b/autumn-harvest/src/reset.rs
@@ -1840,6 +1840,8 @@ mod tests {
                 name: "compute".into(),
                 input: Value::Null,
                 retry_policy: None,
+                resolved: false,
+                start_to_close_millis: None,
             },
             WorkflowEvent::LocalActivityFailed {
                 activity_id,
@@ -1875,6 +1877,8 @@ mod tests {
                 name: "compute".into(),
                 input: Value::Null,
                 retry_policy: None,
+                resolved: false,
+                start_to_close_millis: None,
             },
             WorkflowEvent::LocalActivityFailed {
                 activity_id,

--- a/autumn-harvest/src/reset.rs
+++ b/autumn-harvest/src/reset.rs
@@ -1839,6 +1839,7 @@ mod tests {
                 activity_id,
                 name: "compute".into(),
                 input: Value::Null,
+                retry_policy: None,
             },
             WorkflowEvent::LocalActivityFailed {
                 activity_id,
@@ -1873,6 +1874,7 @@ mod tests {
                 activity_id,
                 name: "compute".into(),
                 input: Value::Null,
+                retry_policy: None,
             },
             WorkflowEvent::LocalActivityFailed {
                 activity_id,

--- a/autumn-harvest/src/reset.rs
+++ b/autumn-harvest/src/reset.rs
@@ -1841,7 +1841,7 @@ mod tests {
                 input: Value::Null,
                 retry_policy: None,
                 resolved: false,
-                start_to_close_millis: None,
+                start_to_close_nanos: None,
             },
             WorkflowEvent::LocalActivityFailed {
                 activity_id,
@@ -1878,7 +1878,7 @@ mod tests {
                 input: Value::Null,
                 retry_policy: None,
                 resolved: false,
-                start_to_close_millis: None,
+                start_to_close_nanos: None,
             },
             WorkflowEvent::LocalActivityFailed {
                 activity_id,

--- a/autumn-harvest/src/testing.rs
+++ b/autumn-harvest/src/testing.rs
@@ -3747,6 +3747,7 @@ impl WorkflowTestEnv {
                 activity_id,
                 name,
                 input: act_input,
+                retry_policy,
                 ..
             } => {
                 let call_num = Self::next_call_count(call_counts, &name);
@@ -3755,6 +3756,10 @@ impl WorkflowTestEnv {
                     activity_id,
                     name: name.clone(),
                     input: act_input,
+                    // Issue #620: mirror the worker anchor — record the resolved
+                    // retry policy the command carried so harness-based replay
+                    // fixtures observe the same frozen budget the worker writes.
+                    retry_policy,
                 });
                 Self::push_local_activity_terminal(deferred_events, activity_id, result);
                 Ok(true)

--- a/autumn-harvest/src/testing.rs
+++ b/autumn-harvest/src/testing.rs
@@ -3748,7 +3748,7 @@ impl WorkflowTestEnv {
                 name,
                 input: act_input,
                 retry_policy,
-                start_to_close_millis,
+                start_to_close,
                 ..
             } => {
                 let call_num = Self::next_call_count(call_counts, &name);
@@ -3761,10 +3761,11 @@ impl WorkflowTestEnv {
                     // #620+ schedule, so record the resolution marker plus the
                     // resolved retry/STC the command carried, so harness-based
                     // replay fixtures observe the same frozen budget/timeout the
-                    // worker writes.
+                    // worker writes. STC frozen as full-precision nanos.
                     resolved: true,
                     retry_policy,
-                    start_to_close_millis,
+                    start_to_close_nanos: start_to_close
+                        .map(|d| u64::try_from(d.as_nanos()).unwrap_or(u64::MAX)),
                 });
                 Self::push_local_activity_terminal(deferred_events, activity_id, result);
                 Ok(true)

--- a/autumn-harvest/src/testing.rs
+++ b/autumn-harvest/src/testing.rs
@@ -3748,6 +3748,7 @@ impl WorkflowTestEnv {
                 name,
                 input: act_input,
                 retry_policy,
+                start_to_close_millis,
                 ..
             } => {
                 let call_num = Self::next_call_count(call_counts, &name);
@@ -3756,10 +3757,14 @@ impl WorkflowTestEnv {
                     activity_id,
                     name: name.clone(),
                     input: act_input,
-                    // Issue #620: mirror the worker anchor — record the resolved
-                    // retry policy the command carried so harness-based replay
-                    // fixtures observe the same frozen budget the worker writes.
+                    // Issue #620 (Codex P2): mirror the worker anchor — this is a
+                    // #620+ schedule, so record the resolution marker plus the
+                    // resolved retry/STC the command carried, so harness-based
+                    // replay fixtures observe the same frozen budget/timeout the
+                    // worker writes.
+                    resolved: true,
                     retry_policy,
+                    start_to_close_millis,
                 });
                 Self::push_local_activity_terminal(deferred_events, activity_id, result);
                 Ok(true)

--- a/autumn-harvest/src/timeline.rs
+++ b/autumn-harvest/src/timeline.rs
@@ -1197,6 +1197,8 @@ mod tests {
                     name: "checksum".into(),
                     input: serde_json::Value::Null,
                     retry_policy: None,
+                    resolved: false,
+                    start_to_close_millis: None,
                 },
             ),
             row(
@@ -1247,6 +1249,8 @@ mod tests {
                     name: "checksum".into(),
                     input: serde_json::Value::Null,
                     retry_policy: None,
+                    resolved: false,
+                    start_to_close_millis: None,
                 },
             ),
             row(
@@ -1387,6 +1391,8 @@ mod tests {
                     name: "checksum".into(),
                     input: serde_json::Value::Null,
                     retry_policy: None,
+                    resolved: false,
+                    start_to_close_millis: None,
                 },
             ),
             row(
@@ -1420,6 +1426,8 @@ mod tests {
                     name: "checksum".into(),
                     input: serde_json::Value::Null,
                     retry_policy: None,
+                    resolved: false,
+                    start_to_close_millis: None,
                 },
             ),
             row(

--- a/autumn-harvest/src/timeline.rs
+++ b/autumn-harvest/src/timeline.rs
@@ -1196,6 +1196,7 @@ mod tests {
                     activity_id: a1,
                     name: "checksum".into(),
                     input: serde_json::Value::Null,
+                    retry_policy: None,
                 },
             ),
             row(
@@ -1245,6 +1246,7 @@ mod tests {
                     activity_id: a1,
                     name: "checksum".into(),
                     input: serde_json::Value::Null,
+                    retry_policy: None,
                 },
             ),
             row(
@@ -1384,6 +1386,7 @@ mod tests {
                     activity_id: a1,
                     name: "checksum".into(),
                     input: serde_json::Value::Null,
+                    retry_policy: None,
                 },
             ),
             row(
@@ -1416,6 +1419,7 @@ mod tests {
                     activity_id: a1,
                     name: "checksum".into(),
                     input: serde_json::Value::Null,
+                    retry_policy: None,
                 },
             ),
             row(

--- a/autumn-harvest/src/timeline.rs
+++ b/autumn-harvest/src/timeline.rs
@@ -1198,7 +1198,7 @@ mod tests {
                     input: serde_json::Value::Null,
                     retry_policy: None,
                     resolved: false,
-                    start_to_close_millis: None,
+                    start_to_close_nanos: None,
                 },
             ),
             row(
@@ -1250,7 +1250,7 @@ mod tests {
                     input: serde_json::Value::Null,
                     retry_policy: None,
                     resolved: false,
-                    start_to_close_millis: None,
+                    start_to_close_nanos: None,
                 },
             ),
             row(
@@ -1392,7 +1392,7 @@ mod tests {
                     input: serde_json::Value::Null,
                     retry_policy: None,
                     resolved: false,
-                    start_to_close_millis: None,
+                    start_to_close_nanos: None,
                 },
             ),
             row(
@@ -1427,7 +1427,7 @@ mod tests {
                     input: serde_json::Value::Null,
                     retry_policy: None,
                     resolved: false,
-                    start_to_close_millis: None,
+                    start_to_close_nanos: None,
                 },
             ),
             row(

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -4551,10 +4551,12 @@ async fn persist_scheduled_activities(
             params.required_capabilities = Some(serde_json::to_value(&reqs)?);
         }
 
-        let effective_retry = scheduled
-            .retry_policy_override
-            .clone()
-            .or_else(|| activity.default_retry_policy.clone());
+        // Issue #620: call-site override → activity default → builder default.
+        let effective_retry = crate::policy::resolve_effective_retry(
+            scheduled.retry_policy_override.clone(),
+            activity.default_retry_policy.clone(),
+            registry.default_activity_retry_policy(),
+        );
         if let Some(retry_policy) = effective_retry {
             params.max_attempts = i32::try_from(retry_policy.max_attempts).map_err(|_| {
                 HarvestError::Config(format!(
@@ -4569,9 +4571,12 @@ async fn persist_scheduled_activities(
             params.heartbeat_timeout =
                 Some(chrono_duration_from_std(timeout, "heartbeat timeout")?);
         }
-        let effective_stc = scheduled
-            .start_to_close_override
-            .or(activity.default_start_to_close);
+        // Issue #620: call-site override → activity default → builder default.
+        let effective_stc = crate::policy::resolve_effective_start_to_close(
+            scheduled.start_to_close_override,
+            activity.default_start_to_close,
+            registry.default_activity_start_to_close(),
+        );
         if let Some(timeout) = effective_stc {
             params.start_to_close =
                 Some(chrono_duration_from_std(timeout, "start_to_close timeout")?);

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -2263,6 +2263,12 @@ async fn run_local_activity_inline(
             activity_id: run.activity_id,
             name: run.name.clone(),
             input: run.input.clone(),
+            // Issue #620 (AC8): freeze the fully-resolved retry policy (already
+            // call → activity → builder resolved in `execute_local_activity_raw`)
+            // so a crash-recovery replay keeps this original budget even if the
+            // builder-level default changed in the crash window. `None` when no
+            // retry policy was resolved (pre-#620 behaviour preserved).
+            retry_policy: run.retry_policy.clone(),
         });
     }
     prefix_events.extend(post_schedule_events);
@@ -4560,10 +4566,24 @@ async fn persist_scheduled_activities(
         }
 
         // Issue #620: call-site override → activity default → builder default.
+        //
+        // Reserved worker-session internal activities (issue #606,
+        // `__harvest_session_acquire` / `__harvest_session_release`) are
+        // engine-internal machinery bounded by schedule_to_start /
+        // SessionOptions::acquisition_timeout, NOT by a user retry/timeout
+        // floor. They must NOT inherit the builder-level default — fall back to
+        // the pre-feature resolution (call-site override → activity default) for
+        // them so an operator's floor never governs session acquire/release.
+        let is_reserved = crate::context::is_reserved_session_activity_name(&scheduled.name);
+        let builder_retry_default = if is_reserved {
+            None
+        } else {
+            registry.default_activity_retry_policy()
+        };
         let effective_retry = crate::policy::resolve_effective_retry(
             scheduled.retry_policy_override.clone(),
             activity.default_retry_policy.clone(),
-            registry.default_activity_retry_policy(),
+            builder_retry_default,
         );
         if let Some(retry_policy) = effective_retry {
             params.max_attempts = i32::try_from(retry_policy.max_attempts).map_err(|_| {
@@ -4580,10 +4600,17 @@ async fn persist_scheduled_activities(
                 Some(chrono_duration_from_std(timeout, "heartbeat timeout")?);
         }
         // Issue #620: call-site override → activity default → builder default.
+        // Reserved session-internal activities skip the builder floor (see the
+        // retry resolution above for the rationale).
+        let builder_stc_default = if is_reserved {
+            None
+        } else {
+            registry.default_activity_start_to_close()
+        };
         let effective_stc = crate::policy::resolve_effective_start_to_close(
             scheduled.start_to_close_override,
             activity.default_start_to_close,
-            registry.default_activity_start_to_close(),
+            builder_stc_default,
         );
         if let Some(timeout) = effective_stc {
             params.start_to_close =

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -1619,10 +1619,10 @@ struct LocalActivityRun {
     activity_id: crate::types::ActivityExecId,
     name: String,
     input: serde_json::Value,
-    /// Resolved per-attempt `start_to_close` in **milliseconds** (issue #620,
-    /// Codex P2 — millis, not seconds, so a subsecond floor is never truncated
+    /// Resolved per-attempt `start_to_close` as a full [`Duration`] (issue #620,
+    /// Codex P2 — full precision, not secs/millis, so no floor is ever truncated
     /// to `0`). `None` defers to the worker cap.
-    start_to_close_millis: Option<u64>,
+    start_to_close: Option<Duration>,
     retry_policy: Option<crate::policy::RetryPolicy>,
     /// `true` when `LocalActivityScheduled` is already in the durable history —
     /// the worker crashed after appending it but before recording a terminal event.
@@ -1716,7 +1716,7 @@ fn extract_run_local_activity(commands: Vec<WorkflowCommand>) -> LocalActivityCo
                 activity_id,
                 name,
                 input,
-                start_to_close_millis,
+                start_to_close,
                 retry_policy,
                 result_tx,
                 already_scheduled,
@@ -1728,7 +1728,7 @@ fn extract_run_local_activity(commands: Vec<WorkflowCommand>) -> LocalActivityCo
                     activity_id,
                     name,
                     input,
-                    start_to_close_millis,
+                    start_to_close,
                     retry_policy,
                     already_scheduled,
                     failed_attempts,
@@ -2251,14 +2251,14 @@ async fn run_local_activity_inline(
     }
     let history_event_hard_cap = registry.history_policy().event_hard_cap();
 
-    // Per-attempt timeout in **milliseconds** (issue #620, Codex P2). A
-    // subsecond floor (`start_to_close_millis = Some(500)`) must NOT truncate to
-    // `Duration::from_secs(0)` and instantly time out — the command now carries
-    // millis, so `Duration::from_millis(500)` is honored, then clamped by the
-    // worker cap.
+    // Per-attempt timeout at FULL `Duration` precision (issue #620, Codex P2). A
+    // subsecond OR sub-millisecond floor must NOT truncate to
+    // `Duration::from_secs(0)`/`from_millis(0)` and instantly time out — the
+    // command carries the exact `Duration`, honored directly, then clamped by the
+    // worker cap (`Duration` implements `Ord`).
     let per_attempt_timeout = run
-        .start_to_close_millis
-        .map_or(max_start_to_close, Duration::from_millis)
+        .start_to_close
+        .unwrap_or(max_start_to_close)
         .min(max_start_to_close);
 
     let max_attempts = run.retry_policy.as_ref().map_or(1, |p| p.max_attempts);
@@ -2282,9 +2282,12 @@ async fn run_local_activity_inline(
             // `execute_local_activity_raw_resolved`) so a crash-recovery replay
             // keeps this ORIGINAL budget/timeout even if the builder-level
             // default changed in the crash window. `None` = "explicitly resolved
-            // to no floor" — still frozen, since the marker is `true`.
+            // to no floor" — still frozen, since the marker is `true`. Stored as
+            // full-precision nanos so recovery restores the exact `Duration`.
             retry_policy: run.retry_policy.clone(),
-            start_to_close_millis: run.start_to_close_millis,
+            start_to_close_nanos: run
+                .start_to_close
+                .map(|d| u64::try_from(d.as_nanos()).unwrap_or(u64::MAX)),
         });
     }
     prefix_events.extend(post_schedule_events);
@@ -17300,7 +17303,7 @@ mod tests {
                 activity_id: crate::types::ActivityExecId::new(),
                 name: "format_data".to_string(),
                 input: serde_json::Value::Null,
-                start_to_close_millis: None,
+                start_to_close: None,
                 retry_policy: None,
                 result_tx: oneshot::channel::<Result<serde_json::Value, String>>().0,
                 already_scheduled: false,
@@ -17349,7 +17352,7 @@ mod tests {
                 activity_id: crate::types::ActivityExecId::new(),
                 name: "format_data".to_string(),
                 input: serde_json::Value::Null,
-                start_to_close_millis: None,
+                start_to_close: None,
                 retry_policy: None,
                 result_tx: oneshot::channel::<Result<serde_json::Value, String>>().0,
                 already_scheduled: false,

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -465,6 +465,13 @@ pub struct HandlerRegistry {
     /// manual publish step.
     #[cfg(feature = "wasm-activities")]
     wasm_module_registrations: Vec<(String, Vec<u8>)>,
+    /// Builder-level default activity retry policy (issue #620). `None` = no
+    /// floor configured; the schedule-time resolution is a pure no-op preserving
+    /// today's behaviour byte-for-byte.
+    default_activity_retry_policy: Option<crate::policy::RetryPolicy>,
+    /// Builder-level default activity `start_to_close` (issue #620). `None` = no
+    /// floor configured.
+    default_activity_start_to_close: Option<Duration>,
 }
 
 impl HandlerRegistry {
@@ -609,6 +616,8 @@ impl HandlerRegistry {
             wasm_store: None,
             #[cfg(feature = "wasm-activities")]
             wasm_module_registrations: Vec::new(),
+            default_activity_retry_policy: None,
+            default_activity_start_to_close: None,
         }
     }
 
@@ -764,6 +773,35 @@ impl HandlerRegistry {
     #[must_use]
     pub fn wasm_module_registrations(&self) -> &[(String, Vec<u8>)] {
         &self.wasm_module_registrations
+    }
+
+    /// Install the builder-level default activity retry/timeout floor (issue #620).
+    ///
+    /// Both are `None` by default — an unset floor is a pure no-op preserving
+    /// today's behaviour byte-for-byte. Resolved at schedule time as the
+    /// lowest-priority fallback: a call-site override or an activity's own
+    /// `#[activity(retry = …/start_to_close = …)]` default both win.
+    #[must_use]
+    pub fn with_activity_defaults(
+        mut self,
+        retry: Option<crate::policy::RetryPolicy>,
+        start_to_close: Option<Duration>,
+    ) -> Self {
+        self.default_activity_retry_policy = retry;
+        self.default_activity_start_to_close = start_to_close;
+        self
+    }
+
+    /// Borrow the builder-level default activity retry policy (issue #620).
+    #[must_use]
+    pub fn default_activity_retry_policy(&self) -> Option<crate::policy::RetryPolicy> {
+        self.default_activity_retry_policy.clone()
+    }
+
+    /// The builder-level default activity `start_to_close` (issue #620).
+    #[must_use]
+    pub const fn default_activity_start_to_close(&self) -> Option<Duration> {
+        self.default_activity_start_to_close
     }
 
     /// Clone the shared state reference for runtime contexts.
@@ -10406,6 +10444,10 @@ async fn process_workflow_task(
                     .payload_offloader()
                     .map(crate::payload_store::PayloadOffloader::threshold),
                 telemetry.metrics.clone(),
+                // Issue #620: builder-level default activity retry/timeout floor,
+                // consumed by the LOCAL activity path in `execute_local_activity_with_opts`.
+                registry.default_activity_retry_policy(),
+                registry.default_activity_start_to_close(),
             )
             .await;
 

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -1619,7 +1619,10 @@ struct LocalActivityRun {
     activity_id: crate::types::ActivityExecId,
     name: String,
     input: serde_json::Value,
-    start_to_close_secs: Option<u64>,
+    /// Resolved per-attempt `start_to_close` in **milliseconds** (issue #620,
+    /// Codex P2 — millis, not seconds, so a subsecond floor is never truncated
+    /// to `0`). `None` defers to the worker cap.
+    start_to_close_millis: Option<u64>,
     retry_policy: Option<crate::policy::RetryPolicy>,
     /// `true` when `LocalActivityScheduled` is already in the durable history —
     /// the worker crashed after appending it but before recording a terminal event.
@@ -1713,7 +1716,7 @@ fn extract_run_local_activity(commands: Vec<WorkflowCommand>) -> LocalActivityCo
                 activity_id,
                 name,
                 input,
-                start_to_close_secs,
+                start_to_close_millis,
                 retry_policy,
                 result_tx,
                 already_scheduled,
@@ -1725,7 +1728,7 @@ fn extract_run_local_activity(commands: Vec<WorkflowCommand>) -> LocalActivityCo
                     activity_id,
                     name,
                     input,
-                    start_to_close_secs,
+                    start_to_close_millis,
                     retry_policy,
                     already_scheduled,
                     failed_attempts,
@@ -2248,9 +2251,14 @@ async fn run_local_activity_inline(
     }
     let history_event_hard_cap = registry.history_policy().event_hard_cap();
 
+    // Per-attempt timeout in **milliseconds** (issue #620, Codex P2). A
+    // subsecond floor (`start_to_close_millis = Some(500)`) must NOT truncate to
+    // `Duration::from_secs(0)` and instantly time out — the command now carries
+    // millis, so `Duration::from_millis(500)` is honored, then clamped by the
+    // worker cap.
     let per_attempt_timeout = run
-        .start_to_close_secs
-        .map_or(max_start_to_close, Duration::from_secs)
+        .start_to_close_millis
+        .map_or(max_start_to_close, Duration::from_millis)
         .min(max_start_to_close);
 
     let max_attempts = run.retry_policy.as_ref().map_or(1, |p| p.max_attempts);
@@ -2263,12 +2271,20 @@ async fn run_local_activity_inline(
             activity_id: run.activity_id,
             name: run.name.clone(),
             input: run.input.clone(),
-            // Issue #620 (AC8): freeze the fully-resolved retry policy (already
-            // call → activity → builder resolved in `execute_local_activity_raw`)
-            // so a crash-recovery replay keeps this original budget even if the
-            // builder-level default changed in the crash window. `None` when no
-            // retry policy was resolved (pre-#620 behaviour preserved).
+            // Issue #620 (AC8; Codex P2): the resolution marker. Every #620+
+            // schedule writes `true` at this first-schedule anchor so the
+            // crash-recovery path treats the frozen retry/STC below as
+            // authoritative (even when `None`), distinct from a pre-#620 legacy
+            // event (marker absent → `false` → re-derive live).
+            resolved: true,
+            // Freeze the fully-resolved retry policy AND start_to_close (already
+            // call → activity → builder resolved in
+            // `execute_local_activity_raw_resolved`) so a crash-recovery replay
+            // keeps this ORIGINAL budget/timeout even if the builder-level
+            // default changed in the crash window. `None` = "explicitly resolved
+            // to no floor" — still frozen, since the marker is `true`.
             retry_policy: run.retry_policy.clone(),
+            start_to_close_millis: run.start_to_close_millis,
         });
     }
     prefix_events.extend(post_schedule_events);
@@ -17284,7 +17300,7 @@ mod tests {
                 activity_id: crate::types::ActivityExecId::new(),
                 name: "format_data".to_string(),
                 input: serde_json::Value::Null,
-                start_to_close_secs: None,
+                start_to_close_millis: None,
                 retry_policy: None,
                 result_tx: oneshot::channel::<Result<serde_json::Value, String>>().0,
                 already_scheduled: false,
@@ -17333,7 +17349,7 @@ mod tests {
                 activity_id: crate::types::ActivityExecId::new(),
                 name: "format_data".to_string(),
                 input: serde_json::Value::Null,
-                start_to_close_secs: None,
+                start_to_close_millis: None,
                 retry_policy: None,
                 result_tx: oneshot::channel::<Result<serde_json::Value, String>>().0,
                 already_scheduled: false,

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -903,6 +903,14 @@ impl std::fmt::Debug for HandlerRegistry {
             .field(
                 "activity_interceptor_count",
                 &self.activity_interceptors.len(),
+            )
+            .field(
+                "default_activity_retry_policy",
+                &self.default_activity_retry_policy,
+            )
+            .field(
+                "default_activity_start_to_close",
+                &self.default_activity_start_to_close,
             );
         #[cfg(feature = "wasm-activities")]
         d.field("wasm_activity_count", &self.wasm_activities.len())
@@ -15912,6 +15920,8 @@ mod tests {
             cancellation_grace_period: Duration::from_secs(10),
             shard_assignments: vec![crate::types::ShardId::new(0)],
             max_local_activity_start_to_close: Duration::from_secs(60),
+            default_activity_retry_policy: None,
+            default_activity_start_to_close: None,
             worker_heartbeat_interval: Duration::from_secs(5),
             build_id: String::new(),
             deployment_name: None,

--- a/autumn-harvest/tests/integration/activity_default_floor_tests.rs
+++ b/autumn-harvest/tests/integration/activity_default_floor_tests.rs
@@ -1,5 +1,5 @@
 #![cfg(feature = "db")]
-//! Builder-level default activity retry + start_to_close floor — issue #620.
+//! Builder-level default activity retry + `start_to_close` floor — issue #620.
 //!
 //! RED PHASE (TDD): these tests reference the not-yet-existing
 //! `HandlerRegistry::with_activity_defaults(retry, start_to_close)` builder, so

--- a/autumn-harvest/tests/integration/activity_default_floor_tests.rs
+++ b/autumn-harvest/tests/integration/activity_default_floor_tests.rs
@@ -319,11 +319,7 @@ async fn load_history(url: &str, exec_id: ExecutionId) -> Vec<WorkflowEvent> {
 }
 
 /// Load the single enqueued *activity* task row for `activity_name`.
-async fn load_activity_task(
-    url: &str,
-    exec_id: ExecutionId,
-    activity_name: &str,
-) -> TaskQueueItem {
+async fn load_activity_task(url: &str, exec_id: ExecutionId, activity_name: &str) -> TaskQueueItem {
     let mut conn = connect(url).await;
     let rows: Vec<TaskQueueItem> = harvest_task_queue::table
         .filter(harvest_task_queue::workflow_exec_id.eq(Some(exec_id.as_uuid())))
@@ -483,7 +479,13 @@ async fn no_retry_activity_under_builder_default_gets_max_attempts_n() {
     let (url, _container) = setup_db().await;
     let queue = "q620-builder-default";
     let mut conn = connect(&url).await;
-    let exec_id = seed_workflow(&mut conn, "wf_one_activity", serde_json::json!({"v": 1}), queue).await;
+    let exec_id = seed_workflow(
+        &mut conn,
+        "wf_one_activity",
+        serde_json::json!({"v": 1}),
+        queue,
+    )
+    .await;
 
     // Builder default max_attempts = 4; activity declares no retry.
     let registry = build_registry(
@@ -492,7 +494,12 @@ async fn no_retry_activity_under_builder_default_gets_max_attempts_n() {
         Some(RetryPolicy::fixed(4, Duration::from_millis(10))),
         None,
     );
-    let worker = build_worker("w620-default", queue, Arc::clone(&registry), Duration::from_secs(60));
+    let worker = build_worker(
+        "w620-default",
+        queue,
+        Arc::clone(&registry),
+        Duration::from_secs(60),
+    );
     let pool = build_pool(&url);
 
     let task = run_until_activity_enqueued(
@@ -524,7 +531,13 @@ async fn raw_dispatched_activity_honours_builder_default() {
     let (url, _container) = setup_db().await;
     let queue = "q620-raw-default";
     let mut conn = connect(&url).await;
-    let exec_id = seed_workflow(&mut conn, "wf_one_activity", serde_json::json!({"v": 1}), queue).await;
+    let exec_id = seed_workflow(
+        &mut conn,
+        "wf_one_activity",
+        serde_json::json!({"v": 1}),
+        queue,
+    )
+    .await;
 
     // `wf_one_activity` uses `ctx.execute_activity_raw` — the DAG/raw path.
     let registry = build_registry(
@@ -533,7 +546,12 @@ async fn raw_dispatched_activity_honours_builder_default() {
         Some(RetryPolicy::fixed(4, Duration::from_millis(10))),
         None,
     );
-    let worker = build_worker("w620-raw", queue, Arc::clone(&registry), Duration::from_secs(60));
+    let worker = build_worker(
+        "w620-raw",
+        queue,
+        Arc::clone(&registry),
+        Duration::from_secs(60),
+    );
     let pool = build_pool(&url);
 
     let task = run_until_activity_enqueued(
@@ -561,7 +579,13 @@ async fn declared_retry_activity_unaffected_by_builder_default() {
     let (url, _container) = setup_db().await;
     let queue = "q620-declared-wins";
     let mut conn = connect(&url).await;
-    let exec_id = seed_workflow(&mut conn, "wf_one_activity", serde_json::json!({"v": 1}), queue).await;
+    let exec_id = seed_workflow(
+        &mut conn,
+        "wf_one_activity",
+        serde_json::json!({"v": 1}),
+        queue,
+    )
+    .await;
 
     // Activity declares its own retry (max_attempts=2); builder default is 9.
     let registry = build_registry(
@@ -576,7 +600,12 @@ async fn declared_retry_activity_unaffected_by_builder_default() {
         Some(RetryPolicy::fixed(9, Duration::from_millis(10))),
         None,
     );
-    let worker = build_worker("w620-declared", queue, Arc::clone(&registry), Duration::from_secs(60));
+    let worker = build_worker(
+        "w620-declared",
+        queue,
+        Arc::clone(&registry),
+        Duration::from_secs(60),
+    );
     let pool = build_pool(&url);
 
     let task = run_until_activity_enqueued(
@@ -622,7 +651,12 @@ async fn call_site_override_wins_over_builder_default() {
         Some(RetryPolicy::fixed(9, Duration::from_millis(10))),
         None,
     );
-    let worker = build_worker("w620-call", queue, Arc::clone(&registry), Duration::from_secs(60));
+    let worker = build_worker(
+        "w620-call",
+        queue,
+        Arc::clone(&registry),
+        Duration::from_secs(60),
+    );
     let pool = build_pool(&url);
 
     let task = run_until_activity_enqueued(
@@ -659,7 +693,13 @@ async fn no_defaults_set_is_byte_for_byte_current_behaviour() {
     let (url, _container) = setup_db().await;
     let queue = "q620-no-defaults";
     let mut conn = connect(&url).await;
-    let exec_id = seed_workflow(&mut conn, "wf_one_activity", serde_json::json!({"v": 1}), queue).await;
+    let exec_id = seed_workflow(
+        &mut conn,
+        "wf_one_activity",
+        serde_json::json!({"v": 1}),
+        queue,
+    )
+    .await;
 
     // No builder default, no activity default, no call-site override.
     let registry = build_registry(
@@ -668,7 +708,12 @@ async fn no_defaults_set_is_byte_for_byte_current_behaviour() {
         None,
         None,
     );
-    let worker = build_worker("w620-nodefault", queue, Arc::clone(&registry), Duration::from_secs(60));
+    let worker = build_worker(
+        "w620-nodefault",
+        queue,
+        Arc::clone(&registry),
+        Duration::from_secs(60),
+    );
     let pool = build_pool(&url);
 
     let task = run_until_activity_enqueued(
@@ -705,7 +750,13 @@ async fn local_activity_honours_builder_default_retry() {
     let (url, _container) = setup_db().await;
     let queue = "q620-local-retry";
     let mut conn = connect(&url).await;
-    let exec_id = seed_workflow(&mut conn, "wf_failing_local", serde_json::json!({"v": 1}), queue).await;
+    let exec_id = seed_workflow(
+        &mut conn,
+        "wf_failing_local",
+        serde_json::json!({"v": 1}),
+        queue,
+    )
+    .await;
 
     // Builder default retry max_attempts=3; local activity always fails; the
     // workflow supplies NO call-site retry override, so the builder default is
@@ -716,10 +767,23 @@ async fn local_activity_honours_builder_default_retry() {
         Some(RetryPolicy::fixed(3, Duration::from_millis(10))),
         None,
     );
-    let worker = build_worker("w620-local-retry", queue, Arc::clone(&registry), Duration::from_secs(60));
+    let worker = build_worker(
+        "w620-local-retry",
+        queue,
+        Arc::clone(&registry),
+        Duration::from_secs(60),
+    );
     let pool = build_pool(&url);
 
-    run_to_state(&url, &pool, worker, exec_id, "FAILED", Duration::from_secs(20)).await;
+    run_to_state(
+        &url,
+        &pool,
+        worker,
+        exec_id,
+        "FAILED",
+        Duration::from_secs(20),
+    )
+    .await;
 
     let history = load_history(&url, exec_id).await;
     assert_eq!(
@@ -749,7 +813,13 @@ async fn local_activity_builder_default_stc_clamped_by_max() {
     let (url, _container) = setup_db().await;
     let queue = "q620-local-stc";
     let mut conn = connect(&url).await;
-    let exec_id = seed_workflow(&mut conn, "wf_slow_local", serde_json::json!({"v": 1}), queue).await;
+    let exec_id = seed_workflow(
+        &mut conn,
+        "wf_slow_local",
+        serde_json::json!({"v": 1}),
+        queue,
+    )
+    .await;
 
     // Builder default STC = 300s, worker max_local_activity_start_to_close =
     // 200ms. A 500ms-sleeping local activity must NOT be granted the full 300s;
@@ -768,8 +838,15 @@ async fn local_activity_builder_default_stc_clamped_by_max() {
     );
     let pool = build_pool(&url);
 
-    let execution =
-        run_to_state(&url, &pool, worker, exec_id, "FAILED", Duration::from_secs(20)).await;
+    let execution = run_to_state(
+        &url,
+        &pool,
+        worker,
+        exec_id,
+        "FAILED",
+        Duration::from_secs(20),
+    )
+    .await;
 
     assert_eq!(
         execution.state, "FAILED",

--- a/autumn-harvest/tests/integration/activity_default_floor_tests.rs
+++ b/autumn-harvest/tests/integration/activity_default_floor_tests.rs
@@ -391,6 +391,7 @@ async fn seed_workflow(
 /// `recorded_resolved` is the #620 disambiguation marker (Codex P2): `true`
 /// models a #620+ event whose frozen values are authoritative (even `None`);
 /// `false` models a pre-#620 legacy event that falls back to live re-derivation.
+#[allow(clippy::too_many_arguments)]
 async fn seed_local_activity_in_progress(
     conn: &mut AsyncPgConnection,
     workflow_name: &'static str,

--- a/autumn-harvest/tests/integration/activity_default_floor_tests.rs
+++ b/autumn-harvest/tests/integration/activity_default_floor_tests.rs
@@ -175,7 +175,7 @@ fn wf_slower_local(ctx: &WorkflowContext, input: serde_json::Value) -> BoxFut<'_
     })
 }
 
-/// Workflow: schedule one regular activity WITH a call-site START_TO_CLOSE
+/// Workflow: schedule one regular activity WITH a call-site `start_to_close`
 /// override (5s), no retry override. Used to prove the call-site STC wins over
 /// the builder-default STC on the regular dispatch path.
 fn wf_one_activity_stc_override(ctx: &WorkflowContext, input: serde_json::Value) -> BoxFut<'_> {

--- a/autumn-harvest/tests/integration/activity_default_floor_tests.rs
+++ b/autumn-harvest/tests/integration/activity_default_floor_tests.rs
@@ -176,9 +176,9 @@ fn wf_slower_local(ctx: &WorkflowContext, input: serde_json::Value) -> BoxFut<'_
 }
 
 /// Local activity that sleeps ~50ms then echoes — well under a 500ms subsecond
-/// builder-default STC, so it MUST complete. Without the millis fix (issue #620,
-/// Codex P2) the 500ms builder default truncates to `Duration::from_secs(0)` and
-/// even this 50ms activity is instantly timed out.
+/// builder-default STC, so it MUST complete. Without the full-`Duration` fix
+/// (issue #620, Codex P2) the 500ms builder default truncates to
+/// `Duration::from_secs(0)` and even this 50ms activity is instantly timed out.
 fn fast_local(_ctx: &autumn_harvest::ActivityContext, input: serde_json::Value) -> BoxFut<'_> {
     Box::pin(async move {
         tokio::time::sleep(Duration::from_millis(50)).await;
@@ -382,7 +382,7 @@ async fn seed_workflow(
 
 /// Seed a RUNNING execution whose local activity is MID-RETRY: its history
 /// already carries `LocalActivityScheduled` (frozen with `recorded_resolved` /
-/// `recorded_retry` / `recorded_stc_millis`) and one
+/// `recorded_retry` / `recorded_stc_nanos`) and one
 /// `LocalActivityFailed(attempt=1)`, and a workflow task is enqueued so a
 /// worker resumes it. This reproduces the crash-recovery window for AC8: the
 /// original retry budget/timeout is frozen in history and must survive a later
@@ -399,7 +399,7 @@ async fn seed_local_activity_in_progress(
     queue: &str,
     recorded_resolved: bool,
     recorded_retry: Option<RetryPolicy>,
-    recorded_stc_millis: Option<u64>,
+    recorded_stc_nanos: Option<u64>,
 ) -> ExecutionId {
     let exec_id = ExecutionId::new_for_shard(autumn_harvest::types::ShardId::new(0));
     let row = NewWorkflowExecution {
@@ -457,7 +457,7 @@ async fn seed_local_activity_in_progress(
                 input: input.clone(),
                 resolved: recorded_resolved,
                 retry_policy: recorded_retry,
-                start_to_close_millis: recorded_stc_millis,
+                start_to_close_nanos: recorded_stc_nanos,
             },
             WorkflowEvent::LocalActivityFailed {
                 activity_id,
@@ -648,6 +648,22 @@ fn count_local_failed(history: &[WorkflowEvent]) -> usize {
         .iter()
         .filter(|e| matches!(e, WorkflowEvent::LocalActivityFailed { .. }))
         .count()
+}
+
+/// The `start_to_close_nanos` the worker FROZE onto the recorded
+/// `LocalActivityScheduled` — i.e. the fully-resolved effective per-attempt
+/// timeout, in nanoseconds (issue #620, Codex P2). This is the pre-clamp
+/// resolved `Duration` value, so asserting it proves the resolution carried the
+/// configured `Duration` with no truncation at any unit — deterministically,
+/// with no wall-clock timing dependence.
+fn local_scheduled_stc_nanos(history: &[WorkflowEvent]) -> Option<u64> {
+    history.iter().find_map(|e| match e {
+        WorkflowEvent::LocalActivityScheduled {
+            start_to_close_nanos,
+            ..
+        } => Some(*start_to_close_nanos),
+        _ => None,
+    })?
 }
 
 // ---------------------------------------------------------------------------
@@ -980,13 +996,13 @@ async fn local_activity_honours_builder_default_retry() {
 // This is the discriminating rework of the original clamp test: builder-default
 // STC = 1s (well below the 60s worker cap), local activity sleeps ~2s. The
 // local path's per-attempt timeout is
-// `run.start_to_close_secs.map_or(max, from_secs).min(max)` — WITH the feature
-// `start_to_close_secs = Some(1)` (the builder default, `.as_secs()`), so the
-// timeout is `min(1s, 60s) = 1s` and the 2s activity FAILS. WITHOUT the feature
-// `start_to_close_secs = None`, so the timeout is the 60s cap and the 2s
-// activity would COMPLETE. The outcome therefore depends on the feature's exact
-// value, not merely the cap. (Local path is seconds-granularity, so 1s is the
-// smallest meaningful builder STC.)
+// `run.start_to_close.unwrap_or(max).min(max)` — WITH the feature the resolved
+// `Duration` is `Some(1s)`, so the timeout is `min(1s, 60s) = 1s` and the 2s
+// activity FAILS. WITHOUT the feature it is `None`, so the timeout is the 60s
+// cap and the 2s activity would COMPLETE. The outcome therefore depends on the
+// feature's exact value, not merely the cap. (The local path carries the full
+// `Duration`, so subsecond builder STCs are meaningful — see the
+// `local_activity_subsecond_*` tests below.)
 // ---------------------------------------------------------------------------
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
@@ -1388,6 +1404,114 @@ async fn local_activity_resolved_to_no_floor_ignores_a_later_added_default() {
          A count of 3 would mean the marker was ignored and the added default \
          wrongly re-derived (the AC8-violating bug)."
     );
+}
+
+// ---------------------------------------------------------------------------
+// FIX 3 (Codex P2, value proof) — the EFFECTIVE resolved local start_to_close
+// must EQUAL the configured Duration with NO loss at any unit. The command and
+// the frozen `LocalActivityScheduled.start_to_close_nanos` carry the full
+// Duration (nanoseconds), so:
+//   * a `from_millis(1500)` builder default resolves to EXACTLY 1.5s
+//     (1_500_000_000 ns) — not 1s (a seconds field would truncate it);
+//   * a `from_micros(500)` sub-millisecond value is preserved as 500_000 ns —
+//     NON-ZERO (a millis field would zero it → instant timeout).
+// This asserts the resolved Duration VALUE from recorded history — deterministic,
+// no wall-clock timing race — and subsumes the "subsecond not zeroed" outcome
+// assertion below (which additionally proves the worker HONORS the value
+// end-to-end at a robust 10x margin).
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn local_activity_resolved_stc_equals_configured_duration_no_truncation() {
+    let (url, _container) = setup_db().await;
+    let pool = build_pool(&url);
+
+    // Scenario 1: from_millis(1500) → exactly 1.5s frozen, and (1.5s > 50ms
+    // activity, 60s cap) the run COMPLETES.
+    {
+        let queue = "q620-stc-value-1500ms";
+        let mut conn = connect(&url).await;
+        let exec_id = seed_workflow(
+            &mut conn,
+            "wf_fast_local",
+            serde_json::json!({"v": 1}),
+            queue,
+        )
+        .await;
+        let registry = build_registry(
+            vec![wf_info("wf_fast_local", wf_fast_local)],
+            vec![act_info("fast_local", fast_local, true, None, None)],
+            None,
+            Some(Duration::from_millis(1500)),
+        );
+        let worker = build_worker(
+            "w620-stc-value-1500ms",
+            queue,
+            Arc::clone(&registry),
+            Duration::from_secs(60),
+        );
+        run_to_state(
+            &url,
+            &pool,
+            worker,
+            exec_id,
+            "COMPLETED",
+            Duration::from_secs(20),
+        )
+        .await;
+        let history = load_history(&url, exec_id).await;
+        assert_eq!(
+            local_scheduled_stc_nanos(&history),
+            Some(1_500_000_000),
+            "a from_millis(1500) builder default must freeze EXACTLY 1.5s \
+             (1_500_000_000 ns) — a seconds field would have truncated it to 1s"
+        );
+    }
+
+    // Scenario 2: from_micros(500) → 500_000 ns frozen (NON-ZERO), proving
+    // sub-millisecond precision survives. The 500µs per-attempt timeout kills
+    // the 50ms activity (→ FAILED), but the FROZEN value is recorded at schedule
+    // time regardless, so the value assertion is outcome-independent.
+    {
+        let queue = "q620-stc-value-500us";
+        let mut conn = connect(&url).await;
+        let exec_id = seed_workflow(
+            &mut conn,
+            "wf_fast_local",
+            serde_json::json!({"v": 2}),
+            queue,
+        )
+        .await;
+        let registry = build_registry(
+            vec![wf_info("wf_fast_local", wf_fast_local)],
+            vec![act_info("fast_local", fast_local, true, None, None)],
+            None,
+            Some(Duration::from_micros(500)),
+        );
+        let worker = build_worker(
+            "w620-stc-value-500us",
+            queue,
+            Arc::clone(&registry),
+            Duration::from_secs(60),
+        );
+        run_to_state(
+            &url,
+            &pool,
+            worker,
+            exec_id,
+            "FAILED",
+            Duration::from_secs(20),
+        )
+        .await;
+        let history = load_history(&url, exec_id).await;
+        assert_eq!(
+            local_scheduled_stc_nanos(&history),
+            Some(500_000),
+            "a from_micros(500) sub-millisecond builder default must freeze \
+             500_000 ns (NON-ZERO) — a millis field would have zeroed it, \
+             instantly timing out every attempt"
+        );
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/autumn-harvest/tests/integration/activity_default_floor_tests.rs
+++ b/autumn-harvest/tests/integration/activity_default_floor_tests.rs
@@ -157,6 +157,29 @@ fn slow_local(_ctx: &autumn_harvest::ActivityContext, input: serde_json::Value) 
     })
 }
 
+/// Workflow: schedule the reserved session-acquire internal activity via the
+/// raw path (mirroring how `create_session` dispatches it). Used to prove the
+/// builder-level floor does NOT leak onto engine-internal session machinery.
+/// The worker is shut down at enqueue time, so the reserved dispatch handler
+/// never runs.
+fn wf_session_acquire(ctx: &WorkflowContext, input: serde_json::Value) -> BoxFut<'_> {
+    Box::pin(async move {
+        let queue = ctx.queue_name().to_string();
+        // Reserved engine-internal session-acquire activity name (issue #606);
+        // the public `is_reserved_session_activity_name` helper classifies it,
+        // and the worker auto-registers an `ActivityInfo` stub for it so the
+        // enqueue-time lookup succeeds.
+        ctx.execute_activity_raw(RESERVED_SESSION_ACQUIRE, input, &queue)
+            .await
+            .map_err(|e| e.to_string())
+    })
+}
+
+/// The reserved worker-session acquire activity name (issue #606). Kept in sync
+/// with `autumn_harvest::context`'s `pub(crate)` constant via the public
+/// `is_reserved_session_activity_name` classifier (asserted in the test below).
+const RESERVED_SESSION_ACQUIRE: &str = "__harvest_session_acquire";
+
 // ---------------------------------------------------------------------------
 // Registry / worker construction.
 // ---------------------------------------------------------------------------
@@ -296,6 +319,97 @@ async fn seed_workflow(
     queue::enqueue(conn, &params)
         .await
         .expect("enqueue workflow task");
+
+    exec_id
+}
+
+/// Seed a RUNNING execution whose local activity is MID-RETRY: its history
+/// already carries `LocalActivityScheduled` (frozen with `recorded_retry`) and
+/// one `LocalActivityFailed(attempt=1)`, and a workflow task is enqueued so a
+/// worker resumes it. This reproduces the crash-recovery window for AC8: the
+/// original retry budget is frozen in history and must survive a later change to
+/// the builder-level default.
+async fn seed_local_activity_in_progress(
+    conn: &mut AsyncPgConnection,
+    workflow_name: &'static str,
+    activity_name: &str,
+    input: serde_json::Value,
+    queue: &str,
+    recorded_retry: Option<RetryPolicy>,
+) -> ExecutionId {
+    let exec_id = ExecutionId::new_for_shard(autumn_harvest::types::ShardId::new(0));
+    let row = NewWorkflowExecution {
+        id: exec_id.as_uuid(),
+        workflow_name,
+        workflow_id: &format!("wf-{}", exec_id.as_uuid()),
+        run_id: Uuid::new_v4(),
+        shard_id: 0,
+        input: input.clone(),
+        parent_id: None,
+        queue_name: queue,
+        execution_timeout: None,
+        deadline_at: None,
+        memo: None,
+        search_attrs: None,
+        assigned_build_id: None,
+        parent_close_policy: None,
+        owner: None,
+        runbook_url: None,
+        severity: None,
+        context_headers: None,
+        sla: None,
+        sla_deadline_at: None,
+        schedule_id: None,
+        scheduled_for: None,
+        workflow_attempt: 1,
+        workflow_retry_policy: None,
+        retry_of_exec_id: None,
+        origin: None,
+        completion_callbacks: None,
+        continued_from_exec_id: None,
+        first_exec_id: None,
+    };
+    diesel::insert_into(harvest_workflow_executions::table)
+        .values(&row)
+        .execute(conn)
+        .await
+        .expect("insert workflow execution");
+
+    let activity_id = autumn_harvest::types::ActivityExecId::new();
+    store::append_events(
+        conn,
+        exec_id,
+        &[
+            WorkflowEvent::WorkflowStarted {
+                input: input.clone(),
+                timestamp: Utc::now(),
+                last_completion_result: None,
+                last_error: None,
+                scheduled_time: None,
+            },
+            WorkflowEvent::LocalActivityScheduled {
+                activity_id,
+                name: activity_name.to_string(),
+                input: input.clone(),
+                retry_policy: recorded_retry,
+            },
+            WorkflowEvent::LocalActivityFailed {
+                activity_id,
+                error: "attempt 1 failed (pre-crash)".to_string(),
+                attempt: 1,
+            },
+        ],
+        0,
+    )
+    .await
+    .expect("append partial local-activity history");
+
+    let mut params = EnqueueParams::new(queue, TaskType::Workflow, input);
+    params.workflow_exec_id = Some(exec_id.as_uuid());
+    params.scheduled_at = Utc::now() - chrono::Duration::seconds(5);
+    queue::enqueue(conn, &params)
+        .await
+        .expect("enqueue resume workflow task");
 
     exec_id
 }
@@ -859,5 +973,209 @@ async fn local_activity_builder_default_stc_clamped_by_max() {
             .iter()
             .any(|e| matches!(e, WorkflowEvent::LocalActivityFailed { .. })),
         "the clamped local activity must record a LocalActivityFailed (timeout)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// FIX 1 (issue #606 interaction) — the builder-level floor must NOT leak onto
+// the reserved worker-session internal activities. They are engine machinery
+// bounded by schedule_to_start / acquisition-timeout, not a user retry/timeout
+// floor; inheriting a builder default would govern session acquire/release.
+// The enqueued reserved task must therefore keep the PRE-FEATURE resolution:
+// the EnqueueParams default (max_attempts = 3) and a NULL start_to_close.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn reserved_session_activity_does_not_inherit_builder_default() {
+    // Sanity: the literal used by the workflow handler is the classified
+    // reserved name, so this test cannot silently drift from the engine const.
+    assert!(
+        autumn_harvest::context::is_reserved_session_activity_name(RESERVED_SESSION_ACQUIRE),
+        "the test's reserved-name literal must match the engine classifier"
+    );
+
+    let (url, _container) = setup_db().await;
+    let queue = "q620-reserved-session";
+    let mut conn = connect(&url).await;
+    let exec_id = seed_workflow(
+        &mut conn,
+        "wf_session_acquire",
+        serde_json::json!({"v": 1}),
+        queue,
+    )
+    .await;
+
+    // A deliberately conspicuous builder default (max_attempts = 9, STC = 30s).
+    // The reserved session-acquire activity declares neither its own retry nor
+    // start_to_close, so WITHOUT the guard it would inherit 9 / 30s; WITH the
+    // guard it must stay at the pre-feature values (3 / NULL).
+    let registry = build_registry(
+        vec![wf_info("wf_session_acquire", wf_session_acquire)],
+        // No user activity registration needed — the worker auto-registers the
+        // reserved session-acquire ActivityInfo stub for the enqueue lookup.
+        vec![],
+        Some(RetryPolicy::fixed(9, Duration::from_millis(10))),
+        Some(Duration::from_secs(30)),
+    );
+    let worker = build_worker(
+        "w620-reserved",
+        queue,
+        Arc::clone(&registry),
+        Duration::from_secs(60),
+    );
+    let pool = build_pool(&url);
+
+    let task = run_until_activity_enqueued(
+        &url,
+        &pool,
+        worker,
+        exec_id,
+        RESERVED_SESSION_ACQUIRE,
+        Duration::from_secs(20),
+    )
+    .await;
+
+    assert_eq!(
+        task.max_attempts, 3,
+        "a reserved session-internal activity must NOT inherit the builder \
+         default retry (9); it keeps the EnqueueParams default (3)"
+    );
+    assert!(
+        task.retry_policy.is_none(),
+        "a reserved session-internal activity must carry a NULL retry_policy — \
+         the builder default must not be resolved for it"
+    );
+    assert!(
+        task.start_to_close.is_none(),
+        "a reserved session-internal activity must carry a NULL start_to_close — \
+         the builder default (30s) must not be resolved for it"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// FIX 2 (AC8) — a local activity mid-retry must keep its ORIGINAL retry budget
+// across a crash even if the builder-level default is changed in the recovery
+// window. The budget is frozen into the `LocalActivityScheduled` event at first
+// schedule; the recovery path reads it back rather than re-deriving from the
+// (now-changed) builder default.
+//
+// Scenario: original builder default fixed(2). The activity ran attempt 1 and
+// crashed (history: LocalActivityScheduled{retry=fixed(2)} + Failed(1)). The
+// operator then LOWERS the builder default to fixed(1) and the worker resumes.
+// With the fix, the recorded fixed(2) governs → attempt 2 runs → 2 failures.
+// WITHOUT the fix, the re-derived fixed(1) would exhaust immediately (only the
+// 1 pre-crash failure), never running attempt 2.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn local_activity_mid_retry_keeps_original_budget_across_default_change() {
+    let (url, _container) = setup_db().await;
+    let queue = "q620-ac8-recovery";
+    let mut conn = connect(&url).await;
+
+    // Freeze the ORIGINAL builder default (fixed(2)) into the scheduled event,
+    // exactly as the worker would have at first schedule.
+    let exec_id = seed_local_activity_in_progress(
+        &mut conn,
+        "wf_failing_local",
+        "failing_local",
+        serde_json::json!({"v": 1}),
+        queue,
+        Some(RetryPolicy::fixed(2, Duration::from_millis(10))),
+    )
+    .await;
+
+    // The operator has since LOWERED the builder default to fixed(1). If the
+    // recovery path re-derived from this, the activity would exhaust at once.
+    let registry = build_registry(
+        vec![wf_info("wf_failing_local", wf_failing_local)],
+        vec![act_info("failing_local", failing_local, true, None, None)],
+        Some(RetryPolicy::fixed(1, Duration::from_millis(10))),
+        None,
+    );
+    let worker = build_worker(
+        "w620-ac8",
+        queue,
+        Arc::clone(&registry),
+        Duration::from_secs(60),
+    );
+    let pool = build_pool(&url);
+
+    run_to_state(
+        &url,
+        &pool,
+        worker,
+        exec_id,
+        "FAILED",
+        Duration::from_secs(20),
+    )
+    .await;
+
+    let history = load_history(&url, exec_id).await;
+    assert_eq!(
+        count_local_failed(&history),
+        2,
+        "the ORIGINAL frozen retry budget (fixed(2)) must survive the builder \
+         default change to fixed(1): attempt 2 must still run, yielding 2 \
+         LocalActivityFailed events — not 1 (which a re-derived fixed(1) would \
+         produce by exhausting immediately)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// FIX 2 (backward compat) — a PRE-#620 partial history (no recorded
+// `retry_policy` on `LocalActivityScheduled`, i.e. `None`) falls back to the
+// current re-derived builder default on recovery, exactly as today. Here the
+// resumed builder default is fixed(3): with no frozen budget the recovery path
+// re-derives fixed(3) and runs to 3 failures.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn local_activity_mid_retry_without_recorded_budget_uses_current_default() {
+    let (url, _container) = setup_db().await;
+    let queue = "q620-ac8-legacy";
+    let mut conn = connect(&url).await;
+
+    // Pre-#620 event: no frozen retry_policy.
+    let exec_id = seed_local_activity_in_progress(
+        &mut conn,
+        "wf_failing_local",
+        "failing_local",
+        serde_json::json!({"v": 1}),
+        queue,
+        None,
+    )
+    .await;
+
+    let registry = build_registry(
+        vec![wf_info("wf_failing_local", wf_failing_local)],
+        vec![act_info("failing_local", failing_local, true, None, None)],
+        Some(RetryPolicy::fixed(3, Duration::from_millis(10))),
+        None,
+    );
+    let worker = build_worker(
+        "w620-ac8-legacy",
+        queue,
+        Arc::clone(&registry),
+        Duration::from_secs(60),
+    );
+    let pool = build_pool(&url);
+
+    run_to_state(
+        &url,
+        &pool,
+        worker,
+        exec_id,
+        "FAILED",
+        Duration::from_secs(20),
+    )
+    .await;
+
+    let history = load_history(&url, exec_id).await;
+    assert_eq!(
+        count_local_failed(&history),
+        3,
+        "with NO frozen budget (pre-#620 event), recovery re-derives the current \
+         builder default (fixed(3)) — 1 pre-crash failure + 2 more = 3 total"
     );
 }

--- a/autumn-harvest/tests/integration/activity_default_floor_tests.rs
+++ b/autumn-harvest/tests/integration/activity_default_floor_tests.rs
@@ -157,6 +157,42 @@ fn slow_local(_ctx: &autumn_harvest::ActivityContext, input: serde_json::Value) 
     })
 }
 
+/// Local activity that sleeps ~2s then echoes — long enough that a 1s
+/// builder-default STC kills it while the 60s worker cap alone would not.
+fn slower_local(_ctx: &autumn_harvest::ActivityContext, input: serde_json::Value) -> BoxFut<'_> {
+    Box::pin(async move {
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        Ok(input)
+    })
+}
+
+/// Workflow: run the ~2s local activity with NO call-site STC override.
+fn wf_slower_local(ctx: &WorkflowContext, input: serde_json::Value) -> BoxFut<'_> {
+    Box::pin(async move {
+        ctx.execute_local_activity_raw("slower_local", input, None, None)
+            .await
+            .map_err(|e| e.to_string())
+    })
+}
+
+/// Workflow: schedule one regular activity WITH a call-site START_TO_CLOSE
+/// override (5s), no retry override. Used to prove the call-site STC wins over
+/// the builder-default STC on the regular dispatch path.
+fn wf_one_activity_stc_override(ctx: &WorkflowContext, input: serde_json::Value) -> BoxFut<'_> {
+    Box::pin(async move {
+        let queue = ctx.queue_name().to_string();
+        ctx.execute_activity_raw_with_opts(
+            "echo",
+            input,
+            &queue,
+            None,
+            Some(Duration::from_secs(5)),
+        )
+        .await
+        .map_err(|e| e.to_string())
+    })
+}
+
 /// Workflow: schedule the reserved session-acquire internal activity via the
 /// raw path (mirroring how `create_session` dispatches it). Used to prove the
 /// builder-level floor does NOT leak onto engine-internal session machinery.
@@ -908,24 +944,85 @@ async fn local_activity_honours_builder_default_retry() {
 }
 
 // ---------------------------------------------------------------------------
-// AC7 — a local activity's builder-default STC is clamped by the worker max.
+// AC7 (discriminating) — a local activity's builder-default STC BELOW the
+// worker cap is enforced at its EXACT value.
 //
-// NOTE (RED-phase limitation, flagged to the coordinator): asserting the
-// builder-default STC end-to-end is awkward. The local path's per-attempt
-// timeout is `run.start_to_close_secs.map_or(max, from_secs).min(max)`, so a
-// no-call-site-STC local activity ALREADY falls back to `max` today —
-// meaning a builder default LARGER than `max` (300s vs 60s) yields the same
-// clamped value (60s) with or without the feature. This integration test can
-// therefore only assert the weaker AC "the builder default does not grant the
-// full 300s": a 500ms-sleeping local activity under a small `max` (200ms) times
-// out (FAILED) rather than completing. The precedence itself is pinned by the
-// pure `resolve_effective_start_to_close_precedence` unit test in policy.rs.
+// This is the discriminating rework of the original clamp test: builder-default
+// STC = 1s (well below the 60s worker cap), local activity sleeps ~2s. The
+// local path's per-attempt timeout is
+// `run.start_to_close_secs.map_or(max, from_secs).min(max)` — WITH the feature
+// `start_to_close_secs = Some(1)` (the builder default, `.as_secs()`), so the
+// timeout is `min(1s, 60s) = 1s` and the 2s activity FAILS. WITHOUT the feature
+// `start_to_close_secs = None`, so the timeout is the 60s cap and the 2s
+// activity would COMPLETE. The outcome therefore depends on the feature's exact
+// value, not merely the cap. (Local path is seconds-granularity, so 1s is the
+// smallest meaningful builder STC.)
 // ---------------------------------------------------------------------------
 
 #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-async fn local_activity_builder_default_stc_clamped_by_max() {
+async fn local_activity_builder_default_stc_below_cap_is_enforced() {
     let (url, _container) = setup_db().await;
-    let queue = "q620-local-stc";
+    let queue = "q620-local-stc-enforced";
+    let mut conn = connect(&url).await;
+    let exec_id = seed_workflow(
+        &mut conn,
+        "wf_slower_local",
+        serde_json::json!({"v": 1}),
+        queue,
+    )
+    .await;
+
+    // Builder default STC = 1s, worker cap = 60s. No retry (so exactly one
+    // attempt), no activity-level STC, no call-site STC — the builder default
+    // is the sole source. The ~2s activity must be killed by the 1s builder STC.
+    let registry = build_registry(
+        vec![wf_info("wf_slower_local", wf_slower_local)],
+        vec![act_info("slower_local", slower_local, true, None, None)],
+        None,
+        Some(Duration::from_secs(1)),
+    );
+    let worker = build_worker(
+        "w620-local-stc-enforced",
+        queue,
+        Arc::clone(&registry),
+        Duration::from_secs(60),
+    );
+    let pool = build_pool(&url);
+
+    let execution = run_to_state(
+        &url,
+        &pool,
+        worker,
+        exec_id,
+        "FAILED",
+        Duration::from_secs(20),
+    )
+    .await;
+
+    assert_eq!(
+        execution.state, "FAILED",
+        "the builder-default 1s STC (below the 60s cap) must kill the ~2s local \
+         activity — without the feature the 60s cap alone would let it complete"
+    );
+    let history = load_history(&url, exec_id).await;
+    assert!(
+        history
+            .iter()
+            .any(|e| matches!(e, WorkflowEvent::LocalActivityFailed { .. })),
+        "the STC-killed local activity must record a LocalActivityFailed (timeout)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// AC7 (clamp-proof) — a builder-default STC LARGER than the worker cap is still
+// clamped by the cap. Cheap companion to the discriminating test above: it
+// pins that the builder default can never GRANT more than the worker cap.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn local_activity_builder_default_stc_larger_than_cap_is_clamped() {
+    let (url, _container) = setup_db().await;
+    let queue = "q620-local-stc-clamp";
     let mut conn = connect(&url).await;
     let exec_id = seed_workflow(
         &mut conn,
@@ -935,9 +1032,8 @@ async fn local_activity_builder_default_stc_clamped_by_max() {
     )
     .await;
 
-    // Builder default STC = 300s, worker max_local_activity_start_to_close =
-    // 200ms. A 500ms-sleeping local activity must NOT be granted the full 300s;
-    // it is clamped and times out → FAILED.
+    // Builder default STC = 300s, worker cap = 200ms. A 500ms-sleeping local
+    // activity must NOT be granted the full 300s; it is clamped → times out.
     let registry = build_registry(
         vec![wf_info("wf_slow_local", wf_slow_local)],
         vec![act_info("slow_local", slow_local, true, None, None)],
@@ -945,7 +1041,7 @@ async fn local_activity_builder_default_stc_clamped_by_max() {
         Some(Duration::from_secs(300)),
     );
     let worker = build_worker(
-        "w620-local-stc",
+        "w620-local-stc-clamp",
         queue,
         Arc::clone(&registry),
         Duration::from_millis(200),
@@ -965,7 +1061,7 @@ async fn local_activity_builder_default_stc_clamped_by_max() {
     assert_eq!(
         execution.state, "FAILED",
         "a 500ms local activity under a 200ms clamp must time out — the \
-         builder-default 300s STC must not grant the full window"
+         builder-default 300s STC must never grant more than the worker cap"
     );
     let history = load_history(&url, exec_id).await;
     assert!(
@@ -1177,5 +1273,297 @@ async fn local_activity_mid_retry_without_recorded_budget_uses_current_default()
         3,
         "with NO frozen budget (pre-#620 event), recovery re-derives the current \
          builder default (fixed(3)) — 1 pre-crash failure + 2 more = 3 total"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Item 3 (P1) — the builder-default start_to_close reaches a REGULAR activity's
+// enqueued task.start_to_close (the positive STC path — the retry equivalent is
+// already covered by no_retry_activity_under_builder_default_gets_max_attempts_n).
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn regular_activity_under_builder_default_gets_start_to_close() {
+    let (url, _container) = setup_db().await;
+    let queue = "q620-stc-positive";
+    let mut conn = connect(&url).await;
+    let exec_id = seed_workflow(
+        &mut conn,
+        "wf_one_activity",
+        serde_json::json!({"v": 1}),
+        queue,
+    )
+    .await;
+
+    // Builder default STC = 30s; activity declares no STC; no call override.
+    let registry = build_registry(
+        vec![wf_info("wf_one_activity", wf_one_activity)],
+        vec![act_info("echo", echo_activity, false, None, None)],
+        None,
+        Some(Duration::from_secs(30)),
+    );
+    let worker = build_worker(
+        "w620-stc-positive",
+        queue,
+        Arc::clone(&registry),
+        Duration::from_secs(60),
+    );
+    let pool = build_pool(&url);
+
+    let task = run_until_activity_enqueued(
+        &url,
+        &pool,
+        worker,
+        exec_id,
+        "echo",
+        Duration::from_secs(20),
+    )
+    .await;
+
+    assert_eq!(
+        task.start_to_close,
+        Some(chrono::Duration::seconds(30)),
+        "the builder-default start_to_close (30s) must reach the enqueued \
+         regular activity task's start_to_close column"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Item 6 (P2) — STC precedence on the regular path: a call-site START_TO_CLOSE
+// override wins over the builder-default STC (the STC mirror of AC5 for retry).
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn call_site_stc_override_wins_over_builder_default_stc() {
+    let (url, _container) = setup_db().await;
+    let queue = "q620-stc-call-wins";
+    let mut conn = connect(&url).await;
+    let exec_id = seed_workflow(
+        &mut conn,
+        "wf_one_activity_stc_override",
+        serde_json::json!({"v": 1}),
+        queue,
+    )
+    .await;
+
+    // Call-site STC override = 5s; builder default STC = 30s; activity none.
+    let registry = build_registry(
+        vec![wf_info(
+            "wf_one_activity_stc_override",
+            wf_one_activity_stc_override,
+        )],
+        vec![act_info("echo", echo_activity, false, None, None)],
+        None,
+        Some(Duration::from_secs(30)),
+    );
+    let worker = build_worker(
+        "w620-stc-call",
+        queue,
+        Arc::clone(&registry),
+        Duration::from_secs(60),
+    );
+    let pool = build_pool(&url);
+
+    let task = run_until_activity_enqueued(
+        &url,
+        &pool,
+        worker,
+        exec_id,
+        "echo",
+        Duration::from_secs(20),
+    )
+    .await;
+
+    assert_eq!(
+        task.start_to_close,
+        Some(chrono::Duration::seconds(5)),
+        "the call-site start_to_close override (5s) must win over the \
+         builder-default STC (30s)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Item 6 (P2) — STC precedence on the regular path: an activity-declared
+// #[activity(start_to_close = …)] default wins over the builder-default STC.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn declared_activity_stc_wins_over_builder_default_stc() {
+    let (url, _container) = setup_db().await;
+    let queue = "q620-stc-declared-wins";
+    let mut conn = connect(&url).await;
+    let exec_id = seed_workflow(
+        &mut conn,
+        "wf_one_activity",
+        serde_json::json!({"v": 1}),
+        queue,
+    )
+    .await;
+
+    // Activity declares its own STC = 7s; builder default STC = 30s.
+    let registry = build_registry(
+        vec![wf_info("wf_one_activity", wf_one_activity)],
+        vec![act_info(
+            "echo",
+            echo_activity,
+            false,
+            None,
+            Some(Duration::from_secs(7)),
+        )],
+        None,
+        Some(Duration::from_secs(30)),
+    );
+    let worker = build_worker(
+        "w620-stc-declared",
+        queue,
+        Arc::clone(&registry),
+        Duration::from_secs(60),
+    );
+    let pool = build_pool(&url);
+
+    let task = run_until_activity_enqueued(
+        &url,
+        &pool,
+        worker,
+        exec_id,
+        "echo",
+        Duration::from_secs(20),
+    )
+    .await;
+
+    assert_eq!(
+        task.start_to_close,
+        Some(chrono::Duration::seconds(7)),
+        "the activity's own declared start_to_close (7s) must win over the \
+         builder-default STC (30s)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Item 7 (P3) — the FULL builder-default retry policy (not just max_attempts)
+// round-trips into the enqueued task.retry_policy JSON: an EXPONENTIAL default
+// with a distinct initial_interval + backoff must be observable after decode.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn builder_default_exponential_retry_policy_round_trips_into_task() {
+    let (url, _container) = setup_db().await;
+    let queue = "q620-retry-roundtrip";
+    let mut conn = connect(&url).await;
+    let exec_id = seed_workflow(
+        &mut conn,
+        "wf_one_activity",
+        serde_json::json!({"v": 1}),
+        queue,
+    )
+    .await;
+
+    // A distinctive exponential policy: 4 attempts, 2500ms initial, ×2 backoff.
+    let builder_policy = RetryPolicy::exponential(4, Duration::from_millis(2500));
+    assert!(
+        (builder_policy.backoff_coefficient - 2.0).abs() < f64::EPSILON,
+        "sanity: exponential backoff coefficient is 2.0"
+    );
+
+    let registry = build_registry(
+        vec![wf_info("wf_one_activity", wf_one_activity)],
+        vec![act_info("echo", echo_activity, false, None, None)],
+        Some(builder_policy),
+        None,
+    );
+    let worker = build_worker(
+        "w620-roundtrip",
+        queue,
+        Arc::clone(&registry),
+        Duration::from_secs(60),
+    );
+    let pool = build_pool(&url);
+
+    let task = run_until_activity_enqueued(
+        &url,
+        &pool,
+        worker,
+        exec_id,
+        "echo",
+        Duration::from_secs(20),
+    )
+    .await;
+
+    assert_eq!(
+        task.max_attempts, 4,
+        "the exponential builder default max_attempts (4) must reach the task"
+    );
+    let policy_json = task
+        .retry_policy
+        .expect("the enqueued task must carry the resolved retry policy JSON");
+    let decoded: RetryPolicy = serde_json::from_value(policy_json)
+        .expect("task.retry_policy must decode into RetryPolicy");
+    assert_eq!(
+        decoded.max_attempts, 4,
+        "decoded max_attempts must round-trip"
+    );
+    assert_eq!(
+        decoded.initial_interval,
+        Duration::from_millis(2500),
+        "decoded initial_interval must round-trip (guards against dropping the \
+         backoff curve while keeping max_attempts)"
+    );
+    assert!(
+        (decoded.backoff_coefficient - 2.0).abs() < f64::EPSILON,
+        "decoded backoff_coefficient (2.0 = exponential) must round-trip"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Item 8 (P3) — with builder defaults UNSET, a failing LOCAL activity records
+// exactly ONE LocalActivityFailed (the local fallback is 1 attempt, vs 3 for a
+// regular activity). Guards the local no-op path byte-for-byte.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn local_activity_no_defaults_records_single_failure() {
+    let (url, _container) = setup_db().await;
+    let queue = "q620-local-noop";
+    let mut conn = connect(&url).await;
+    let exec_id = seed_workflow(
+        &mut conn,
+        "wf_failing_local",
+        serde_json::json!({"v": 1}),
+        queue,
+    )
+    .await;
+
+    // No builder default, no activity default, no call-site override → the
+    // local fallback of a single attempt governs.
+    let registry = build_registry(
+        vec![wf_info("wf_failing_local", wf_failing_local)],
+        vec![act_info("failing_local", failing_local, true, None, None)],
+        None,
+        None,
+    );
+    let worker = build_worker(
+        "w620-local-noop",
+        queue,
+        Arc::clone(&registry),
+        Duration::from_secs(60),
+    );
+    let pool = build_pool(&url);
+
+    run_to_state(
+        &url,
+        &pool,
+        worker,
+        exec_id,
+        "FAILED",
+        Duration::from_secs(20),
+    )
+    .await;
+
+    let history = load_history(&url, exec_id).await;
+    assert_eq!(
+        count_local_failed(&history),
+        1,
+        "with no defaults a failing local activity runs exactly once — a single \
+         LocalActivityFailed (the local fallback of 1 attempt), byte-for-byte"
     );
 }

--- a/autumn-harvest/tests/integration/activity_default_floor_tests.rs
+++ b/autumn-harvest/tests/integration/activity_default_floor_tests.rs
@@ -175,6 +175,27 @@ fn wf_slower_local(ctx: &WorkflowContext, input: serde_json::Value) -> BoxFut<'_
     })
 }
 
+/// Local activity that sleeps ~50ms then echoes — well under a 500ms subsecond
+/// builder-default STC, so it MUST complete. Without the millis fix (issue #620,
+/// Codex P2) the 500ms builder default truncates to `Duration::from_secs(0)` and
+/// even this 50ms activity is instantly timed out.
+fn fast_local(_ctx: &autumn_harvest::ActivityContext, input: serde_json::Value) -> BoxFut<'_> {
+    Box::pin(async move {
+        tokio::time::sleep(Duration::from_millis(50)).await;
+        Ok(input)
+    })
+}
+
+/// Workflow: run the ~50ms local activity with NO call-site STC override, so the
+/// subsecond builder-default STC governs.
+fn wf_fast_local(ctx: &WorkflowContext, input: serde_json::Value) -> BoxFut<'_> {
+    Box::pin(async move {
+        ctx.execute_local_activity_raw("fast_local", input, None, None)
+            .await
+            .map_err(|e| e.to_string())
+    })
+}
+
 /// Workflow: schedule one regular activity WITH a call-site `start_to_close`
 /// override (5s), no retry override. Used to prove the call-site STC wins over
 /// the builder-default STC on the regular dispatch path.
@@ -360,18 +381,25 @@ async fn seed_workflow(
 }
 
 /// Seed a RUNNING execution whose local activity is MID-RETRY: its history
-/// already carries `LocalActivityScheduled` (frozen with `recorded_retry`) and
-/// one `LocalActivityFailed(attempt=1)`, and a workflow task is enqueued so a
+/// already carries `LocalActivityScheduled` (frozen with `recorded_resolved` /
+/// `recorded_retry` / `recorded_stc_millis`) and one
+/// `LocalActivityFailed(attempt=1)`, and a workflow task is enqueued so a
 /// worker resumes it. This reproduces the crash-recovery window for AC8: the
-/// original retry budget is frozen in history and must survive a later change to
-/// the builder-level default.
+/// original retry budget/timeout is frozen in history and must survive a later
+/// change to the builder-level default.
+///
+/// `recorded_resolved` is the #620 disambiguation marker (Codex P2): `true`
+/// models a #620+ event whose frozen values are authoritative (even `None`);
+/// `false` models a pre-#620 legacy event that falls back to live re-derivation.
 async fn seed_local_activity_in_progress(
     conn: &mut AsyncPgConnection,
     workflow_name: &'static str,
     activity_name: &str,
     input: serde_json::Value,
     queue: &str,
+    recorded_resolved: bool,
     recorded_retry: Option<RetryPolicy>,
+    recorded_stc_millis: Option<u64>,
 ) -> ExecutionId {
     let exec_id = ExecutionId::new_for_shard(autumn_harvest::types::ShardId::new(0));
     let row = NewWorkflowExecution {
@@ -427,7 +455,9 @@ async fn seed_local_activity_in_progress(
                 activity_id,
                 name: activity_name.to_string(),
                 input: input.clone(),
+                resolved: recorded_resolved,
                 retry_policy: recorded_retry,
+                start_to_close_millis: recorded_stc_millis,
             },
             WorkflowEvent::LocalActivityFailed {
                 activity_id,
@@ -1170,14 +1200,17 @@ async fn local_activity_mid_retry_keeps_original_budget_across_default_change() 
     let mut conn = connect(&url).await;
 
     // Freeze the ORIGINAL builder default (fixed(2)) into the scheduled event,
-    // exactly as the worker would have at first schedule.
+    // exactly as the worker would have at first schedule. A #620+ event
+    // (resolved = true) → the frozen fixed(2) is authoritative.
     let exec_id = seed_local_activity_in_progress(
         &mut conn,
         "wf_failing_local",
         "failing_local",
         serde_json::json!({"v": 1}),
         queue,
+        true,
         Some(RetryPolicy::fixed(2, Duration::from_millis(10))),
+        None,
     )
     .await;
 
@@ -1232,13 +1265,16 @@ async fn local_activity_mid_retry_without_recorded_budget_uses_current_default()
     let queue = "q620-ac8-legacy";
     let mut conn = connect(&url).await;
 
-    // Pre-#620 event: no frozen retry_policy.
+    // Pre-#620 legacy event: the resolution marker is absent (resolved =
+    // false) and no frozen retry_policy → recovery re-derives the live default.
     let exec_id = seed_local_activity_in_progress(
         &mut conn,
         "wf_failing_local",
         "failing_local",
         serde_json::json!({"v": 1}),
         queue,
+        false,
+        None,
         None,
     )
     .await;
@@ -1273,6 +1309,206 @@ async fn local_activity_mid_retry_without_recorded_budget_uses_current_default()
         3,
         "with NO frozen budget (pre-#620 event), recovery re-derives the current \
          builder default (fixed(3)) — 1 pre-crash failure + 2 more = 3 total"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// FIX 2 (AC8 — Codex P2, the resolution-marker refinement). A #620+ event that
+// resolved to NO floor (retry = None) is serialized identically to a genuine
+// pre-#620 legacy event (field absent → None). The `resolved` marker
+// disambiguates them: a #620+ event with `resolved = true` must keep its FROZEN
+// "no floor" (implicit 1 attempt) on recovery, NOT fall through to a builder
+// default that was ADDED FROM NOTHING after the activity was scheduled.
+//
+// Scenario: original schedule had NO retry floor of any kind (resolved = true,
+// retry = None → implicit 1 attempt). History: LocalActivityScheduled{resolved,
+// retry=None} + Failed(1). The operator then ADDS a builder default fixed(3) and
+// the worker resumes. With the marker, the frozen implicit 1 attempt governs →
+// `failed_attempts(1) >= max_attempts(1)` → exhausts immediately, NEVER running
+// attempt 2 → exactly 1 LocalActivityFailed. WITHOUT the marker, the added
+// fixed(3) would wrongly apply and run 3 total (the AC8-violating bug).
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn local_activity_resolved_to_no_floor_ignores_a_later_added_default() {
+    let (url, _container) = setup_db().await;
+    let queue = "q620-ac8-nofloor";
+    let mut conn = connect(&url).await;
+
+    // A #620+ event that resolved to NO retry AND NO STC floor: resolved = true,
+    // retry = None, stc = None — exactly what the worker writes when there is no
+    // call-site / activity-level / builder default at first schedule.
+    let exec_id = seed_local_activity_in_progress(
+        &mut conn,
+        "wf_failing_local",
+        "failing_local",
+        serde_json::json!({"v": 1}),
+        queue,
+        true,
+        None,
+        None,
+    )
+    .await;
+
+    // The operator has since ADDED a builder default (retry fixed(3) AND a 30s
+    // STC) that did NOT exist when the activity was scheduled. The frozen "no
+    // floor" must win — the added default must NOT leak onto this in-flight run.
+    let registry = build_registry(
+        vec![wf_info("wf_failing_local", wf_failing_local)],
+        vec![act_info("failing_local", failing_local, true, None, None)],
+        Some(RetryPolicy::fixed(3, Duration::from_millis(10))),
+        Some(Duration::from_secs(30)),
+    );
+    let worker = build_worker(
+        "w620-ac8-nofloor",
+        queue,
+        Arc::clone(&registry),
+        Duration::from_secs(60),
+    );
+    let pool = build_pool(&url);
+
+    run_to_state(
+        &url,
+        &pool,
+        worker,
+        exec_id,
+        "FAILED",
+        Duration::from_secs(20),
+    )
+    .await;
+
+    let history = load_history(&url, exec_id).await;
+    assert_eq!(
+        count_local_failed(&history),
+        1,
+        "a #620+ event that resolved to NO floor (resolved = true, retry = None) \
+         must keep its FROZEN implicit 1 attempt on recovery — the builder \
+         default fixed(3) ADDED after scheduling must NOT apply. Exactly 1 \
+         LocalActivityFailed (the pre-crash attempt); attempt 2 must never run. \
+         A count of 3 would mean the marker was ignored and the added default \
+         wrongly re-derived (the AC8-violating bug)."
+    );
+}
+
+// ---------------------------------------------------------------------------
+// FIX 3 (Codex P2) — a SUBSECOND builder-default start_to_close must NOT
+// truncate to 0 and instantly time out every local activity. The command now
+// carries millis (not seconds), so `Duration::from_millis(500)` is honored
+// rather than `Duration::from_secs(0)`.
+//
+// Discriminating pair under a 500ms subsecond builder default (worker cap 60s):
+//   * a ~50ms activity COMPLETES — WITHOUT the fix, 500ms.as_secs() = 0 →
+//     from_secs(0) → even 50ms is instantly timed out → the workflow FAILS;
+//   * a ~2s activity TIMES OUT — proving the 500ms STC is actually enforced
+//     (not silently ignored / defaulting to the 60s cap).
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn local_activity_subsecond_builder_default_stc_is_not_truncated_to_zero() {
+    let (url, _container) = setup_db().await;
+    let queue = "q620-subsecond-fast";
+    let mut conn = connect(&url).await;
+    let exec_id = seed_workflow(
+        &mut conn,
+        "wf_fast_local",
+        serde_json::json!({"v": 1}),
+        queue,
+    )
+    .await;
+
+    // Builder default STC = 500ms (SUBSECOND — the bug trigger), worker cap 60s.
+    // No retry, no activity-level STC, no call-site STC — the subsecond builder
+    // default is the sole source. The ~50ms activity must COMPLETE.
+    let registry = build_registry(
+        vec![wf_info("wf_fast_local", wf_fast_local)],
+        vec![act_info("fast_local", fast_local, true, None, None)],
+        None,
+        Some(Duration::from_millis(500)),
+    );
+    let worker = build_worker(
+        "w620-subsecond-fast",
+        queue,
+        Arc::clone(&registry),
+        Duration::from_secs(60),
+    );
+    let pool = build_pool(&url);
+
+    let execution = run_to_state(
+        &url,
+        &pool,
+        worker,
+        exec_id,
+        "COMPLETED",
+        Duration::from_secs(20),
+    )
+    .await;
+
+    assert_eq!(
+        execution.state, "COMPLETED",
+        "a ~50ms local activity under a 500ms SUBSECOND builder-default STC must \
+         COMPLETE. Without the millis fix, 500ms truncates to Duration::from_secs(0) \
+         and even a 50ms activity is instantly timed out → FAILED."
+    );
+    let history = load_history(&url, exec_id).await;
+    assert!(
+        !history
+            .iter()
+            .any(|e| matches!(e, WorkflowEvent::LocalActivityFailed { .. })),
+        "a completed subsecond-STC local activity must record NO LocalActivityFailed"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn local_activity_subsecond_builder_default_stc_still_enforces_the_deadline() {
+    let (url, _container) = setup_db().await;
+    let queue = "q620-subsecond-slow";
+    let mut conn = connect(&url).await;
+    let exec_id = seed_workflow(
+        &mut conn,
+        "wf_slower_local",
+        serde_json::json!({"v": 1}),
+        queue,
+    )
+    .await;
+
+    // Builder default STC = 500ms (subsecond), worker cap 60s. The ~2s activity
+    // must TIME OUT — the 500ms floor is actually enforced, not silently ignored.
+    let registry = build_registry(
+        vec![wf_info("wf_slower_local", wf_slower_local)],
+        vec![act_info("slower_local", slower_local, true, None, None)],
+        None,
+        Some(Duration::from_millis(500)),
+    );
+    let worker = build_worker(
+        "w620-subsecond-slow",
+        queue,
+        Arc::clone(&registry),
+        Duration::from_secs(60),
+    );
+    let pool = build_pool(&url);
+
+    let execution = run_to_state(
+        &url,
+        &pool,
+        worker,
+        exec_id,
+        "FAILED",
+        Duration::from_secs(20),
+    )
+    .await;
+
+    assert_eq!(
+        execution.state, "FAILED",
+        "a ~2s local activity under a 500ms subsecond builder-default STC must \
+         TIME OUT — proving the subsecond floor is enforced, not defaulting to \
+         the 60s worker cap"
+    );
+    let history = load_history(&url, exec_id).await;
+    assert!(
+        history
+            .iter()
+            .any(|e| matches!(e, WorkflowEvent::LocalActivityFailed { .. })),
+        "the STC-killed subsecond local activity must record a LocalActivityFailed"
     );
 }
 

--- a/autumn-harvest/tests/integration/activity_default_floor_tests.rs
+++ b/autumn-harvest/tests/integration/activity_default_floor_tests.rs
@@ -1,0 +1,786 @@
+#![cfg(feature = "db")]
+//! Builder-level default activity retry + start_to_close floor — issue #620.
+//!
+//! RED PHASE (TDD): these tests reference the not-yet-existing
+//! `HandlerRegistry::with_activity_defaults(retry, start_to_close)` builder, so
+//! the file fails to COMPILE against the missing symbol until the green phase
+//! adds it (the #543/#593 "red = compile error" precedent). They pin the
+//! schedule-time precedence the feature must implement:
+//!
+//!   call-site override  →  activity `#[activity(retry=…/start_to_close=…)]`
+//!   default  →  builder default  →  implicit fallback
+//!
+//! Harness (DB setup, pool, worker, seed, load helpers) is copied verbatim from
+//! `activity_interceptor_tests.rs` so this suite EXECUTES against a migrated
+//! Postgres when `HARVEST_TEST_DATABASE_URL` is set, otherwise boots a fresh
+//! testcontainers Postgres 16. Each test uses a unique task queue + unique
+//! `ExecutionId` so a shared cluster run stays isolated.
+//!
+//! Assertions read the *enqueued* activity task's `max_attempts` /
+//! `start_to_close` / `retry_policy` columns (regular path) and the recorded
+//! `LocalActivityFailed` event count (local path).
+
+use std::collections::HashMap;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::Duration;
+
+use autumn_harvest::event::WorkflowEvent;
+use autumn_harvest::info::{ActivityInfo, WorkflowInfo};
+use autumn_harvest::models::{NewWorkflowExecution, TaskQueueItem, WorkflowExecution};
+use autumn_harvest::queue::{self, EnqueueParams, TaskType};
+use autumn_harvest::schema::{harvest_task_queue, harvest_workflow_executions};
+use autumn_harvest::telemetry::TelemetryConfig;
+use autumn_harvest::types::ExecutionId;
+use autumn_harvest::worker::{DbPool, HandlerRegistry, Worker, WorkerRuntimeConfig};
+use autumn_harvest::{RetryPolicy, WorkflowContext, store};
+
+use chrono::Utc;
+use diesel::prelude::*;
+use diesel_async::pooled_connection::AsyncDieselConnectionManager;
+use diesel_async::{AsyncConnection, AsyncPgConnection, RunQueryDsl};
+use testcontainers::ContainerAsync;
+use testcontainers::ImageExt;
+use testcontainers_modules::postgres::Postgres;
+use testcontainers_modules::testcontainers::runners::AsyncRunner;
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// DB setup — env-var-redirectable, otherwise testcontainers.
+// ---------------------------------------------------------------------------
+
+fn init_sql() -> Vec<u8> {
+    autumn_harvest::full_migrations_sql().as_bytes().to_vec()
+}
+
+async fn setup_db() -> (String, Option<ContainerAsync<Postgres>>) {
+    if let Ok(url) = std::env::var("HARVEST_TEST_DATABASE_URL") {
+        return (url, None);
+    }
+    let container = Postgres::default()
+        .with_init_sql(init_sql())
+        .with_tag("16")
+        .start()
+        .await
+        .expect("failed to start Postgres container");
+    let host = container.get_host().await.expect("host");
+    let port = container.get_host_port_ipv4(5432).await.expect("port");
+    let url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+    (url, Some(container))
+}
+
+fn build_pool(url: &str) -> DbPool {
+    let manager = AsyncDieselConnectionManager::<AsyncPgConnection>::new(url);
+    deadpool::managed::Pool::builder(manager)
+        .max_size(8)
+        .build()
+        .expect("pool build failed")
+}
+
+async fn connect(url: &str) -> AsyncPgConnection {
+    <AsyncPgConnection as AsyncConnection>::establish(url)
+        .await
+        .expect("failed to connect to Postgres")
+}
+
+// ---------------------------------------------------------------------------
+// Handlers.
+// ---------------------------------------------------------------------------
+
+type BoxFut<'a> =
+    Pin<Box<dyn std::future::Future<Output = Result<serde_json::Value, String>> + Send + 'a>>;
+
+/// Regular activity: echoes its input.
+fn echo_activity(_ctx: &autumn_harvest::ActivityContext, input: serde_json::Value) -> BoxFut<'_> {
+    Box::pin(async move { Ok(input) })
+}
+
+/// Local activity that always fails (so retry counting is observable).
+fn failing_local(_ctx: &autumn_harvest::ActivityContext, _input: serde_json::Value) -> BoxFut<'_> {
+    Box::pin(async move { Err("failing_local always errors".to_string()) })
+}
+
+/// Workflow: schedule one regular activity via the plain raw path (no per-call
+/// overrides) onto the workflow's own queue, then suspend on it.
+fn wf_one_activity(ctx: &WorkflowContext, input: serde_json::Value) -> BoxFut<'_> {
+    Box::pin(async move {
+        let queue = ctx.queue_name().to_string();
+        ctx.execute_activity_raw("echo", input, &queue)
+            .await
+            .map_err(|e| e.to_string())
+    })
+}
+
+/// Workflow: schedule one regular activity WITH a call-site retry override
+/// (`max_attempts = 5`). Mirrors the DAG unified handler's opts path.
+fn wf_one_activity_call_override(ctx: &WorkflowContext, input: serde_json::Value) -> BoxFut<'_> {
+    Box::pin(async move {
+        let queue = ctx.queue_name().to_string();
+        ctx.execute_activity_raw_with_opts(
+            "echo",
+            input,
+            &queue,
+            Some(RetryPolicy::fixed(5, Duration::from_millis(10))),
+            None,
+        )
+        .await
+        .map_err(|e| e.to_string())
+    })
+}
+
+/// Workflow: run a failing local activity with NO call-site retry/STC override,
+/// so the builder default is what must apply. Propagates the terminal Err.
+fn wf_failing_local(ctx: &WorkflowContext, input: serde_json::Value) -> BoxFut<'_> {
+    Box::pin(async move {
+        ctx.execute_local_activity_raw("failing_local", input, None, None)
+            .await
+            .map_err(|e| e.to_string())
+    })
+}
+
+/// Workflow: run a slow local activity with NO call-site STC override, so the
+/// builder-default STC (clamped by `max_local_activity_start_to_close`) governs
+/// the per-attempt timeout. Propagates the terminal Err (timeout → FAILED).
+fn wf_slow_local(ctx: &WorkflowContext, input: serde_json::Value) -> BoxFut<'_> {
+    Box::pin(async move {
+        ctx.execute_local_activity_raw("slow_local", input, None, None)
+            .await
+            .map_err(|e| e.to_string())
+    })
+}
+
+/// Local activity that sleeps ~500ms then echoes.
+fn slow_local(_ctx: &autumn_harvest::ActivityContext, input: serde_json::Value) -> BoxFut<'_> {
+    Box::pin(async move {
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        Ok(input)
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Registry / worker construction.
+// ---------------------------------------------------------------------------
+
+/// Build a registry, optionally installing builder-level activity defaults.
+///
+/// RED PHASE: `HandlerRegistry::with_activity_defaults` does not exist yet —
+/// this is the not-yet-existing symbol these tests fail to compile against.
+fn build_registry(
+    workflows: Vec<WorkflowInfo>,
+    activities: Vec<ActivityInfo>,
+    default_retry: Option<RetryPolicy>,
+    default_stc: Option<Duration>,
+) -> Arc<HandlerRegistry> {
+    let telemetry = Arc::new(TelemetryConfig::default());
+    Arc::new(
+        HandlerRegistry::with_state_and_telemetry(
+            workflows,
+            activities,
+            autumn_harvest::context::empty_shared_state(),
+            telemetry,
+        )
+        .with_activity_defaults(default_retry, default_stc),
+    )
+}
+
+fn build_worker(
+    worker_id: &str,
+    queue: &str,
+    registry: Arc<HandlerRegistry>,
+    max_local_stc: Duration,
+) -> Arc<Worker> {
+    Arc::new(
+        Worker::new(
+            WorkerRuntimeConfig {
+                worker_id: worker_id.to_string(),
+                queues: vec![queue.to_string()],
+                notification_database_url: None,
+                max_concurrent_workflows: 1,
+                max_concurrent_activities: 1,
+                poll_interval: Duration::from_millis(25),
+                shutdown_timeout: Duration::from_secs(1),
+                cancellation_grace_period: Duration::from_secs(1),
+                sticky_timeout: Duration::from_secs(5),
+                max_local_activity_start_to_close: max_local_stc,
+                shard_assignments: vec![autumn_harvest::types::ShardId::new(0)],
+                worker_heartbeat_interval: Duration::from_secs(5),
+                build_id: String::new(),
+                deployment_name: None,
+                workflow_cache_size: 1000,
+                priority_aging_secs: None,
+                unknown_target_grace_window: Duration::from_secs(5),
+                poison_pill_threshold: 3,
+                workflow_task_timeout: Duration::from_secs(10),
+                workflow_panic_max_attempts: 3,
+                labels: HashMap::new(),
+                queue_weights: HashMap::new(),
+                max_workflow_pause_duration: Duration::from_secs(24 * 3600),
+                max_workflow_history_events: None,
+                shard_notification_database_urls: Vec::new(),
+                sharded_pool: None,
+                slot_tuner: None,
+                max_concurrent_sessions: 0,
+            },
+            registry,
+        )
+        .expect("worker should build"),
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Seeding + read helpers.
+// ---------------------------------------------------------------------------
+
+async fn seed_workflow(
+    conn: &mut AsyncPgConnection,
+    workflow_name: &'static str,
+    input: serde_json::Value,
+    queue: &str,
+) -> ExecutionId {
+    let exec_id = ExecutionId::new_for_shard(autumn_harvest::types::ShardId::new(0));
+    let row = NewWorkflowExecution {
+        id: exec_id.as_uuid(),
+        workflow_name,
+        workflow_id: &format!("wf-{}", exec_id.as_uuid()),
+        run_id: Uuid::new_v4(),
+        shard_id: 0,
+        input: input.clone(),
+        parent_id: None,
+        queue_name: queue,
+        execution_timeout: None,
+        deadline_at: None,
+        memo: None,
+        search_attrs: None,
+        assigned_build_id: None,
+        parent_close_policy: None,
+        owner: None,
+        runbook_url: None,
+        severity: None,
+        context_headers: None,
+        sla: None,
+        sla_deadline_at: None,
+        schedule_id: None,
+        scheduled_for: None,
+        workflow_attempt: 1,
+        workflow_retry_policy: None,
+        retry_of_exec_id: None,
+        origin: None,
+        completion_callbacks: None,
+        continued_from_exec_id: None,
+        first_exec_id: None,
+    };
+    diesel::insert_into(harvest_workflow_executions::table)
+        .values(&row)
+        .execute(conn)
+        .await
+        .expect("insert workflow execution");
+
+    store::append_events(
+        conn,
+        exec_id,
+        &[WorkflowEvent::WorkflowStarted {
+            input: input.clone(),
+            timestamp: Utc::now(),
+            last_completion_result: None,
+            last_error: None,
+            scheduled_time: None,
+        }],
+        0,
+    )
+    .await
+    .expect("append WorkflowStarted");
+
+    let mut params = EnqueueParams::new(queue, TaskType::Workflow, input);
+    params.workflow_exec_id = Some(exec_id.as_uuid());
+    params.scheduled_at = Utc::now() - chrono::Duration::seconds(5);
+    queue::enqueue(conn, &params)
+        .await
+        .expect("enqueue workflow task");
+
+    exec_id
+}
+
+async fn load_execution(url: &str, exec_id: ExecutionId) -> WorkflowExecution {
+    let mut conn = connect(url).await;
+    harvest_workflow_executions::table
+        .find(exec_id.as_uuid())
+        .select(WorkflowExecution::as_select())
+        .first(&mut conn)
+        .await
+        .expect("reload workflow execution")
+}
+
+async fn load_history(url: &str, exec_id: ExecutionId) -> Vec<WorkflowEvent> {
+    let mut conn = connect(url).await;
+    store::load_history(&mut conn, exec_id)
+        .await
+        .expect("load_history")
+        .events
+}
+
+/// Load the single enqueued *activity* task row for `activity_name`.
+async fn load_activity_task(
+    url: &str,
+    exec_id: ExecutionId,
+    activity_name: &str,
+) -> TaskQueueItem {
+    let mut conn = connect(url).await;
+    let rows: Vec<TaskQueueItem> = harvest_task_queue::table
+        .filter(harvest_task_queue::workflow_exec_id.eq(Some(exec_id.as_uuid())))
+        .filter(harvest_task_queue::activity_name.eq(Some(activity_name.to_string())))
+        .select(TaskQueueItem::as_select())
+        .load(&mut conn)
+        .await
+        .expect("reload task rows");
+    assert_eq!(
+        rows.len(),
+        1,
+        "expected exactly one enqueued activity task for '{activity_name}'"
+    );
+    rows.into_iter().next().unwrap()
+}
+
+async fn wait_for_state(
+    url: &str,
+    exec_id: ExecutionId,
+    want: &str,
+    timeout: Duration,
+) -> WorkflowExecution {
+    tokio::time::timeout(timeout, async {
+        loop {
+            let e = load_execution(url, exec_id).await;
+            if e.state == want {
+                break e;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("execution did not reach state {want} within {timeout:?}"))
+}
+
+/// Drive a worker until `exec_id` reaches `want`, then shut it down cleanly.
+async fn run_to_state(
+    url: &str,
+    pool: &DbPool,
+    worker: Arc<Worker>,
+    exec_id: ExecutionId,
+    want: &str,
+    timeout: Duration,
+) -> WorkflowExecution {
+    let runner = Arc::clone(&worker);
+    let pool_for_run = pool.clone();
+    let handle = tokio::spawn(async move { runner.run(&pool_for_run).await });
+    let execution = wait_for_state(url, exec_id, want, timeout).await;
+    worker.shutdown();
+    handle.await.expect("worker task joins cleanly");
+    execution
+}
+
+/// Drive the worker until the activity task for `activity_name` has been
+/// enqueued (the workflow suspended on it), then shut down. Returns the row.
+async fn run_until_activity_enqueued(
+    url: &str,
+    pool: &DbPool,
+    worker: Arc<Worker>,
+    exec_id: ExecutionId,
+    activity_name: &str,
+    timeout: Duration,
+) -> TaskQueueItem {
+    let runner = Arc::clone(&worker);
+    let pool_for_run = pool.clone();
+    let handle = tokio::spawn(async move { runner.run(&pool_for_run).await });
+    let row = tokio::time::timeout(timeout, async {
+        loop {
+            let mut conn = connect(url).await;
+            let rows: Vec<TaskQueueItem> = harvest_task_queue::table
+                .filter(harvest_task_queue::workflow_exec_id.eq(Some(exec_id.as_uuid())))
+                .filter(harvest_task_queue::activity_name.eq(Some(activity_name.to_string())))
+                .select(TaskQueueItem::as_select())
+                .load(&mut conn)
+                .await
+                .expect("reload task rows");
+            if let Some(r) = rows.into_iter().next() {
+                break r;
+            }
+            tokio::time::sleep(Duration::from_millis(25)).await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("activity '{activity_name}' not enqueued within {timeout:?}"));
+    worker.shutdown();
+    handle.await.expect("worker task joins cleanly");
+    row
+}
+
+fn wf_info(name: &'static str, handler: autumn_harvest::info::WorkflowHandlerFn) -> WorkflowInfo {
+    WorkflowInfo {
+        mcp: false,
+        name,
+        module: "activity_default_floor_tests",
+        handler,
+        execution_timeout: None,
+        sla: None,
+        concurrency: None,
+        debounce: None,
+        batch: None,
+        throttle: None,
+        max_input_bytes: None,
+        owner: None,
+        runbook_url: None,
+        severity: None,
+        description: None,
+        input_schema: None,
+        output_schema: None,
+        error_schema: None,
+        retry_policy: None,
+    }
+}
+
+fn act_info(
+    name: &'static str,
+    handler: autumn_harvest::info::ActivityHandlerFn,
+    is_local: bool,
+    retry: Option<RetryPolicy>,
+    start_to_close: Option<Duration>,
+) -> ActivityInfo {
+    ActivityInfo {
+        name,
+        module: "activity_default_floor_tests",
+        default_retry_policy: retry,
+        default_start_to_close: start_to_close,
+        default_heartbeat_timeout: None,
+        default_schedule_to_start: None,
+        default_schedule_to_close: None,
+        default_queue: Some("default"),
+        max_concurrent: None,
+        concurrency_key: None,
+        rate_limit_rps: None,
+        rate_limit_burst: None,
+        rate_limit_key: None,
+        circuit_breaker: None,
+        is_local,
+        max_input_bytes: None,
+        max_result_bytes: None,
+        requires: None,
+        handler,
+    }
+}
+
+fn count_local_failed(history: &[WorkflowEvent]) -> usize {
+    history
+        .iter()
+        .filter(|e| matches!(e, WorkflowEvent::LocalActivityFailed { .. }))
+        .count()
+}
+
+// ---------------------------------------------------------------------------
+// AC3 — a no-`retry` activity under a builder default gets max_attempts = N.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn no_retry_activity_under_builder_default_gets_max_attempts_n() {
+    let (url, _container) = setup_db().await;
+    let queue = "q620-builder-default";
+    let mut conn = connect(&url).await;
+    let exec_id = seed_workflow(&mut conn, "wf_one_activity", serde_json::json!({"v": 1}), queue).await;
+
+    // Builder default max_attempts = 4; activity declares no retry.
+    let registry = build_registry(
+        vec![wf_info("wf_one_activity", wf_one_activity)],
+        vec![act_info("echo", echo_activity, false, None, None)],
+        Some(RetryPolicy::fixed(4, Duration::from_millis(10))),
+        None,
+    );
+    let worker = build_worker("w620-default", queue, Arc::clone(&registry), Duration::from_secs(60));
+    let pool = build_pool(&url);
+
+    let task = run_until_activity_enqueued(
+        &url,
+        &pool,
+        worker,
+        exec_id,
+        "echo",
+        Duration::from_secs(20),
+    )
+    .await;
+
+    assert_eq!(
+        task.max_attempts, 4,
+        "builder default retry (max_attempts=4) must apply to a no-retry activity"
+    );
+    assert!(
+        task.retry_policy.is_some(),
+        "the enqueued task must carry the resolved retry policy JSON"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// AC3 — the raw dispatch path (used by DAGs) honours the builder default.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn raw_dispatched_activity_honours_builder_default() {
+    let (url, _container) = setup_db().await;
+    let queue = "q620-raw-default";
+    let mut conn = connect(&url).await;
+    let exec_id = seed_workflow(&mut conn, "wf_one_activity", serde_json::json!({"v": 1}), queue).await;
+
+    // `wf_one_activity` uses `ctx.execute_activity_raw` — the DAG/raw path.
+    let registry = build_registry(
+        vec![wf_info("wf_one_activity", wf_one_activity)],
+        vec![act_info("echo", echo_activity, false, None, None)],
+        Some(RetryPolicy::fixed(4, Duration::from_millis(10))),
+        None,
+    );
+    let worker = build_worker("w620-raw", queue, Arc::clone(&registry), Duration::from_secs(60));
+    let pool = build_pool(&url);
+
+    let task = run_until_activity_enqueued(
+        &url,
+        &pool,
+        worker,
+        exec_id,
+        "echo",
+        Duration::from_secs(20),
+    )
+    .await;
+
+    assert_eq!(
+        task.max_attempts, 4,
+        "the raw dispatch path must resolve the builder default retry floor"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// AC4 — a declared-retry activity is unaffected by the builder default.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn declared_retry_activity_unaffected_by_builder_default() {
+    let (url, _container) = setup_db().await;
+    let queue = "q620-declared-wins";
+    let mut conn = connect(&url).await;
+    let exec_id = seed_workflow(&mut conn, "wf_one_activity", serde_json::json!({"v": 1}), queue).await;
+
+    // Activity declares its own retry (max_attempts=2); builder default is 9.
+    let registry = build_registry(
+        vec![wf_info("wf_one_activity", wf_one_activity)],
+        vec![act_info(
+            "echo",
+            echo_activity,
+            false,
+            Some(RetryPolicy::fixed(2, Duration::from_millis(10))),
+            None,
+        )],
+        Some(RetryPolicy::fixed(9, Duration::from_millis(10))),
+        None,
+    );
+    let worker = build_worker("w620-declared", queue, Arc::clone(&registry), Duration::from_secs(60));
+    let pool = build_pool(&url);
+
+    let task = run_until_activity_enqueued(
+        &url,
+        &pool,
+        worker,
+        exec_id,
+        "echo",
+        Duration::from_secs(20),
+    )
+    .await;
+
+    assert_eq!(
+        task.max_attempts, 2,
+        "the activity's own declared retry must win over the builder default"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// AC5 — a call-site override wins over the builder default.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn call_site_override_wins_over_builder_default() {
+    let (url, _container) = setup_db().await;
+    let queue = "q620-call-wins";
+    let mut conn = connect(&url).await;
+    let exec_id = seed_workflow(
+        &mut conn,
+        "wf_one_activity_call_override",
+        serde_json::json!({"v": 1}),
+        queue,
+    )
+    .await;
+
+    // Call-site override max_attempts=5; builder default 9; activity default none.
+    let registry = build_registry(
+        vec![wf_info(
+            "wf_one_activity_call_override",
+            wf_one_activity_call_override,
+        )],
+        vec![act_info("echo", echo_activity, false, None, None)],
+        Some(RetryPolicy::fixed(9, Duration::from_millis(10))),
+        None,
+    );
+    let worker = build_worker("w620-call", queue, Arc::clone(&registry), Duration::from_secs(60));
+    let pool = build_pool(&url);
+
+    let task = run_until_activity_enqueued(
+        &url,
+        &pool,
+        worker,
+        exec_id,
+        "echo",
+        Duration::from_secs(20),
+    )
+    .await;
+
+    assert_eq!(
+        task.max_attempts, 5,
+        "the call-site retry override must win over the builder default"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// AC6 — no defaults set anywhere is byte-for-byte today's behaviour.
+//
+// NOTE (RED-phase deviation, flagged to the coordinator): the task brief said
+// to assert `max_attempts == 1`, but the CURRENT engine enqueues a no-retry
+// activity with `max_attempts == 3` (the `EnqueueParams::new` default) and a
+// NULL `retry_policy` — and `worker::next_retry_delay` actively retries up to
+// `max_attempts` when `retry_policy` is None. So today a no-`retry` activity
+// gets 3 attempts, NOT a single attempt. Since AC6 is explicitly "byte-for-byte
+// today's behaviour", this test asserts the real current values (3 + NULL). The
+// green phase MUST NOT change this no-default path.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn no_defaults_set_is_byte_for_byte_current_behaviour() {
+    let (url, _container) = setup_db().await;
+    let queue = "q620-no-defaults";
+    let mut conn = connect(&url).await;
+    let exec_id = seed_workflow(&mut conn, "wf_one_activity", serde_json::json!({"v": 1}), queue).await;
+
+    // No builder default, no activity default, no call-site override.
+    let registry = build_registry(
+        vec![wf_info("wf_one_activity", wf_one_activity)],
+        vec![act_info("echo", echo_activity, false, None, None)],
+        None,
+        None,
+    );
+    let worker = build_worker("w620-nodefault", queue, Arc::clone(&registry), Duration::from_secs(60));
+    let pool = build_pool(&url);
+
+    let task = run_until_activity_enqueued(
+        &url,
+        &pool,
+        worker,
+        exec_id,
+        "echo",
+        Duration::from_secs(20),
+    )
+    .await;
+
+    assert_eq!(
+        task.max_attempts, 3,
+        "with no defaults the enqueued max_attempts must remain the current \
+         EnqueueParams default (3) — byte-for-byte"
+    );
+    assert!(
+        task.retry_policy.is_none(),
+        "with no defaults the enqueued task must carry a NULL retry_policy"
+    );
+    assert!(
+        task.start_to_close.is_none(),
+        "with no defaults the enqueued task must carry a NULL start_to_close"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// AC7 — a local activity honours the builder-default retry.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn local_activity_honours_builder_default_retry() {
+    let (url, _container) = setup_db().await;
+    let queue = "q620-local-retry";
+    let mut conn = connect(&url).await;
+    let exec_id = seed_workflow(&mut conn, "wf_failing_local", serde_json::json!({"v": 1}), queue).await;
+
+    // Builder default retry max_attempts=3; local activity always fails; the
+    // workflow supplies NO call-site retry override, so the builder default is
+    // what governs the attempt count.
+    let registry = build_registry(
+        vec![wf_info("wf_failing_local", wf_failing_local)],
+        vec![act_info("failing_local", failing_local, true, None, None)],
+        Some(RetryPolicy::fixed(3, Duration::from_millis(10))),
+        None,
+    );
+    let worker = build_worker("w620-local-retry", queue, Arc::clone(&registry), Duration::from_secs(60));
+    let pool = build_pool(&url);
+
+    run_to_state(&url, &pool, worker, exec_id, "FAILED", Duration::from_secs(20)).await;
+
+    let history = load_history(&url, exec_id).await;
+    assert_eq!(
+        count_local_failed(&history),
+        3,
+        "the builder-default retry (max_attempts=3) must drive 3 local-activity attempts"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// AC7 — a local activity's builder-default STC is clamped by the worker max.
+//
+// NOTE (RED-phase limitation, flagged to the coordinator): asserting the
+// builder-default STC end-to-end is awkward. The local path's per-attempt
+// timeout is `run.start_to_close_secs.map_or(max, from_secs).min(max)`, so a
+// no-call-site-STC local activity ALREADY falls back to `max` today —
+// meaning a builder default LARGER than `max` (300s vs 60s) yields the same
+// clamped value (60s) with or without the feature. This integration test can
+// therefore only assert the weaker AC "the builder default does not grant the
+// full 300s": a 500ms-sleeping local activity under a small `max` (200ms) times
+// out (FAILED) rather than completing. The precedence itself is pinned by the
+// pure `resolve_effective_start_to_close_precedence` unit test in policy.rs.
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn local_activity_builder_default_stc_clamped_by_max() {
+    let (url, _container) = setup_db().await;
+    let queue = "q620-local-stc";
+    let mut conn = connect(&url).await;
+    let exec_id = seed_workflow(&mut conn, "wf_slow_local", serde_json::json!({"v": 1}), queue).await;
+
+    // Builder default STC = 300s, worker max_local_activity_start_to_close =
+    // 200ms. A 500ms-sleeping local activity must NOT be granted the full 300s;
+    // it is clamped and times out → FAILED.
+    let registry = build_registry(
+        vec![wf_info("wf_slow_local", wf_slow_local)],
+        vec![act_info("slow_local", slow_local, true, None, None)],
+        None,
+        Some(Duration::from_secs(300)),
+    );
+    let worker = build_worker(
+        "w620-local-stc",
+        queue,
+        Arc::clone(&registry),
+        Duration::from_millis(200),
+    );
+    let pool = build_pool(&url);
+
+    let execution =
+        run_to_state(&url, &pool, worker, exec_id, "FAILED", Duration::from_secs(20)).await;
+
+    assert_eq!(
+        execution.state, "FAILED",
+        "a 500ms local activity under a 200ms clamp must time out — the \
+         builder-default 300s STC must not grant the full window"
+    );
+    let history = load_history(&url, exec_id).await;
+    assert!(
+        history
+            .iter()
+            .any(|e| matches!(e, WorkflowEvent::LocalActivityFailed { .. })),
+        "the clamped local activity must record a LocalActivityFailed (timeout)"
+    );
+}

--- a/autumn-harvest/tests/integration/mod.rs
+++ b/autumn-harvest/tests/integration/mod.rs
@@ -1,5 +1,6 @@
 #![allow(dead_code)]
 
+mod activity_default_floor_tests;
 mod activity_failure_tests;
 mod activity_interceptor_tests;
 mod activity_outcome_metrics_tests;

--- a/autumn-harvest/tests/integration/replay_tests.rs
+++ b/autumn-harvest/tests/integration/replay_tests.rs
@@ -412,6 +412,8 @@ async fn local_activity_completes_from_full_history() {
             name: "format_data".into(),
             input: Value::Null,
             retry_policy: None,
+            resolved: false,
+            start_to_close_millis: None,
         },
         WorkflowEvent::LocalActivityCompleted {
             activity_id: local_id,
@@ -493,6 +495,8 @@ async fn local_activity_replays_correctly_across_simulated_worker_restart() {
             name: "step_1".into(),
             input: Value::Null,
             retry_policy: None,
+            resolved: false,
+            start_to_close_millis: None,
         },
         WorkflowEvent::LocalActivityCompleted {
             activity_id: id1,
@@ -503,6 +507,8 @@ async fn local_activity_replays_correctly_across_simulated_worker_restart() {
             name: "step_2".into(),
             input: out1.clone(),
             retry_policy: None,
+            resolved: false,
+            start_to_close_millis: None,
         },
         WorkflowEvent::LocalActivityCompleted {
             activity_id: id2,
@@ -542,6 +548,8 @@ async fn local_activity_with_retry_in_history_replays_final_success() {
             name: "step_1".into(),
             input: Value::Null,
             retry_policy: None,
+            resolved: false,
+            start_to_close_millis: None,
         },
         WorkflowEvent::LocalActivityFailed {
             activity_id: id1,
@@ -562,6 +570,8 @@ async fn local_activity_with_retry_in_history_replays_final_success() {
             name: "step_2".into(),
             input: final_out.clone(),
             retry_policy: None,
+            resolved: false,
+            start_to_close_millis: None,
         },
         WorkflowEvent::LocalActivityCompleted {
             activity_id: id2,
@@ -598,6 +608,8 @@ async fn local_activity_exhausted_retries_fails_the_workflow() {
             name: "step_1".into(),
             input: Value::Null,
             retry_policy: None,
+            resolved: false,
+            start_to_close_millis: None,
         },
         WorkflowEvent::LocalActivityFailed {
             activity_id: id,

--- a/autumn-harvest/tests/integration/replay_tests.rs
+++ b/autumn-harvest/tests/integration/replay_tests.rs
@@ -413,7 +413,7 @@ async fn local_activity_completes_from_full_history() {
             input: Value::Null,
             retry_policy: None,
             resolved: false,
-            start_to_close_millis: None,
+            start_to_close_nanos: None,
         },
         WorkflowEvent::LocalActivityCompleted {
             activity_id: local_id,
@@ -496,7 +496,7 @@ async fn local_activity_replays_correctly_across_simulated_worker_restart() {
             input: Value::Null,
             retry_policy: None,
             resolved: false,
-            start_to_close_millis: None,
+            start_to_close_nanos: None,
         },
         WorkflowEvent::LocalActivityCompleted {
             activity_id: id1,
@@ -508,7 +508,7 @@ async fn local_activity_replays_correctly_across_simulated_worker_restart() {
             input: out1.clone(),
             retry_policy: None,
             resolved: false,
-            start_to_close_millis: None,
+            start_to_close_nanos: None,
         },
         WorkflowEvent::LocalActivityCompleted {
             activity_id: id2,
@@ -549,7 +549,7 @@ async fn local_activity_with_retry_in_history_replays_final_success() {
             input: Value::Null,
             retry_policy: None,
             resolved: false,
-            start_to_close_millis: None,
+            start_to_close_nanos: None,
         },
         WorkflowEvent::LocalActivityFailed {
             activity_id: id1,
@@ -571,7 +571,7 @@ async fn local_activity_with_retry_in_history_replays_final_success() {
             input: final_out.clone(),
             retry_policy: None,
             resolved: false,
-            start_to_close_millis: None,
+            start_to_close_nanos: None,
         },
         WorkflowEvent::LocalActivityCompleted {
             activity_id: id2,
@@ -609,7 +609,7 @@ async fn local_activity_exhausted_retries_fails_the_workflow() {
             input: Value::Null,
             retry_policy: None,
             resolved: false,
-            start_to_close_millis: None,
+            start_to_close_nanos: None,
         },
         WorkflowEvent::LocalActivityFailed {
             activity_id: id,

--- a/autumn-harvest/tests/integration/replay_tests.rs
+++ b/autumn-harvest/tests/integration/replay_tests.rs
@@ -411,6 +411,7 @@ async fn local_activity_completes_from_full_history() {
             activity_id: local_id,
             name: "format_data".into(),
             input: Value::Null,
+            retry_policy: None,
         },
         WorkflowEvent::LocalActivityCompleted {
             activity_id: local_id,
@@ -491,6 +492,7 @@ async fn local_activity_replays_correctly_across_simulated_worker_restart() {
             activity_id: id1,
             name: "step_1".into(),
             input: Value::Null,
+            retry_policy: None,
         },
         WorkflowEvent::LocalActivityCompleted {
             activity_id: id1,
@@ -500,6 +502,7 @@ async fn local_activity_replays_correctly_across_simulated_worker_restart() {
             activity_id: id2,
             name: "step_2".into(),
             input: out1.clone(),
+            retry_policy: None,
         },
         WorkflowEvent::LocalActivityCompleted {
             activity_id: id2,
@@ -538,6 +541,7 @@ async fn local_activity_with_retry_in_history_replays_final_success() {
             activity_id: id1,
             name: "step_1".into(),
             input: Value::Null,
+            retry_policy: None,
         },
         WorkflowEvent::LocalActivityFailed {
             activity_id: id1,
@@ -557,6 +561,7 @@ async fn local_activity_with_retry_in_history_replays_final_success() {
             activity_id: id2,
             name: "step_2".into(),
             input: final_out.clone(),
+            retry_policy: None,
         },
         WorkflowEvent::LocalActivityCompleted {
             activity_id: id2,
@@ -592,6 +597,7 @@ async fn local_activity_exhausted_retries_fails_the_workflow() {
             activity_id: id,
             name: "step_1".into(),
             input: Value::Null,
+            retry_policy: None,
         },
         WorkflowEvent::LocalActivityFailed {
             activity_id: id,

--- a/docs/getting-started/07-reliability-knobs.md
+++ b/docs/getting-started/07-reliability-knobs.md
@@ -10,6 +10,41 @@ These come up in roughly the order you'll need them.
 for a flat retry, or build a `RetryPolicy` directly when you need a custom
 shape (max interval, backoff coefficient, non-retryable error filters).
 
+**A fleet-wide reliability floor (builder-default retry / `start_to_close`).**
+Instead of repeating the same `retry = …` / `start_to_close = …` on every
+`#[activity]`, set a default *floor* once on the worker and let activities that
+care override it:
+
+```rust
+WorkerConfig::default()
+    .with_default_activity_retry_policy(RetryPolicy::fixed(3, Duration::from_secs(1)))
+    .with_default_activity_start_to_close(Duration::from_secs(30))
+```
+
+The floor is resolved at **schedule time** as the lowest-priority fallback. The
+full precedence, highest first:
+
+1. **call-site override** — `ctx.execute_activity_with_opts(..)` / the DAG opts path
+2. **activity's own default** — `#[activity(retry = …, start_to_close = …)]`
+3. **builder default** — the two `with_default_activity_*` methods above
+4. **implicit fallback** — today's behaviour when nothing is set anywhere
+
+It is **opt-in**: leave both unset and every activity behaves byte-for-byte as
+it does today. In particular the implicit fallback is *not* "a single attempt" —
+a regular activity with no retry configured anywhere is still enqueued with the
+engine's default `max_attempts = 3` (a local activity's implicit fallback is a
+single attempt). The floor only raises the bar for activities that declared
+*nothing*; an activity that declares its own `retry` (or a call site that passes
+one) always wins.
+
+Scope: this covers **retry** and **`start_to_close`** only —
+`heartbeat_timeout` and `schedule_to_start` are deliberately out of scope (they
+have no fleet-wide "floor" semantics). For **local** activities the resolved
+`start_to_close` is still clamped by
+`WorkerConfig::max_local_activity_start_to_close` (60 s by default), so a
+builder default larger than that cap never grants a local activity more than the
+cap.
+
 **Per-activity concurrency caps.** Add `max_concurrent = N` to bound the
 cluster-wide in-flight count without provisioning a dedicated worker. Share
 the budget across activities by giving them the same `concurrency_key`.


### PR DESCRIPTION
Closes #620.

## Before / After

**Before.** An activity declared with no `#[activity(retry = …)]` inherits nothing org-wide. A platform team that wants a reliability floor (retry every activity ≥3×, cap every activity at a 30s `start_to_close`) has to hand-edit *every* `#[activity]` annotation, and forgetting one fails *silent* — it compiles, it works on the happy path, and it falls over on the first prod blip. There is no single knob to raise the floor centrally. (Note the implicit fallback today is not literally "one attempt" for a regular activity — a no-retry regular activity is already enqueued with `max_attempts = 3`, and a local activity with `1`; the gap is that there is no way to *raise* that floor without touching source.)

**After.** A platform team sets the floor once on the worker:

```rust
WorkerConfig::default()
    .with_default_activity_retry_policy(RetryPolicy::fixed(3, Duration::from_secs(1)))
    .with_default_activity_start_to_close(Duration::from_secs(30))
```

Every activity that declares neither a `retry` nor a `start_to_close` inherits the floor at **schedule time**, with precedence **call-site override → activity's own `#[activity(...)]` default → builder default → today's implicit fallback**. It is fully **opt-in**: leave both unset and behaviour is byte-for-byte identical to today. An activity (or a call site) that declares its own policy always wins — the floor only raises the bar for activities that declared *nothing*.

## How (implementation)

- **Pure precedence helpers** — `policy::resolve_effective_retry` / `resolve_effective_start_to_close` (`src/policy.rs`), each `call.or(activity).or(builder)`, so the two dispatch paths share one authoritative resolution.
- **Two `WorkerConfig` fields + builder methods** — `default_activity_retry_policy` / `default_activity_start_to_close` (`Option`, default `None`) with `with_default_activity_retry_policy(RetryPolicy)` / `with_default_activity_start_to_close(Duration)` (`src/builder.rs`).
- **Registry threading** — wired out of `WorkerConfig` into the `HandlerRegistry` via **both** `into_worker_parts` and `into_worker_parts_with_extra_state` (the plugin extra-state runner path), plus into `WorkflowContext` for the local path (`src/executor.rs`).
- **Regular / DAG (task-queue) resolution** — `persist_scheduled_activities` (`src/worker.rs`) swaps to the shared `resolve_effective_*` helpers. Isolated in its own commit (`45e19015`) for a clean rebase against concurrent edits in that function.
- **Local activity resolution** — `execute_local_activity_raw` (`src/context.rs`) appends the builder default as the lowest-priority fallback after `_with_opts` has resolved call→activity; the resolved `start_to_close` is then clamped by `WorkerConfig::max_local_activity_start_to_close` in `run_local_activity_inline`.
- **Reserved-session-activity guard** (issue #606 interaction) — the reserved `__harvest_session_acquire` / `__harvest_session_release` internal activities are engine machinery bounded by `schedule_to_start`/`SessionOptions::acquisition_timeout`, so they explicitly do **not** inherit the builder floor.
- **AC8 in-flight immunity** — an additive optional `retry_policy: Option<RetryPolicy>` field on the **existing** `LocalActivityScheduled` event freezes the resolved budget at first-schedule time; the crash-recovery replay path (`HistoryMatcher::recorded_local_activity_retry`) reads it so a builder-default change during the recovery window cannot shrink an in-flight local activity's budget. Pre-#620 events (field absent → `None`) fall back to the current re-derivation. **This is an additive optional field on an existing variant — not a new `WorkflowEvent` variant and not a migration.**
- Extra: the resolved floors are surfaced on `GET /admin/config` (`src/effective_config.rs`).

## AC → Evidence

| AC | Text (short) | Status | Evidence |
|----|--------------|--------|----------|
| 1 | Builder exposes `default_activity_retry_policy` / `default_activity_start_to_close` | ✅ | `WorkerConfig::with_default_activity_retry_policy` / `with_default_activity_start_to_close` — `src/builder.rs:2828`, `:2842`; unit test `worker_config_activity_defaults_default_to_none` `src/builder.rs:3697` |
| 2 | Precedence call→activity→builder→fallback at schedule time | ✅ | Pure `policy::resolve_effective_retry`/`resolve_effective_start_to_close` `src/policy.rs:1291`,`:1309` (`call.or(activity).or(builder)`); unit tests `resolve_effective_retry_precedence`/`resolve_effective_start_to_close_precedence` `src/policy.rs:1332`,`:1363`; applied at the two authoritative sites — `persist_scheduled_activities` `src/worker.rs:4475-4519` and `execute_local_activity_raw` `src/context.rs:4571-4573`; e2e STC precedence `call_site_stc_override_wins_over_builder_default_stc`/`declared_activity_stc_wins_over_builder_default_stc` (floor tests) |
| 3 | No-retry activity under builder default N → task `max_attempts = N` | ✅ | `no_retry_activity_under_builder_default_gets_max_attempts_n` floor:628 (asserts `task.max_attempts == 4`); raw/DAG path `raw_dispatched_activity_honours_builder_default` floor:680 |
| 4 | Declared-retry activity unaffected | ✅ | `declared_retry_activity_unaffected_by_builder_default` floor:728; STC sibling `declared_activity_stc_wins_over_builder_default_stc` floor:1391 |
| 5 | Call-site override wins (retry AND STC) | ✅ | `call_site_override_wins_over_builder_default` floor:782; `call_site_stc_override_wins_over_builder_default_stc` floor:1337 |
| 6 | Opt-in byte-for-byte (regular=3, local=1) | ✅ | `no_defaults_set_is_byte_for_byte_current_behaviour` floor:842 (asserts `max_attempts==3`, `retry_policy` NULL, `start_to_close` NULL); local unset `local_activity_no_defaults_records_single_failure` floor:1524; config-default unit test `src/builder.rs:3697` |
| 7 | Local honours default retry + STC clamped by `max_local_activity_start_to_close` | ✅ | `local_activity_honours_builder_default_retry` floor:899; discriminating STC-below-cap `local_activity_builder_default_stc_below_cap_is_enforced` floor:963 (1s floor kills a ~2s activity that the 60s cap alone would let complete); clamp-proof `local_activity_builder_default_stc_larger_than_cap_is_clamped` floor:1023; impl clamp `src/worker.rs:2168-2171` |
| 8 | No new variant / migration / replay change; in-flight unaffected by later default change | ✅ | **No new `WorkflowEvent` variant** (52 == 52 both sides) and **no migration/schema change** (`migrations/`, `schema.rs` untouched) — AC8 immunity rides an *additive optional* field on the existing `LocalActivityScheduled` variant (`src/event.rs:326`, `#[serde(default, skip_serializing_if)]`) + `recorded_local_activity_retry` reader `src/replay.rs:4870`; regular-path replay immunity is structural (recorded `max_attempts`); tests `local_activity_mid_retry_keeps_original_budget_across_default_change` floor:1167 (frozen `fixed(2)` survives a builder change to `fixed(1)`) and backward-compat `local_activity_mid_retry_without_recorded_budget_uses_current_default` floor:1230 |
| 9 | Doc note on precedence chain | ✅ | `docs/getting-started/07-reliability-knobs.md` (new "fleet-wide reliability floor" section: 4-level precedence list, opt-in note, local-STC clamp caveat) |

**Extra hardening beyond the ACs:** the reserved-session-activity guard (`reserved_session_activity_does_not_inherit_builder_default` floor:1085) and CI-suite-manifest wiring (`.github/ci/integration-suites.txt` — `linux … activity_default_floor_tests`).

## Testing

- **RAN & PASSED** on local **Postgres 16**: the DB integration suite `activity_default_floor` — **16 tests** (`autumn-harvest/tests/integration/activity_default_floor_tests.rs`).
- Pure/unit + no-DB suites pass (`policy` precedence tests, `builder` config/threading tests, `event`/`replay` serde round-trip).
- Lint clean at `cargo +1.97.0`: `fmt --check`, `clippy --all-features` and plugin `--all-targets`, both `-D warnings`.
- The cross-crate plugin fixture change (`autumn-harvest-plugin/tests/read_path_decode_integration.rs` — three `LocalActivityScheduled` struct literals gain `retry_policy: None` for the new field) is **compile-checked only here** (no Docker in this sandbox); CI runs that testcontainers suite Docker-backed.

## Collision note

This branch touches three files also edited by concurrent sibling sessions; the branch is currently **0 commits behind `trunk-dev`** so no conflict exists right now:
- `src/replay.rs` — a small read-only matcher helper (`recorded_local_activity_retry`) + a `..` in the strict-matcher `LocalActivityScheduled` arm (overlaps #1071, `fix/1071-replay-interleaved-sibling-tolerance`).
- `src/worker.rs` — the only *behavioural* worker edit is the isolated `persist_scheduled_activities` resolution + reserved-name guard, kept in commit `45e19015` for a clean rebase (overlaps #1072).
- `src/event.rs` — the additive optional field on `LocalActivityScheduled`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TVqbPJQmzKgy1Xg1VeMbst

---
_Generated by [Claude Code](https://claude.ai/code/session_01TVqbPJQmzKgy1Xg1VeMbst)_