### PR TITLE
feat(dlq): cause-targeted bulk replay/discard + dlq_reason/error_class facets (#613)

### DIFF
--- a/.github/ci/integration-suites.txt
+++ b/.github/ci/integration-suites.txt
@@ -70,6 +70,8 @@ linux        autumn-harvest-plugin  build_ramp_integration           -          
 linux        autumn-harvest-plugin  by_id_integration                -                          -
 linux        autumn-harvest-plugin  completion_triggers_integration  -                          -
 linux        autumn-harvest-plugin  dag_run_graph_integration        -                          -
+linux        autumn-harvest-plugin  dlq_aggregate_integration        -                          -
+linux        autumn-harvest-plugin  dlq_bulk_integration             -                          -
 linux        autumn-harvest-plugin  eligibility_tests                -                          -
 linux        autumn-harvest-plugin  fail_now_integration             -                          -
 linux        autumn-harvest-plugin  fanout_degradation_integration   -                          -

--- a/autumn-harvest-cli/src/lib.rs
+++ b/autumn-harvest-cli/src/lib.rs
@@ -1580,6 +1580,18 @@ enum DeadLetterCommand {
         /// Exclusive upper bound on `failed_at` (RFC 3339).
         #[arg(long)]
         failed_before: Option<String>,
+        /// Filter by derived error class (exact, PascalCase; e.g. `CircuitOpen`,
+        /// `PoisonPill`, `HandlerPanic`). Matching is exact-equality, not case-folded.
+        #[arg(long)]
+        error_class: Option<String>,
+        /// Filter by derived DLQ reason class (exact, snake_case; e.g.
+        /// `poison_pill`, `workflow_task_timeout`, `retry_exhaustion`). Exact-equality.
+        #[arg(long)]
+        dlq_reason: Option<String>,
+        /// Filter by derived failure signature (exact match on the normalized
+        /// first line of the error).
+        #[arg(long)]
+        failure_signature: Option<String>,
         /// Maximum rows to act on per call (default 100, max 1000).
         #[arg(long, value_parser = clap::value_parser!(u32).range(1..=1000))]
         limit: Option<u32>,
@@ -1592,10 +1604,12 @@ enum DeadLetterCommand {
     /// Groups the DLQ by one or more dimensions and reports per-group counts
     /// with representative sample IDs, merged across shards. Renders a table by
     /// default; pass --json for piping.
+    #[command(alias = "summary")]
     Aggregate {
         /// Grouping dimensions (comma-separated or repeated). Supported:
         /// `workflow_name`, `activity_name`, `queue_name`, `task_type`,
-        /// `time_bucket`, `failure_signature`. Order builds a hierarchical key.
+        /// `time_bucket`, `failure_signature`, `dlq_reason`, `error_class`.
+        /// Order builds a hierarchical key.
         #[arg(long = "group-by", value_delimiter = ',', required = true)]
         group_by: Vec<String>,
         /// Granularity for the `time_bucket` dimension: hour (default) or day.
@@ -1646,6 +1660,18 @@ enum DeadLetterCommand {
         /// Exclusive upper bound on `failed_at` (RFC 3339).
         #[arg(long)]
         failed_before: Option<String>,
+        /// Filter by derived error class (exact, PascalCase; e.g. `CircuitOpen`,
+        /// `PoisonPill`, `HandlerPanic`). Matching is exact-equality, not case-folded.
+        #[arg(long)]
+        error_class: Option<String>,
+        /// Filter by derived DLQ reason class (exact, snake_case; e.g.
+        /// `poison_pill`, `workflow_task_timeout`, `retry_exhaustion`). Exact-equality.
+        #[arg(long)]
+        dlq_reason: Option<String>,
+        /// Filter by derived failure signature (exact match on the normalized
+        /// first line of the error).
+        #[arg(long)]
+        failure_signature: Option<String>,
         /// Maximum rows to act on per call (default 100, max 1000).
         #[arg(long, value_parser = clap::value_parser!(u32).range(1..=1000))]
         limit: Option<u32>,
@@ -5333,6 +5359,9 @@ fn dead_letter_request(command: &DeadLetterCommand) -> ApiRequest {
             workflow_name,
             failed_after,
             failed_before,
+            error_class,
+            dlq_reason,
+            failure_signature,
             limit,
             dry_run,
         } => ApiRequest::post(
@@ -5342,6 +5371,9 @@ fn dead_letter_request(command: &DeadLetterCommand) -> ApiRequest {
                 workflow_name.as_deref(),
                 failed_after.as_deref(),
                 failed_before.as_deref(),
+                error_class.as_deref(),
+                dlq_reason.as_deref(),
+                failure_signature.as_deref(),
                 *limit,
                 *dry_run,
             )),
@@ -5351,6 +5383,9 @@ fn dead_letter_request(command: &DeadLetterCommand) -> ApiRequest {
             workflow_name,
             failed_after,
             failed_before,
+            error_class,
+            dlq_reason,
+            failure_signature,
             limit,
             dry_run,
         } => ApiRequest::post(
@@ -5360,6 +5395,9 @@ fn dead_letter_request(command: &DeadLetterCommand) -> ApiRequest {
                 workflow_name.as_deref(),
                 failed_after.as_deref(),
                 failed_before.as_deref(),
+                error_class.as_deref(),
+                dlq_reason.as_deref(),
+                failure_signature.as_deref(),
                 *limit,
                 *dry_run,
             )),
@@ -5471,11 +5509,15 @@ fn build_redrive_dlq_body(
     Value::Object(body)
 }
 
+#[allow(clippy::too_many_arguments)]
 fn build_bulk_dlq_body(
     activity_name: Option<&str>,
     workflow_name: Option<&str>,
     failed_after: Option<&str>,
     failed_before: Option<&str>,
+    error_class: Option<&str>,
+    dlq_reason: Option<&str>,
+    failure_signature: Option<&str>,
     limit: Option<u32>,
     dry_run: bool,
 ) -> Value {
@@ -5484,6 +5526,9 @@ fn build_bulk_dlq_body(
     insert_string(&mut body, "workflow_name", workflow_name);
     insert_string(&mut body, "failed_after", failed_after);
     insert_string(&mut body, "failed_before", failed_before);
+    insert_string(&mut body, "error_class", error_class);
+    insert_string(&mut body, "dlq_reason", dlq_reason);
+    insert_string(&mut body, "failure_signature", failure_signature);
     if let Some(l) = limit {
         body.insert("limit".to_string(), json!(l));
     }

--- a/autumn-harvest-cli/src/lib.rs
+++ b/autumn-harvest-cli/src/lib.rs
@@ -1574,6 +1574,12 @@ enum DeadLetterCommand {
         /// Exact match on workflow name.
         #[arg(long)]
         workflow_name: Option<String>,
+        /// Exact match on task queue name (e.g. to reproduce a queue-scoped facet).
+        #[arg(long)]
+        queue_name: Option<String>,
+        /// Only include entries with at least this many attempts.
+        #[arg(long)]
+        min_attempts: Option<i32>,
         /// Inclusive lower bound on `failed_at` (RFC 3339, e.g. `2026-04-27T12:30:00Z`).
         #[arg(long)]
         failed_after: Option<String>,
@@ -1654,6 +1660,12 @@ enum DeadLetterCommand {
         /// Exact match on workflow name.
         #[arg(long)]
         workflow_name: Option<String>,
+        /// Exact match on task queue name (e.g. to reproduce a queue-scoped facet).
+        #[arg(long)]
+        queue_name: Option<String>,
+        /// Only include entries with at least this many attempts.
+        #[arg(long)]
+        min_attempts: Option<i32>,
         /// Inclusive lower bound on `failed_at` (RFC 3339, e.g. `2026-04-27T12:30:00Z`).
         #[arg(long)]
         failed_after: Option<String>,
@@ -5357,6 +5369,8 @@ fn dead_letter_request(command: &DeadLetterCommand) -> ApiRequest {
         DeadLetterCommand::BulkReplay {
             activity_name,
             workflow_name,
+            queue_name,
+            min_attempts,
             failed_after,
             failed_before,
             error_class,
@@ -5369,6 +5383,8 @@ fn dead_letter_request(command: &DeadLetterCommand) -> ApiRequest {
             Some(build_bulk_dlq_body(
                 activity_name.as_deref(),
                 workflow_name.as_deref(),
+                queue_name.as_deref(),
+                *min_attempts,
                 failed_after.as_deref(),
                 failed_before.as_deref(),
                 error_class.as_deref(),
@@ -5381,6 +5397,8 @@ fn dead_letter_request(command: &DeadLetterCommand) -> ApiRequest {
         DeadLetterCommand::BulkDiscard {
             activity_name,
             workflow_name,
+            queue_name,
+            min_attempts,
             failed_after,
             failed_before,
             error_class,
@@ -5393,6 +5411,8 @@ fn dead_letter_request(command: &DeadLetterCommand) -> ApiRequest {
             Some(build_bulk_dlq_body(
                 activity_name.as_deref(),
                 workflow_name.as_deref(),
+                queue_name.as_deref(),
+                *min_attempts,
                 failed_after.as_deref(),
                 failed_before.as_deref(),
                 error_class.as_deref(),
@@ -5513,6 +5533,8 @@ fn build_redrive_dlq_body(
 fn build_bulk_dlq_body(
     activity_name: Option<&str>,
     workflow_name: Option<&str>,
+    queue_name: Option<&str>,
+    min_attempts: Option<i32>,
     failed_after: Option<&str>,
     failed_before: Option<&str>,
     error_class: Option<&str>,
@@ -5524,6 +5546,10 @@ fn build_bulk_dlq_body(
     let mut body = Map::new();
     insert_string(&mut body, "activity_name", activity_name);
     insert_string(&mut body, "workflow_name", workflow_name);
+    insert_string(&mut body, "queue_name", queue_name);
+    if let Some(m) = min_attempts {
+        body.insert("min_attempts".to_string(), json!(m));
+    }
     insert_string(&mut body, "failed_after", failed_after);
     insert_string(&mut body, "failed_before", failed_before);
     insert_string(&mut body, "error_class", error_class);

--- a/autumn-harvest-cli/src/lib.rs
+++ b/autumn-harvest-cli/src/lib.rs
@@ -1580,11 +1580,11 @@ enum DeadLetterCommand {
         /// Exclusive upper bound on `failed_at` (RFC 3339).
         #[arg(long)]
         failed_before: Option<String>,
-        /// Filter by derived error class (exact, PascalCase; e.g. `CircuitOpen`,
+        /// Filter by derived error class (exact, `PascalCase`; e.g. `CircuitOpen`,
         /// `PoisonPill`, `HandlerPanic`). Matching is exact-equality, not case-folded.
         #[arg(long)]
         error_class: Option<String>,
-        /// Filter by derived DLQ reason class (exact, snake_case; e.g.
+        /// Filter by derived DLQ reason class (exact, `snake_case`; e.g.
         /// `poison_pill`, `workflow_task_timeout`, `retry_exhaustion`). Exact-equality.
         #[arg(long)]
         dlq_reason: Option<String>,
@@ -1660,11 +1660,11 @@ enum DeadLetterCommand {
         /// Exclusive upper bound on `failed_at` (RFC 3339).
         #[arg(long)]
         failed_before: Option<String>,
-        /// Filter by derived error class (exact, PascalCase; e.g. `CircuitOpen`,
+        /// Filter by derived error class (exact, `PascalCase`; e.g. `CircuitOpen`,
         /// `PoisonPill`, `HandlerPanic`). Matching is exact-equality, not case-folded.
         #[arg(long)]
         error_class: Option<String>,
-        /// Filter by derived DLQ reason class (exact, snake_case; e.g.
+        /// Filter by derived DLQ reason class (exact, `snake_case`; e.g.
         /// `poison_pill`, `workflow_task_timeout`, `retry_exhaustion`). Exact-equality.
         #[arg(long)]
         dlq_reason: Option<String>,

--- a/autumn-harvest-cli/tests/integration/contract_coverage.rs
+++ b/autumn-harvest-cli/tests/integration/contract_coverage.rs
@@ -839,6 +839,30 @@ fn dlq_bulk_discard_cause_body_fields_are_documented() {
 }
 
 #[test]
+fn dlq_bulk_replay_queue_and_min_attempts_body_fields_are_documented() {
+    assert_body_fields_documented(&[
+        "dlq",
+        "bulk-replay",
+        "--queue-name",
+        "low-pri",
+        "--min-attempts",
+        "3",
+    ]);
+}
+
+#[test]
+fn dlq_bulk_discard_queue_and_min_attempts_body_fields_are_documented() {
+    assert_body_fields_documented(&[
+        "dlq",
+        "bulk-discard",
+        "--queue-name",
+        "low-pri",
+        "--min-attempts",
+        "3",
+    ]);
+}
+
+#[test]
 fn handoff_complete_body_fields_are_documented() {
     assert_body_fields_documented(&[
         "handoff",

--- a/autumn-harvest-cli/tests/integration/contract_coverage.rs
+++ b/autumn-harvest-cli/tests/integration/contract_coverage.rs
@@ -811,6 +811,34 @@ fn dlq_bulk_discard_body_fields_are_documented() {
 }
 
 #[test]
+fn dlq_bulk_replay_cause_body_fields_are_documented() {
+    assert_body_fields_documented(&[
+        "dlq",
+        "bulk-replay",
+        "--error-class",
+        "CircuitOpen",
+        "--dlq-reason",
+        "poison_pill",
+        "--failure-signature",
+        "connection refused",
+    ]);
+}
+
+#[test]
+fn dlq_bulk_discard_cause_body_fields_are_documented() {
+    assert_body_fields_documented(&[
+        "dlq",
+        "bulk-discard",
+        "--error-class",
+        "CircuitOpen",
+        "--dlq-reason",
+        "poison_pill",
+        "--failure-signature",
+        "connection refused",
+    ]);
+}
+
+#[test]
 fn handoff_complete_body_fields_are_documented() {
     assert_body_fields_documented(&[
         "handoff",

--- a/autumn-harvest-cli/tests/integration/request_mapping.rs
+++ b/autumn-harvest-cli/tests/integration/request_mapping.rs
@@ -1097,6 +1097,95 @@ fn dlq_bulk_replay_with_all_filters_maps_correctly() {
 }
 
 #[test]
+fn dlq_bulk_replay_with_cause_filters_maps_to_body() {
+    let cli = Cli::try_parse_from([
+        "harvest",
+        "dlq",
+        "bulk-replay",
+        "--dlq-reason",
+        "poison_pill",
+        "--error-class",
+        "CircuitOpen",
+        "--failure-signature",
+        "connection refused",
+    ])
+    .expect("bulk-replay cause args should parse");
+
+    let request = cli.api_request().expect("request should build");
+
+    assert_eq!(request.method, ApiMethod::Post);
+    assert_eq!(request.path, "/dead-letters/replay");
+    let body = request.body.expect("should have body");
+    assert_eq!(body["dlq_reason"], "poison_pill");
+    assert_eq!(body["error_class"], "CircuitOpen");
+    assert_eq!(body["failure_signature"], "connection refused");
+}
+
+#[test]
+fn dlq_bulk_discard_with_cause_filters_maps_to_body() {
+    let cli = Cli::try_parse_from([
+        "harvest",
+        "dlq",
+        "bulk-discard",
+        "--dlq-reason",
+        "workflow_task_timeout",
+        "--error-class",
+        "WorkflowTaskTimeout",
+        "--failure-signature",
+        "task timed out",
+    ])
+    .expect("bulk-discard cause args should parse");
+
+    let request = cli.api_request().expect("request should build");
+
+    assert_eq!(request.method, ApiMethod::Post);
+    assert_eq!(request.path, "/dead-letters/discard");
+    let body = request.body.expect("should have body");
+    assert_eq!(body["dlq_reason"], "workflow_task_timeout");
+    assert_eq!(body["error_class"], "WorkflowTaskTimeout");
+    assert_eq!(body["failure_signature"], "task timed out");
+}
+
+#[test]
+fn dlq_summary_alias_maps_like_aggregate() {
+    let summary = Cli::try_parse_from([
+        "harvest",
+        "dlq",
+        "summary",
+        "--group-by",
+        "dlq_reason",
+    ])
+    .expect("dlq summary should parse")
+    .api_request()
+    .expect("summary request should build");
+
+    let aggregate = Cli::try_parse_from([
+        "harvest",
+        "dlq",
+        "aggregate",
+        "--group-by",
+        "dlq_reason",
+    ])
+    .expect("dlq aggregate should parse")
+    .api_request()
+    .expect("aggregate request should build");
+
+    assert_eq!(summary.method, ApiMethod::Get);
+    assert_eq!(summary.method, aggregate.method);
+    assert_eq!(summary.path, aggregate.path);
+    assert!(
+        summary.path.starts_with("/dead-letters/aggregate?"),
+        "unexpected path: {}",
+        summary.path
+    );
+    assert!(
+        summary.path.contains("group_by=dlq_reason"),
+        "unexpected path: {}",
+        summary.path
+    );
+}
+
+#[test]
 fn workflow_update_maps_to_post_with_wait_query() {
     let cli = Cli::try_parse_from([
         "harvest",

--- a/autumn-harvest-cli/tests/integration/request_mapping.rs
+++ b/autumn-harvest-cli/tests/integration/request_mapping.rs
@@ -1122,6 +1122,50 @@ fn dlq_bulk_replay_with_cause_filters_maps_to_body() {
 }
 
 #[test]
+fn dlq_bulk_replay_with_queue_and_min_attempts_maps_to_body() {
+    let cli = Cli::try_parse_from([
+        "harvest",
+        "dlq",
+        "bulk-replay",
+        "--queue-name",
+        "low-pri",
+        "--min-attempts",
+        "3",
+    ])
+    .expect("bulk-replay queue/min-attempts args should parse");
+
+    let request = cli.api_request().expect("request should build");
+
+    assert_eq!(request.method, ApiMethod::Post);
+    assert_eq!(request.path, "/dead-letters/replay");
+    let body = request.body.expect("should have body");
+    assert_eq!(body["queue_name"], "low-pri");
+    assert_eq!(body["min_attempts"], 3);
+}
+
+#[test]
+fn dlq_bulk_discard_with_queue_and_min_attempts_maps_to_body() {
+    let cli = Cli::try_parse_from([
+        "harvest",
+        "dlq",
+        "bulk-discard",
+        "--queue-name",
+        "low-pri",
+        "--min-attempts",
+        "5",
+    ])
+    .expect("bulk-discard queue/min-attempts args should parse");
+
+    let request = cli.api_request().expect("request should build");
+
+    assert_eq!(request.method, ApiMethod::Post);
+    assert_eq!(request.path, "/dead-letters/discard");
+    let body = request.body.expect("should have body");
+    assert_eq!(body["queue_name"], "low-pri");
+    assert_eq!(body["min_attempts"], 5);
+}
+
+#[test]
 fn dlq_bulk_discard_with_cause_filters_maps_to_body() {
     let cli = Cli::try_parse_from([
         "harvest",

--- a/autumn-harvest-cli/tests/integration/request_mapping.rs
+++ b/autumn-harvest-cli/tests/integration/request_mapping.rs
@@ -1148,27 +1148,16 @@ fn dlq_bulk_discard_with_cause_filters_maps_to_body() {
 
 #[test]
 fn dlq_summary_alias_maps_like_aggregate() {
-    let summary = Cli::try_parse_from([
-        "harvest",
-        "dlq",
-        "summary",
-        "--group-by",
-        "dlq_reason",
-    ])
-    .expect("dlq summary should parse")
-    .api_request()
-    .expect("summary request should build");
+    let summary = Cli::try_parse_from(["harvest", "dlq", "summary", "--group-by", "dlq_reason"])
+        .expect("dlq summary should parse")
+        .api_request()
+        .expect("summary request should build");
 
-    let aggregate = Cli::try_parse_from([
-        "harvest",
-        "dlq",
-        "aggregate",
-        "--group-by",
-        "dlq_reason",
-    ])
-    .expect("dlq aggregate should parse")
-    .api_request()
-    .expect("aggregate request should build");
+    let aggregate =
+        Cli::try_parse_from(["harvest", "dlq", "aggregate", "--group-by", "dlq_reason"])
+            .expect("dlq aggregate should parse")
+            .api_request()
+            .expect("aggregate request should build");
 
     assert_eq!(summary.method, ApiMethod::Get);
     assert_eq!(summary.method, aggregate.method);

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -5007,6 +5007,9 @@ pub const fn management_api_request_fields()
                 "workflow_name",
                 "failed_after",
                 "failed_before",
+                "error_class",
+                "dlq_reason",
+                "failure_signature",
                 "limit",
                 "dry_run",
             ]),
@@ -5019,6 +5022,9 @@ pub const fn management_api_request_fields()
                 "workflow_name",
                 "failed_after",
                 "failed_before",
+                "error_class",
+                "dlq_reason",
+                "failure_signature",
                 "limit",
                 "dry_run",
             ]),
@@ -22752,6 +22758,12 @@ struct BulkDlqApiBody {
     #[serde(default)]
     failed_before: Option<chrono::DateTime<chrono::Utc>>,
     #[serde(default)]
+    error_class: Option<String>,
+    #[serde(default)]
+    dlq_reason: Option<String>,
+    #[serde(default)]
+    failure_signature: Option<String>,
+    #[serde(default)]
     shard_id: Option<i32>,
     #[serde(default)]
     limit: Option<u32>,
@@ -22772,6 +22784,9 @@ impl BulkDlqApiBody {
                 workflow_name: self.workflow_name,
                 failed_after: self.failed_after,
                 failed_before: self.failed_before,
+                error_class: normalize_cause_filter(self.error_class)?,
+                dlq_reason: normalize_cause_filter(self.dlq_reason)?,
+                failure_signature: normalize_cause_filter(self.failure_signature)?,
                 limit: self.limit,
                 dry_run: self.dry_run,
             },
@@ -22779,6 +22794,26 @@ impl BulkDlqApiBody {
             task_type,
             shard_id: self.shard_id,
         })
+    }
+}
+
+/// Normalize a compute-on-read cause filter value (issue #613): an absent
+/// value stays absent; a present value is trimmed and, if empty after
+/// trimming, rejected with `400` rather than silently downgraded to "no
+/// filter" (which would replay/discard a far larger cohort than intended).
+fn normalize_cause_filter(value: Option<String>) -> Result<Option<String>, AutumnError> {
+    match value {
+        None => Ok(None),
+        Some(raw) => {
+            let trimmed = raw.trim();
+            if trimmed.is_empty() {
+                Err(AutumnError::bad_request_msg(
+                    "cause filter (error_class/dlq_reason/failure_signature) must not be empty",
+                ))
+            } else {
+                Ok(Some(trimmed.to_string()))
+            }
+        }
     }
 }
 
@@ -22871,6 +22906,19 @@ fn parse_bulk_dlq_form(body: &[u8]) -> Result<ParsedBulkDlqRequest, AutumnError>
     for (key, value) in parse_urlencoded_form(raw)? {
         let field = key.trim();
         let value = value.trim();
+        // Cause filters (issue #613) must be rejected — not silently skipped —
+        // when empty, so an accidental empty form value can't widen the cohort
+        // (the generic empty-value skip below would otherwise drop them).
+        if matches!(field, "error_class" | "dlq_reason" | "failure_signature") {
+            let normalized = normalize_cause_filter(Some(value.to_string()))?;
+            match field {
+                "error_class" => selector.filter.error_class = normalized,
+                "dlq_reason" => selector.filter.dlq_reason = normalized,
+                "failure_signature" => selector.filter.failure_signature = normalized,
+                _ => unreachable!(),
+            }
+            continue;
+        }
         if value.is_empty() {
             continue;
         }
@@ -23007,7 +23055,7 @@ fn dlq_bulk_empty_filter_response(request: &ParsedBulkDlqRequest) -> axum::respo
 
     const MESSAGE: &str = "bulk filter must specify at least one criterion: dead_letter_id, \
                            activity_name, workflow_name, task_type, failed_after, failed_before, \
-                           or shard_id";
+                           error_class, dlq_reason, failure_signature, or shard_id";
 
     if request.wants_redirect {
         return dlq_form_redirect(request.return_to.as_deref(), MESSAGE);
@@ -23615,6 +23663,20 @@ async fn count_api_bulk_filter_matches(
 ) -> HarvestResult<i64> {
     let mut query = harvest_dead_letters::table.into_boxed();
     query = apply_api_bulk_filters(query, selector);
+    // Cause dimensions (issue #613) are compute-on-read: load the SQL-filtered
+    // `error` strings and count the ones passing the cause post-filter.
+    if selector.filter.has_cause_filter() {
+        let errors: Vec<String> = query
+            .select(harvest_dead_letters::error)
+            .load(conn)
+            .await
+            .map_err(database_error)?;
+        let matched = errors
+            .iter()
+            .filter(|e| selector.filter.cause_matches(e))
+            .count();
+        return Ok(i64::try_from(matched).unwrap_or(i64::MAX));
+    }
     query.count().get_result(conn).await.map_err(database_error)
 }
 
@@ -23622,16 +23684,33 @@ async fn query_dead_letters_for_api_bulk(
     conn: &mut AsyncPgConnection,
     selector: &DlqBulkSelector,
 ) -> HarvestResult<Vec<DeadLetter>> {
+    // Cause dimensions (issue #613) are compute-on-read, so the SQL row limit
+    // cannot precede the post-filter (it would clip pre-filter rows). Drop the
+    // SQL limit, order oldest-first, then post-filter and `take` the limit — so
+    // the cause post-filter precedes the limit.
+    let cause = selector.filter.has_cause_filter();
     let mut query = harvest_dead_letters::table
         .into_boxed()
-        .order(harvest_dead_letters::failed_at.asc())
-        .limit(selector.filter.effective_limit());
+        .order(harvest_dead_letters::failed_at.asc());
+    if !cause {
+        query = query.limit(selector.filter.effective_limit());
+    }
     query = apply_api_bulk_filters(query, selector);
-    query
+    let rows = query
         .select(DeadLetter::as_select())
         .load(conn)
         .await
-        .map_err(database_error)
+        .map_err(database_error)?;
+    if cause {
+        let limit = usize::try_from(selector.filter.effective_limit()).unwrap_or(usize::MAX);
+        Ok(rows
+            .into_iter()
+            .filter(|r| selector.filter.cause_matches(&r.error))
+            .take(limit)
+            .collect())
+    } else {
+        Ok(rows)
+    }
 }
 
 fn apply_api_bulk_filters<'a>(

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -22802,9 +22802,9 @@ impl BulkDlqApiBody {
 /// trimming, rejected with `400` rather than silently downgraded to "no
 /// filter" (which would replay/discard a far larger cohort than intended).
 fn normalize_cause_filter(value: Option<String>) -> Result<Option<String>, AutumnError> {
-    match value {
-        None => Ok(None),
-        Some(raw) => {
+    value.map_or_else(
+        || Ok(None),
+        |raw| {
             let trimmed = raw.trim();
             if trimmed.is_empty() {
                 Err(AutumnError::bad_request_msg(
@@ -22813,8 +22813,8 @@ fn normalize_cause_filter(value: Option<String>) -> Result<Option<String>, Autum
             } else {
                 Ok(Some(trimmed.to_string()))
             }
-        }
-    }
+        },
+    )
 }
 
 /// Parsed `POST /dlq/redrive` request (issue #510): the core filter plus the

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -22796,7 +22796,10 @@ impl BulkDlqApiBody {
                 // dimensions (whose empty value would dangerously skip the
                 // filter and widen the cohort).
                 queue_name: self.queue_name,
-                min_attempts: self.min_attempts,
+                min_attempts: self
+                    .min_attempts
+                    .map(validate_bulk_min_attempts)
+                    .transpose()?,
                 failed_after: self.failed_after,
                 failed_before: self.failed_before,
                 error_class: normalize_cause_filter(self.error_class)?,
@@ -22830,6 +22833,26 @@ fn normalize_cause_filter(value: Option<String>) -> Result<Option<String>, Autum
             }
         },
     )
+}
+
+/// Validate a bulk-DLQ `min_attempts` filter (issue #613). The aggregate read
+/// parser (`DlqAggregateParams::from_query_pairs`) only rejects negatives
+/// (accepting `>= 0`), but the bulk replay/discard paths are DESTRUCTIVE so we
+/// are stricter: attempt counts are 1-based, so a `min_attempts` of `0` or a
+/// negative value produces the predicate `attempts >= 0` (or lower) which
+/// matches EVERY DLQ row. That is not a genuine narrowing criterion, so it must
+/// not satisfy the substantive-filter safety guard (AC8) — otherwise a
+/// malformed request slips past `BulkDlqFilter::is_empty()` and acts on the
+/// whole DLQ. Reject at the request boundary (mirroring `normalize_cause_filter`)
+/// rather than touching the SQL predicate; require `>= 1`.
+fn validate_bulk_min_attempts(value: i32) -> Result<i32, AutumnError> {
+    if value < 1 {
+        Err(AutumnError::bad_request_msg(format!(
+            "invalid min_attempts '{value}'; expected a positive integer (>= 1)"
+        )))
+    } else {
+        Ok(value)
+    }
 }
 
 /// Parsed `POST /dlq/redrive` request (issue #510): the core filter plus the
@@ -22945,7 +22968,10 @@ fn parse_bulk_dlq_form(body: &[u8]) -> Result<ParsedBulkDlqRequest, AutumnError>
             "workflow_name" => selector.filter.workflow_name = Some(value.to_string()),
             "queue_name" => selector.filter.queue_name = Some(value.to_string()),
             "min_attempts" => {
-                selector.filter.min_attempts = Some(parse_i32_field(value, "min_attempts")?);
+                selector.filter.min_attempts = Some(validate_bulk_min_attempts(parse_i32_field(
+                    value,
+                    "min_attempts",
+                )?)?);
             }
             "task_kind" | "task_type" => {
                 selector.task_type = Some(parse_dlq_task_type_filter(value)?);
@@ -31005,6 +31031,18 @@ mod tests {
             .iter()
             .map(|(k, v)| ((*k).to_string(), (*v).to_string()))
             .collect()
+    }
+
+    /// The bulk DLQ `min_attempts` guard (issue #613): `>= 1` is accepted, but
+    /// `0` and negatives — which match every 1-based-attempt row — are rejected
+    /// so a malformed request can't slip past the empty-filter safety guard.
+    #[test]
+    fn validate_bulk_min_attempts_rejects_non_positive() {
+        assert_eq!(validate_bulk_min_attempts(1).unwrap(), 1);
+        assert_eq!(validate_bulk_min_attempts(3).unwrap(), 3);
+        assert!(validate_bulk_min_attempts(0).is_err());
+        assert!(validate_bulk_min_attempts(-1).is_err());
+        assert!(validate_bulk_min_attempts(i32::MIN).is_err());
     }
 
     /// A narrow, NON-fleet (queue-scoped) gate on `gated-q`, so a start on a

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -5005,6 +5005,8 @@ pub const fn management_api_request_fields()
             Some(&[
                 "activity_name",
                 "workflow_name",
+                "queue_name",
+                "min_attempts",
                 "failed_after",
                 "failed_before",
                 "error_class",
@@ -5020,6 +5022,8 @@ pub const fn management_api_request_fields()
             Some(&[
                 "activity_name",
                 "workflow_name",
+                "queue_name",
+                "min_attempts",
                 "failed_after",
                 "failed_before",
                 "error_class",
@@ -22751,6 +22755,10 @@ struct BulkDlqApiBody {
     activity_name: Option<String>,
     #[serde(default)]
     workflow_name: Option<String>,
+    #[serde(default)]
+    queue_name: Option<String>,
+    #[serde(default)]
+    min_attempts: Option<i32>,
     #[serde(default, alias = "task_kind")]
     task_type: Option<String>,
     #[serde(default)]
@@ -22782,6 +22790,13 @@ impl BulkDlqApiBody {
             filter: dlq::BulkDlqFilter {
                 activity_name: self.activity_name,
                 workflow_name: self.workflow_name,
+                // `queue_name` is a plain positive-equality filter — treat empty
+                // exactly like `activity_name`/`workflow_name` (a harmless
+                // matches-nothing predicate), not like the strict-reject cause
+                // dimensions (whose empty value would dangerously skip the
+                // filter and widen the cohort).
+                queue_name: self.queue_name,
+                min_attempts: self.min_attempts,
                 failed_after: self.failed_after,
                 failed_before: self.failed_before,
                 error_class: normalize_cause_filter(self.error_class)?,
@@ -22928,6 +22943,10 @@ fn parse_bulk_dlq_form(body: &[u8]) -> Result<ParsedBulkDlqRequest, AutumnError>
             }
             "activity_name" => selector.filter.activity_name = Some(value.to_string()),
             "workflow_name" => selector.filter.workflow_name = Some(value.to_string()),
+            "queue_name" => selector.filter.queue_name = Some(value.to_string()),
+            "min_attempts" => {
+                selector.filter.min_attempts = Some(parse_i32_field(value, "min_attempts")?);
+            }
             "task_kind" | "task_type" => {
                 selector.task_type = Some(parse_dlq_task_type_filter(value)?);
             }
@@ -23729,6 +23748,12 @@ fn apply_api_bulk_filters<'a>(
                 .bind::<diesel::sql_types::Text, _>(task_type.clone())
                 .sql(")"),
         );
+    }
+    if let Some(ref queue) = selector.filter.queue_name {
+        query = query.filter(harvest_dead_letters::queue_name.eq(queue.clone()));
+    }
+    if let Some(min) = selector.filter.min_attempts {
+        query = query.filter(harvest_dead_letters::attempts.ge(min));
     }
     if let Some(after) = selector.filter.failed_after {
         query = query.filter(harvest_dead_letters::failed_at.ge(after));

--- a/autumn-harvest-plugin/src/ui.rs
+++ b/autumn-harvest-plugin/src/ui.rs
@@ -2710,7 +2710,9 @@ fn dlq_summary_drilldown_href(
             DlqGroupDimension::ActivityName
             | DlqGroupDimension::QueueName
             | DlqGroupDimension::TimeBucket
-            | DlqGroupDimension::FailureSignature => {
+            | DlqGroupDimension::FailureSignature
+            | DlqGroupDimension::DlqReason
+            | DlqGroupDimension::ErrorClass => {
                 partial = true;
             }
         }

--- a/autumn-harvest-plugin/tests/dlq_aggregate_integration.rs
+++ b/autumn-harvest-plugin/tests/dlq_aggregate_integration.rs
@@ -550,8 +550,8 @@ fn callback_exhausted_error() -> String {
 
 /// Seed a 10-row cause fixture with three distinct engine-authored quarantine
 /// reasons plus a plain retry-exhaustion cohort:
-///   poison_pill = 4, workflow_task_timeout = 2,
-///   callback_delivery_exhausted = 1, retry_exhaustion (plain) = 3.
+///   `poison_pill` = 4, `workflow_task_timeout` = 2,
+///   `callback_delivery_exhausted` = 1, `retry_exhaustion` (plain) = 3.
 async fn seed_cause_fixture(database_url: &str, shard: i32) {
     let exec = insert_execution(database_url, shard, "cause_wf").await;
     insert_dlq_rows(database_url, exec, "a", &poison_pill_error(), 4).await;

--- a/autumn-harvest-plugin/tests/dlq_aggregate_integration.rs
+++ b/autumn-harvest-plugin/tests/dlq_aggregate_integration.rs
@@ -517,3 +517,127 @@ async fn aggregate_merges_counts_across_shards() {
     assert_eq!(counts.get("reporting"), Some(&14));
     assert_eq!(sum_group_counts(groups), 100);
 }
+
+// ---------------------------------------------------------------------------
+// Cause-dimension aggregation (issue #613)
+// ---------------------------------------------------------------------------
+
+fn poison_pill_error() -> String {
+    autumn_harvest::dlq::DeadLetterReason::PoisonPill {
+        crash_strikes: 3,
+        last_worker_id: Some("worker-7".to_string()),
+    }
+    .to_string()
+}
+
+fn task_timeout_error() -> String {
+    autumn_harvest::dlq::DeadLetterReason::WorkflowTaskTimeout {
+        task_timeout_strikes: 3,
+        timeout_secs: 30,
+    }
+    .to_string()
+}
+
+fn callback_exhausted_error() -> String {
+    autumn_harvest::dlq::DeadLetterReason::CallbackDeliveryExhausted {
+        delivery_id: uuid::Uuid::new_v4(),
+        attempts: 10,
+        last_status: Some(503),
+        target: "https://hooks.example.com/x".to_string(),
+    }
+    .to_string()
+}
+
+/// Seed a 10-row cause fixture with three distinct engine-authored quarantine
+/// reasons plus a plain retry-exhaustion cohort:
+///   poison_pill = 4, workflow_task_timeout = 2,
+///   callback_delivery_exhausted = 1, retry_exhaustion (plain) = 3.
+async fn seed_cause_fixture(database_url: &str, shard: i32) {
+    let exec = insert_execution(database_url, shard, "cause_wf").await;
+    insert_dlq_rows(database_url, exec, "a", &poison_pill_error(), 4).await;
+    insert_dlq_rows(database_url, exec, "a", &task_timeout_error(), 2).await;
+    insert_dlq_rows(database_url, exec, "a", &callback_exhausted_error(), 1).await;
+    insert_dlq_rows(database_url, exec, "a", "connection refused", 3).await;
+}
+
+#[tokio::test]
+async fn aggregate_group_by_dlq_reason_orders_by_count() {
+    let (database_url, _container) = setup_test_database_url().await;
+    let app = build_dlq_app(build_test_pool(&database_url));
+    seed_cause_fixture(&database_url, 0).await;
+
+    let (status, body) = get_json(&app, "/dead-letters/aggregate?group_by=dlq_reason").await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+
+    let groups = body["groups"].as_array().expect("groups array");
+    let counts = counts_by(groups, "dlq_reason");
+    assert_eq!(counts.get("poison_pill"), Some(&4), "counts: {counts:?}");
+    assert_eq!(
+        counts.get("workflow_task_timeout"),
+        Some(&2),
+        "counts: {counts:?}"
+    );
+    assert_eq!(
+        counts.get("callback_delivery_exhausted"),
+        Some(&1),
+        "counts: {counts:?}"
+    );
+    assert_eq!(
+        counts.get("retry_exhaustion"),
+        Some(&3),
+        "counts: {counts:?}"
+    );
+    assert_eq!(sum_group_counts(groups), 10, "reconcile to filtered_total");
+    assert_eq!(body["filtered_total"], 10);
+    // Descending-count ordering: the largest group comes first.
+    assert_eq!(groups[0]["key"]["dlq_reason"], "poison_pill");
+}
+
+#[tokio::test]
+async fn aggregate_group_by_error_class() {
+    let (database_url, _container) = setup_test_database_url().await;
+    let app = build_dlq_app(build_test_pool(&database_url));
+    seed_cause_fixture(&database_url, 0).await;
+
+    let (status, body) = get_json(&app, "/dead-letters/aggregate?group_by=error_class").await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+
+    let groups = body["groups"].as_array().expect("groups array");
+    let counts = counts_by(groups, "error_class");
+    assert_eq!(counts.get("PoisonPill"), Some(&4), "counts: {counts:?}");
+    assert_eq!(
+        counts.get("WorkflowTaskTimeout"),
+        Some(&2),
+        "counts: {counts:?}"
+    );
+    assert_eq!(
+        counts.get("CallbackDeliveryExhausted"),
+        Some(&1),
+        "counts: {counts:?}"
+    );
+    // Plain "connection refused" -> normalized leading token "connection".
+    assert_eq!(counts.get("connection"), Some(&3), "counts: {counts:?}");
+    assert_eq!(sum_group_counts(groups), 10);
+}
+
+#[tokio::test]
+async fn aggregate_group_by_dlq_reason_merges_across_shards() {
+    let ((shard0_url, shard1_url), _container) = setup_sharded_test_database_urls().await;
+    let app = build_sharded_dlq_app(&shard0_url, &shard1_url);
+
+    seed_cause_fixture(&shard0_url, 0).await;
+    seed_cause_fixture(&shard1_url, 1).await;
+
+    let (status, body) = get_json(&app, "/dead-letters/aggregate?group_by=dlq_reason").await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    assert_eq!(body["total"], 20, "total sums across shards");
+    assert_eq!(body["filtered_total"], 20);
+
+    let groups = body["groups"].as_array().expect("groups array");
+    let counts = counts_by(groups, "dlq_reason");
+    assert_eq!(counts.get("poison_pill"), Some(&8));
+    assert_eq!(counts.get("workflow_task_timeout"), Some(&4));
+    assert_eq!(counts.get("callback_delivery_exhausted"), Some(&2));
+    assert_eq!(counts.get("retry_exhaustion"), Some(&6));
+    assert_eq!(sum_group_counts(groups), 20);
+}

--- a/autumn-harvest-plugin/tests/dlq_bulk_integration.rs
+++ b/autumn-harvest-plugin/tests/dlq_bulk_integration.rs
@@ -889,3 +889,42 @@ async fn bulk_min_attempts_filter_narrows() {
         "the attempts=1 row must survive"
     );
 }
+
+/// A non-positive `min_attempts` matches EVERY DLQ row (`attempts >= 0` is
+/// universally true, attempt counts being 1-based), so on the DESTRUCTIVE bulk
+/// path it must be rejected with `400` at the request boundary rather than
+/// slipping past the empty-filter safety guard (AC8, issue #613). Covers both
+/// the reported negative case and `0`; asserts nothing is acted on.
+#[tokio::test]
+async fn bulk_negative_min_attempts_is_rejected_400() {
+    let (database_url, _container) = setup_test_database_url().await;
+    let app = build_dlq_app(build_test_pool(&database_url));
+
+    insert_dlq_row_full(&database_url, "flaky", "default", 1, "connection refused").await;
+    insert_dlq_row_full(&database_url, "flaky", "default", 3, "connection refused").await;
+
+    // Negative: the reported all-rows-match bypass.
+    let (neg_status, neg_body) =
+        post_json(&app, "/dead-letters/discard", json!({ "min_attempts": -1 })).await;
+    assert_eq!(
+        neg_status,
+        StatusCode::BAD_REQUEST,
+        "negative min_attempts must 400, body: {neg_body}"
+    );
+
+    // Zero: `attempts >= 0` also matches every row.
+    let (zero_status, zero_body) =
+        post_json(&app, "/dead-letters/discard", json!({ "min_attempts": 0 })).await;
+    assert_eq!(
+        zero_status,
+        StatusCode::BAD_REQUEST,
+        "zero min_attempts must 400, body: {zero_body}"
+    );
+
+    // Neither malformed request touched the DLQ.
+    assert_eq!(
+        count_dlq_rows(&database_url).await,
+        2,
+        "a rejected bulk request must act on no rows"
+    );
+}

--- a/autumn-harvest-plugin/tests/dlq_bulk_integration.rs
+++ b/autumn-harvest-plugin/tests/dlq_bulk_integration.rs
@@ -745,3 +745,147 @@ async fn bulk_cause_across_shards_honors_global_limit() {
     let remaining = count_dlq_rows(&shard0_url).await + count_dlq_rows(&shard1_url).await;
     assert_eq!(remaining, 3, "8 matched - 5 acted = 3 remain");
 }
+
+/// Insert a dead-letter row on a specific `queue_name` with a specific
+/// `attempts` count (issue #613, P2-1: exercise the SQL-expressible bulk filter
+/// dimensions).
+async fn insert_dlq_row_full(
+    database_url: &str,
+    activity_name: &str,
+    queue_name: &str,
+    attempts: i32,
+    error: &str,
+) -> uuid::Uuid {
+    let mut conn = <AsyncPgConnection as AsyncConnection>::establish(database_url)
+        .await
+        .expect("failed to connect for dead-letter insert");
+    autumn_harvest::dlq::dead_letter(
+        &mut conn,
+        &autumn_harvest::dlq::NewDeadLetterEntry {
+            original_task_id: uuid::Uuid::new_v4(),
+            queue_name: queue_name.to_string(),
+            task_type: "ACTIVITY".to_string(),
+            workflow_exec_id: None,
+            activity_name: Some(activity_name.to_string()),
+            input: json!({ "test": true }),
+            error: error.to_string(),
+            attempts,
+            owner: None,
+            severity: None,
+        },
+    )
+    .await
+    .expect("dead-letter insert should succeed")
+}
+
+async fn count_dlq_rows_by_queue(database_url: &str, queue_name: &str) -> i64 {
+    let mut conn = <AsyncPgConnection as AsyncConnection>::establish(database_url)
+        .await
+        .expect("failed to connect for dead-letter count");
+    harvest_dead_letters::table
+        .filter(harvest_dead_letters::queue_name.eq(queue_name))
+        .count()
+        .get_result(&mut conn)
+        .await
+        .expect("failed to count dead letters by queue")
+}
+
+/// The AC5 over-action superset money test (issue #613, P2-1): a cause facet
+/// read scoped to one queue must re-select EXACTLY that queue's rows in a bulk
+/// operation — never every queue's. Before the bulk filter learned
+/// `queue_name`, an operator feeding a `?queue_name=qa` facet into a discard
+/// would silently act across ALL queues.
+#[tokio::test]
+async fn bulk_cause_plus_queue_round_trips_exactly() {
+    let (database_url, _container) = setup_test_database_url().await;
+    let app = build_dlq_app(build_test_pool(&database_url));
+
+    // Same cause (poison_pill) split across two queues.
+    for _ in 0..3 {
+        insert_dlq_row_full(&database_url, "pp", "qa", 3, &poison_pill_error()).await;
+    }
+    for _ in 0..2 {
+        insert_dlq_row_full(&database_url, "pp", "qb", 3, &poison_pill_error()).await;
+    }
+
+    // Aggregate facet scoped to qa reports 3 poison_pill rows.
+    let (agg_status, agg_body) = get_json_bulk(
+        &app,
+        "/dead-letters/aggregate?queue_name=qa&group_by=dlq_reason",
+    )
+    .await;
+    assert_eq!(agg_status, StatusCode::OK, "agg body: {agg_body}");
+    let facet = agg_body["groups"]
+        .as_array()
+        .expect("groups")
+        .iter()
+        .find(|g| g["key"]["dlq_reason"] == "poison_pill")
+        .expect("poison_pill facet")["count"]
+        .as_i64()
+        .expect("count");
+    assert_eq!(facet, 3, "aggregate facet scoped to qa sees only qa's rows");
+
+    // Discard dry-run with the SAME scope must match exactly 3 (NOT 5).
+    let (dstatus, dbody) = post_json(
+        &app,
+        "/dead-letters/discard",
+        json!({ "dlq_reason": "poison_pill", "queue_name": "qa", "dry_run": true }),
+    )
+    .await;
+    assert_eq!(dstatus, StatusCode::OK, "body: {dbody}");
+    assert_eq!(
+        dbody["matched"], 3,
+        "scoped discard must match only qa's cohort, not all queues"
+    );
+
+    // Execute it: only qa's 3 removed, qb's 2 survive.
+    let (estatus, ebody) = post_json(
+        &app,
+        "/dead-letters/discard",
+        json!({ "dlq_reason": "poison_pill", "queue_name": "qa" }),
+    )
+    .await;
+    assert_eq!(estatus, StatusCode::OK, "body: {ebody}");
+    assert_eq!(ebody["matched"], 3);
+    assert_eq!(ebody["acted_on"], 3);
+
+    assert_eq!(
+        count_dlq_rows_by_queue(&database_url, "qa").await,
+        0,
+        "qa's cohort must be fully discarded"
+    );
+    assert_eq!(
+        count_dlq_rows_by_queue(&database_url, "qb").await,
+        2,
+        "qb's rows must survive — the over-action gap is closed"
+    );
+}
+
+/// `min_attempts` narrows a bulk operation to entries at or above the bound
+/// (issue #613, P2-1).
+#[tokio::test]
+async fn bulk_min_attempts_filter_narrows() {
+    let (database_url, _container) = setup_test_database_url().await;
+    let app = build_dlq_app(build_test_pool(&database_url));
+
+    insert_dlq_row_full(&database_url, "flaky", "default", 1, "connection refused").await;
+    insert_dlq_row_full(&database_url, "flaky", "default", 3, "connection refused").await;
+    insert_dlq_row_full(&database_url, "flaky", "default", 5, "connection refused").await;
+
+    // min_attempts=3 acts only on the attempts>=3 rows (the 3 and the 5).
+    let (status, body) = post_json(
+        &app,
+        "/dead-letters/discard",
+        json!({ "activity_name": "flaky", "min_attempts": 3 }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    assert_eq!(body["matched"], 2, "only attempts>=3 rows match");
+    assert_eq!(body["acted_on"], 2);
+
+    assert_eq!(
+        count_dlq_rows(&database_url).await,
+        1,
+        "the attempts=1 row must survive"
+    );
+}

--- a/autumn-harvest-plugin/tests/dlq_bulk_integration.rs
+++ b/autumn-harvest-plugin/tests/dlq_bulk_integration.rs
@@ -156,6 +156,24 @@ async fn post_json(
     (status, json)
 }
 
+async fn get_json_bulk(app: &HarvestApiApp, uri: impl Into<String>) -> (StatusCode, Value) {
+    let uri = uri.into();
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(&uri)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("GET request failed");
+    let status = response.status();
+    let json = read_json_response(response).await;
+    (status, json)
+}
+
 async fn insert_dlq_row(database_url: &str, activity_name: &str, task_type: &str) -> uuid::Uuid {
     let mut conn = <AsyncPgConnection as AsyncConnection>::establish(database_url)
         .await
@@ -452,4 +470,278 @@ async fn bulk_replay_after_drain_returns_zero_matched() {
     assert_eq!(second_body["acted_on"], 0);
     let ids = second_body["ids"].as_array().expect("ids must be an array");
     assert!(ids.is_empty(), "no ids expected when nothing matched");
+}
+
+// ---------------------------------------------------------------------------
+// Cause-dimension bulk filters (issue #613)
+// ---------------------------------------------------------------------------
+
+fn poison_pill_error() -> String {
+    autumn_harvest::dlq::DeadLetterReason::PoisonPill {
+        crash_strikes: 3,
+        last_worker_id: Some("worker-7".to_string()),
+    }
+    .to_string()
+}
+
+/// Insert a dead-letter row carrying an arbitrary `error` string.
+async fn insert_dlq_row_with_error(
+    database_url: &str,
+    activity_name: &str,
+    error: &str,
+) -> uuid::Uuid {
+    let mut conn = <AsyncPgConnection as AsyncConnection>::establish(database_url)
+        .await
+        .expect("failed to connect for dead-letter insert");
+    autumn_harvest::dlq::dead_letter(
+        &mut conn,
+        &autumn_harvest::dlq::NewDeadLetterEntry {
+            original_task_id: uuid::Uuid::new_v4(),
+            queue_name: "default".to_string(),
+            task_type: "ACTIVITY".to_string(),
+            workflow_exec_id: None,
+            activity_name: Some(activity_name.to_string()),
+            input: json!({ "test": true }),
+            error: error.to_string(),
+            attempts: 3,
+            owner: None,
+            severity: None,
+        },
+    )
+    .await
+    .expect("dead-letter insert should succeed")
+}
+
+async fn count_dlq_rows_by_activity(database_url: &str, activity_name: &str) -> i64 {
+    let mut conn = <AsyncPgConnection as AsyncConnection>::establish(database_url)
+        .await
+        .expect("failed to connect for dead-letter count");
+    harvest_dead_letters::table
+        .filter(harvest_dead_letters::activity_name.eq(activity_name))
+        .count()
+        .get_result(&mut conn)
+        .await
+        .expect("failed to count dead letters by activity")
+}
+
+async fn post_form(app: &HarvestApiApp, uri: &str, body: &str) -> (StatusCode, Value) {
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(uri)
+                .header("content-type", "application/x-www-form-urlencoded")
+                .body(Body::from(body.to_string()))
+                .unwrap(),
+        )
+        .await
+        .expect("POST form request failed");
+    let status = response.status();
+    let json = read_json_response(response).await;
+    (status, json)
+}
+
+/// The AC5 round-trip money test: the bulk dry-run `matched` count for a cause
+/// cohort equals the same cohort's count from the aggregate facet, proving both
+/// surfaces share the classifier (lossless by construction).
+#[tokio::test]
+async fn bulk_cause_dry_run_count_equals_aggregate_facet() {
+    let (database_url, _container) = setup_test_database_url().await;
+    let app = build_dlq_app(build_test_pool(&database_url));
+
+    for _ in 0..4 {
+        insert_dlq_row_with_error(&database_url, "pp", &poison_pill_error()).await;
+    }
+    for _ in 0..3 {
+        insert_dlq_row_with_error(&database_url, "plain", "connection refused").await;
+    }
+
+    // Aggregate facet count for poison_pill.
+    let (agg_status, agg_body) =
+        get_json_bulk(&app, "/dead-letters/aggregate?group_by=dlq_reason").await;
+    assert_eq!(agg_status, StatusCode::OK, "agg body: {agg_body}");
+    let facet = agg_body["groups"]
+        .as_array()
+        .expect("groups")
+        .iter()
+        .find(|g| g["key"]["dlq_reason"] == "poison_pill")
+        .expect("poison_pill facet")["count"]
+        .as_i64()
+        .expect("count");
+    assert_eq!(facet, 4);
+
+    // Bulk discard dry-run for the same cohort must report the same matched.
+    let (status, body) = post_json(
+        &app,
+        "/dead-letters/discard",
+        json!({ "dlq_reason": "poison_pill", "dry_run": true }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    assert_eq!(body["matched"], facet, "discard matched must equal facet");
+    assert_eq!(body["dry_run"], true);
+
+    // Same for replay dry-run.
+    let (rstatus, rbody) = post_json(
+        &app,
+        "/dead-letters/replay",
+        json!({ "dlq_reason": "poison_pill", "dry_run": true }),
+    )
+    .await;
+    assert_eq!(rstatus, StatusCode::OK, "body: {rbody}");
+    assert_eq!(rbody["matched"], facet, "replay matched must equal facet");
+}
+
+#[tokio::test]
+async fn bulk_discard_error_class_deletes_only_matching() {
+    let (database_url, _container) = setup_test_database_url().await;
+    let app = build_dlq_app(build_test_pool(&database_url));
+
+    for _ in 0..4 {
+        insert_dlq_row_with_error(&database_url, "pp", &poison_pill_error()).await;
+    }
+    for _ in 0..3 {
+        insert_dlq_row_with_error(&database_url, "plain", "connection refused").await;
+    }
+
+    let (status, body) = post_json(
+        &app,
+        "/dead-letters/discard",
+        json!({ "error_class": "PoisonPill" }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    assert_eq!(body["matched"], 4);
+    assert_eq!(body["acted_on"], 4);
+
+    assert_eq!(
+        count_dlq_rows_by_activity(&database_url, "pp").await,
+        0,
+        "all PoisonPill rows discarded"
+    );
+    assert_eq!(
+        count_dlq_rows_by_activity(&database_url, "plain").await,
+        3,
+        "non-matching rows must survive"
+    );
+}
+
+#[tokio::test]
+async fn bulk_cause_post_filter_precedes_limit() {
+    let (database_url, _container) = setup_test_database_url().await;
+    let app = build_dlq_app(build_test_pool(&database_url));
+
+    // Interleave poison_pill and plain rows so a limit applied BEFORE the cause
+    // post-filter would clip the wrong rows.
+    for _ in 0..5 {
+        insert_dlq_row_with_error(&database_url, "pp", &poison_pill_error()).await;
+        insert_dlq_row_with_error(&database_url, "plain", "connection refused").await;
+    }
+
+    let (status, body) = post_json(
+        &app,
+        "/dead-letters/discard",
+        json!({ "dlq_reason": "poison_pill", "limit": 3 }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    assert_eq!(
+        body["matched"], 5,
+        "matched counts all matching (pre-limit)"
+    );
+    assert_eq!(body["acted_on"], 3, "limit caps acted-on to 3");
+
+    // Exactly 3 poison_pill rows discarded; every plain row untouched — proving
+    // the cause post-filter ran before the limit clip.
+    assert_eq!(
+        count_dlq_rows_by_activity(&database_url, "pp").await,
+        2,
+        "3 of 5 poison_pill rows discarded"
+    );
+    assert_eq!(
+        count_dlq_rows_by_activity(&database_url, "plain").await,
+        5,
+        "no plain rows may be discarded"
+    );
+}
+
+#[tokio::test]
+async fn bulk_empty_cause_filter_json_is_rejected_400() {
+    let (database_url, _container) = setup_test_database_url().await;
+    let app = build_dlq_app(build_test_pool(&database_url));
+
+    let (status, _body) =
+        post_json(&app, "/dead-letters/discard", json!({ "dlq_reason": "" })).await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "empty cause must 400");
+
+    let (wstatus, _wbody) = post_json(
+        &app,
+        "/dead-letters/discard",
+        json!({ "dlq_reason": "   " }),
+    )
+    .await;
+    assert_eq!(
+        wstatus,
+        StatusCode::BAD_REQUEST,
+        "whitespace-only cause must 400"
+    );
+}
+
+#[tokio::test]
+async fn bulk_empty_cause_filter_form_is_rejected_400() {
+    let (database_url, _container) = setup_test_database_url().await;
+    let app = build_dlq_app(build_test_pool(&database_url));
+
+    // An empty cause value in a form must be REJECTED, never silently dropped
+    // (which would leave workflow_name=x as the only filter and widen scope).
+    let (status, _body) =
+        post_form(&app, "/dead-letters/discard", "dlq_reason=&workflow_name=x").await;
+    assert_eq!(status, StatusCode::BAD_REQUEST, "empty form cause must 400");
+}
+
+#[tokio::test]
+async fn bulk_cause_only_filter_is_not_rejected_as_empty() {
+    let (database_url, _container) = setup_test_database_url().await;
+    let app = build_dlq_app(build_test_pool(&database_url));
+
+    // A cause-only filter is substantive: it must not trip the empty-filter 400.
+    let (status, body) = post_json(
+        &app,
+        "/dead-letters/discard",
+        json!({ "dlq_reason": "poison_pill", "dry_run": true }),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "cause-only filter must be accepted: {body}"
+    );
+}
+
+#[tokio::test]
+async fn bulk_cause_across_shards_honors_global_limit() {
+    let ((shard0_url, shard1_url), _container) = setup_sharded_test_database_urls().await;
+    let app = build_sharded_dlq_app(&shard0_url, &shard1_url);
+
+    for _ in 0..4 {
+        insert_dlq_row_with_error(&shard0_url, "pp", &poison_pill_error()).await;
+        insert_dlq_row_with_error(&shard1_url, "pp", &poison_pill_error()).await;
+    }
+
+    let (status, body) = post_json(
+        &app,
+        "/dead-letters/discard",
+        json!({ "dlq_reason": "poison_pill", "limit": 5 }),
+    )
+    .await;
+    assert_eq!(status, StatusCode::OK, "body: {body}");
+    assert_eq!(body["matched"], 8, "matched sums the cohort across shards");
+    assert_eq!(
+        body["acted_on"], 5,
+        "global limit caps acted-on across shards"
+    );
+
+    let remaining = count_dlq_rows(&shard0_url).await + count_dlq_rows(&shard1_url).await;
+    assert_eq!(remaining, 3, "8 matched - 5 acted = 3 remain");
 }

--- a/autumn-harvest/src/dlq.rs
+++ b/autumn-harvest/src/dlq.rs
@@ -41,6 +41,18 @@ pub struct BulkDlqFilter {
     pub failed_after: Option<chrono::DateTime<chrono::Utc>>,
     /// Exclusive upper bound on `failed_at`.
     pub failed_before: Option<chrono::DateTime<chrono::Utc>>,
+    /// Exact match on the derived [`error_class`] of the entry's error text
+    /// (issue #613). Applied as a compute-on-read post-filter.
+    #[serde(default)]
+    pub error_class: Option<String>,
+    /// Exact match on the derived [`dlq_reason`] class (issue #613). Applied
+    /// as a compute-on-read post-filter.
+    #[serde(default)]
+    pub dlq_reason: Option<String>,
+    /// Exact match on the derived [`failure_signature`] (issue #613). Applied
+    /// as a compute-on-read post-filter.
+    #[serde(default)]
+    pub failure_signature: Option<String>,
     /// Cap on rows acted on per call. Defaults to 100, hard-capped at 1000.
     pub limit: Option<u32>,
     /// When `true`, return matching rows and count without writing.
@@ -58,6 +70,35 @@ impl BulkDlqFilter {
             && self.workflow_name.is_none()
             && self.failed_after.is_none()
             && self.failed_before.is_none()
+            && self.error_class.is_none()
+            && self.dlq_reason.is_none()
+            && self.failure_signature.is_none()
+    }
+
+    /// Returns `true` if any compute-on-read *cause* dimension is set
+    /// (issue #613). When set, the SQL predicate cannot express the filter, so
+    /// callers must load rows and post-filter via [`Self::cause_matches`].
+    #[must_use]
+    pub const fn has_cause_filter(&self) -> bool {
+        self.error_class.is_some() || self.dlq_reason.is_some() || self.failure_signature.is_some()
+    }
+
+    /// Returns `true` if `error` satisfies every set cause dimension
+    /// (issue #613). Unset dimensions never exclude, so a filter with no cause
+    /// dimension matches every row.
+    #[must_use]
+    pub fn cause_matches(&self, error: &str) -> bool {
+        self.error_class
+            .as_ref()
+            .is_none_or(|v| error_class(error) == *v)
+            && self
+                .dlq_reason
+                .as_ref()
+                .is_none_or(|v| dlq_reason(error) == *v)
+            && self
+                .failure_signature
+                .as_ref()
+                .is_none_or(|v| failure_signature(error) == *v)
     }
 
     /// Effective row limit: uses the provided value clamped to [1, 1000],
@@ -256,6 +297,33 @@ impl std::fmt::Display for DeadLetterReason {
         match serde_json::to_string(self) {
             Ok(json) => f.write_str(&json),
             Err(_) => f.write_str("DeadLetterReasonSerializationFailed"),
+        }
+    }
+}
+
+impl DeadLetterReason {
+    /// Stable, low-cardinality snake_case class name for this quarantine
+    /// reason (issue #613). This is the value the `dlq_reason` aggregation
+    /// dimension and bulk-filter dimension key on.
+    #[must_use]
+    pub const fn reason_class(&self) -> &'static str {
+        match self {
+            Self::HistoryCapExceeded { .. } => "history_cap_exceeded",
+            Self::PoisonPill { .. } => "poison_pill",
+            Self::WorkflowTaskTimeout { .. } => "workflow_task_timeout",
+            Self::CallbackDeliveryExhausted { .. } => "callback_delivery_exhausted",
+        }
+    }
+
+    /// PascalCase serde `"type"` tag for this reason, used as the derived
+    /// `error_class` for an engine-authored quarantine entry (issue #613).
+    #[must_use]
+    pub const fn type_tag(&self) -> &'static str {
+        match self {
+            Self::HistoryCapExceeded { .. } => "HistoryCapExceeded",
+            Self::PoisonPill { .. } => "PoisonPill",
+            Self::WorkflowTaskTimeout { .. } => "WorkflowTaskTimeout",
+            Self::CallbackDeliveryExhausted { .. } => "CallbackDeliveryExhausted",
         }
     }
 }
@@ -600,6 +668,18 @@ pub async fn count_bulk_filter_matches(
         query = query.filter(dsl::failed_at.lt(before));
     }
 
+    // Cause dimensions (issue #613) are compute-on-read: load the SQL-filtered
+    // `error` strings and count the ones that pass the cause post-filter.
+    if filter.has_cause_filter() {
+        let errors: Vec<String> = query
+            .select(dsl::error)
+            .load(conn)
+            .await
+            .map_err(crate::error::database_error)?;
+        let matched = errors.iter().filter(|e| filter.cause_matches(e)).count();
+        return Ok(i64::try_from(matched).unwrap_or(i64::MAX));
+    }
+
     query
         .count()
         .get_result(conn)
@@ -617,10 +697,17 @@ async fn query_dead_letters_for_bulk(
     use diesel::dsl::sql;
     use diesel::sql_types::{Bool, Text};
 
+    // Cause dimensions (issue #613) are compute-on-read, so the SQL row limit
+    // cannot be applied before the post-filter (it would clip pre-filter rows).
+    // Drop the SQL limit, order oldest-first, then post-filter and `take` the
+    // effective limit — so the cause filter precedes the limit.
+    let cause = filter.has_cause_filter();
     let mut query = dsl::harvest_dead_letters
         .into_boxed()
-        .order(dsl::failed_at.asc())
-        .limit(filter.effective_limit());
+        .order(dsl::failed_at.asc());
+    if !cause {
+        query = query.limit(filter.effective_limit());
+    }
 
     if let Some(ref name) = filter.activity_name {
         query = query.filter(dsl::activity_name.eq(name.clone()));
@@ -639,11 +726,22 @@ async fn query_dead_letters_for_bulk(
         query = query.filter(dsl::failed_at.lt(before));
     }
 
-    query
+    let rows = query
         .select(DeadLetter::as_select())
         .load(conn)
         .await
-        .map_err(crate::error::database_error)
+        .map_err(crate::error::database_error)?;
+
+    if cause {
+        let limit = usize::try_from(filter.effective_limit()).unwrap_or(usize::MAX);
+        Ok(rows
+            .into_iter()
+            .filter(|r| filter.cause_matches(&r.error))
+            .take(limit)
+            .collect())
+    } else {
+        Ok(rows)
+    }
 }
 
 /// Bulk replay dead-letter entries matching `filter`.
@@ -1130,6 +1228,53 @@ pub fn failure_signature(error: &str) -> String {
     truncate_chars(normalized.trim(), SIGNATURE_MAX_LEN)
 }
 
+/// Maximum length of a derived `error_class`, in characters.
+pub const ERROR_CLASS_MAX_LEN: usize = 80;
+
+/// Classify a DLQ `error` string into a low-cardinality *reason* class
+/// (issue #613).
+///
+/// Engine-authored quarantine entries serialize a tagged [`DeadLetterReason`]
+/// as their `error` (see `dead_letter`'s callers); those map to the reason's
+/// stable snake_case [`DeadLetterReason::reason_class`]. Every other error —
+/// a plain `Err(String)` or a typed activity-failure envelope — is retry
+/// exhaustion (there is no production path that dead-letters a plain
+/// retry-exhausted activity, but tests and embedders can), so it maps to
+/// `"retry_exhaustion"`. Pure and deterministic: identical across queries and
+/// shards for the same input.
+#[must_use]
+pub fn dlq_reason(error: &str) -> String {
+    match serde_json::from_str::<DeadLetterReason>(error) {
+        Ok(reason) => reason.reason_class().to_string(),
+        Err(_) => "retry_exhaustion".to_string(),
+    }
+}
+
+/// Classify a DLQ `error` string into a low-cardinality *error class*
+/// (issue #613).
+///
+/// Resolution order:
+/// 1. A typed activity-failure envelope → its stable `error_type` (e.g.
+///    `"CircuitOpen"`, `"HandlerPanic"`).
+/// 2. A tagged [`DeadLetterReason`] → its PascalCase [`DeadLetterReason::type_tag`].
+/// 3. Otherwise → the normalized leading token of the first line (dynamic
+///    runs collapsed to placeholders).
+///
+/// The result is truncated to [`ERROR_CLASS_MAX_LEN`] characters. Pure and
+/// deterministic: identical across queries and shards for the same input.
+#[must_use]
+pub fn error_class(error: &str) -> String {
+    if let Some(failure) = crate::failure::parse_typed_payload(error) {
+        return truncate_chars(&failure.error_type, ERROR_CLASS_MAX_LEN);
+    }
+    if let Ok(reason) = serde_json::from_str::<DeadLetterReason>(error) {
+        return reason.type_tag().to_string();
+    }
+    let first_line = error.lines().next().unwrap_or("").trim();
+    let token = first_line.split_whitespace().next().unwrap_or("");
+    truncate_chars(&normalize_token(token), ERROR_CLASS_MAX_LEN)
+}
+
 fn truncate_chars(s: &str, max: usize) -> String {
     if s.chars().count() <= max {
         s.to_string()
@@ -1236,6 +1381,10 @@ pub enum DlqGroupDimension {
     TimeBucket,
     /// Derived [`failure_signature`] of the error text.
     FailureSignature,
+    /// Derived [`dlq_reason`] class of the error text (issue #613).
+    DlqReason,
+    /// Derived [`error_class`] of the error text (issue #613).
+    ErrorClass,
 }
 
 impl DlqGroupDimension {
@@ -1249,6 +1398,8 @@ impl DlqGroupDimension {
             Self::TaskType => "task_type",
             Self::TimeBucket => "time_bucket",
             Self::FailureSignature => "failure_signature",
+            Self::DlqReason => "dlq_reason",
+            Self::ErrorClass => "error_class",
         }
     }
 
@@ -1262,6 +1413,8 @@ impl DlqGroupDimension {
             "task_type" => Self::TaskType,
             "time_bucket" => Self::TimeBucket,
             "failure_signature" => Self::FailureSignature,
+            "dlq_reason" => Self::DlqReason,
+            "error_class" => Self::ErrorClass,
             _ => return None,
         })
     }
@@ -1359,7 +1512,7 @@ impl DlqAggregateParams {
                         format!(
                             "unknown group_by dimension '{value}'; expected one of: \
                              workflow_name, activity_name, queue_name, task_type, \
-                             time_bucket, failure_signature"
+                             time_bucket, failure_signature, dlq_reason, error_class"
                         )
                     })?;
                     if !params.group_by.contains(&dim) {
@@ -1777,6 +1930,8 @@ pub async fn aggregate_dead_letters(
                 DlqGroupDimension::TaskType => Some(task_type.clone()),
                 DlqGroupDimension::TimeBucket => Some(params.time_bucket.format(failed_at)),
                 DlqGroupDimension::FailureSignature => Some(failure_signature(&error)),
+                DlqGroupDimension::DlqReason => Some(dlq_reason(&error)),
+                DlqGroupDimension::ErrorClass => Some(error_class(&error)),
             })
             .collect();
 
@@ -2170,6 +2325,9 @@ mod tests {
             workflow_name: Some("billing".into()),
             failed_after: None,
             failed_before: None,
+            error_class: None,
+            dlq_reason: None,
+            failure_signature: None,
             limit: Some(200),
             dry_run: true,
         };
@@ -2245,6 +2403,249 @@ mod tests {
         // Same root cause with different dynamic ids collapses identically.
         let c = failure_signature("stripe charge ch_3Abc declined for user 9999");
         assert_eq!(a, c);
+    }
+
+    // ----- Cause classifiers: dlq_reason / error_class (issue #613) -----
+
+    fn poison_pill_json() -> String {
+        DeadLetterReason::PoisonPill {
+            crash_strikes: 3,
+            last_worker_id: Some("worker-7".to_string()),
+        }
+        .to_string()
+    }
+
+    fn history_cap_json() -> String {
+        DeadLetterReason::HistoryCapExceeded {
+            count: 10_001,
+            cap: 10_000,
+            workflow_type: "big_wf".to_string(),
+        }
+        .to_string()
+    }
+
+    fn task_timeout_json() -> String {
+        DeadLetterReason::WorkflowTaskTimeout {
+            task_timeout_strikes: 3,
+            timeout_secs: 30,
+        }
+        .to_string()
+    }
+
+    fn callback_exhausted_json() -> String {
+        DeadLetterReason::CallbackDeliveryExhausted {
+            delivery_id: Uuid::new_v4(),
+            attempts: 10,
+            last_status: Some(503),
+            target: "https://hooks.example.com/x".to_string(),
+        }
+        .to_string()
+    }
+
+    #[test]
+    fn dlq_reason_maps_every_typed_variant_to_snake_case() {
+        assert_eq!(dlq_reason(&poison_pill_json()), "poison_pill");
+        assert_eq!(dlq_reason(&history_cap_json()), "history_cap_exceeded");
+        assert_eq!(dlq_reason(&task_timeout_json()), "workflow_task_timeout");
+        assert_eq!(
+            dlq_reason(&callback_exhausted_json()),
+            "callback_delivery_exhausted"
+        );
+    }
+
+    #[test]
+    fn dlq_reason_plain_string_is_retry_exhaustion() {
+        assert_eq!(dlq_reason("connection refused"), "retry_exhaustion");
+        assert_eq!(dlq_reason(""), "retry_exhaustion");
+    }
+
+    #[test]
+    fn dlq_reason_typed_activity_envelope_is_retry_exhaustion() {
+        use crate::failure::{ActivityFailure, IntoActivityErrorString};
+        let envelope = ActivityFailure::retryable("RateLimitExceeded", "429").into_error_payload();
+        // An activity-failure envelope is NOT a DeadLetterReason, so it is not
+        // an engine-authored quarantine — it is retry exhaustion.
+        assert_eq!(dlq_reason(&envelope), "retry_exhaustion");
+    }
+
+    #[test]
+    fn error_class_typed_envelope_uses_error_type() {
+        use crate::failure::{ActivityFailure, IntoActivityErrorString};
+        let circuit = ActivityFailure::non_retryable("CircuitOpen", "open").into_error_payload();
+        assert_eq!(error_class(&circuit), "CircuitOpen");
+        let panic = ActivityFailure::retryable("HandlerPanic", "boom").into_error_payload();
+        assert_eq!(error_class(&panic), "HandlerPanic");
+    }
+
+    #[test]
+    fn error_class_dead_letter_reason_uses_pascal_case_tag() {
+        assert_eq!(error_class(&poison_pill_json()), "PoisonPill");
+        assert_eq!(error_class(&history_cap_json()), "HistoryCapExceeded");
+        assert_eq!(error_class(&task_timeout_json()), "WorkflowTaskTimeout");
+        assert_eq!(
+            error_class(&callback_exhausted_json()),
+            "CallbackDeliveryExhausted"
+        );
+    }
+
+    #[test]
+    fn error_class_plain_string_uses_normalized_leading_token() {
+        assert_eq!(error_class("connection refused"), "connection");
+        assert_eq!(error_class("timeout while dialing host"), "timeout");
+        // Leading token normalization collapses dynamic runs.
+        assert_eq!(error_class("user_1234 not found"), "user_<NUM>");
+        assert_eq!(error_class(""), "");
+    }
+
+    #[test]
+    fn error_class_is_bounded_and_deterministic() {
+        let long = "x".repeat(500);
+        let class = error_class(&long);
+        assert!(class.chars().count() <= ERROR_CLASS_MAX_LEN);
+        assert_eq!(error_class(&long), class);
+    }
+
+    #[test]
+    fn cause_classifiers_are_deterministic() {
+        let e = poison_pill_json();
+        assert_eq!(dlq_reason(&e), dlq_reason(&e));
+        assert_eq!(error_class(&e), error_class(&e));
+        assert_eq!(failure_signature(&e), failure_signature(&e));
+    }
+
+    #[test]
+    fn bulk_filter_is_not_empty_when_only_a_cause_is_set() {
+        let f = BulkDlqFilter {
+            dlq_reason: Some("poison_pill".to_string()),
+            ..Default::default()
+        };
+        assert!(!f.is_empty());
+        assert!(f.has_cause_filter());
+
+        let ec = BulkDlqFilter {
+            error_class: Some("CircuitOpen".to_string()),
+            ..Default::default()
+        };
+        assert!(!ec.is_empty());
+
+        let fs = BulkDlqFilter {
+            failure_signature: Some("boom".to_string()),
+            ..Default::default()
+        };
+        assert!(!fs.is_empty());
+    }
+
+    #[test]
+    fn bulk_filter_empty_and_has_cause_helpers() {
+        let empty = BulkDlqFilter::default();
+        assert!(empty.is_empty());
+        assert!(!empty.has_cause_filter());
+
+        let structural = BulkDlqFilter {
+            activity_name: Some("send_email".to_string()),
+            ..Default::default()
+        };
+        assert!(!structural.is_empty());
+        assert!(!structural.has_cause_filter());
+    }
+
+    #[test]
+    fn cause_matches_uses_exact_equality() {
+        let f = BulkDlqFilter {
+            dlq_reason: Some("poison_pill".to_string()),
+            ..Default::default()
+        };
+        assert!(f.cause_matches(&poison_pill_json()));
+        assert!(!f.cause_matches(&task_timeout_json()));
+        assert!(!f.cause_matches("connection refused"));
+
+        // No cause filter matches everything.
+        let none = BulkDlqFilter::default();
+        assert!(none.cause_matches("anything"));
+
+        // error_class is exact, not case-folded.
+        let ec = BulkDlqFilter {
+            error_class: Some("poisonpill".to_string()),
+            ..Default::default()
+        };
+        assert!(!ec.cause_matches(&poison_pill_json()));
+    }
+
+    #[test]
+    fn cause_matches_ands_multiple_cause_dimensions() {
+        let both = BulkDlqFilter {
+            dlq_reason: Some("poison_pill".to_string()),
+            error_class: Some("PoisonPill".to_string()),
+            ..Default::default()
+        };
+        assert!(both.cause_matches(&poison_pill_json()));
+
+        let mismatch = BulkDlqFilter {
+            dlq_reason: Some("poison_pill".to_string()),
+            error_class: Some("WorkflowTaskTimeout".to_string()),
+            ..Default::default()
+        };
+        assert!(!mismatch.cause_matches(&poison_pill_json()));
+    }
+
+    #[test]
+    fn group_dimension_wire_round_trips_cause_dims() {
+        assert_eq!(DlqGroupDimension::DlqReason.as_wire(), "dlq_reason");
+        assert_eq!(DlqGroupDimension::ErrorClass.as_wire(), "error_class");
+        assert_eq!(
+            DlqGroupDimension::from_wire("dlq_reason"),
+            Some(DlqGroupDimension::DlqReason)
+        );
+        assert_eq!(
+            DlqGroupDimension::from_wire("error_class"),
+            Some(DlqGroupDimension::ErrorClass)
+        );
+        assert_eq!(DlqGroupDimension::from_wire("nope"), None);
+    }
+
+    #[test]
+    fn params_parse_cause_group_by_and_still_reject_unknown() {
+        let p = DlqAggregateParams::from_query_pairs(
+            &pairs(&[("group_by", "dlq_reason"), ("group_by", "error_class")]),
+            Utc::now(),
+        )
+        .expect("valid");
+        assert_eq!(
+            p.group_by,
+            vec![DlqGroupDimension::DlqReason, DlqGroupDimension::ErrorClass]
+        );
+
+        let err = DlqAggregateParams::from_query_pairs(
+            &pairs(&[("group_by", "bogus_dim")]),
+            Utc::now(),
+        )
+        .expect_err("unknown dim must still error");
+        assert!(err.contains("dlq_reason"), "message should list new dims: {err}");
+        assert!(err.contains("error_class"), "message should list new dims: {err}");
+    }
+
+    #[test]
+    fn merge_groups_by_dlq_reason() {
+        let params = DlqAggregateParams {
+            group_by: vec![DlqGroupDimension::DlqReason],
+            ..Default::default()
+        };
+        let partials = vec![
+            DlqAggregatePartial {
+                total: 5,
+                filtered_total: 4,
+                groups: vec![raw_group(&[Some("poison_pill")], 4, &["a"])],
+            },
+            DlqAggregatePartial {
+                total: 3,
+                filtered_total: 2,
+                groups: vec![raw_group(&[Some("poison_pill")], 2, &["b"])],
+            },
+        ];
+        let resp = merge_dlq_aggregates(&params, partials);
+        assert_eq!(resp.groups.len(), 1);
+        assert_eq!(resp.groups[0].count, 6);
+        assert_eq!(resp.groups[0].key["dlq_reason"], "poison_pill");
     }
 
     // ----- Parameter parsing & validation (issue #385) -----

--- a/autumn-harvest/src/dlq.rs
+++ b/autumn-harvest/src/dlq.rs
@@ -28,15 +28,27 @@ pub const MAX_BULK_LIMIT: u32 = 1000;
 
 /// Filter for bulk DLQ operations.
 ///
-/// At least one of `activity_name`, `workflow_name`, `failed_after`, or
-/// `failed_before` must be set. A filter with only `limit` or `dry_run` is
-/// considered empty and rejected with 400 at the API layer.
+/// At least one substantive criterion (any of `activity_name`, `workflow_name`,
+/// `queue_name`, `min_attempts`, `failed_after`, `failed_before`, or a cause
+/// dimension) must be set. A filter with only `limit` or `dry_run` is considered
+/// empty and rejected with 400 at the API layer.
 #[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
 pub struct BulkDlqFilter {
     /// Exact match on `activity_name`.
     pub activity_name: Option<String>,
     /// Exact match on the workflow name of the parent execution.
     pub workflow_name: Option<String>,
+    /// Exact match on `queue_name` (issue #613). SQL-expressible (real column),
+    /// so it carries no compute-on-read cost. Lets an operator reproduce a
+    /// `queue_name`-scoped aggregate facet exactly (AC5).
+    #[serde(default)]
+    pub queue_name: Option<String>,
+    /// Inclusive lower bound on `attempts` (issue #613). SQL-expressible (real
+    /// column), so it carries no compute-on-read cost. Mirrors the aggregate
+    /// endpoint's `min_attempts` filter so a facet read there re-selects the
+    /// same rows here (AC5).
+    #[serde(default)]
+    pub min_attempts: Option<i32>,
     /// Inclusive lower bound on `failed_at`.
     pub failed_after: Option<chrono::DateTime<chrono::Utc>>,
     /// Exclusive upper bound on `failed_at`.
@@ -68,6 +80,8 @@ impl BulkDlqFilter {
     pub const fn is_empty(&self) -> bool {
         self.activity_name.is_none()
             && self.workflow_name.is_none()
+            && self.queue_name.is_none()
+            && self.min_attempts.is_none()
             && self.failed_after.is_none()
             && self.failed_before.is_none()
             && self.error_class.is_none()
@@ -638,6 +652,16 @@ pub async fn replay_dead_letter(
 /// already exhausted, so that `matched` in the aggregated response always
 /// reflects the true pre-limit total across all shards.
 ///
+/// This is part of the external-embedder surface (issue #613): the live HTTP
+/// path uses the `_api_bulk` variants in the plugin's `api.rs`, which apply the
+/// same predicate set. Keep the two in sync when adding a filter dimension.
+///
+/// A cause filter is compute-on-read — it loads all SQL-prefiltered rows and
+/// classifies each in Rust (symmetric with the aggregate endpoint's accepted
+/// cost). `BulkDlqFilter::effective_limit` caps rows *acted on*, not rows
+/// *scanned*; narrow with the SQL-expressible filters (queue/activity/workflow/
+/// time window/`min_attempts`) on large DLQs.
+///
 /// # Errors
 ///
 /// Returns [`HarvestError::Database`] on query failure.
@@ -660,6 +684,12 @@ pub async fn count_bulk_filter_matches(
                 .bind::<Text, _>(wf_name.clone())
                 .sql(")"),
         );
+    }
+    if let Some(ref queue) = filter.queue_name {
+        query = query.filter(dsl::queue_name.eq(queue.clone()));
+    }
+    if let Some(min) = filter.min_attempts {
+        query = query.filter(dsl::attempts.ge(min));
     }
     if let Some(after) = filter.failed_after {
         query = query.filter(dsl::failed_at.ge(after));
@@ -718,6 +748,12 @@ async fn query_dead_letters_for_bulk(
                 .bind::<Text, _>(wf_name.clone())
                 .sql(")"),
         );
+    }
+    if let Some(ref queue) = filter.queue_name {
+        query = query.filter(dsl::queue_name.eq(queue.clone()));
+    }
+    if let Some(min) = filter.min_attempts {
+        query = query.filter(dsl::attempts.ge(min));
     }
     if let Some(after) = filter.failed_after {
         query = query.filter(dsl::failed_at.ge(after));
@@ -1262,10 +1298,18 @@ pub fn dlq_reason(error: &str) -> String {
 ///
 /// The result is truncated to [`ERROR_CLASS_MAX_LEN`] characters. Pure and
 /// deterministic: identical across queries and shards for the same input.
+///
+/// An empty `error` yields an empty-string class, which the bulk-filter
+/// validator rejects with `400` (a degenerate input: production `error` is NOT
+/// NULL and carries a tagged reason or a non-empty message).
 #[must_use]
 pub fn error_class(error: &str) -> String {
+    // Every branch returns a trimmed value so a padded `error_type` facet key
+    // round-trips through the (trimming) bulk-filter validator (issue #613): a
+    // facet key read from this classifier and fed back as a `BulkDlqFilter`
+    // cause dimension must re-select the same rows.
     if let Some(failure) = crate::failure::parse_typed_payload(error) {
-        return truncate_chars(&failure.error_type, ERROR_CLASS_MAX_LEN);
+        return truncate_chars(failure.error_type.trim(), ERROR_CLASS_MAX_LEN);
     }
     if let Ok(reason) = serde_json::from_str::<DeadLetterReason>(error) {
         return reason.type_tag().to_string();

--- a/autumn-harvest/src/dlq.rs
+++ b/autumn-harvest/src/dlq.rs
@@ -2615,13 +2615,17 @@ mod tests {
             vec![DlqGroupDimension::DlqReason, DlqGroupDimension::ErrorClass]
         );
 
-        let err = DlqAggregateParams::from_query_pairs(
-            &pairs(&[("group_by", "bogus_dim")]),
-            Utc::now(),
-        )
-        .expect_err("unknown dim must still error");
-        assert!(err.contains("dlq_reason"), "message should list new dims: {err}");
-        assert!(err.contains("error_class"), "message should list new dims: {err}");
+        let err =
+            DlqAggregateParams::from_query_pairs(&pairs(&[("group_by", "bogus_dim")]), Utc::now())
+                .expect_err("unknown dim must still error");
+        assert!(
+            err.contains("dlq_reason"),
+            "message should list new dims: {err}"
+        );
+        assert!(
+            err.contains("error_class"),
+            "message should list new dims: {err}"
+        );
     }
 
     #[test]

--- a/autumn-harvest/src/dlq.rs
+++ b/autumn-harvest/src/dlq.rs
@@ -302,7 +302,7 @@ impl std::fmt::Display for DeadLetterReason {
 }
 
 impl DeadLetterReason {
-    /// Stable, low-cardinality snake_case class name for this quarantine
+    /// Stable, low-cardinality `snake_case` class name for this quarantine
     /// reason (issue #613). This is the value the `dlq_reason` aggregation
     /// dimension and bulk-filter dimension key on.
     #[must_use]
@@ -315,7 +315,7 @@ impl DeadLetterReason {
         }
     }
 
-    /// PascalCase serde `"type"` tag for this reason, used as the derived
+    /// `PascalCase` serde `"type"` tag for this reason, used as the derived
     /// `error_class` for an engine-authored quarantine entry (issue #613).
     #[must_use]
     pub const fn type_tag(&self) -> &'static str {
@@ -1236,7 +1236,7 @@ pub const ERROR_CLASS_MAX_LEN: usize = 80;
 ///
 /// Engine-authored quarantine entries serialize a tagged [`DeadLetterReason`]
 /// as their `error` (see `dead_letter`'s callers); those map to the reason's
-/// stable snake_case [`DeadLetterReason::reason_class`]. Every other error —
+/// stable `snake_case` [`DeadLetterReason::reason_class`]. Every other error —
 /// a plain `Err(String)` or a typed activity-failure envelope — is retry
 /// exhaustion (there is no production path that dead-letters a plain
 /// retry-exhausted activity, but tests and embedders can), so it maps to
@@ -1244,10 +1244,10 @@ pub const ERROR_CLASS_MAX_LEN: usize = 80;
 /// shards for the same input.
 #[must_use]
 pub fn dlq_reason(error: &str) -> String {
-    match serde_json::from_str::<DeadLetterReason>(error) {
-        Ok(reason) => reason.reason_class().to_string(),
-        Err(_) => "retry_exhaustion".to_string(),
-    }
+    serde_json::from_str::<DeadLetterReason>(error).map_or_else(
+        |_| "retry_exhaustion".to_string(),
+        |reason| reason.reason_class().to_string(),
+    )
 }
 
 /// Classify a DLQ `error` string into a low-cardinality *error class*
@@ -1256,7 +1256,7 @@ pub fn dlq_reason(error: &str) -> String {
 /// Resolution order:
 /// 1. A typed activity-failure envelope → its stable `error_type` (e.g.
 ///    `"CircuitOpen"`, `"HandlerPanic"`).
-/// 2. A tagged [`DeadLetterReason`] → its PascalCase [`DeadLetterReason::type_tag`].
+/// 2. A tagged [`DeadLetterReason`] → its `PascalCase` [`DeadLetterReason::type_tag`].
 /// 3. Otherwise → the normalized leading token of the first line (dynamic
 ///    runs collapsed to placeholders).
 ///

--- a/autumn-harvest/src/dlq.rs
+++ b/autumn-harvest/src/dlq.rs
@@ -2315,6 +2315,24 @@ mod tests {
     }
 
     #[test]
+    fn bulk_dlq_filter_is_empty_false_for_queue_only() {
+        let filter = BulkDlqFilter {
+            queue_name: Some("low-pri".into()),
+            ..BulkDlqFilter::default()
+        };
+        assert!(!filter.is_empty());
+    }
+
+    #[test]
+    fn bulk_dlq_filter_is_empty_false_for_min_attempts_only() {
+        let filter = BulkDlqFilter {
+            min_attempts: Some(3),
+            ..BulkDlqFilter::default()
+        };
+        assert!(!filter.is_empty());
+    }
+
+    #[test]
     fn bulk_filter_is_not_empty_when_failed_before_set() {
         let filter = BulkDlqFilter {
             failed_before: Some(chrono::Utc::now()),
@@ -2367,6 +2385,8 @@ mod tests {
         let filter = BulkDlqFilter {
             activity_name: Some("charge_card".into()),
             workflow_name: Some("billing".into()),
+            queue_name: Some("low-pri".into()),
+            min_attempts: Some(3),
             failed_after: None,
             failed_before: None,
             error_class: None,
@@ -2379,6 +2399,8 @@ mod tests {
         let back: BulkDlqFilter = serde_json::from_str(&json).unwrap();
         assert_eq!(back.activity_name.as_deref(), Some("charge_card"));
         assert_eq!(back.workflow_name.as_deref(), Some("billing"));
+        assert_eq!(back.queue_name.as_deref(), Some("low-pri"));
+        assert_eq!(back.min_attempts, Some(3));
         assert_eq!(back.limit, Some(200));
         assert!(back.dry_run);
     }
@@ -2547,6 +2569,16 @@ mod tests {
         let class = error_class(&long);
         assert!(class.chars().count() <= ERROR_CLASS_MAX_LEN);
         assert_eq!(error_class(&long), class);
+    }
+
+    #[test]
+    fn error_class_trims_padded_error_type_for_round_trip() {
+        use crate::failure::{ActivityFailure, IntoActivityErrorString};
+        // A typed envelope whose error_type carries surrounding whitespace must
+        // classify to the trimmed class so the facet key round-trips through the
+        // (trimming) bulk-filter validator (issue #613, P3-1).
+        let padded = ActivityFailure::non_retryable("  CircuitOpen  ", "open").into_error_payload();
+        assert_eq!(error_class(&padded), "CircuitOpen");
     }
 
     #[test]

--- a/autumn-harvest/tests/integration/ci_run_coverage.rs
+++ b/autumn-harvest/tests/integration/ci_run_coverage.rs
@@ -208,8 +208,6 @@ const ALLOWLIST: &[(&str, &str)] = &[
     ("plugin:batch_operations_integration", ALLOWLIST_DEBT_REASON),
     ("plugin:build_routing_ui_integration", ALLOWLIST_DEBT_REASON),
     ("plugin:dag_retry_integration", ALLOWLIST_DEBT_REASON),
-    ("plugin:dlq_aggregate_integration", ALLOWLIST_DEBT_REASON),
-    ("plugin:dlq_bulk_integration", ALLOWLIST_DEBT_REASON),
     ("plugin:dlq_redrive_integration", ALLOWLIST_DEBT_REASON),
     ("plugin:erase_payloads_integration", ALLOWLIST_DEBT_REASON),
     ("plugin:event_batch_integration", ALLOWLIST_DEBT_REASON),

--- a/docs/api-contract.json
+++ b/docs/api-contract.json
@@ -2485,6 +2485,16 @@
             "description": "Filter by workflow name."
           },
           {
+            "name": "queue_name",
+            "required": false,
+            "description": "Filter by task queue name (exact match; SQL-expressible). Lets an operator reproduce a queue-scoped aggregate facet exactly."
+          },
+          {
+            "name": "min_attempts",
+            "required": false,
+            "description": "Only replay entries with at least this many attempts (SQL-expressible). Mirrors the aggregate endpoint's min_attempts filter."
+          },
+          {
             "name": "failed_after",
             "required": false,
             "description": "RFC 3339 timestamp \u2014 only replay entries failed after this time."
@@ -2564,6 +2574,16 @@
             "name": "workflow_name",
             "required": false,
             "description": "Filter by workflow name."
+          },
+          {
+            "name": "queue_name",
+            "required": false,
+            "description": "Filter by task queue name (exact match; SQL-expressible). Lets an operator reproduce a queue-scoped aggregate facet exactly."
+          },
+          {
+            "name": "min_attempts",
+            "required": false,
+            "description": "Only discard entries with at least this many attempts (SQL-expressible). Mirrors the aggregate endpoint's min_attempts filter."
           },
           {
             "name": "failed_after",

--- a/docs/api-contract.json
+++ b/docs/api-contract.json
@@ -2376,13 +2376,13 @@
       "path": "/dead-letters/aggregate",
       "category": "dlq",
       "read_only": true,
-      "description": "Root-cause aggregation for DLQ triage: group dead-letter entries by workflow_name, activity_name, queue_name, task_type, time_bucket, and/or a derived failure_signature, returning per-group counts and representative sample IDs merged across shards.",
+      "description": "Root-cause aggregation for DLQ triage: group dead-letter entries by workflow_name, activity_name, queue_name, task_type, time_bucket, a derived failure_signature, a derived dlq_reason class, and/or a derived error_class, returning per-group counts and representative sample IDs merged across shards.",
       "params": [
         {
           "name": "group_by",
           "in": "query",
           "required": true,
-          "description": "Repeatable grouping dimension: workflow_name, activity_name, queue_name, task_type, time_bucket, or failure_signature. Repeats build a hierarchical key."
+          "description": "Repeatable grouping dimension: workflow_name, activity_name, queue_name, task_type, time_bucket, failure_signature, dlq_reason, or error_class. Repeats build a hierarchical key."
         },
         {
           "name": "time_bucket",
@@ -2495,6 +2495,21 @@
             "description": "RFC 3339 timestamp \u2014 only replay entries failed before this time."
           },
           {
+            "name": "error_class",
+            "required": false,
+            "description": "Filter by derived error class (compute-on-read, exact match; e.g. CircuitOpen, PoisonPill)."
+          },
+          {
+            "name": "dlq_reason",
+            "required": false,
+            "description": "Filter by derived DLQ reason class (compute-on-read, exact match; e.g. poison_pill, retry_exhaustion)."
+          },
+          {
+            "name": "failure_signature",
+            "required": false,
+            "description": "Filter by derived failure signature (compute-on-read, exact match)."
+          },
+          {
             "name": "limit",
             "required": false,
             "description": "Maximum number of entries to replay."
@@ -2559,6 +2574,21 @@
             "name": "failed_before",
             "required": false,
             "description": "RFC 3339 timestamp \u2014 only discard entries failed before this time."
+          },
+          {
+            "name": "error_class",
+            "required": false,
+            "description": "Filter by derived error class (compute-on-read, exact match; e.g. CircuitOpen, PoisonPill)."
+          },
+          {
+            "name": "dlq_reason",
+            "required": false,
+            "description": "Filter by derived DLQ reason class (compute-on-read, exact match; e.g. poison_pill, retry_exhaustion)."
+          },
+          {
+            "name": "failure_signature",
+            "required": false,
+            "description": "Filter by derived failure signature (compute-on-read, exact match)."
           },
           {
             "name": "limit",

--- a/docs/changelog.d/pr-1083-dlq-cause-bulk-replay.md
+++ b/docs/changelog.d/pr-1083-dlq-cause-bulk-replay.md
@@ -1,0 +1,69 @@
+## Phase 3.52 — Cause-targeted bulk DLQ replay/discard + `dlq_reason`/`error_class` facets (issue #613)
+
+**Before:** during a DLQ flood an operator could aggregate dead-letter counts by
+workflow/activity/queue/failure-signature (`GET /dead-letters/aggregate`, shipped
+in #385) but could **not** group by *why* entries failed, and could **not** target
+a bulk replay/discard at a specific failure cause — `BulkDlqFilter` matched only
+workflow/activity/time. "Replay every poison-pilled entry" or "discard everything
+that failed with `CircuitOpen`" required scripting over the raw row list.
+
+**After:** a two-call incident runbook. (1) `GET /dead-letters/aggregate?group_by=dlq_reason`
+(or `error_class`) shows the flood's cause shape; (2) feed a facet's cause tuple
+back into `POST /dead-letters/replay|discard` (or `harvest dlq replay/discard
+--dlq-reason poison_pill`) to act on exactly that cohort. A facet's cause round-trips
+into the bulk filter and re-selects exactly the rows it counted.
+
+**Reconciliation with prior art (#385).** Per the #543/#593 reconciliation
+precedent, #613's ACs were ground-truthed against the code first: the
+faceted-aggregation half of #613 **already shipped in #385** (the `/aggregate`
+route *is* the AC1 "summary" route — reconciled name; per-group
+`first_seen`/`last_seen` == the AC's `earliest`/`latest`; `dlq::failure_signature`,
+`merge_dlq_aggregates`, cross-shard fan-out, top-N rollup, time-window narrowing,
+descending sort, and the CLI `dlq aggregate` command all reused verbatim). The
+genuine residual shipped here is the **cause dimension** #385 did not ship: the
+`dlq_reason`/`error_class` grouping facets (AC1 named them explicitly; #385 shipped
+only `failure_signature`) and the entire cause-targeted **bulk filter** (AC4/AC5/AC6),
+tied together by AC5's round-trip tuple `(workflow_name, activity_name, dlq_reason,
+error_class)`.
+
+**What shipped.**
+- **Two pure classifiers** in `dlq.rs`, compute-on-read from the freeform `error`
+  TEXT column (all production DLQ rows are `DeadLetterReason` tagged JSON):
+  `dlq_reason(error)` → snake_case mechanism class
+  (`poison_pill`/`history_cap_exceeded`/`workflow_task_timeout`/`callback_delivery_exhausted`,
+  else `retry_exhaustion`); `error_class(error)` → typed activity `error_type`
+  (`CircuitOpen`, …) if present, else the `DeadLetterReason` PascalCase tag, else a
+  normalized leading token. Both bounded and deterministic. `failure_signature`
+  reused unchanged.
+- **Aggregate**: two new `DlqGroupDimension` variants (`DlqReason`, `ErrorClass`)
+  plug into the existing load-and-classify pass — no new SQL.
+- **Bulk filter**: `BulkDlqFilter` gains `error_class`/`dlq_reason`/`failure_signature`
+  (compute-on-read Rust post-filter, applied before the limit) plus
+  `queue_name`/`min_attempts` (SQL) so any aggregate scope is reproducible.
+  `is_empty`/`MAX_BULK_LIMIT`/`dry_run` preserved. An empty/whitespace cause value
+  is **rejected `400`** in both the JSON and form paths (an empty cause must never
+  silently widen a bulk op).
+- **CLI**: `dlq summary` (alias of `aggregate`);
+  `--dlq-reason`/`--error-class`/`--failure-signature`/`--queue-name`/`--min-attempts`
+  on `dlq replay`/`discard`.
+- **Contract + CI**: `management_api_request_fields()` and `docs/api-contract.json`
+  updated (contract-regression green); `dlq_aggregate_integration`/`dlq_bulk_integration`
+  graduated from the CI ALLOWLIST into `.github/ci/integration-suites.txt` so the new
+  tests run under Docker in CI.
+
+**Invariants.** **No new `WorkflowEvent` variant, no migration, no `schema.rs`
+column, no event-log write** (AC7) — read-mostly, plus the additive bulk-filter
+dimension.
+
+**Review + tests.** Multi-angle adversarial review, no P1. **P2-1** (aggregate
+`queue_name`/`min_attempts` scope not reproducible in the bulk filter → cross-queue
+over-action) fixed by adding those two SQL filters — `bulk_cause_plus_queue_round_trips_exactly`
+proves a queue-scoped facet no longer over-acts. **P2-2** (cause matching is a
+compute-on-read full-shard scan) documented — symmetric with the already-shipped
+aggregate's accepted cost; `MAX_BULK_LIMIT` caps rows acted-on, narrowable by
+time/queue/activity/workflow/min_attempts. Executed on real Postgres 16
+(testcontainers): `dlq_bulk_integration` 17/17, `dlq_aggregate_integration` 14/14,
+`contract_regression` 22/22, core `dlq` (`--features db`) 71/71; plus the pure-unit
+tests `aggregate_group_by_dlq_reason_orders_by_count`, `aggregate_group_by_error_class`,
+`aggregate_group_by_dlq_reason_merges_across_shards`, `bulk_cause_dry_run_count_equals_aggregate_facet`,
+and CLI `request_mapping`/`contract_coverage` coverage.

--- a/examples/saga-choreography/src/main.rs
+++ b/examples/saga-choreography/src/main.rs
@@ -266,6 +266,8 @@ mod tests {
             context_headers: None,
             execution_timeout: None,
             deadline_at: None,
+            parent_execution_id: None,
+            workflow_id: None,
         };
         let json = serde_json::to_string(&snapshot).unwrap();
         WorkflowReplayer::new()


### PR DESCRIPTION
## Before / After

**Before.** During a DLQ flood an operator could see aggregate DLQ counts by workflow/activity/queue/signature (`GET /dead-letters/aggregate`, shipped in #385) but could **not** group by *why* entries failed (`dlq_reason`, `error_class`), and could **not** target a bulk replay/discard at a specific failure cause — `BulkDlqFilter` only matched workflow/activity/time. "Replay every poison-pilled entry" or "discard everything that failed with CircuitOpen" required scripting over the row list.

**After.** Two-call incident runbook: (1) `GET /dead-letters/aggregate?group_by=dlq_reason` (or `error_class`) shows the flood's cause shape; (2) feed a facet's cause back into `POST /dead-letters/replay|discard` (or `harvest dlq replay/discard --dlq-reason poison_pill`) to act on exactly that cohort. A facet's cause tuple round-trips into the bulk filter and re-selects exactly the rows it counted.

## Reconciliation with prior art (#385)

Per the #543/#593 reconciliation precedent, #613's ACs were ground-truthed against the code before implementing. **The faceted-aggregation half of #613 already shipped in #385** and is reconciled here, not re-derived:
- `GET /dead-letters/aggregate` **is** the AC1 "summary" route (reconciled name; per-group `first_seen`/`last_seen` == the AC's `earliest`/`latest`).
- `dlq::failure_signature`, `merge_dlq_aggregates`, cross-shard fan-out, top-N rollup, time-window narrowing, descending sort, CLI `dlq aggregate` — all shipped #385, reused verbatim.

**The genuine residual** (this PR) is the cause dimension #385 did not ship: the `dlq_reason`/`error_class` *grouping* facets (AC1 named them explicitly; #385 shipped only `failure_signature`) and the entire cause-targeted *bulk filter* (AC4/AC5/AC6). AC5's round-trip tuple `(workflow_name, activity_name, dlq_reason, error_class)` ties them together — one inseparable slice.

## What changed

- **Two pure classifiers** in `dlq.rs`, compute-on-read from the freeform `error` TEXT column (all production DLQ rows are `DeadLetterReason` tagged JSON): `dlq_reason(error)` → snake_case mechanism class (`poison_pill`/`history_cap_exceeded`/`workflow_task_timeout`/`callback_delivery_exhausted`, else `retry_exhaustion`); `error_class(error)` → typed activity `error_type` (`CircuitOpen`…) if present, else the `DeadLetterReason` PascalCase tag, else a normalized leading token. Both bounded + deterministic. `failure_signature` reused unchanged.
- **Aggregate**: two new `DlqGroupDimension` variants (`DlqReason`, `ErrorClass`) plug into the existing load-and-classify pass — no new SQL.
- **Bulk filter**: `BulkDlqFilter` gains `error_class`/`dlq_reason`/`failure_signature` (compute-on-read Rust post-filter, applied before the limit) plus `queue_name`/`min_attempts` (SQL) so any aggregate scope is reproducible. `is_empty`/`MAX_BULK_LIMIT`/`dry_run` preserved. An empty/whitespace cause value is **rejected 400** in both JSON and form paths (an empty cause must never silently widen a bulk op).
- **CLI**: `dlq summary` (alias of `aggregate`); `--dlq-reason`/`--error-class`/`--failure-signature`/`--queue-name`/`--min-attempts` on `dlq replay`/`discard`.
- **Contract + CI**: `management_api_request_fields()` + `docs/api-contract.json` updated (contract-regression green); `dlq_aggregate_integration`/`dlq_bulk_integration` graduated from the CI ALLOWLIST into `.github/ci/integration-suites.txt` so the new tests run in CI.

**No new `WorkflowEvent` variant, no migration, no schema column, no event-log write** (AC7) — read-mostly plus the additive bulk-filter dimension.

## AC → evidence

| AC | Status | Evidence |
|----|--------|----------|
| AC1 summary grouped by workflow/activity/**dlq_reason**/**error_class**, count+earliest+latest | #385 + **this PR** | `/aggregate` + `DlqGroup{count,first_seen,last_seen}` (#385); new `DlqReason`/`ErrorClass` dims + group-key arms; tests `aggregate_group_by_dlq_reason_orders_by_count`, `aggregate_group_by_error_class` |
| AC2 time-window + group_by + sort desc | #385 | `DlqAggregateParams`, `rollup_top_n` descending |
| AC3 shard-aware merge | #385 (+ new dims) | `merge_dlq_aggregates`; `aggregate_group_by_dlq_reason_merges_across_shards` |
| AC4 `BulkDlqFilter` cause dim; ≥1-criterion + MAX_BULK_LIMIT + dry_run preserved | **this PR** | 3 cause fields + `has_cause_filter`/`cause_matches`; `is_empty` extended; guards preserved |
| AC5 facet tuple → bulk filter re-selects exactly | **this PR** | shared pure classifiers; `bulk_cause_dry_run_count_equals_aggregate_facet`, `bulk_cause_plus_queue_round_trips_exactly` |
| AC6 CLI `dlq summary` + cause flag on replay/discard | **this PR** | `summary` alias; cause + queue/min_attempts flags; `request_mapping`/`contract_coverage` tests |
| AC7 no new event variant / event-log / replay impact | **this PR** | no `WorkflowEvent` variant, no migration, no `schema.rs` change; compute-on-read |
| AC8 tests: ≥3 causes ordered; cause dry_run==facet count; cross-shard; empty rejected | **this PR** | all RAN on Postgres 16 (below) |

## Review + verification

Multi-angle adversarial review: no P1. **P2-1** (aggregate `queue_name`/`min_attempts` scope not reproducible in the bulk filter → cross-queue over-action) **fixed** by adding those two SQL filters — `bulk_cause_plus_queue_round_trips_exactly` proves a queue-scoped facet no longer over-acts. **P2-2** (cause matching is a compute-on-read full-shard scan) documented — symmetric with the already-shipped aggregate's accepted cost; `MAX_BULK_LIMIT` caps rows acted-on; narrow with time/queue/activity/workflow/min_attempts.

CI mirror at the exact CI toolchain (GitHub `@stable` = **1.97.0**, not the sandbox's stale 1.94.1):
- `cargo +1.97.0 clippy --workspace --all-targets --all-features -- -D warnings` — clean; default-feature clippy — clean.
- `cargo +1.88.0 check --workspace` (MSRV) — pass. `cargo fmt --check` — pass.
- Unit: `autumn-harvest --no-default-features` + `autumn-harvest-cli` — pass.
- **RAN on real Postgres 16** (testcontainers): `dlq_bulk_integration` 17/17, `dlq_aggregate_integration` 14/14, `contract_regression` 22/22, core `dlq` (`--features db`) 71/71.

## Notes / out of scope

- Commit `8bcb944` fixes a **pre-existing, unrelated** example compile break (`examples/saga-choreography`, from #698's `ctx.info` struct change) so the mandated `--workspace` clippy is green; real PR CI doesn't lint `examples/*`. Safe to drop or land separately — flagged for the maintainer.
- P2-2's unbounded compute-on-read scan is documented, not hard-capped (a forced co-filter would break the legitimate "discard all poison-pills" incident use case). A scan cap could be a follow-up.

Closes #613.

---
_Generated by [Claude Code](https://claude.ai/code/session_014v7wJQtbmPjyd5ABMaDGvj)_