### PR TITLE
🌟 Nova: [Timeline Chrome Trace Export]

### DIFF
--- a/autumn-harvest/src/lib.rs
+++ b/autumn-harvest/src/lib.rs
@@ -196,7 +196,6 @@ pub mod testing;
 pub mod throttle;
 /// Per-execution timeline read model (issue #739).
 pub mod timeline;
-#[cfg(any(test, feature = "testing"))]
 pub mod trace_export;
 pub mod types;
 pub mod update;
@@ -431,6 +430,7 @@ pub use timeline::{
 };
 #[cfg(any(test, feature = "testing"))]
 pub use trace_export::export_chrome_trace;
+pub use trace_export::export_timeline_trace;
 pub use types::{
     ActivityExecId, BuildId, DeploymentName, ExecutionId, ExternalActivityToken, ExternalCancelId,
     ExternalSignalId, ParentClosePolicy, Priority, SessionId, ShardId, TimerId, UpdateId, WorkerId,

--- a/autumn-harvest/src/trace_export.rs
+++ b/autumn-harvest/src/trace_export.rs
@@ -1,10 +1,13 @@
-//! Chrome Trace Event Format exporter for DAG profiles.
+//! Chrome Trace Event Format exporter for DAG profiles and Timelines.
 //!
-//! Converts a `DagProfile` into a JSON structure compatible with trace viewers
+//! Converts a `DagProfile` or a `Timeline` into a JSON structure compatible with trace viewers
 //! like `chrome://tracing` or `ui.perfetto.dev`.
 
+#[cfg(any(test, feature = "testing"))]
 use crate::dag_profiler::{DagProfile, ProfilerEventKind};
+use crate::timeline::Timeline;
 use serde_json::{Value, json};
+#[cfg(any(test, feature = "testing"))]
 use std::collections::HashMap;
 
 /// Exports a `DagProfile` to Chrome Trace Event Format.
@@ -15,6 +18,7 @@ use std::collections::HashMap;
 ///
 /// # Returns
 /// A JSON `Value` representing the trace events array.
+#[cfg(any(test, feature = "testing"))]
 #[must_use]
 pub fn export_chrome_trace(profile: &DagProfile) -> Value {
     let mut events = Vec::new();
@@ -48,10 +52,79 @@ pub fn export_chrome_trace(profile: &DagProfile) -> Value {
     json!(events)
 }
 
+/// Exports a historical `Timeline` to Chrome Trace Event Format.
+///
+/// Converts a real workflow execution timeline into an array of trace events.
+/// Each timeline step is represented as a span (`"ph": "X"`), with activities
+/// split into 'Queue' and 'Execution' segments if queue-wait splits are available.
+///
+/// # Returns
+/// A JSON `Value` representing the trace events array.
+#[must_use]
+pub fn export_timeline_trace(timeline: &Timeline) -> Value {
+    let mut events = Vec::new();
+
+    for step in &timeline.steps {
+        let start_ts = step.scheduled_at.timestamp_micros();
+        let name = step
+            .name
+            .clone()
+            .unwrap_or_else(|| step.step_kind.as_str().to_string());
+        let cat = step.step_kind.as_str();
+
+        let outcome_val = serde_json::to_value(step.outcome).unwrap_or_else(|_| json!("unknown"));
+
+        if let (Some(wait_ms), Some(exec_ms)) = (step.wait_ms, step.exec_ms) {
+            events.push(json!({
+                "name": format!("Wait: {name}"),
+                "cat": cat,
+                "ph": "X",
+                "ts": start_ts,
+                "dur": wait_ms * 1000,
+                "pid": timeline.workflow_id,
+                "tid": "Queue",
+                "args": { "outcome": outcome_val.clone() }
+            }));
+
+            events.push(json!({
+                "name": name,
+                "cat": cat,
+                "ph": "X",
+                "ts": start_ts + (wait_ms * 1000),
+                "dur": exec_ms * 1000,
+                "pid": timeline.workflow_id,
+                "tid": cat,
+                "args": {
+                    "outcome": outcome_val,
+                    "attempt": step.attempt
+                }
+            }));
+        } else {
+            events.push(json!({
+                "name": name,
+                "cat": cat,
+                "ph": "X",
+                "ts": start_ts,
+                "dur": step.total_ms * 1000,
+                "pid": timeline.workflow_id,
+                "tid": cat,
+                "args": {
+                    "outcome": outcome_val
+                }
+            }));
+        }
+    }
+
+    json!(events)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::dag_profiler::{ProfilerEvent, ProfilerEventKind};
+    use crate::dag_profiler::{DagProfile, ProfilerEvent, ProfilerEventKind};
+    use crate::timeline::{StepKind, StepOutcome, Timeline, TimelineRollup, TimelineStep};
+    use chrono::TimeZone;
+    use std::collections::BTreeMap;
     use std::time::Duration;
 
     #[test]
@@ -80,5 +153,51 @@ mod tests {
         assert_eq!(event["ph"], "X");
         assert_eq!(event["ts"], 1_000_000);
         assert_eq!(event["dur"], 2_000_000);
+    }
+
+    #[test]
+    fn test_export_timeline_trace() {
+        // A fixed time so timestamp_micros is deterministic.
+        let now = chrono::Utc.timestamp_opt(1_600_000_000, 0).unwrap();
+
+        let timeline = Timeline {
+            exec_id: "exec-1".to_string(),
+            workflow_id: "wf-1".to_string(),
+            workflow_name: "test_wf".to_string(),
+            state: "COMPLETED".to_string(),
+            steps: vec![TimelineStep {
+                step_kind: StepKind::Activity,
+                name: Some("activity_a".to_string()),
+                scheduled_at: now,
+                ended_at: Some(now + chrono::Duration::milliseconds(150)),
+                total_ms: 150,
+                wait_ms: Some(50),
+                exec_ms: Some(100),
+                outcome: StepOutcome::Completed,
+                attempt: Some(1),
+            }],
+            rollup: TimelineRollup {
+                total_wall_clock_ms: 150,
+                busy_ms: 100,
+                wait_ms: 50,
+                slowest_step: None,
+                step_count_by_kind: BTreeMap::new(),
+            },
+        };
+
+        let trace = export_timeline_trace(&timeline);
+        let arr = trace.as_array().expect("Expected JSON array");
+        assert_eq!(arr.len(), 2);
+
+        let wait_event = &arr[0];
+        assert_eq!(wait_event["name"], "Wait: activity_a");
+        assert_eq!(wait_event["dur"], 50_000);
+        assert_eq!(wait_event["tid"], "Queue");
+        assert_eq!(wait_event["pid"], "wf-1");
+
+        let exec_event = &arr[1];
+        assert_eq!(exec_event["name"], "activity_a");
+        assert_eq!(exec_event["dur"], 100_000);
+        assert_eq!(exec_event["tid"], "activity");
     }
 }

--- a/examples/saga-choreography/src/main.rs
+++ b/examples/saga-choreography/src/main.rs
@@ -266,6 +266,8 @@ mod tests {
             context_headers: None,
             execution_timeout: None,
             deadline_at: None,
+            parent_execution_id: None,
+            workflow_id: None,
         };
         let json = serde_json::to_string(&snapshot).unwrap();
         WorkflowReplayer::new()


### PR DESCRIPTION
💡 **The Spark:** "I noticed we parse historical `Timeline`s showing exact wait times and execution lengths, but we didn't have an easy way to visualize them outside the textual UI."
🚀 **The Feature:** "Implemented `export_timeline_trace` in `trace_export.rs` to output a real Timeline as a Chrome Trace Event Array (`ph: X` spans)."
🔮 **The Potential:** "Could be used to build a full UI timeline view in Autumn Web, allowing users to drag and drop performance graphs, and see exactly when activities queued vs executed natively in Perfetto!"
⚠️ **Risk:** "Low. Purely an additive read model formatter with deterministic JSON mapping, leaving core DAG logic untouched."

---
*PR created automatically by Jules for task [18162446591396938955](https://jules.google.com/task/18162446591396938955) started by @madmax983*