### PR TITLE
feat: add ctx.publish_progress for live workflow output streaming (#791)

### DIFF
--- a/.github/ci/integration-suites.txt
+++ b/.github/ci/integration-suites.txt
@@ -44,6 +44,7 @@ allos        autumn-harvest         property                         db         
 allos        autumn-harvest-plugin  contract_regression              -                          -
 allos        autumn-harvest-plugin  effective_config_http_tests      -                          -
 allos        autumn-harvest-plugin  security                         -                          -
+allos        autumn-harvest-plugin  sse_stream_tests                 -                          -
 compileonly  autumn-harvest-plugin  mcp_tools_integration            mcp,unified-dag-execution  -
 compileonly  autumn-harvest-plugin  status_summary_localpg           -                          -
 linux        autumn-harvest         integration                      -                          activity_default_floor_tests
@@ -81,6 +82,7 @@ linux        autumn-harvest-plugin  fail_now_integration             -          
 linux        autumn-harvest-plugin  fanout_degradation_integration   -                          -
 linux        autumn-harvest-plugin  interface_schema_integration     -                          -
 linux        autumn-harvest-plugin  legal_hold_integration           -                          -
+linux        autumn-harvest-plugin  progress_stream_integration      -                          -
 linux        autumn-harvest-plugin  query_integration                -                          -
 linux        autumn-harvest-plugin  read_path_decode_integration     -                          -
 linux        autumn-harvest-plugin  run_chain_integration            -                          -

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -27199,6 +27199,10 @@ async fn stream_execution_events(
 
     // Resolve the LISTEN/NOTIFY database URL for this execution's shard
     let shard = exec_id.shard();
+    // NOTE: a not-configured URL here is `HarvestError::Config` → 400 via
+    // `map_error`. That latent misclassification (server misconfig should be
+    // 503) is a pre-existing #324 behavior and out of scope for #791 — the
+    // sibling progress stream below returns 503 for the same case.
     let notification_url = match api_state.sse_notification_url(shard) {
         Ok(url) => url,
         Err(e) => return map_error(e).into_response(),
@@ -27598,9 +27602,24 @@ async fn stream_execution_events(
 const PROGRESS_STREAM_KEEPALIVE: std::time::Duration = std::time::Duration::from_secs(5);
 
 /// Bounded producer→SSE channel capacity for the progress stream. Progress is a
-/// best-effort side channel: if a slow client backs this up, the next send
-/// fails and the producer task ends cleanly (no unbounded buffering).
+/// best-effort side channel: chunks are sent non-blocking (`try_send`), so a
+/// slow client that fills this buffer causes the *excess* chunks to be DROPPED
+/// (never buffered unboundedly, and — critically — never back-pressured into the
+/// shared Postgres async NOTIFY queue). The monotonic `seq` lets the client
+/// detect the resulting gap. A disconnected receiver ends the stream.
 const PROGRESS_STREAM_CHANNEL_CAPACITY: usize = 256;
+
+/// Short, non-zero grace window used to drain any progress chunk still in flight
+/// in the LISTEN driver's internal buffer *before* emitting the terminal
+/// `event: end` frame.
+///
+/// The terminal close is driven by an idle keepalive tick that polls terminal
+/// state. When that tick fires, the workflow's FINAL published chunk may have
+/// been delivered on the listener socket but not yet forwarded by the driver
+/// task. A `Duration::ZERO` poll would race and drop it; a short non-zero grace
+/// gives the driver time to forward a just-delivered notification, so the last
+/// chunk is not lost on close.
+const PROGRESS_STREAM_FINAL_DRAIN_GRACE: std::time::Duration = std::time::Duration::from_millis(75);
 
 /// Poll the execution's terminal state for the progress stream's close check.
 ///
@@ -27661,9 +27680,20 @@ async fn progress_stream_end_reason(
 /// connects after a chunk was published will not see it — deliberate, since
 /// chunk content may be non-deterministic precisely because it is never stored.
 ///
-/// Responses: `404` if the execution does not exist; `503`/`400` if the
-/// LISTEN/NOTIFY database URL is not configured; a single `event: end` frame
-/// (then close) if the execution is already terminal at connect.
+/// **Authorization**: this route only checks that the execution exists (→ 404
+/// otherwise). `exec_id` is effectively a bearer capability for this run's live
+/// chunk *content*; embedders exposing sensitive workflow output MUST add their
+/// own per-execution authorization on top. `exec_id` is a random `UUIDv4` (not
+/// enumerable), which mitigates blind probing but is not an access-control
+/// substitute. Each subscriber also holds one dedicated (non-pooled) Postgres
+/// `LISTEN` connection for the stream's lifetime, so embedders should rate-limit
+/// and/or cap concurrent streams per user to avoid DB connection exhaustion.
+///
+/// Responses: `404` if the execution does not exist; `503` if the LISTEN/NOTIFY
+/// database URL is not configured or the notification database is unreachable
+/// (both server-side conditions, retriable); a single `event: end` frame (then
+/// close) if the execution is already terminal at connect.
+#[allow(clippy::too_many_lines)]
 async fn stream_workflow_progress(
     Extension(api_state): Extension<HarvestApiState>,
     Path(exec_id_raw): Path<String>,
@@ -27679,14 +27709,25 @@ async fn stream_workflow_progress(
     };
 
     // Resolve the LISTEN/NOTIFY database URL for this execution's shard.
+    //
+    // No LISTEN/NOTIFY URL configured is a *server* misconfiguration, not a
+    // client error: return 503 (retriable once configured), matching the handler
+    // contract and docs/api-contract.json. A DB-unreachable failure on `connect`
+    // below is likewise 503 (via `map_error`'s `HarvestError::Database` arm), so
+    // both "not configured" and "unreachable" surface as 503, never a 400.
     let shard = exec_id.shard();
-    let notification_url = match api_state.sse_notification_url(shard) {
-        Ok(url) => url,
-        Err(e) => return map_error(e).into_response(),
+    let Ok(notification_url) = api_state.sse_notification_url(shard) else {
+        return AutumnError::service_unavailable_msg(
+            "progress streaming is not configured (no LISTEN/NOTIFY database URL)",
+        )
+        .into_response();
     };
 
     // Establish LISTEN before verifying the execution so a chunk published in
     // the window between the existence check and LISTEN setup is not missed.
+    // A connect failure is `HarvestError::Database` → 503 via `map_error`
+    // (LISTEN/NOTIFY database unreachable), consistent with the not-configured
+    // case above.
     let listener =
         match WorkflowProgressListener::connect(&notification_url, exec_id.as_uuid()).await {
             Ok(l) => l,
@@ -27713,8 +27754,10 @@ async fn stream_workflow_progress(
         .sse_keepalive_interval()
         .min(PROGRESS_STREAM_KEEPALIVE);
 
-    // Bounded channel: when the axum SSE receiver drops (client disconnect),
-    // further sends fail and the producer task shuts down cleanly.
+    // Bounded channel: chunks are pushed non-blocking (`try_send`) so a slow
+    // client can only ever cause chunk DROPS (best-effort), never unbounded
+    // buffering and never back-pressure into Postgres' NOTIFY queue. A dropped
+    // receiver (client disconnect) ends the producer cleanly.
     let (mut tx, rx) = futures::channel::mpsc::channel::<Result<Event, std::convert::Infallible>>(
         PROGRESS_STREAM_CHANNEL_CAPACITY,
     );
@@ -27727,18 +27770,39 @@ async fn stream_workflow_progress(
         let api_clone = api_state.clone();
         // Producer task: runs independently of the HTTP handler after we return.
         tokio::spawn(async move {
+            // Emit a progress chunk NON-BLOCKING. Returns `false` when the
+            // receiver has been dropped (client disconnected) so the caller
+            // ends the stream; a full channel (slow consumer) DROPS the chunk
+            // and returns `true` (keep going — the monotonic seq lets the
+            // client detect the gap). A blocking `send().await` here would
+            // back-pressure a slow client into the shared Postgres NOTIFY queue
+            // and stall the terminal-close poll below, so it must not block.
+            let emit_chunk = |tx: &mut futures::channel::mpsc::Sender<
+                Result<Event, std::convert::Infallible>,
+            >,
+                              payload: autumn_harvest::notify::ProgressNotifyPayload|
+             -> bool {
+                // `chunk` is already an inner JSON value — serialize it compactly
+                // (single line) and DO NOT re-wrap it in the adjacently-tagged
+                // envelope; `id:` carries the seq.
+                let event = Event::default()
+                    .id(payload.seq.to_string())
+                    .event("progress")
+                    .data(payload.chunk.to_string());
+                match tx.try_send(Ok(event)) {
+                    Ok(()) => true,
+                    // Slow consumer: drop this chunk, keep the stream alive.
+                    Err(e) if e.is_full() => true,
+                    // Receiver dropped (client disconnected): end the stream.
+                    Err(_) => false,
+                }
+            };
+
             let mut listener = listener;
             loop {
                 match listener.wait_for_progress_timeout(keepalive).await {
                     Ok(ProgressWaitOutcome::Chunk(payload)) => {
-                        // `chunk` is already an inner JSON value — serialize it
-                        // compactly (single line) and DO NOT re-wrap it in the
-                        // adjacently-tagged envelope; `id:` carries the seq.
-                        let event = Event::default()
-                            .id(payload.seq.to_string())
-                            .event("progress")
-                            .data(payload.chunk.to_string());
-                        if tx.send(Ok(event)).await.is_err() {
+                        if !emit_chunk(&mut tx, payload) {
                             break; // client disconnected
                         }
                     }
@@ -27753,6 +27817,23 @@ async fn stream_workflow_progress(
                         // chunk, so this bounds close latency to one keepalive.
                         if let Some(reason) = progress_stream_end_reason(&api_clone, exec_id).await
                         {
+                            // Bounded final-chunk drain: the workflow's LAST
+                            // published chunk may have arrived on the listener
+                            // socket but not yet been forwarded by the driver
+                            // task when this idle tick fired. Drain (non-blocking)
+                            // with a short grace so the primary "here's your
+                            // answer" frame is not dropped on close. A non-Chunk
+                            // outcome (no more chunks in flight, timeout, or the
+                            // listener dropped) exits the drain and proceeds to
+                            // close.
+                            while let Ok(ProgressWaitOutcome::Chunk(payload)) = listener
+                                .wait_for_progress_timeout(PROGRESS_STREAM_FINAL_DRAIN_GRACE)
+                                .await
+                            {
+                                if !emit_chunk(&mut tx, payload) {
+                                    return; // client disconnected mid-drain
+                                }
+                            }
                             let end_data = serde_json::json!({ "reason": reason }).to_string();
                             let _ = tx
                                 .send(Ok(Event::default().event("end").data(end_data)))

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -4067,6 +4067,11 @@ pub fn harvest_api_router(api_state: HarvestApiState) -> Router<AppState> {
         .route("/workflows/{id}/stack", get(get_workflow_stack))
         .route("/workflows/{id}/timeline", get(get_workflow_timeline))
         .route("/workflows/{id}/run-chain", get(get_run_chain))
+        // Ephemeral workflow progress SSE stream (issue #791). Deliberately NOT
+        // admin-gated — an app's end-users stream their own workflows (AC5). It
+        // inherits the general management API auth middleware (api_with_auth)
+        // like the other non-admin `/workflows/{id}/…` read routes.
+        .route("/workflows/{id}/stream", get(stream_workflow_progress))
         .route("/workflows/{workflow_name}/start", post(start_workflow))
         .route(
             "/workflows/{workflow_name}/signal-with-start",
@@ -5010,6 +5015,9 @@ pub const fn management_api_routes() -> &'static [(&'static str, &'static str)] 
         ("GET", "/workflows/{id}/stack"),
         ("GET", "/workflows/{id}/timeline"),
         ("GET", "/workflows/{id}/run-chain"),
+        // Ephemeral workflow progress SSE stream (issue #791). Read-only,
+        // text/event-stream; NOT admin-gated (AC5). See docs/api-contract.json.
+        ("GET", "/workflows/{id}/stream"),
         ("POST", "/workflows/{workflow_name}/start"),
         ("POST", "/workflows/{workflow_name}/signal-with-start"),
         ("POST", "/workflows/{workflow_name}/update-with-start"),
@@ -5688,6 +5696,10 @@ pub const fn management_api_response_fields()
             "/workflows/{id}/run-chain",
             Some(&["head_unknown", "workflow_id", "runs"]),
         ),
+        // Ephemeral workflow progress SSE stream (issue #791): text/event-stream,
+        // no JSON body. Frames: `event: progress` (data = the chunk JSON, `id:` =
+        // monotonic seq), a terminal `event: end`, or `event: error`.
+        ("GET", "/workflows/{id}/stream", None),
         (
             "POST",
             "/workflows/{workflow_name}/start",
@@ -27574,6 +27586,198 @@ async fn stream_execution_events(
     // comments every keepalive_interval so proxies don't idle the connection.
     Sse::new(rx)
         .keep_alive(KeepAlive::new().interval(keepalive_interval).text("ping"))
+        .into_response()
+}
+
+/// Terminal-close poll cadence / keepalive ceiling for the workflow progress SSE
+/// stream (issue #791). Bounds how long after a workflow reaches a terminal
+/// state the final `event: end` frame is emitted (there is no terminal *chunk*,
+/// so the close is driven by a periodic terminal-state poll on the idle tick).
+/// Capped by the configured `sse_keepalive_interval` so operators (and tests)
+/// can shorten it; a modest default keeps close latency bounded.
+const PROGRESS_STREAM_KEEPALIVE: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// Bounded producer→SSE channel capacity for the progress stream. Progress is a
+/// best-effort side channel: if a slow client backs this up, the next send
+/// fails and the producer task ends cleanly (no unbounded buffering).
+const PROGRESS_STREAM_CHANNEL_CAPACITY: usize = 256;
+
+/// Poll the execution's terminal state for the progress stream's close check.
+///
+/// Returns `Some(reason)` when the stream should end — the execution reached a
+/// terminal state, or its row was retention-deleted (which only happens once an
+/// execution is already terminal) — and `None` to keep waiting (still running,
+/// or a transient DB/pool error the next idle tick retries).
+async fn progress_stream_end_reason(
+    api_state: &HarvestApiState,
+    exec_id: ExecutionId,
+) -> Option<String> {
+    let mut conn = db_conn_for_execution(api_state, exec_id).await.ok()?;
+    let state: Option<String> = harvest_workflow_executions::table
+        .find(exec_id.as_uuid())
+        .select(harvest_workflow_executions::state)
+        .first(&mut conn)
+        .await
+        .optional()
+        .ok()?;
+    match state {
+        // Row gone: retention only deletes terminal executions, so end the stream.
+        None => Some("deleted".to_string()),
+        Some(s) if is_terminal_state(&s) => Some(s.to_lowercase().replace('_', "-")),
+        // Still running — keep the live loop open.
+        Some(_) => None,
+    }
+}
+
+/// `GET /workflows/{id}/stream`
+///
+/// Ephemeral, best-effort **live-output side channel** (issue #791). Streams the
+/// ordered progress chunks a running workflow publishes via
+/// [`WorkflowContext::publish_progress`](autumn_harvest::context::WorkflowContext::publish_progress)
+/// over Postgres LISTEN/NOTIFY, with sub-second delivery and no DB connection
+/// held between chunks.
+///
+/// **Auth**: this route inherits the management API's configured auth middleware
+/// (`HarvestPlugin::api_with_auth`); it is deliberately **NOT** admin-gated
+/// (issue #791 AC5 — an app's end-users stream their own workflows). If no
+/// middleware is configured the route is open — embedders exposing streams to
+/// untrusted end-users should configure `api_with_auth` or front it with their
+/// own auth.
+///
+/// SSE wire format:
+/// ```text
+/// id: <seq>            (monotonic, epoch-prefixed; a gap ⇒ missed chunk)
+/// event: progress
+/// data: <chunk JSON>   (compact, single-line)
+///
+/// ```
+/// A final `event: end` frame is emitted when the execution reaches a terminal
+/// state and the stream then closes; `event: error` is sent if the LISTEN
+/// connection drops. Keepalive `: ping` comments (axum `KeepAlive`) keep proxies
+/// from idling the connection.
+///
+/// **Progress chunks are EPHEMERAL**: never recorded in `harvest_events`, never
+/// replayed, and there is **no backfill** on (re)connect. A subscriber that
+/// connects after a chunk was published will not see it — deliberate, since
+/// chunk content may be non-deterministic precisely because it is never stored.
+///
+/// Responses: `404` if the execution does not exist; `503`/`400` if the
+/// LISTEN/NOTIFY database URL is not configured; a single `event: end` frame
+/// (then close) if the execution is already terminal at connect.
+async fn stream_workflow_progress(
+    Extension(api_state): Extension<HarvestApiState>,
+    Path(exec_id_raw): Path<String>,
+) -> axum::response::Response {
+    use autumn_harvest::notify::{ProgressWaitOutcome, WorkflowProgressListener};
+    use axum::response::sse::{Event, KeepAlive, Sse};
+    use futures::SinkExt as _;
+
+    // Parse execution ID (400 on malformed).
+    let exec_id = match parse_execution_id(&exec_id_raw) {
+        Ok(id) => id,
+        Err(e) => return e.into_response(),
+    };
+
+    // Resolve the LISTEN/NOTIFY database URL for this execution's shard.
+    let shard = exec_id.shard();
+    let notification_url = match api_state.sse_notification_url(shard) {
+        Ok(url) => url,
+        Err(e) => return map_error(e).into_response(),
+    };
+
+    // Establish LISTEN before verifying the execution so a chunk published in
+    // the window between the existence check and LISTEN setup is not missed.
+    let listener =
+        match WorkflowProgressListener::connect(&notification_url, exec_id.as_uuid()).await {
+            Ok(l) => l,
+            Err(e) => return map_error(e).into_response(),
+        };
+
+    // Verify the execution exists (404 otherwise) and capture its terminal state.
+    let mut conn = match db_conn_for_execution(&api_state, exec_id).await {
+        Ok(c) => c,
+        Err(e) => return e.into_response(),
+    };
+    let execution = match load_execution(&mut conn, exec_id).await {
+        Ok(e) => e,
+        Err(e) => return map_error(e).into_response(),
+    };
+    let already_terminal = is_terminal_state(&execution.state);
+    let terminal_reason = execution.state.to_lowercase().replace('_', "-");
+    // Release the pooled DB connection — SSE streams must not hold connections.
+    drop(conn);
+
+    // Terminal-close poll cadence, bounded by a modest default and shortenable
+    // via the shared SSE keepalive config.
+    let keepalive = api_state
+        .sse_keepalive_interval()
+        .min(PROGRESS_STREAM_KEEPALIVE);
+
+    // Bounded channel: when the axum SSE receiver drops (client disconnect),
+    // further sends fail and the producer task shuts down cleanly.
+    let (mut tx, rx) = futures::channel::mpsc::channel::<Result<Event, std::convert::Infallible>>(
+        PROGRESS_STREAM_CHANNEL_CAPACITY,
+    );
+
+    if already_terminal {
+        // No chunks will come — emit a single end frame and close immediately.
+        let end_data = serde_json::json!({ "reason": terminal_reason }).to_string();
+        let _ = tx.try_send(Ok(Event::default().event("end").data(end_data)));
+    } else {
+        let api_clone = api_state.clone();
+        // Producer task: runs independently of the HTTP handler after we return.
+        tokio::spawn(async move {
+            let mut listener = listener;
+            loop {
+                match listener.wait_for_progress_timeout(keepalive).await {
+                    Ok(ProgressWaitOutcome::Chunk(payload)) => {
+                        // `chunk` is already an inner JSON value — serialize it
+                        // compactly (single line) and DO NOT re-wrap it in the
+                        // adjacently-tagged envelope; `id:` carries the seq.
+                        let event = Event::default()
+                            .id(payload.seq.to_string())
+                            .event("progress")
+                            .data(payload.chunk.to_string());
+                        if tx.send(Ok(event)).await.is_err() {
+                            break; // client disconnected
+                        }
+                    }
+                    Ok(ProgressWaitOutcome::TimedOut) => {
+                        // Detect a client that disconnected while idle (send /
+                        // try_send only observe a drop on a write attempt); the
+                        // axum KeepAlive wrapper emits the `: ping` comment.
+                        if tx.is_closed() {
+                            break;
+                        }
+                        // Periodic terminal-state poll: there is no terminal
+                        // chunk, so this bounds close latency to one keepalive.
+                        if let Some(reason) = progress_stream_end_reason(&api_clone, exec_id).await
+                        {
+                            let end_data = serde_json::json!({ "reason": reason }).to_string();
+                            let _ = tx
+                                .send(Ok(Event::default().event("end").data(end_data)))
+                                .await;
+                            break;
+                        }
+                    }
+                    Ok(ProgressWaitOutcome::ChannelClosed) => {
+                        // LISTEN connection dropped; end with an error frame
+                        // rather than hanging (mirrors #597 watch robustness).
+                        let err_data =
+                            serde_json::json!({ "error": "listen_connection_closed" }).to_string();
+                        let _ = tx
+                            .send(Ok(Event::default().event("error").data(err_data)))
+                            .await;
+                        break;
+                    }
+                    Err(_) => break,
+                }
+            }
+        });
+    }
+
+    Sse::new(rx)
+        .keep_alive(KeepAlive::new().interval(keepalive).text("ping"))
         .into_response()
 }
 

--- a/autumn-harvest-plugin/tests/contract_regression.rs
+++ b/autumn-harvest-plugin/tests/contract_regression.rs
@@ -393,6 +393,47 @@ fn timeline_route_is_classified() {
     );
 }
 
+/// The ephemeral workflow progress SSE stream (issue #791) must be registered
+/// in the management route list AND classified `ReadOnly` in
+/// `autumn_harvest::audit::CLASSIFIED_ROUTES`, appearing in the route manifest
+/// with no audit operation (`None`) and listed in `EXCLUDED_ROUTES` — the exact
+/// read-only precedent set by `GET /workflows/{id}/timeline`.
+///
+/// Mirrors `timeline_route_is_classified`: the audit-side mutual cross-check
+/// (`CLASSIFIED_ROUTES` vs `ALL_MUTATION_ROUTES`) stays green if a route is
+/// dropped from BOTH lists, so this pins the route against the live router
+/// registry. Note the route is deliberately NOT admin-gated (AC5).
+#[test]
+fn progress_stream_route_is_classified() {
+    use autumn_harvest::audit::{
+        ALL_MUTATION_ROUTES, CLASSIFIED_ROUTES, EXCLUDED_ROUTES, RouteClass,
+    };
+
+    let route = "GET /workflows/{id}/stream";
+    assert!(
+        management_api_routes()
+            .iter()
+            .any(|(m, p)| format!("{m} {p}") == route),
+        "{route} must be registered in management_api_routes()"
+    );
+    assert!(
+        CLASSIFIED_ROUTES
+            .iter()
+            .any(|(r, class)| *r == route && matches!(class, RouteClass::ReadOnly)),
+        "{route} must be classified ReadOnly in autumn_harvest::audit::CLASSIFIED_ROUTES"
+    );
+    assert!(
+        ALL_MUTATION_ROUTES
+            .iter()
+            .any(|(r, op)| *r == route && op.is_none()),
+        "{route} must appear in ALL_MUTATION_ROUTES with no audit operation (None)"
+    );
+    assert!(
+        EXCLUDED_ROUTES.contains(&route),
+        "{route} is read-only and must be listed in EXCLUDED_ROUTES"
+    );
+}
+
 /// The tiered/summary retention list (issue #752) must be registered in the
 /// live route registry and classified `ReadOnly`, listed in
 /// `ALL_MUTATION_ROUTES` with no audit op, and in `EXCLUDED_ROUTES`.

--- a/autumn-harvest-plugin/tests/progress_stream_integration.rs
+++ b/autumn-harvest-plugin/tests/progress_stream_integration.rs
@@ -51,7 +51,9 @@ use tower::ServiceExt;
 /// created database is left in place — the sandbox is ephemeral).
 #[allow(dead_code)]
 enum DbGuard {
-    Container(ContainerAsync<Postgres>),
+    // Boxed to keep the enum small (clippy::large_enum_variant): the container
+    // variant is ~800 bytes while LocalPg carries no data.
+    Container(Box<ContainerAsync<Postgres>>),
     LocalPg,
 }
 
@@ -91,7 +93,7 @@ async fn setup_database() -> (String, DbGuard) {
         let host = container.get_host().await.unwrap();
         let port = container.get_host_port_ipv4(5432).await.unwrap();
         let url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
-        (url, DbGuard::Container(container))
+        (url, DbGuard::Container(Box::new(container)))
     }
 }
 
@@ -120,29 +122,58 @@ fn progress_workflow<'a>(
     })
 }
 
+/// A workflow that publishes one chunk, suspends on a durable 1-second timer
+/// (ending decision cycle 1), then resumes (decision cycle 2) and publishes a
+/// second chunk before completing. The timer's `TimerStarted`/`TimerFired`
+/// events grow the loaded-history length (the `seq` epoch) between the two
+/// cycles, so the second chunk's `seq` must land in a strictly higher epoch than
+/// the first — the AC6 cross-cycle monotonicity crux.
+fn progress_multicycle_workflow<'a>(
+    ctx: &'a autumn_harvest::context::WorkflowContext,
+    input: Value,
+) -> Pin<Box<dyn std::future::Future<Output = Result<Value, String>> + Send + 'a>> {
+    Box::pin(async move {
+        ctx.publish_progress(json!({"cycle": 1, "msg": "before timer"}))
+            .map_err(|e| e.to_string())?;
+        // Suspend for a durable timer — this ends decision cycle 1 and appends
+        // TimerStarted; on fire, TimerFired is ingested before cycle 2 resumes.
+        ctx.timer("gate", 1).await.map_err(|e| e.to_string())?;
+        ctx.publish_progress(json!({"cycle": 2, "msg": "after timer"}))
+            .map_err(|e| e.to_string())?;
+        Ok(input)
+    })
+}
+
+fn wf_info(name: &'static str, handler: autumn_harvest::info::WorkflowHandlerFn) -> WorkflowInfo {
+    WorkflowInfo {
+        mcp: false,
+        name,
+        module: "tests",
+        handler,
+        execution_timeout: None,
+        sla: None,
+        concurrency: None,
+        debounce: None,
+        batch: None,
+        throttle: None,
+        max_input_bytes: None,
+        description: None,
+        input_schema: None,
+        output_schema: None,
+        error_schema: None,
+        retry_policy: None,
+        owner: None,
+        runbook_url: None,
+        severity: None,
+    }
+}
+
 fn test_registry() -> Arc<HandlerRegistry> {
     Arc::new(HandlerRegistry::new(
-        vec![WorkflowInfo {
-            mcp: false,
-            name: "progress_wf",
-            module: "tests",
-            handler: progress_workflow,
-            execution_timeout: None,
-            sla: None,
-            concurrency: None,
-            debounce: None,
-            batch: None,
-            throttle: None,
-            max_input_bytes: None,
-            description: None,
-            input_schema: None,
-            output_schema: None,
-            error_schema: None,
-            retry_policy: None,
-            owner: None,
-            runbook_url: None,
-            severity: None,
-        }],
+        vec![
+            wf_info("progress_wf", progress_workflow),
+            wf_info("progress_multicycle_wf", progress_multicycle_workflow),
+        ],
         vec![],
     ))
 }
@@ -169,8 +200,16 @@ fn build_app(pool: &DbPool, url: &str) -> axum::Router {
 }
 
 fn start_params(exec_id: ExecutionId, workflow_id: &'static str) -> StartWorkflowParams<'static> {
+    start_params_named(exec_id, "progress_wf", workflow_id)
+}
+
+fn start_params_named(
+    exec_id: ExecutionId,
+    workflow_name: &'static str,
+    workflow_id: &'static str,
+) -> StartWorkflowParams<'static> {
     StartWorkflowParams {
-        workflow_name: "progress_wf",
+        workflow_name,
         workflow_id,
         exec_id,
         input: json!({"ok": true}),
@@ -277,8 +316,7 @@ async fn read_sse(
                         {
                             first_progress_at = Some(start.elapsed());
                         }
-                        let terminal =
-                            matches!(frame.event.as_deref(), Some("end") | Some("error"));
+                        let terminal = matches!(frame.event.as_deref(), Some("end" | "error"));
                         frames.push(frame);
                         if terminal {
                             return (frames, first_progress_at);
@@ -435,6 +473,100 @@ async fn progress_stream_on_already_terminal_execution_closes_immediately() {
         frames.last().and_then(|f| f.event.as_deref()),
         Some("end"),
         "already-terminal execution closes immediately with event:end"
+    );
+}
+
+/// AC6 (cross-cycle crux): a REAL workflow that publishes across TWO decision
+/// cycles (separated by a durable timer) must emit progress `seq`s whose EPOCH
+/// strictly grows across the cycle boundary — proving the epoch actually
+/// advances with the loaded-history length, not just the within-cycle local
+/// index. This exercises the real worker path (suspend → append timer events →
+/// resume) end-to-end and reads the real `seq`s off the live SSE stream.
+#[tokio::test]
+async fn progress_stream_seq_strictly_increases_across_decision_cycles() {
+    let (url, _guard) = setup_database().await;
+    let pool = build_pool(&url);
+    let app = build_app(&pool, &url);
+    let mut conn = pool.get().await.unwrap();
+
+    let exec_id = ExecutionId::new_for_shard(ShardId::new(0));
+    start_or_load_workflow_execution(
+        &mut conn,
+        start_params_named(exec_id, "progress_multicycle_wf", "progress-multicycle"),
+        None,
+    )
+    .await
+    .unwrap();
+
+    // Subscribe before the worker runs (progress has no backfill).
+    let resp = sse_response(&app, &format!("/workflows/{exec_id}/stream")).await;
+    assert_eq!(resp.status(), StatusCode::OK, "stream must open with 200");
+
+    let mut runtime_config = WorkerRuntimeConfig::from(WorkerConfig::default());
+    runtime_config.worker_id = "progress-multicycle-worker".to_string();
+    runtime_config.queues = vec!["default".to_string()];
+    runtime_config.poll_interval = Duration::from_millis(20);
+    runtime_config.shard_assignments = vec![ShardId::new(0)];
+    let worker = Arc::new(Worker::new(runtime_config, test_registry()).unwrap());
+    let worker_handle = {
+        let worker = worker.clone();
+        let pool = pool.clone();
+        tokio::spawn(async move {
+            worker.run(&pool).await;
+        })
+    };
+
+    // Deadline must exceed the 1-second durable timer.
+    let (frames, _first_at) = read_sse(resp, Duration::from_secs(20)).await;
+
+    worker.shutdown();
+    let _ = worker_handle.await;
+
+    let progress: Vec<&SseFrame> = frames
+        .iter()
+        .filter(|f| f.event.as_deref() == Some("progress"))
+        .collect();
+    assert_eq!(
+        progress.len(),
+        2,
+        "expected exactly 2 progress frames (one per cycle), got frames: {frames:#?}"
+    );
+
+    let seqs: Vec<u64> = progress
+        .iter()
+        .map(|f| {
+            f.id.as_deref()
+                .expect("progress frame carries an id (seq)")
+                .parse::<u64>()
+                .expect("seq is a u64")
+        })
+        .collect();
+
+    // Strictly increasing overall.
+    assert!(
+        seqs[1] > seqs[0],
+        "cross-cycle progress seqs must strictly increase, got {seqs:?}"
+    );
+
+    // The CRUX: the epoch (high bits, seq >> PROGRESS_SEQ_LOCAL_BITS=24) must be
+    // strictly higher for the second cycle — the loaded-history length grew when
+    // the timer's TimerStarted/TimerFired events were appended between cycles.
+    // A within-cycle local-index bump would leave the epoch unchanged; this
+    // asserts the epoch itself advanced across the decision-cycle boundary.
+    let epoch0 = seqs[0] >> 24;
+    let epoch1 = seqs[1] >> 24;
+    assert!(
+        epoch1 > epoch0,
+        "the second cycle's progress seq must land in a strictly higher epoch \
+         (epoch grows with loaded-history length across cycles): epoch1={epoch1} \
+         !> epoch0={epoch0} (seqs {seqs:?})"
+    );
+
+    // Stream closes on terminal state.
+    assert_eq!(
+        frames.last().and_then(|f| f.event.as_deref()),
+        Some("end"),
+        "stream must close with event:end on terminal state"
     );
 }
 

--- a/autumn-harvest-plugin/tests/progress_stream_integration.rs
+++ b/autumn-harvest-plugin/tests/progress_stream_integration.rs
@@ -1,0 +1,454 @@
+//! Integration tests for `GET /api/harvest/workflows/{id}/stream` — the
+//! ephemeral progress SSE subscriber for `ctx.publish_progress` (issue #791).
+//!
+//! End-to-end proof (AC3/AC4): a real worker runs a workflow that publishes
+//! ordered progress chunks then completes; a subscriber on the stream receives
+//! every chunk in publish order with monotonically increasing `id:` seq, the
+//! exact chunk JSON in each `event: progress` frame, and a terminal `event: end`
+//! when the workflow reaches a terminal state. Also: an already-terminal
+//! execution closes immediately with `event: end`, and an unknown execution id
+//! returns 404.
+//!
+//! Dual-mode DB: prefers `HARVEST_TEST_DATABASE_URL` (creates a fresh uniquely
+//! named database on that server, migrates it) so the suite is runnable without
+//! Docker; falls back to testcontainers Postgres 16 (the mode CI runs).
+
+#![allow(clippy::too_many_lines)]
+
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::Duration;
+
+use autumn_harvest::builder::WorkerConfig;
+use autumn_harvest::info::WorkflowInfo;
+use autumn_harvest::scheduler::{DagCatalog, SchedulerMonitor};
+use autumn_harvest::schema::harvest_workflow_executions;
+use autumn_harvest::shard::ShardRouter;
+use autumn_harvest::types::{ExecutionId, Priority, ShardId};
+use autumn_harvest::worker::{DbPool, HandlerRegistry, Worker, WorkerRuntimeConfig};
+use autumn_harvest::{StartWorkflowParams, start_or_load_workflow_execution};
+use autumn_harvest_plugin::HarvestDbPool;
+use autumn_harvest_plugin::api::{
+    HarvestApiRuntime, HarvestApiState, HarvestRetentionRuntime, harvest_api_router,
+};
+use autumn_web::AppState;
+use autumn_web::reexports::axum;
+use axum::body::Body;
+use axum::http::{Request, StatusCode};
+use diesel::prelude::*;
+use diesel_async::pooled_connection::AsyncDieselConnectionManager;
+use diesel_async::{AsyncConnection, AsyncPgConnection, RunQueryDsl, SimpleAsyncConnection};
+use futures::StreamExt as _;
+use serde_json::{Value, json};
+use testcontainers::ContainerAsync;
+use testcontainers::ImageExt;
+use testcontainers_modules::postgres::Postgres;
+use testcontainers_modules::testcontainers::runners::AsyncRunner;
+use tower::ServiceExt;
+
+/// Keeps the backing database alive for the test's duration. In testcontainers
+/// mode this owns the container; in local-Postgres mode it is a marker (the
+/// created database is left in place — the sandbox is ephemeral).
+#[allow(dead_code)]
+enum DbGuard {
+    Container(ContainerAsync<Postgres>),
+    LocalPg,
+}
+
+/// Replace the database name (final path segment) in a Postgres URL.
+fn with_db(base: &str, db: &str) -> String {
+    let (before, _after) = base.rsplit_once('/').expect("url has a database segment");
+    format!("{before}/{db}")
+}
+
+/// Provision a migrated Postgres database. Prefers `HARVEST_TEST_DATABASE_URL`
+/// (Docker-free); otherwise spins up a testcontainers Postgres 16 (CI mode).
+async fn setup_database() -> (String, DbGuard) {
+    if let Ok(admin_url) = std::env::var("HARVEST_TEST_DATABASE_URL") {
+        let db_name = format!("harvest_progress_{}", uuid::Uuid::new_v4().simple());
+        let mut admin = AsyncPgConnection::establish(&admin_url)
+            .await
+            .expect("connect admin");
+        diesel::sql_query(format!("CREATE DATABASE \"{db_name}\""))
+            .execute(&mut admin)
+            .await
+            .expect("create test database");
+        let url = with_db(&admin_url, &db_name);
+        let mut conn = AsyncPgConnection::establish(&url)
+            .await
+            .expect("connect test db");
+        conn.batch_execute(autumn_harvest::full_migrations_sql())
+            .await
+            .expect("run migrations");
+        (url, DbGuard::LocalPg)
+    } else {
+        let container = Postgres::default()
+            .with_init_sql(autumn_harvest::full_migrations_sql().as_bytes().to_vec())
+            .with_tag("16")
+            .start()
+            .await
+            .expect("postgres container should start");
+        let host = container.get_host().await.unwrap();
+        let port = container.get_host_port_ipv4(5432).await.unwrap();
+        let url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+        (url, DbGuard::Container(container))
+    }
+}
+
+fn build_pool(url: &str) -> DbPool {
+    let manager = AsyncDieselConnectionManager::<AsyncPgConnection>::new(url);
+    deadpool::managed::Pool::builder(manager)
+        .max_size(8)
+        .build()
+        .expect("pool should build")
+}
+
+/// A workflow that publishes three ordered progress chunks then completes in a
+/// single decision cycle (progress flushes on the terminal persist).
+fn progress_workflow<'a>(
+    ctx: &'a autumn_harvest::context::WorkflowContext,
+    input: Value,
+) -> Pin<Box<dyn std::future::Future<Output = Result<Value, String>> + Send + 'a>> {
+    Box::pin(async move {
+        ctx.publish_progress(json!({"step": 1, "msg": "starting"}))
+            .map_err(|e| e.to_string())?;
+        ctx.publish_progress(json!({"step": 2, "msg": "working"}))
+            .map_err(|e| e.to_string())?;
+        ctx.publish_progress(json!({"step": 3, "msg": "done"}))
+            .map_err(|e| e.to_string())?;
+        Ok(input)
+    })
+}
+
+fn test_registry() -> Arc<HandlerRegistry> {
+    Arc::new(HandlerRegistry::new(
+        vec![WorkflowInfo {
+            mcp: false,
+            name: "progress_wf",
+            module: "tests",
+            handler: progress_workflow,
+            execution_timeout: None,
+            sla: None,
+            concurrency: None,
+            debounce: None,
+            batch: None,
+            throttle: None,
+            max_input_bytes: None,
+            description: None,
+            input_schema: None,
+            output_schema: None,
+            error_schema: None,
+            retry_policy: None,
+            owner: None,
+            runbook_url: None,
+            severity: None,
+        }],
+        vec![],
+    ))
+}
+
+fn build_app(pool: &DbPool, url: &str) -> axum::Router {
+    let api_state = HarvestApiState::new();
+    api_state.install_storage_pool(HarvestDbPool::from(pool.clone()));
+    // Required so the stream handler can open a LISTEN connection for the shard.
+    api_state.set_workflow_result_notification_database_url(url.to_string());
+    // Shorten the terminal-close poll cadence so `event: end` follows the last
+    // chunk quickly (bounded by min(keepalive, PROGRESS_STREAM_KEEPALIVE)).
+    api_state.set_sse_keepalive_interval(Duration::from_millis(150));
+    api_state.install(HarvestApiRuntime::new(
+        test_registry(),
+        Arc::new(DagCatalog::default()),
+        Arc::new(Vec::new()),
+        Some("progress-stream-test".to_string()),
+        vec!["default".to_string()],
+        SchedulerMonitor::offline(),
+        HarvestRetentionRuntime::disabled(autumn_harvest::RetentionConfig::default()),
+        ShardRouter::default(),
+    ));
+    harvest_api_router(api_state).with_state(AppState::for_test().with_profile("test"))
+}
+
+fn start_params(exec_id: ExecutionId, workflow_id: &'static str) -> StartWorkflowParams<'static> {
+    StartWorkflowParams {
+        workflow_name: "progress_wf",
+        workflow_id,
+        exec_id,
+        input: json!({"ok": true}),
+        parent_id: None,
+        queue_name: "default",
+        execution_timeout: None,
+        memo: None,
+        search_attrs: None,
+        reuse_policy: autumn_harvest::WorkflowIdReusePolicy::AllowDuplicate,
+        trace_context: None,
+        max_execution_timeout_ceiling: None,
+        concurrency_key: None,
+        concurrency_limit: None,
+        priority: Priority::default(),
+        max_workflow_input_bytes: 0,
+        start_at: None,
+        delay: None,
+        max_workflow_start_delay: None,
+        owner: None,
+        runbook_url: None,
+        severity: None,
+        context_headers: None,
+        sla: None,
+        schedule_id: None,
+        scheduled_for: None,
+        workflow_attempt: 1,
+        workflow_retry_policy: None,
+        retry_of_exec_id: None,
+        max_workflow_attempts_ceiling: None,
+        origin: None,
+        completion_callbacks: None,
+        start_source: autumn_harvest::StartSource::Api,
+        start_source_ref: None,
+        started_by: None,
+    }
+}
+
+// ── SSE frame reader ──────────────────────────────────────────────────────────
+
+#[derive(Debug, Clone)]
+struct SseFrame {
+    id: Option<String>,
+    event: Option<String>,
+    data: String,
+}
+
+fn parse_frame(raw: &str) -> Option<SseFrame> {
+    let mut id = None;
+    let mut event = None;
+    let mut data_lines: Vec<String> = Vec::new();
+    let mut has_field = false;
+    for line in raw.split('\n') {
+        let line = line.trim_end_matches('\r');
+        if line.is_empty() || line.starts_with(':') {
+            continue; // blank line / keepalive comment
+        }
+        if let Some(v) = line.strip_prefix("id:") {
+            id = Some(v.trim().to_string());
+            has_field = true;
+        } else if let Some(v) = line.strip_prefix("event:") {
+            event = Some(v.trim().to_string());
+            has_field = true;
+        } else if let Some(v) = line.strip_prefix("data:") {
+            data_lines.push(v.strip_prefix(' ').unwrap_or(v).to_string());
+            has_field = true;
+        }
+    }
+    if !has_field {
+        return None;
+    }
+    Some(SseFrame {
+        id,
+        event,
+        data: data_lines.join("\n"),
+    })
+}
+
+/// Consume an SSE response body, collecting frames until a terminal (`end` /
+/// `error`) frame arrives or `deadline` elapses. Returns the frames plus the
+/// wall-clock elapsed at the first `progress` frame (time-to-first-chunk).
+async fn read_sse(
+    resp: axum::response::Response,
+    deadline: Duration,
+) -> (Vec<SseFrame>, Option<Duration>) {
+    let mut stream = resp.into_body().into_data_stream();
+    let mut buf = String::new();
+    let mut frames: Vec<SseFrame> = Vec::new();
+    let mut first_progress_at: Option<Duration> = None;
+    let start = std::time::Instant::now();
+    let sleep = tokio::time::sleep(deadline);
+    tokio::pin!(sleep);
+    loop {
+        tokio::select! {
+            () = &mut sleep => break,
+            chunk = stream.next() => match chunk {
+                Some(Ok(bytes)) => {
+                    buf.push_str(&String::from_utf8_lossy(&bytes));
+                    while let Some(idx) = buf.find("\n\n") {
+                        let raw: String = buf[..idx].to_string();
+                        buf.drain(..idx + 2);
+                        let Some(frame) = parse_frame(&raw) else { continue };
+                        if frame.event.as_deref() == Some("progress")
+                            && first_progress_at.is_none()
+                        {
+                            first_progress_at = Some(start.elapsed());
+                        }
+                        let terminal =
+                            matches!(frame.event.as_deref(), Some("end") | Some("error"));
+                        frames.push(frame);
+                        if terminal {
+                            return (frames, first_progress_at);
+                        }
+                    }
+                }
+                Some(Err(_)) | None => break,
+            }
+        }
+    }
+    (frames, first_progress_at)
+}
+
+async fn sse_response(app: &axum::Router, uri: &str) -> axum::response::Response {
+    app.clone()
+        .oneshot(
+            Request::builder()
+                .method("GET")
+                .uri(uri)
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .expect("stream request")
+}
+
+// ── Tests ─────────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn progress_stream_delivers_ordered_chunks_and_ends_on_terminal() {
+    let (url, _guard) = setup_database().await;
+    let pool = build_pool(&url);
+    let app = build_app(&pool, &url);
+    let mut conn = pool.get().await.unwrap();
+
+    // Start the workflow (task enqueued, RUNNING) BEFORE the worker runs.
+    let exec_id = ExecutionId::new_for_shard(ShardId::new(0));
+    start_or_load_workflow_execution(&mut conn, start_params(exec_id, "progress-ordered"), None)
+        .await
+        .unwrap();
+
+    // Open the subscription first so LISTEN is established before any chunk is
+    // published (progress has no backfill). `oneshot` resolves once the handler
+    // has connected the listener and returned the streaming response.
+    let resp = sse_response(&app, &format!("/workflows/{exec_id}/stream")).await;
+    assert_eq!(resp.status(), StatusCode::OK, "stream must open with 200");
+
+    // Now run the worker so the workflow publishes chunks and completes.
+    let mut runtime_config = WorkerRuntimeConfig::from(WorkerConfig::default());
+    runtime_config.worker_id = "progress-stream-worker".to_string();
+    runtime_config.queues = vec!["default".to_string()];
+    runtime_config.poll_interval = Duration::from_millis(20);
+    runtime_config.shard_assignments = vec![ShardId::new(0)];
+    let worker = Arc::new(Worker::new(runtime_config, test_registry()).unwrap());
+    let worker_handle = {
+        let worker = worker.clone();
+        let pool = pool.clone();
+        tokio::spawn(async move {
+            worker.run(&pool).await;
+        })
+    };
+
+    let (frames, first_at) = read_sse(resp, Duration::from_secs(20)).await;
+
+    worker.shutdown();
+    let _ = worker_handle.await;
+
+    let progress: Vec<&SseFrame> = frames
+        .iter()
+        .filter(|f| f.event.as_deref() == Some("progress"))
+        .collect();
+    assert_eq!(
+        progress.len(),
+        3,
+        "expected exactly 3 progress frames, got frames: {frames:#?}"
+    );
+
+    // (a) Ordered, monotonically increasing `id:` seq.
+    let seqs: Vec<u64> = progress
+        .iter()
+        .map(|f| {
+            f.id.as_deref()
+                .expect("progress frame carries an id (seq)")
+                .parse::<u64>()
+                .expect("seq is a u64")
+        })
+        .collect();
+    assert!(
+        seqs.windows(2).all(|w| w[1] > w[0]),
+        "progress seqs must be strictly increasing, got {seqs:?}"
+    );
+
+    // (b) Each frame carries the exact chunk JSON, in publish order.
+    let expected = [
+        json!({"step": 1, "msg": "starting"}),
+        json!({"step": 2, "msg": "working"}),
+        json!({"step": 3, "msg": "done"}),
+    ];
+    for (frame, want) in progress.iter().zip(expected.iter()) {
+        let got: Value = serde_json::from_str(&frame.data).expect("chunk data is JSON");
+        assert_eq!(&got, want, "chunk JSON must match the published chunk");
+    }
+
+    // (c) Stream ends with a terminal `event: end` frame.
+    assert_eq!(
+        frames.last().and_then(|f| f.event.as_deref()),
+        Some("end"),
+        "stream must close with an event:end frame on terminal state"
+    );
+
+    // (d) Time-to-first-chunk is well under a second (smoke bound).
+    let first_at = first_at.expect("a first progress frame arrived");
+    assert!(
+        first_at < Duration::from_secs(2),
+        "time-to-first-chunk must be well under a second, was {first_at:?}"
+    );
+}
+
+#[tokio::test]
+async fn progress_stream_on_already_terminal_execution_closes_immediately() {
+    let (url, _guard) = setup_database().await;
+    let pool = build_pool(&url);
+    let app = build_app(&pool, &url);
+    let mut conn = pool.get().await.unwrap();
+
+    let exec_id = ExecutionId::new_for_shard(ShardId::new(0));
+    start_or_load_workflow_execution(&mut conn, start_params(exec_id, "progress-terminal"), None)
+        .await
+        .unwrap();
+    // Seal it terminal directly (no worker) — no chunks will ever be published.
+    diesel::update(harvest_workflow_executions::table.find(exec_id.as_uuid()))
+        .set((
+            harvest_workflow_executions::state.eq("COMPLETED"),
+            harvest_workflow_executions::completed_at.eq(chrono::Utc::now()),
+        ))
+        .execute(&mut conn)
+        .await
+        .unwrap();
+
+    let resp = sse_response(&app, &format!("/workflows/{exec_id}/stream")).await;
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let (frames, first_at) = read_sse(resp, Duration::from_secs(5)).await;
+    assert!(
+        first_at.is_none(),
+        "an already-terminal execution must emit no progress frames"
+    );
+    assert_eq!(
+        frames.iter().filter(|f| f.event.is_some()).count(),
+        1,
+        "exactly one (end) frame expected, got: {frames:#?}"
+    );
+    assert_eq!(
+        frames.last().and_then(|f| f.event.as_deref()),
+        Some("end"),
+        "already-terminal execution closes immediately with event:end"
+    );
+}
+
+#[tokio::test]
+async fn progress_stream_unknown_execution_returns_404() {
+    let (url, _guard) = setup_database().await;
+    let pool = build_pool(&url);
+    let app = build_app(&pool, &url);
+
+    let unknown = ExecutionId::new_for_shard(ShardId::new(0));
+    let resp = sse_response(&app, &format!("/workflows/{unknown}/stream")).await;
+    assert_eq!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "an unknown execution id must return 404"
+    );
+}

--- a/autumn-harvest-plugin/tests/sse_stream_tests.rs
+++ b/autumn-harvest-plugin/tests/sse_stream_tests.rs
@@ -123,6 +123,103 @@ async fn sse_stream_returns_service_unavailable_when_not_configured() {
     );
 }
 
+// ── Progress stream (issue #791) ──────────────────────────────────────────────
+
+#[test]
+fn progress_stream_route_is_registered_in_management_api_routes() {
+    let routes = management_api_routes();
+    assert!(
+        routes.contains(&("GET", "/workflows/{id}/stream")),
+        "progress stream route not found in management_api_routes(); \
+         add it to the router and the canonical route list"
+    );
+}
+
+#[test]
+fn progress_stream_route_is_classified_as_read_only() {
+    use autumn_harvest::audit::{CLASSIFIED_ROUTES, RouteClass};
+    let route = "GET /workflows/{id}/stream";
+    let classification = CLASSIFIED_ROUTES
+        .iter()
+        .find(|(r, _)| *r == route)
+        .map(|(_, c)| c);
+    assert_eq!(
+        classification,
+        Some(&RouteClass::ReadOnly),
+        "progress stream route '{route}' must be classified as ReadOnly in CLASSIFIED_ROUTES"
+    );
+}
+
+/// AC5: the progress stream is deliberately NOT admin-gated — an app's
+/// end-users stream their own workflows. Prove it by contrast: with the admin
+/// boundary closed and no session, the admin-gated events stream rejects the
+/// request (401), while the same unauthenticated request to the progress stream
+/// REACHES the handler (never 401/403; here it fails config-side because no
+/// notification URL is set). This is the exact posture #791 AC5 requires.
+#[tokio::test]
+async fn progress_stream_is_not_admin_gated() {
+    use autumn_web::reexports::axum::body::Body;
+    use autumn_web::reexports::http::{Method, Request, StatusCode};
+    use tower::ServiceExt;
+
+    // Default state: admin boundary NOT open, no session, no notification URL.
+    let app = autumn_harvest_plugin::api::harvest_api_router(HarvestApiState::new())
+        .with_state(autumn_web::AppState::for_test());
+
+    let uuid = "00000000-0000-0000-0000-000000000001";
+
+    // The admin-gated events stream (#324) rejects an unauthenticated request.
+    let admin_resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri(format!("/executions/{uuid}/events/stream"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(
+        admin_resp.status(),
+        StatusCode::UNAUTHORIZED,
+        "control: the admin-gated events stream must reject an unauthenticated request"
+    );
+
+    // The progress stream reaches the handler for the SAME request (not admin-gated).
+    let resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method(Method::GET)
+                .uri(format!("/workflows/{uuid}/stream"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_ne!(
+        resp.status(),
+        StatusCode::UNAUTHORIZED,
+        "progress stream must NOT be admin-gated (issue #791 AC5)"
+    );
+    assert_ne!(
+        resp.status(),
+        StatusCode::FORBIDDEN,
+        "progress stream must NOT be admin-gated (issue #791 AC5)"
+    );
+    assert_ne!(
+        resp.status(),
+        StatusCode::NOT_FOUND,
+        "progress stream route must be registered"
+    );
+    assert_ne!(
+        resp.status(),
+        StatusCode::METHOD_NOT_ALLOWED,
+        "progress stream route registered with wrong HTTP method"
+    );
+}
+
 #[tokio::test]
 async fn sse_stream_route_exists_in_router() {
     use autumn_web::reexports::axum::body::Body;

--- a/autumn-harvest-plugin/tests/sse_stream_tests.rs
+++ b/autumn-harvest-plugin/tests/sse_stream_tests.rs
@@ -220,6 +220,34 @@ async fn progress_stream_is_not_admin_gated() {
     );
 }
 
+/// FIX (#791 review): an unconfigured / unavailable LISTEN/NOTIFY URL is a
+/// *server* misconfiguration, so the progress stream must return 503 (retriable),
+/// not the 400 a `HarvestError::Config` would otherwise map to. With no
+/// notification URL configured, the handler short-circuits to 503.
+#[tokio::test]
+async fn progress_stream_returns_service_unavailable_when_not_configured() {
+    use autumn_web::reexports::axum::body::Body;
+    use autumn_web::reexports::http::{Method, Request, StatusCode};
+    use tower::ServiceExt;
+
+    let app = autumn_harvest_plugin::api::harvest_api_router(HarvestApiState::new())
+        .with_state(autumn_web::AppState::for_test());
+
+    let req = Request::builder()
+        .method(Method::GET)
+        .uri("/workflows/00000000-0000-0000-0000-000000000001/stream")
+        .body(Body::empty())
+        .unwrap();
+
+    let res = app.oneshot(req).await.unwrap();
+    assert_eq!(
+        res.status(),
+        StatusCode::SERVICE_UNAVAILABLE,
+        "progress stream must return 503 (not 400) when the LISTEN/NOTIFY URL is \
+         not configured — it is a retriable server misconfiguration"
+    );
+}
+
 #[tokio::test]
 async fn sse_stream_route_exists_in_router() {
     use autumn_web::reexports::axum::body::Body;

--- a/autumn-harvest-sqlite/src/runtime.rs
+++ b/autumn-harvest-sqlite/src/runtime.rs
@@ -1379,9 +1379,13 @@ impl SqliteRuntime {
                 // already-scheduled activity the worker pass completes;
                 // `SetCurrentDetails` is an operator status breadcrumb (issue #593)
                 // the core actively encourages — hard-erroring it would wedge an
-                // otherwise fully in-subset workflow.
+                // otherwise fully in-subset workflow. `PublishProgress` (issue #791)
+                // is an ephemeral live-output side channel delivered over Postgres
+                // LISTEN/NOTIFY, which this single-writer backend has no equivalent
+                // for — so it is a benign NO-OP here (streaming is Postgres-only).
                 WorkflowCommand::WaitForActivity { .. }
-                | WorkflowCommand::SetCurrentDetails { .. } => {}
+                | WorkflowCommand::SetCurrentDetails { .. }
+                | WorkflowCommand::PublishProgress { .. } => {}
                 // Bookkeeping commands that carry an event MUST be persisted, even
                 // when they ride in the same batch as a suspending command: a
                 // dropped `SideEffectRecorded`/`MarkerRecorded` would make the next
@@ -1919,8 +1923,11 @@ fn persist_terminal_pending_commands(
                 apply_cancel_race_losers(conn, exec, activities, children, timers)?;
             }
             // Benign bookkeeping — appends no event, gates no control flow.
-            WorkflowCommand::WaitForActivity { .. } | WorkflowCommand::SetCurrentDetails { .. } => {
-            }
+            // `PublishProgress` (issue #791) is an ephemeral Postgres-only
+            // LISTEN/NOTIFY side channel — a benign NO-OP on this backend.
+            WorkflowCommand::WaitForActivity { .. }
+            | WorkflowCommand::SetCurrentDetails { .. }
+            | WorkflowCommand::PublishProgress { .. } => {}
             // Cancellable durable timers (issue #768) — a v0.1 non-goal — can also
             // be drained in the terminal cycle (e.g. `ctx.start_timer(...)` right
             // before `Ok(..)`). Reject by NAME with the same actionable message as
@@ -2078,6 +2085,7 @@ const fn command_name(cmd: &WorkflowCommand) -> &'static str {
         WorkflowCommand::RecordUpdateResult { .. } => "RecordUpdateResult",
         WorkflowCommand::UpsertSearchAttributes { .. } => "UpsertSearchAttributes",
         WorkflowCommand::SetCurrentDetails { .. } => "SetCurrentDetails",
+        WorkflowCommand::PublishProgress { .. } => "PublishProgress",
         WorkflowCommand::CancelRaceLosers { .. } => "CancelRaceLosers",
         WorkflowCommand::ArmTimer { .. } => "ArmTimer",
         WorkflowCommand::CancelTimer { .. } => "CancelTimer",

--- a/autumn-harvest/examples/streaming_agent.rs
+++ b/autumn-harvest/examples/streaming_agent.rs
@@ -1,0 +1,273 @@
+#![allow(clippy::all, clippy::pedantic, clippy::nursery)]
+//! Live workflow output streaming via `ctx.publish_progress` — issue #791.
+//!
+//! ## The problem
+//!
+//! You are building a durable AI agent (or a long import, or any interactive
+//! flow) on Harvest. The run executes reliably, but the end user staring at a
+//! spinner sees *nothing* until it finishes. Polling a query handler is a
+//! snapshot pull; `set_current_details` (#473/#593) is one overwriting status
+//! line; the engine-event SSE tail (#324) streams `ActivityScheduled` machinery
+//! and is admin-only. None of them push the author's *content* — the tokens,
+//! the reasoning steps, the per-item progress — to the user as it happens. The
+//! usual escape hatch is to stand up an external message bus.
+//!
+//! ## The solution: `ctx.publish_progress(chunk)`
+//!
+//! One replay-safe call. It streams an ordered, author-defined chunk to a
+//! subscriber on `GET /api/harvest/workflows/{id}/stream` over the existing
+//! Postgres LISTEN/NOTIFY plumbing — no external broker, no event-log bloat.
+//!
+//! ```rust,ignore
+//! ctx.publish_progress(serde_json::json!({
+//!     "step": i, "status": "thinking", "token": tok,
+//! }))?;
+//! ```
+//!
+//! ## Consuming the stream (the other half of AC8)
+//!
+//! An example binary can't cleanly host a live HTTP server, so here is exactly
+//! how a client subscribes with `curl`. Start your Autumn app (which mounts the
+//! Harvest management API), trigger this workflow to get an `{exec_id}`, then:
+//!
+//! ```console
+//! $ curl -N http://localhost:8080/api/harvest/workflows/{exec_id}/stream
+//! event: progress
+//! id: 16777217
+//! data: {"status":"started","prompt":"summarize the doc"}
+//!
+//! event: progress
+//! id: 16777218
+//! data: {"step":0,"status":"thinking"}
+//!
+//! event: progress
+//! id: 33554433
+//! data: {"step":0,"status":"token","token":"tok0","emitted_after_ms":3}
+//!
+//! event: end
+//! data: {"reason":"completed"}
+//! ```
+//!
+//! `event: progress` frames carry the raw chunk in `data:` and the monotonic
+//! sequence number in `id:` (use it to detect gaps after a reconnect); `event:
+//! end` closes the stream when the run reaches a terminal state; `event: error`
+//! closes it if the underlying LISTEN connection drops. The route is **not**
+//! admin-gated (AC5) — it is an end-user read path; front it with your app's own
+//! auth. See `docs/streaming-progress.md` for the full contract.
+//!
+//! ## Determinism contract (AC7)
+//!
+//! `publish_progress` is a **pure side effect**: a no-op during replay, and it
+//! writes **nothing** to `harvest_events`. A workflow that publishes N chunks
+//! has a byte-for-byte identical history to one that publishes none (asserted by
+//! `tests::agent_run_leaves_zero_event_footprint` and
+//! `tests::replay_self_check_succeeds` below). Crucially, **chunk content MAY be
+//! non-deterministic** — precisely because it is never recorded or replayed.
+//! This example deliberately publishes a wall-clock-derived field to demonstrate
+//! that (see the heavily-commented block in `streaming_agent`).
+//!
+//! Run with:
+//!   cargo run --example streaming_agent
+
+use autumn_harvest::prelude::*;
+use serde::{Deserialize, Serialize};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct AgentRequest {
+    prompt: String,
+    steps: u32,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct AgentResult {
+    answer: String,
+    tokens_emitted: u32,
+}
+
+/// An AI-agent-shaped workflow that streams a chunk at every reasoning step,
+/// interleaved with a mock "LLM call" activity. Because each `execute_activity`
+/// await suspends the workflow into a fresh decision cycle, successive
+/// `publish_progress` calls genuinely span multiple cycles — this is live,
+/// per-step streaming, not one batched flush at the end.
+///
+/// NOTE ON `allow_nondeterministic_apis`: this workflow reads the wall clock
+/// (`std::time::SystemTime::now`) to build a "how long did this token take"
+/// field. That call would normally be a hard determinism error (guardrail
+/// HVG001) — and it is suppressed here **only** to demonstrate AC7. It is safe
+/// in this exact spot because the wall-clock value flows *exclusively* into a
+/// `publish_progress` chunk, which is never recorded and never replayed, so it
+/// cannot affect the run's history or result. Do NOT copy this pattern for a
+/// value that reaches an activity input, a workflow command, or the return
+/// value — there, a fresh timestamp corrupts replay. For a deterministic clock
+/// use `ctx.now()` / `ctx.system_now()` instead.
+#[workflow(allow_nondeterministic_apis)]
+async fn streaming_agent(ctx: &WorkflowContext, req: AgentRequest) -> Result<AgentResult, String> {
+    // First chunk: the run has begun. Deterministic structural content.
+    ctx.publish_progress(serde_json::json!({
+        "status": "started",
+        "prompt": req.prompt,
+    }))
+    .map_err(|e| e.to_string())?;
+
+    let started = std::time::Instant::now();
+    let mut answer = String::new();
+
+    for step in 0..req.steps {
+        // "Thinking" chunk BEFORE the activity — the user sees the agent move to
+        // the next step immediately, before the (possibly slow) LLM call returns.
+        ctx.publish_progress(serde_json::json!({
+            "step": step,
+            "status": "thinking",
+        }))
+        .map_err(|e| e.to_string())?;
+
+        // The mock "LLM call". In a real agent this is where a token / reasoning
+        // step is generated. It runs as a durable activity, so its RESULT is
+        // recorded in history and replays deterministically.
+        let token: String = ctx
+            .execute_activity(&generate_token_info(), step)
+            .await
+            .map_err(|e| e.to_string())?;
+        answer.push_str(&token);
+
+        // Token chunk AFTER the activity. This carries `emitted_after_ms`, a
+        // wall-clock delta that is genuinely NON-DETERMINISTIC — it differs on
+        // every run and every replay. Publishing it is SAFE (AC7) precisely
+        // because a chunk never enters `harvest_events` and is never replayed:
+        // during a replay pass `publish_progress` is a no-op, so this value is
+        // computed and then discarded, and the recorded history is unaffected.
+        let emitted_after_ms = started.elapsed().as_millis() as u64;
+        ctx.publish_progress(serde_json::json!({
+            "step": step,
+            "status": "token",
+            "token": token,          // non-deterministic at generation; safe to stream
+            "emitted_after_ms": emitted_after_ms, // wall-clock; safe only in a chunk
+        }))
+        .map_err(|e| e.to_string())?;
+    }
+
+    // Final chunk: done. A subscriber can also just wait for `event: end`.
+    ctx.publish_progress(serde_json::json!({ "status": "done" }))
+        .map_err(|e| e.to_string())?;
+
+    Ok(AgentResult {
+        answer,
+        tokens_emitted: req.steps,
+    })
+}
+
+/// Mock LLM call — returns a deterministic token for a given step. In a real
+/// agent this would call an inference API; its output is recorded once and
+/// replays identically.
+#[activity(start_to_close = "30s")]
+async fn generate_token(_ctx: &ActivityContext, step: u32) -> Result<String, String> {
+    Ok(format!("tok{step}"))
+}
+
+fn main() {
+    // Registration example only — not a runnable binary without an Autumn app.
+    let _wfs = workflows![streaming_agent];
+    let _acts = activities![generate_token];
+    println!("streaming_agent example compiled successfully");
+    println!();
+    println!("Publish from workflow code with ctx.publish_progress(chunk).");
+    println!("Consume the stream from a client:");
+    println!("  curl -N http://localhost:8080/api/harvest/workflows/{{exec_id}}/stream");
+    println!("See docs/streaming-progress.md for the full contract.");
+}
+
+// Gated on the `testing` feature as well as `test`: the example itself must keep
+// building under `--no-default-features` (which CI exercises), while
+// `autumn_harvest::testing` only exists for external consumers when the
+// `testing` feature is enabled. Run with:
+//   cargo test -p autumn-harvest --features testing --example streaming_agent
+#[cfg(all(test, feature = "testing"))]
+mod tests {
+    use super::*;
+    use autumn_harvest::event::WorkflowEvent;
+    use autumn_harvest::testing::{ReplayStatus, WorkflowTestEnv};
+    use serde_json::json;
+
+    fn run_env() -> WorkflowTestEnv {
+        WorkflowTestEnv::new().mock_activity("generate_token", |input| {
+            let step = input.as_u64().unwrap_or(0);
+            Ok(json!(format!("tok{step}")))
+        })
+    }
+
+    #[tokio::test]
+    async fn agent_run_completes_and_streams_every_step() {
+        let outcome = run_env()
+            .run(
+                streaming_agent_info().handler,
+                json!({ "prompt": "summarize the doc", "steps": 3 }),
+            )
+            .await;
+
+        assert!(outcome.result.is_ok(), "run failed: {:?}", outcome.result);
+        assert_eq!(
+            outcome.result.as_ref().unwrap(),
+            &json!({ "answer": "tok0tok1tok2", "tokens_emitted": 3 })
+        );
+    }
+
+    #[tokio::test]
+    async fn agent_run_leaves_zero_event_footprint() {
+        // The falsifiable AC2 bar: publishing N chunks must add 0 bytes to
+        // `harvest_events`. The only events recorded are the three activity
+        // dispatches/completions — the many publish_progress calls (one at
+        // start, two per step, one at the end = 8 chunks) leave no trace.
+        let outcome = run_env()
+            .run(
+                streaming_agent_info().handler,
+                json!({ "prompt": "p", "steps": 3 }),
+            )
+            .await;
+        assert!(outcome.result.is_ok(), "run failed: {:?}", outcome.result);
+
+        let events = outcome.events();
+        let scheduled = events
+            .iter()
+            .filter(|e| matches!(e, WorkflowEvent::ActivityScheduled { .. }))
+            .count();
+        let completed = events
+            .iter()
+            .filter(|e| matches!(e, WorkflowEvent::ActivityCompleted { .. }))
+            .count();
+        assert_eq!(
+            scheduled, 3,
+            "expected exactly three ActivityScheduled events"
+        );
+        assert_eq!(
+            completed, 3,
+            "expected exactly three ActivityCompleted events"
+        );
+        // Nothing but activity + lifecycle events — no progress footprint.
+        for e in events {
+            assert!(
+                !format!("{e:?}").to_lowercase().contains("progress"),
+                "publish_progress must leave zero footprint in harvest_events, found: {e:?}"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn replay_self_check_succeeds() {
+        // AC2: a replay of a history whose workflow publishes chunks (including a
+        // non-deterministic wall-clock chunk) must report ReplaySucceeded — the
+        // chunks never enter history, so replay sees byte-identical events.
+        let outcome = run_env()
+            .run(
+                streaming_agent_info().handler,
+                json!({ "prompt": "p", "steps": 3 }),
+            )
+            .await;
+        assert!(outcome.result.is_ok(), "run failed: {:?}", outcome.result);
+
+        let report = outcome.replay_check(streaming_agent_info().handler).await;
+        assert!(
+            matches!(report.status, ReplayStatus::ReplaySucceeded),
+            "publish_progress must be replay-safe:\n{report}"
+        );
+    }
+}

--- a/autumn-harvest/src/audit.rs
+++ b/autumn-harvest/src/audit.rs
@@ -381,6 +381,9 @@ pub const CLASSIFIED_ROUTES: &[(&str, RouteClass)] = &[
         "GET /executions/{exec_id}/events/stream",
         RouteClass::ReadOnly,
     ),
+    // SSE ephemeral workflow progress stream (issue #791): read-only side
+    // channel over LISTEN/NOTIFY, never mutates state. NOT admin-gated (AC5).
+    ("GET /workflows/{id}/stream", RouteClass::ReadOnly),
     // ── Mutating ── modifies workflow execution or system configuration ───────
     // All of these are covered by the audit trail (harvest_audit_log) or are
     // explicitly listed in EXCLUDED_ROUTES with an audit disposition note.
@@ -750,6 +753,9 @@ pub const EXCLUDED_ROUTES: &[&str] = &[
     "GET /admin/audit",
     // SSE stream is read-only; stream open/close are audited manually in the handler.
     "GET /executions/{exec_id}/events/stream",
+    // Ephemeral progress stream (issue #791): read-only, no audit trail
+    // (disposable side channel; no open/close audit rows are written).
+    "GET /workflows/{id}/stream",
     // Build routing reads and the retire safety check never write audit rows.
     "GET /admin/build-routing",
     "GET /admin/build-routing/compat",
@@ -936,6 +942,8 @@ pub const ALL_MUTATION_ROUTES: &[(&str, Option<&str>)] = &[
     ("GET /admin/audit", None),
     // SSE execution event stream (issue #324): read-only; open/close audited in handler.
     ("GET /executions/{exec_id}/events/stream", None),
+    // Ephemeral progress stream (issue #791): read-only, not audited.
+    ("GET /workflows/{id}/stream", None),
     // Build routing management (issue #362)
     ("GET /admin/build-routing", None),
     (
@@ -1428,6 +1436,34 @@ mod tests {
         assert!(
             EXCLUDED_ROUTES.contains(&route),
             "{route} must appear in EXCLUDED_ROUTES (read-only, no audit trail; issue #690)"
+        );
+    }
+
+    #[test]
+    fn progress_stream_route_is_classified_read_only() {
+        // The ephemeral workflow progress SSE stream (issue #791) is a
+        // read-only, best-effort side channel; it never mutates state and
+        // writes no audit rows. This pinned test — not just the general
+        // exhaustiveness guards below, which only cross-check CLASSIFIED_ROUTES
+        // and ALL_MUTATION_ROUTES against each other rather than against the
+        // live router — is what actually catches the route being dropped from
+        // BOTH lists at once.
+        let route = "GET /workflows/{id}/stream";
+        assert!(
+            CLASSIFIED_ROUTES
+                .iter()
+                .any(|(r, c)| *r == route && *c == RouteClass::ReadOnly),
+            "{route} must be classified RouteClass::ReadOnly in CLASSIFIED_ROUTES (issue #791)"
+        );
+        assert!(
+            ALL_MUTATION_ROUTES
+                .iter()
+                .any(|(r, op)| *r == route && op.is_none()),
+            "{route} must appear in ALL_MUTATION_ROUTES with no audit operation (issue #791)"
+        );
+        assert!(
+            EXCLUDED_ROUTES.contains(&route),
+            "{route} must appear in EXCLUDED_ROUTES (read-only, no audit trail; issue #791)"
         );
     }
 

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -61,6 +61,62 @@ pub const DEFAULT_CONTINUE_AS_NEW_DEADLINE_FRACTION: f64 = 0.8;
 /// Values longer than this cap are truncated to this length on the byte boundary.
 pub const DEFAULT_CURRENT_DETAILS_CAP_BYTES: usize = 1024;
 
+/// Maximum serialized byte length of a single [`publish_progress`] chunk
+/// (issue #791).
+///
+/// Postgres `NOTIFY` has a hard **8000-byte** payload limit. Progress chunks are
+/// wrapped in a `{"seq":..,"chunk":..}` envelope
+/// ([`ProgressNotifyPayload`](crate::notify::ProgressNotifyPayload)) that adds a
+/// small, bounded prefix (`{"seq":<=20 digits,"chunk":}` ≈ 40 bytes), so chunk
+/// content is capped **below** 8000 to leave headroom for the envelope. A chunk
+/// whose serialized JSON exceeds this cap is **replaced** with a truncation
+/// marker (`{"_harvest_progress_truncated": true, "bytes": <original_len>}`)
+/// rather than dropped, so the ordered `seq` slot survives and the SSE client
+/// learns content was cut.
+///
+/// [`publish_progress`]: WorkflowContext::publish_progress
+pub const PROGRESS_CHUNK_MAX_BYTES: usize = 7000;
+
+/// Bits reserved for the per-cycle local index in a progress `seq` (issue #791).
+///
+/// A progress `seq` is `(epoch << PROGRESS_SEQ_LOCAL_BITS) | local_index`, where
+/// `epoch` is the loaded-history length at the current decision cycle's start
+/// (it strictly grows across cycles, so seq is monotonic over the whole
+/// execution lifetime) and `local_index` is a per-cycle 0-based counter. The
+/// low 24 bits hold up to ~16.7M chunks per cycle before `local_index`
+/// saturates.
+const PROGRESS_SEQ_LOCAL_BITS: u32 = 24;
+
+/// Mask isolating the per-cycle local-index bits of a progress `seq` (issue #791).
+const PROGRESS_SEQ_LOCAL_MASK: u64 = (1u64 << PROGRESS_SEQ_LOCAL_BITS) - 1;
+
+/// Stride between successive epochs in a progress `seq` (`= 1 << PROGRESS_SEQ_LOCAL_BITS`).
+const PROGRESS_SEQ_LOCAL_STRIDE: u64 = 1u64 << PROGRESS_SEQ_LOCAL_BITS;
+
+/// Encode a monotonic, epoch-prefixed progress `seq` (issue #791).
+///
+/// `epoch` (the loaded-history length at the cycle's start) is placed in the high
+/// bits and `local_index` (per-cycle 0-based) in the low
+/// [`PROGRESS_SEQ_LOCAL_BITS`] bits. Because `epoch` strictly grows across
+/// decision cycles (a cycle that publishes always appends ≥1 event before the
+/// next cycle loads), the resulting `seq` is **strictly increasing over the whole
+/// execution lifetime** — a reconnecting SSE client can detect gaps. It is also
+/// **deterministic on a crash-retry of the same cycle** (same `epoch`, same
+/// publish order ⇒ same seq), giving idempotent seqs on best-effort redelivery.
+///
+/// `local_index` is clamped to [`PROGRESS_SEQ_LOCAL_MASK`] so it can never spill
+/// into the epoch bits, and the epoch shift is saturating so an astronomically
+/// long history cannot overflow `u64`.
+#[must_use]
+const fn encode_progress_seq(epoch: u64, local_index: u64) -> u64 {
+    let clamped_local = if local_index > PROGRESS_SEQ_LOCAL_MASK {
+        PROGRESS_SEQ_LOCAL_MASK
+    } else {
+        local_index
+    };
+    epoch.saturating_mul(PROGRESS_SEQ_LOCAL_STRIDE) | clamped_local
+}
+
 /// Replay-safe history guardrails made available to workflow code.
 ///
 /// `PartialEq` (but not `Eq`) because
@@ -424,6 +480,25 @@ pub enum WorkflowCommand {
         /// string -- the only condition that should clear the column.
         explicit_clear: bool,
     },
+    /// Publish an ephemeral, ordered progress chunk (issue #791).
+    ///
+    /// Emitted by [`WorkflowContext::publish_progress`] during live execution
+    /// (suppressed during replay). Pure **bookkeeping**: it carries no result
+    /// channel, never drives a suspension shape, and — unlike every other
+    /// command — appends **nothing** to `harvest_events`. The worker fires a
+    /// best-effort `pg_notify` per chunk on the per-execution progress channel
+    /// so any live SSE subscriber receives it; chunks are never recorded and
+    /// never replayed (their content MAY be non-deterministic).
+    PublishProgress {
+        /// Monotonic, epoch-prefixed sequence number (see
+        /// [`encode_progress_seq`]). Strictly increasing over the execution's
+        /// lifetime so a reconnecting subscriber can detect gaps.
+        seq: u64,
+        /// The chunk payload (already serialized to JSON and size-capped; an
+        /// oversize chunk is a `{"_harvest_progress_truncated": true, ..}`
+        /// marker).
+        chunk: Value,
+    },
     /// Spawn a child workflow in detached mode and return its `ExecutionId`
     /// immediately without suspending the parent.
     ///
@@ -667,6 +742,11 @@ impl std::fmt::Debug for WorkflowCommand {
                 .debug_struct("SetCurrentDetails")
                 .field("value", value)
                 .field("explicit_clear", explicit_clear)
+                .finish(),
+            Self::PublishProgress { seq, chunk } => f
+                .debug_struct("PublishProgress")
+                .field("seq", seq)
+                .field("chunk", chunk)
                 .finish(),
             Self::RecordUpdateResult { update_id, result } => f
                 .debug_struct("RecordUpdateResult")
@@ -1713,6 +1793,14 @@ pub struct WorkflowContext {
     /// so each session has a stable, unique `session:{seq}` marker name across
     /// replays, mirroring `fan_out_seq`/`race_seq`.
     session_seq: Mutex<u32>,
+    /// Per-cycle 0-based local index for progress `seq` generation (issue #791).
+    /// Incremented once per live [`publish_progress`](Self::publish_progress)
+    /// call; combined with the loaded-history-length epoch by
+    /// [`encode_progress_seq`] into a lifetime-monotonic `seq`. A fresh context
+    /// is constructed per decision cycle, so this resets to 0 each cycle — the
+    /// epoch (in the high bits) is what carries monotonicity across cycles.
+    /// Not part of replay state: `publish_progress` is a no-op during replay.
+    progress_local_index: std::sync::atomic::AtomicU64,
     /// Monotonically increasing counter for naming saga compensation dedup
     /// markers (issue #801). Each non-empty `Saga` unwind increments this
     /// once so each compensation sequence has stable, unique
@@ -2182,6 +2270,7 @@ impl WorkflowContext {
             child_timeout_seq: Mutex::new(0),
             race_seq: Mutex::new(0),
             session_seq: Mutex::new(0),
+            progress_local_index: std::sync::atomic::AtomicU64::new(0),
             saga_seq: Mutex::new(0),
             cancellable_timer_state: Mutex::new(std::collections::HashMap::new()),
             classic_timer_ids: Mutex::new(std::collections::HashSet::new()),
@@ -2326,6 +2415,7 @@ impl WorkflowContext {
             child_timeout_seq: Mutex::new(0),
             race_seq: Mutex::new(0),
             session_seq: Mutex::new(0),
+            progress_local_index: std::sync::atomic::AtomicU64::new(0),
             saga_seq: Mutex::new(0),
             cancellable_timer_state: Mutex::new(std::collections::HashMap::new()),
             classic_timer_ids: Mutex::new(std::collections::HashSet::new()),
@@ -2385,6 +2475,7 @@ impl WorkflowContext {
             child_timeout_seq: Mutex::new(0),
             race_seq: Mutex::new(0),
             session_seq: Mutex::new(0),
+            progress_local_index: std::sync::atomic::AtomicU64::new(0),
             saga_seq: Mutex::new(0),
             cancellable_timer_state: Mutex::new(std::collections::HashMap::new()),
             classic_timer_ids: Mutex::new(std::collections::HashSet::new()),
@@ -9671,6 +9762,83 @@ impl WorkflowContext {
             value: capped,
             explicit_clear,
         });
+    }
+
+    /// Publish an ordered, **ephemeral** progress chunk to any live SSE
+    /// subscriber (issue #791).
+    ///
+    /// This is a purpose-built live-output side channel for long-running or
+    /// streaming workflows (AI agents, large imports): it pushes ordered chunks
+    /// that the worker delivers over Postgres `LISTEN`/`NOTIFY` to a connected
+    /// `GET /workflows/{id}/stream` subscriber.
+    ///
+    /// # Semantics
+    ///
+    /// - **Best-effort**: a chunk is dropped when no subscriber is connected.
+    ///   There is no durable buffer, no delivery guarantee, and no back-pressure
+    ///   on the workflow.
+    /// - **Replay-neutral**: this is a **no-op during replay** and appends
+    ///   **nothing** to `harvest_events`. There is no new `WorkflowEvent`
+    ///   variant and no migration — a workflow that publishes progress produces
+    ///   byte-for-byte the same event history as one that does not.
+    /// - **Content MAY be non-deterministic**: precisely because chunks are
+    ///   never recorded or replayed, the payload can reflect live wall-clock
+    ///   state, partial output, token streams, etc. (This is the one place a
+    ///   workflow may emit non-deterministic data safely.)
+    /// - **Ordered `seq`**: each published chunk carries a monotonic, epoch-
+    ///   prefixed sequence number that strictly increases over the execution's
+    ///   whole lifetime, so a reconnecting subscriber can detect gaps.
+    /// - **Size-capped**: a chunk whose serialized JSON exceeds
+    ///   [`PROGRESS_CHUNK_MAX_BYTES`] (Postgres `NOTIFY` payload headroom) is
+    ///   **replaced** with a truncation marker
+    ///   (`{"_harvest_progress_truncated": true, "bytes": <original_len>}`)
+    ///   rather than dropped, so the ordered slot and the "content cut" signal
+    ///   survive.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HarvestError::Serialization`] if `chunk` cannot be serialized
+    /// to JSON. This is the only fallible part of the call; on replay it always
+    /// returns `Ok(())` without touching `chunk`.
+    pub fn publish_progress(&self, chunk: impl serde::Serialize) -> HarvestResult<()> {
+        // Replay-neutrality gate: a progress chunk is never recorded and never
+        // replayed, so on replay we push no command and consume no seq slot.
+        // This mirrors `set_current_details` (issue #593) and query handlers
+        // (#234): a zero-footprint, replay-suppressed side channel.
+        if self.is_replaying() {
+            return Ok(());
+        }
+        // Serialize the caller's chunk (the only fallible step).
+        let mut value = serde_json::to_value(&chunk).map_err(HarvestError::Serialization)?;
+        // Cap the serialized size below the Postgres NOTIFY payload limit.
+        // Oversize chunks are REPLACED with a truncation marker (never silently
+        // dropped) so the ordered seq slot survives and the SSE client learns
+        // content was cut.
+        let serialized_len = serde_json::to_vec(&value).map_or(usize::MAX, |v| v.len());
+        if serialized_len > PROGRESS_CHUNK_MAX_BYTES {
+            value = serde_json::json!({
+                "_harvest_progress_truncated": true,
+                "bytes": serialized_len,
+            });
+        }
+        // Epoch = the loaded-history length at this cycle's start. It is a pure
+        // function of the recorded history (the matcher's events vec is
+        // immutable within a cycle), constant across every `publish_progress`
+        // call in the cycle, and strictly grows across cycles (a cycle that
+        // publishes always appends >=1 event before the next cycle loads). We
+        // lock the matcher directly — NOT via `match_history` — so this read
+        // never triggers the `pump_signal_handlers` post-hook (mirroring
+        // `info()`).
+        let epoch = {
+            let matcher = self.matcher.lock().expect("matcher lock poisoned");
+            matcher.event_count()
+        };
+        let local_index = self
+            .progress_local_index
+            .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+        let seq = encode_progress_seq(epoch, local_index);
+        self.push_command(WorkflowCommand::PublishProgress { seq, chunk: value });
+        Ok(())
     }
 
     /// Drain all accumulated commands. Called by the worker after the
@@ -18049,7 +18217,10 @@ mod tests {
         assert_eq!(cmds.len(), 1, "exactly one PublishProgress command");
         match &cmds[0] {
             WorkflowCommand::PublishProgress { seq, chunk } => {
-                assert_eq!(*seq, 0, "first live chunk in a fresh cycle has local index 0");
+                assert_eq!(
+                    *seq, 0,
+                    "first live chunk in a fresh cycle has local index 0"
+                );
                 assert_eq!(chunk, &serde_json::json!({"phase": "loading", "pct": 10}));
             }
             other => panic!("expected PublishProgress, got {other:?}"),
@@ -18060,7 +18231,8 @@ mod tests {
     fn publish_progress_local_index_increases_within_cycle() {
         let ctx = WorkflowContext::new_test();
         ctx.publish_progress(serde_json::json!("a")).expect("first");
-        ctx.publish_progress(serde_json::json!("b")).expect("second");
+        ctx.publish_progress(serde_json::json!("b"))
+            .expect("second");
         let cmds = ctx.drain_commands();
         assert_eq!(cmds.len(), 2, "two PublishProgress commands");
         let seq0 = match &cmds[0] {
@@ -18095,7 +18267,10 @@ mod tests {
                     "an oversize chunk must be REPLACED with a truncation marker, not dropped"
                 );
                 assert!(
-                    chunk.get("bytes").and_then(serde_json::Value::as_u64).unwrap_or(0)
+                    chunk
+                        .get("bytes")
+                        .and_then(serde_json::Value::as_u64)
+                        .unwrap_or(0)
                         > PROGRESS_CHUNK_MAX_BYTES as u64,
                     "the truncation marker must report the original byte length"
                 );

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -97,12 +97,15 @@ const PROGRESS_SEQ_LOCAL_STRIDE: u64 = 1u64 << PROGRESS_SEQ_LOCAL_BITS;
 ///
 /// `epoch` (the loaded-history length at the cycle's start) is placed in the high
 /// bits and `local_index` (per-cycle 0-based) in the low
-/// [`PROGRESS_SEQ_LOCAL_BITS`] bits. Because `epoch` strictly grows across
-/// decision cycles (a cycle that publishes always appends ≥1 event before the
-/// next cycle loads), the resulting `seq` is **strictly increasing over the whole
-/// execution lifetime** — a reconnecting SSE client can detect gaps. It is also
-/// **deterministic on a crash-retry of the same cycle** (same `epoch`, same
-/// publish order ⇒ same seq), giving idempotent seqs on best-effort redelivery.
+/// [`PROGRESS_SEQ_LOCAL_BITS`] bits. `seq` is a **logical-position identity**:
+/// for a chunk to fire LIVE in a later cycle the workflow must reach a live
+/// position PAST the previous frontier, which requires the loaded history
+/// (`epoch`) to have grown — so a later live cycle's `seq` strictly exceeds every
+/// earlier one, and a reconnecting SSE client detects gaps via forward jumps. A
+/// same-position re-drive (spurious wake / rolled-back retry) re-loads the same
+/// history and re-runs the same publish order, so it is **deterministic on a
+/// crash-retry of the same cycle** (same `epoch`, same order ⇒ same seq), giving
+/// idempotent, dedupe-by-seq redelivery.
 ///
 /// `local_index` is clamped to [`PROGRESS_SEQ_LOCAL_MASK`] so it can never spill
 /// into the epoch bits, and the epoch shift is saturating so an astronomically
@@ -9786,8 +9789,16 @@ impl WorkflowContext {
     ///   state, partial output, token streams, etc. (This is the one place a
     ///   workflow may emit non-deterministic data safely.)
     /// - **Ordered `seq`**: each published chunk carries a monotonic, epoch-
-    ///   prefixed sequence number that strictly increases over the execution's
-    ///   whole lifetime, so a reconnecting subscriber can detect gaps.
+    ///   prefixed sequence number. `seq` is a **logical-position identity**, not
+    ///   a per-chunk counter: it strictly increases as the workflow advances
+    ///   over its lifetime, and a re-driven position (spurious wake / rolled-back
+    ///   retry) deterministically re-emits the **same** `seq`. A subscriber
+    ///   should therefore **dedupe by `seq` (keep-first)** for at-most-once-per-
+    ///   position display and use forward `seq` **jumps** to detect gaps after a
+    ///   reconnect. A re-emitted chunk MAY carry different content for a
+    ///   non-deterministic chunk — the first-delivered is canonical. `seq` is
+    ///   per `exec_id`; a continue-as-new successor is a new `exec_id` on a new
+    ///   stream whose `seq` restarts.
     /// - **Size-capped**: a chunk whose serialized JSON exceeds
     ///   [`PROGRESS_CHUNK_MAX_BYTES`] (Postgres `NOTIFY` payload headroom) is
     ///   **replaced** with a truncation marker
@@ -9799,15 +9810,39 @@ impl WorkflowContext {
     ///
     /// Returns [`HarvestError::Serialization`] if `chunk` cannot be serialized
     /// to JSON. This is the only fallible part of the call; on replay it always
-    /// returns `Ok(())` without touching `chunk`.
+    /// returns `Ok(())` without touching `chunk`. Serialization failure is
+    /// effectively unreachable for a well-formed chunk, so fire-and-forget usage
+    /// (`let _ = ctx.publish_progress(..);`) is fine.
+    ///
+    /// # Panics
+    ///
+    /// Panics if the internal matcher mutex is poisoned (mirroring
+    /// [`is_replaying`](Self::is_replaying)).
     pub fn publish_progress(&self, chunk: impl serde::Serialize) -> HarvestResult<()> {
-        // Replay-neutrality gate: a progress chunk is never recorded and never
-        // replayed, so on replay we push no command and consume no seq slot.
-        // This mirrors `set_current_details` (issue #593) and query handlers
-        // (#234): a zero-footprint, replay-suppressed side channel.
-        if self.is_replaying() {
-            return Ok(());
-        }
+        // Single matcher lock: read the replay flag AND the epoch together. We
+        // lock the matcher directly — NOT via `match_history`/`is_replaying()` —
+        // so this read never triggers the `pump_signal_handlers` post-hook
+        // (mirroring `info()`).
+        //
+        // - Replay-neutrality gate: a progress chunk is never recorded and never
+        //   replayed, so on replay we push no command and consume no seq slot
+        //   (mirrors `set_current_details` #593 and query handlers #234). We
+        //   return BEFORE any serialization or command push.
+        // - Epoch = the loaded-history length at this cycle's start: a pure
+        //   function of the recorded history (the matcher's events vec is
+        //   immutable within a cycle), constant across every `publish_progress`
+        //   call in the cycle. Monotonicity across cycles holds because for a
+        //   chunk to fire LIVE in a later cycle the workflow must reach a live
+        //   position PAST the previous frontier, which requires the loaded
+        //   history (epoch) to have grown; a same-position re-drive (spurious
+        //   wake / rolled-back retry) re-emits the SAME seq deterministically.
+        let epoch = {
+            let matcher = self.matcher.lock().expect("matcher lock poisoned");
+            if matcher.is_replaying() {
+                return Ok(());
+            }
+            matcher.event_count()
+        };
         // Serialize the caller's chunk (the only fallible step).
         let mut value = serde_json::to_value(&chunk).map_err(HarvestError::Serialization)?;
         // Cap the serialized size below the Postgres NOTIFY payload limit.
@@ -9821,18 +9856,6 @@ impl WorkflowContext {
                 "bytes": serialized_len,
             });
         }
-        // Epoch = the loaded-history length at this cycle's start. It is a pure
-        // function of the recorded history (the matcher's events vec is
-        // immutable within a cycle), constant across every `publish_progress`
-        // call in the cycle, and strictly grows across cycles (a cycle that
-        // publishes always appends >=1 event before the next cycle loads). We
-        // lock the matcher directly — NOT via `match_history` — so this read
-        // never triggers the `pump_signal_handlers` post-hook (mirroring
-        // `info()`).
-        let epoch = {
-            let matcher = self.matcher.lock().expect("matcher lock poisoned");
-            matcher.event_count()
-        };
         let local_index = self
             .progress_local_index
             .fetch_add(1, std::sync::atomic::Ordering::Relaxed);
@@ -18281,10 +18304,14 @@ mod tests {
 
     #[test]
     fn encode_progress_seq_is_monotonic_across_epochs() {
-        // Epoch = loaded-history length at cycle start; it strictly grows across
-        // decision cycles (a cycle that makes progress appends >=1 event), so a
-        // higher-epoch seq must exceed EVERY lower-epoch seq regardless of the
-        // per-cycle local index — proving execution-lifetime monotonicity (AC6).
+        // Epoch = loaded-history length at cycle start. For a chunk to fire LIVE
+        // in a later cycle the workflow must reach a live position past the prior
+        // frontier, which requires the loaded history (epoch) to have grown — so
+        // a higher-epoch seq must exceed EVERY lower-epoch seq regardless of the
+        // per-cycle local index, proving execution-lifetime monotonicity (AC6).
+        // (That epoch actually grows across REAL cycles is proven end-to-end by
+        // `progress_stream_seq_strictly_increases_across_decision_cycles` in the
+        // plugin's progress_stream_integration.rs.)
         let cycle_n_last = encode_progress_seq(4, PROGRESS_SEQ_LOCAL_MASK);
         let cycle_n_plus_1_first = encode_progress_seq(5, 0);
         assert!(

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -18011,6 +18011,118 @@ mod tests {
         );
     }
 
+    // ── publish_progress (issue #791) ────────────────────────────────────
+
+    #[test]
+    fn publish_progress_suppressed_during_replay() {
+        let events = vec![
+            WorkflowEvent::WorkflowStarted {
+                input: Value::Null,
+                timestamp: Utc::now(),
+                last_completion_result: None,
+                last_error: None,
+                scheduled_time: None,
+            },
+            WorkflowEvent::MarkerRecorded {
+                name: "some-marker".into(),
+                details: Value::Null,
+            },
+        ];
+        let ctx = WorkflowContext::for_replay(ExecutionId::new(), events);
+        assert!(ctx.is_replaying(), "context must be in replay mode");
+        let outcome = ctx.publish_progress(serde_json::json!({"pct": 42}));
+        assert!(outcome.is_ok(), "publish_progress must not error on replay");
+        // On replay, publish_progress is a no-op: zero commands, no seq consumed.
+        let cmds = ctx.drain_commands();
+        assert!(
+            cmds.is_empty(),
+            "publish_progress must be suppressed during replay: no commands emitted"
+        );
+    }
+
+    #[test]
+    fn publish_progress_emits_bookkeeping_command_when_live() {
+        let ctx = WorkflowContext::new_test();
+        ctx.publish_progress(serde_json::json!({"phase": "loading", "pct": 10}))
+            .expect("publish_progress must succeed live");
+        let cmds = ctx.drain_commands();
+        assert_eq!(cmds.len(), 1, "exactly one PublishProgress command");
+        match &cmds[0] {
+            WorkflowCommand::PublishProgress { seq, chunk } => {
+                assert_eq!(*seq, 0, "first live chunk in a fresh cycle has local index 0");
+                assert_eq!(chunk, &serde_json::json!({"phase": "loading", "pct": 10}));
+            }
+            other => panic!("expected PublishProgress, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn publish_progress_local_index_increases_within_cycle() {
+        let ctx = WorkflowContext::new_test();
+        ctx.publish_progress(serde_json::json!("a")).expect("first");
+        ctx.publish_progress(serde_json::json!("b")).expect("second");
+        let cmds = ctx.drain_commands();
+        assert_eq!(cmds.len(), 2, "two PublishProgress commands");
+        let seq0 = match &cmds[0] {
+            WorkflowCommand::PublishProgress { seq, .. } => *seq,
+            other => panic!("expected PublishProgress, got {other:?}"),
+        };
+        let seq1 = match &cmds[1] {
+            WorkflowCommand::PublishProgress { seq, .. } => *seq,
+            other => panic!("expected PublishProgress, got {other:?}"),
+        };
+        assert!(
+            seq1 > seq0,
+            "seq must strictly increase within a cycle: {seq1} !> {seq0}"
+        );
+    }
+
+    #[test]
+    fn publish_progress_oversize_chunk_becomes_truncation_marker() {
+        let ctx = WorkflowContext::new_test();
+        // A string whose serialized JSON form far exceeds the chunk cap.
+        let huge = "x".repeat(PROGRESS_CHUNK_MAX_BYTES + 500);
+        ctx.publish_progress(serde_json::Value::String(huge))
+            .expect("oversize publish must still succeed");
+        let cmds = ctx.drain_commands();
+        assert_eq!(cmds.len(), 1, "one command even for an oversize chunk");
+        match &cmds[0] {
+            WorkflowCommand::PublishProgress { seq, chunk } => {
+                assert_eq!(*seq, 0, "the ordered seq slot must be preserved");
+                assert_eq!(
+                    chunk.get("_harvest_progress_truncated"),
+                    Some(&serde_json::Value::Bool(true)),
+                    "an oversize chunk must be REPLACED with a truncation marker, not dropped"
+                );
+                assert!(
+                    chunk.get("bytes").and_then(serde_json::Value::as_u64).unwrap_or(0)
+                        > PROGRESS_CHUNK_MAX_BYTES as u64,
+                    "the truncation marker must report the original byte length"
+                );
+            }
+            other => panic!("expected PublishProgress, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn encode_progress_seq_is_monotonic_across_epochs() {
+        // Epoch = loaded-history length at cycle start; it strictly grows across
+        // decision cycles (a cycle that makes progress appends >=1 event), so a
+        // higher-epoch seq must exceed EVERY lower-epoch seq regardless of the
+        // per-cycle local index — proving execution-lifetime monotonicity (AC6).
+        let cycle_n_last = encode_progress_seq(4, PROGRESS_SEQ_LOCAL_MASK);
+        let cycle_n_plus_1_first = encode_progress_seq(5, 0);
+        assert!(
+            cycle_n_plus_1_first > cycle_n_last,
+            "a later cycle's first seq ({cycle_n_plus_1_first}) must exceed the \
+             prior cycle's last seq ({cycle_n_last})"
+        );
+        // Within a cycle (fixed epoch) local index strictly increases seq.
+        assert!(encode_progress_seq(5, 1) > encode_progress_seq(5, 0));
+        // Deterministic on a crash-retry of the same cycle: same inputs → same seq.
+        assert_eq!(encode_progress_seq(7, 3), encode_progress_seq(7, 3));
+    }
+
     #[test]
     fn set_current_details_empty_string_pushes_empty_command() {
         // The context's job is only to forward the raw value (capped, replay-

--- a/autumn-harvest/src/executor.rs
+++ b/autumn-harvest/src/executor.rs
@@ -235,6 +235,10 @@ pub enum QueryReplayOutcome {
 /// - [`UpsertSearchAttributes`](WorkflowCommand::UpsertSearchAttributes) and
 ///   [`SetCurrentDetails`](WorkflowCommand::SetCurrentDetails): operator-facing
 ///   metadata, never part of the deterministic command stream.
+/// - [`PublishProgress`](WorkflowCommand::PublishProgress): an ephemeral,
+///   best-effort live-output side channel (issue #791) that appends nothing to
+///   `harvest_events` and is suppressed during replay — replay-neutral by
+///   construction.
 /// - [`CancelRaceLosers`](WorkflowCommand::CancelRaceLosers): for the
 ///   timer+signal race shape (issue #600) this is a pure, deterministic function
 ///   of already-resolved history (the winner is fixed by recorded order), so it
@@ -258,6 +262,7 @@ pub(crate) const fn is_replay_significant_command(cmd: &WorkflowCommand) -> bool
         cmd,
         WorkflowCommand::UpsertSearchAttributes { .. }
             | WorkflowCommand::SetCurrentDetails { .. }
+            | WorkflowCommand::PublishProgress { .. }
             | WorkflowCommand::CancelRaceLosers { .. }
     )
 }

--- a/autumn-harvest/src/notify.rs
+++ b/autumn-harvest/src/notify.rs
@@ -44,6 +44,34 @@ pub const fn workflow_events_channel() -> &'static str {
     "harvest_events"
 }
 
+/// Postgres NOTIFY channel used for a single execution's ephemeral progress
+/// stream (issue #791).
+///
+/// The convention is `harvest_progress_{exec_hex}` where `exec_hex` is the
+/// execution UUID as 32 lowercase hex digits (no hyphens — Postgres identifiers
+/// cannot contain them). The result is `17 + 32 = 49` characters, comfortably
+/// within Postgres' 63-byte identifier limit.
+///
+/// Unlike [`workflow_events_channel`] (a single global channel fired on real
+/// event appends), progress is per-execution so a subscriber LISTENs only to
+/// the one run it is streaming and is never woken by unrelated workflows.
+///
+/// # Examples
+///
+/// ```
+/// # use autumn_harvest::notify::workflow_progress_channel;
+/// # use uuid::Uuid;
+/// let id = Uuid::parse_str("0191c1a2-3b4c-7d5e-8f60-112233445566").unwrap();
+/// assert_eq!(
+///     workflow_progress_channel(id),
+///     "harvest_progress_0191c1a23b4c7d5e8f60112233445566"
+/// );
+/// ```
+#[must_use]
+pub fn workflow_progress_channel(exec_id: Uuid) -> String {
+    format!("harvest_progress_{}", exec_id.simple())
+}
+
 #[must_use]
 fn quote_pg_identifier(identifier: &str) -> String {
     format!("\"{}\"", identifier.replace('"', "\"\""))
@@ -71,6 +99,24 @@ pub struct WorkflowEventNotifyPayload {
     pub last_event_type: String,
 }
 
+/// Payload sent on [`workflow_progress_channel`] for each published progress
+/// chunk (issue #791).
+///
+/// This is the wire envelope carried in the Postgres `NOTIFY` payload. The
+/// whole envelope must fit within Postgres' 8000-byte `NOTIFY` limit; the
+/// `chunk` is size-capped by the context (see
+/// [`PROGRESS_CHUNK_MAX_BYTES`](crate::context::PROGRESS_CHUNK_MAX_BYTES)) to
+/// leave headroom for the envelope.
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+pub struct ProgressNotifyPayload {
+    /// Monotonic, epoch-prefixed sequence number (strictly increasing over the
+    /// execution's lifetime, so a reconnecting subscriber can detect gaps).
+    pub seq: u64,
+    /// The published chunk (JSON; possibly a truncation marker if the original
+    /// exceeded the size cap).
+    pub chunk: serde_json::Value,
+}
+
 /// Outcome of waiting on a queue listener.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum QueueWaitOutcome {
@@ -90,6 +136,17 @@ pub enum WorkflowEventWaitOutcome {
     /// No notification arrived before the caller's timeout elapsed.
     TimedOut,
     /// The LISTEN connection closed.
+    ChannelClosed,
+}
+
+/// Outcome of waiting on a [`WorkflowProgressListener`] (issue #791).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum ProgressWaitOutcome {
+    /// A progress chunk arrived before the timeout elapsed.
+    Chunk(ProgressNotifyPayload),
+    /// No chunk arrived before the caller's timeout elapsed (send a keepalive).
+    TimedOut,
+    /// The LISTEN connection closed (the SSE stream should end with an error).
     ChannelClosed,
 }
 
@@ -177,6 +234,42 @@ pub async fn notify_workflow_events_appended(
 
     diesel::sql_query("SELECT pg_notify($1, $2)")
         .bind::<Text, _>(workflow_events_channel())
+        .bind::<Text, _>(&payload)
+        .execute(conn)
+        .await
+        .map_err(crate::error::database_error)?;
+
+    Ok(())
+}
+
+/// Fire a `NOTIFY` carrying one ephemeral progress chunk on the per-execution
+/// progress channel (issue #791).
+///
+/// Delivered on commit when called inside a transaction — so a rolled-back
+/// workflow-decision cycle's progress is discarded (never delivered) and the
+/// retried cycle re-fires live, and a committed chunk is delivered exactly once
+/// per commit. Best-effort by contract: callers should treat a failure as
+/// non-fatal (the chunk is disposable).
+///
+/// # Errors
+///
+/// Returns [`HarvestError::Database`] if payload serialization or `pg_notify`
+/// fails.
+pub async fn notify_workflow_progress(
+    conn: &mut AsyncPgConnection,
+    workflow_exec_id: Uuid,
+    seq: u64,
+    chunk: &serde_json::Value,
+) -> HarvestResult<()> {
+    let channel = workflow_progress_channel(workflow_exec_id);
+    let payload = serde_json::to_string(&ProgressNotifyPayload {
+        seq,
+        chunk: chunk.clone(),
+    })
+    .map_err(|e| HarvestError::Database(format!("failed to serialize progress payload: {e}")))?;
+
+    diesel::sql_query("SELECT pg_notify($1, $2)")
+        .bind::<Text, _>(&channel)
         .bind::<Text, _>(&payload)
         .execute(conn)
         .await
@@ -410,6 +503,106 @@ impl WorkflowEventListener {
     }
 }
 
+/// Async listener for a single execution's ephemeral progress stream (issue
+/// #791).
+///
+/// Subscribes to the per-execution [`workflow_progress_channel`] and yields each
+/// [`ProgressNotifyPayload`] the worker fires via [`notify_workflow_progress`].
+/// Intended for the `GET /workflows/{id}/stream` SSE route: connect once per
+/// streamed run, then poll [`wait_for_progress_timeout`](Self::wait_for_progress_timeout)
+/// so the route can interleave keepalive ticks and terminal-state checks.
+pub struct WorkflowProgressListener {
+    /// Client handle kept alive so the LISTEN connection stays open.
+    _client: tokio_postgres::Client,
+    /// Receiver for notifications forwarded by the connection driver task.
+    rx: tokio::sync::mpsc::Receiver<tokio_postgres::Notification>,
+    /// Background connection driver handle kept alive for the connection's lifetime.
+    _connection_handle: tokio::task::JoinHandle<()>,
+}
+
+impl WorkflowProgressListener {
+    /// Connect to Postgres and subscribe to `exec_id`'s progress channel.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HarvestError::Database`] if the connection or LISTEN fails.
+    pub async fn connect(database_url: &str, exec_id: Uuid) -> HarvestResult<Self> {
+        let (client, mut connection) = tokio_postgres::connect(database_url, tokio_postgres::NoTls)
+            .await
+            .map_err(|e| HarvestError::Database(format!("pg connect failed: {e}")))?;
+
+        let (tx, rx) = tokio::sync::mpsc::channel(128);
+        let handle = tokio::spawn(async move {
+            use futures::future::poll_fn;
+
+            loop {
+                let msg = poll_fn(|cx| connection.poll_message(cx)).await;
+                match msg {
+                    Some(Ok(tokio_postgres::AsyncMessage::Notification(n))) => {
+                        if tx.send(n).await.is_err() {
+                            break;
+                        }
+                    }
+                    Some(Ok(_)) => {}
+                    Some(Err(e)) => {
+                        tracing::error!(error = %e, "postgres workflow progress listener error");
+                        break;
+                    }
+                    None => break,
+                }
+            }
+        });
+
+        let channel = quote_pg_identifier(&workflow_progress_channel(exec_id));
+        client
+            .batch_execute(&format!("LISTEN {channel}"))
+            .await
+            .map_err(|e| HarvestError::Database(format!("LISTEN {channel} failed: {e}")))?;
+
+        Ok(Self {
+            _client: client,
+            rx,
+            _connection_handle: handle,
+        })
+    }
+
+    /// Wait indefinitely for the next progress chunk.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HarvestError::Database`] if the notification payload is invalid.
+    pub async fn wait_for_progress(&mut self) -> HarvestResult<ProgressWaitOutcome> {
+        match self.rx.recv().await {
+            Some(notification) => {
+                let payload: ProgressNotifyPayload = serde_json::from_str(notification.payload())
+                    .map_err(|e| {
+                    HarvestError::Database(format!("bad progress notify payload: {e}"))
+                })?;
+                Ok(ProgressWaitOutcome::Chunk(payload))
+            }
+            None => Ok(ProgressWaitOutcome::ChannelClosed),
+        }
+    }
+
+    /// Wait for a progress chunk up to `timeout`.
+    ///
+    /// A [`ProgressWaitOutcome::TimedOut`] lets the SSE route send a keepalive
+    /// and re-check the execution's terminal state before waiting again.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`HarvestError::Database`] if the notification payload is invalid.
+    pub async fn wait_for_progress_timeout(
+        &mut self,
+        timeout: Duration,
+    ) -> HarvestResult<ProgressWaitOutcome> {
+        match tokio::time::timeout(timeout, self.wait_for_progress()).await {
+            Ok(outcome) => outcome,
+            Err(_elapsed) => Ok(ProgressWaitOutcome::TimedOut),
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -477,8 +670,7 @@ mod tests {
 
     #[test]
     fn workflow_progress_channel_naming() {
-        let exec_id =
-            Uuid::parse_str("0191c1a2-3b4c-7d5e-8f60-112233445566").expect("valid uuid");
+        let exec_id = Uuid::parse_str("0191c1a2-3b4c-7d5e-8f60-112233445566").expect("valid uuid");
         let channel = workflow_progress_channel(exec_id);
         assert_eq!(channel, "harvest_progress_0191c1a23b4c7d5e8f60112233445566");
         assert!(
@@ -501,8 +693,7 @@ mod tests {
             chunk: serde_json::json!({"phase": "mid", "pct": 50}),
         };
         let json = serde_json::to_string(&original).expect("serialize");
-        let deserialized: ProgressNotifyPayload =
-            serde_json::from_str(&json).expect("deserialize");
+        let deserialized: ProgressNotifyPayload = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(original, deserialized);
     }
 }

--- a/autumn-harvest/src/notify.rs
+++ b/autumn-harvest/src/notify.rs
@@ -696,4 +696,34 @@ mod tests {
         let deserialized: ProgressNotifyPayload = serde_json::from_str(&json).expect("deserialize");
         assert_eq!(original, deserialized);
     }
+
+    #[test]
+    fn progress_notify_payload_stays_within_pg_notify_limit() {
+        // Postgres `pg_notify` payloads are hard-capped at 8000 bytes. The
+        // context caps each chunk's serialized JSON at
+        // `PROGRESS_CHUNK_MAX_BYTES` (7000) and this envelope wraps it as
+        // `{"seq":..,"chunk":..}`. Pin the worst case directly: a max-`u64` seq
+        // (20 decimal digits) plus a chunk serialized right at the cap must
+        // still leave the whole envelope under the 8000-byte NOTIFY limit.
+        let cap = crate::context::PROGRESS_CHUNK_MAX_BYTES;
+        // A JSON string of (cap - 2) chars serializes (with its two quotes) to
+        // exactly `cap` bytes — the largest chunk the context will forward.
+        let max_chunk = serde_json::Value::String("x".repeat(cap - 2));
+        assert_eq!(
+            serde_json::to_vec(&max_chunk).unwrap().len(),
+            cap,
+            "test fixture: chunk must serialize to exactly the cap"
+        );
+        let payload = ProgressNotifyPayload {
+            seq: u64::MAX,
+            chunk: max_chunk,
+        };
+        let serialized = serde_json::to_string(&payload).expect("serialize");
+        assert!(
+            serialized.len() < 8000,
+            "progress NOTIFY envelope must stay under the Postgres 8000-byte \
+             pg_notify limit (max-u64 seq + max chunk), was {} bytes",
+            serialized.len()
+        );
+    }
 }

--- a/autumn-harvest/src/notify.rs
+++ b/autumn-harvest/src/notify.rs
@@ -472,4 +472,37 @@ mod tests {
             serde_json::from_str(&json).expect("deserialize");
         assert_eq!(original, deserialized);
     }
+
+    // ── publish_progress channel (issue #791) ────────────────────────────
+
+    #[test]
+    fn workflow_progress_channel_naming() {
+        let exec_id =
+            Uuid::parse_str("0191c1a2-3b4c-7d5e-8f60-112233445566").expect("valid uuid");
+        let channel = workflow_progress_channel(exec_id);
+        assert_eq!(channel, "harvest_progress_0191c1a23b4c7d5e8f60112233445566");
+        assert!(
+            !channel.contains('-'),
+            "progress channel must not contain hyphens: {channel}"
+        );
+        // Postgres identifiers are limited to NAMEDATALEN-1 = 63 bytes.
+        assert!(
+            channel.len() <= 63,
+            "progress channel {} exceeds Postgres 63-byte identifier limit ({} bytes)",
+            channel,
+            channel.len()
+        );
+    }
+
+    #[test]
+    fn progress_notify_payload_roundtrips() {
+        let original = ProgressNotifyPayload {
+            seq: 0x0000_0005_00FF_FFFF,
+            chunk: serde_json::json!({"phase": "mid", "pct": 50}),
+        };
+        let json = serde_json::to_string(&original).expect("serialize");
+        let deserialized: ProgressNotifyPayload =
+            serde_json::from_str(&json).expect("deserialize");
+        assert_eq!(original, deserialized);
+    }
 }

--- a/autumn-harvest/src/testing.rs
+++ b/autumn-harvest/src/testing.rs
@@ -4039,6 +4039,9 @@ impl WorkflowTestEnv {
             | WorkflowCommand::RecordUpdateResult { .. }
             | WorkflowCommand::UpsertSearchAttributes { .. }
             | WorkflowCommand::SetCurrentDetails { .. }
+            // Ephemeral progress (issue #791): a bookkeeping no-op in the test
+            // harness — appends no event, changes no history, drives no wait.
+            | WorkflowCommand::PublishProgress { .. }
             | WorkflowCommand::ScheduleExternalActivity { .. }
             | WorkflowCommand::Complete { .. }
             | WorkflowCommand::Fail { .. }

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -973,6 +973,7 @@ const fn workflow_command_name(command: &WorkflowCommand) -> &'static str {
         WorkflowCommand::RecordUpdateResult { .. } => "RecordUpdateResult",
         WorkflowCommand::UpsertSearchAttributes { .. } => "UpsertSearchAttributes",
         WorkflowCommand::SetCurrentDetails { .. } => "SetCurrentDetails",
+        WorkflowCommand::PublishProgress { .. } => "PublishProgress",
         WorkflowCommand::SignalExternalWorkflow { .. } => "SignalExternalWorkflow",
         WorkflowCommand::RequestCancelExternalWorkflow { .. } => "RequestCancelExternalWorkflow",
         WorkflowCommand::SpawnDetachedChildWorkflow { .. } => "SpawnDetachedChildWorkflow",
@@ -1031,6 +1032,7 @@ fn should_requeue_signal_wait(commands: &[WorkflowCommand]) -> bool {
                 | WorkflowCommand::RecordUpdateResult { .. }
                 | WorkflowCommand::UpsertSearchAttributes { .. }
                 | WorkflowCommand::SetCurrentDetails { .. }
+                | WorkflowCommand::PublishProgress { .. }
                 | WorkflowCommand::SpawnDetachedChildWorkflow { .. }
                 | WorkflowCommand::CancelRaceLosers { .. }
                 | WorkflowCommand::ArmTimer { .. }
@@ -1051,6 +1053,7 @@ fn only_bookkeeping_commands(commands: &[WorkflowCommand]) -> bool {
                     | WorkflowCommand::RecordUpdateResult { .. }
                     | WorkflowCommand::UpsertSearchAttributes { .. }
                     | WorkflowCommand::SetCurrentDetails { .. }
+                    | WorkflowCommand::PublishProgress { .. }
                     | WorkflowCommand::SpawnDetachedChildWorkflow { .. }
                     | WorkflowCommand::CancelRaceLosers { .. }
                     | WorkflowCommand::ArmTimer { .. }
@@ -1301,6 +1304,7 @@ fn extract_single_command<T>(
                 | WorkflowCommand::RecordUpdateResult { .. }
                 | WorkflowCommand::UpsertSearchAttributes { .. }
                 | WorkflowCommand::SetCurrentDetails { .. }
+                | WorkflowCommand::PublishProgress { .. }
                 | WorkflowCommand::SpawnDetachedChildWorkflow { .. }
                 | WorkflowCommand::CancelRaceLosers { .. }
                 | WorkflowCommand::ArmTimer { .. }
@@ -1331,6 +1335,7 @@ fn extract_all_scheduled_activities(
             | WorkflowCommand::RecordUpdateResult { .. }
             | WorkflowCommand::UpsertSearchAttributes { .. }
             | WorkflowCommand::SetCurrentDetails { .. }
+            | WorkflowCommand::PublishProgress { .. }
             | WorkflowCommand::SpawnDetachedChildWorkflow { .. }
             | WorkflowCommand::CancelRaceLosers { .. }
             | WorkflowCommand::ArmTimer { .. }
@@ -1380,6 +1385,7 @@ fn extract_all_activity_waits(commands: &[WorkflowCommand]) -> Option<Vec<Activi
             | WorkflowCommand::RecordUpdateResult { .. }
             | WorkflowCommand::UpsertSearchAttributes { .. }
             | WorkflowCommand::SetCurrentDetails { .. }
+            | WorkflowCommand::PublishProgress { .. }
             | WorkflowCommand::SpawnDetachedChildWorkflow { .. }
             | WorkflowCommand::CancelRaceLosers { .. }
             | WorkflowCommand::ArmTimer { .. }
@@ -1436,6 +1442,7 @@ fn extract_started_timer_for_suspension(
                 | WorkflowCommand::RecordUpdateResult { .. }
                 | WorkflowCommand::UpsertSearchAttributes { .. }
                 | WorkflowCommand::SetCurrentDetails { .. }
+                | WorkflowCommand::PublishProgress { .. }
                 | WorkflowCommand::SpawnDetachedChildWorkflow { .. }
                 | WorkflowCommand::CancelRaceLosers { .. }
                 | WorkflowCommand::ArmTimer { .. }
@@ -1463,6 +1470,7 @@ fn extract_all_started_child_workflows(
                     | WorkflowCommand::RecordUpdateResult { .. }
                     | WorkflowCommand::UpsertSearchAttributes { .. }
                     | WorkflowCommand::SetCurrentDetails { .. }
+                    | WorkflowCommand::PublishProgress { .. }
                     | WorkflowCommand::SpawnDetachedChildWorkflow { .. }
                     | WorkflowCommand::CancelRaceLosers { .. }
                     | WorkflowCommand::ArmTimer { .. }
@@ -1580,6 +1588,7 @@ fn extract_child_timeout_race(
             | WorkflowCommand::RecordUpdateResult { .. }
             | WorkflowCommand::UpsertSearchAttributes { .. }
             | WorkflowCommand::SetCurrentDetails { .. }
+            | WorkflowCommand::PublishProgress { .. }
             | WorkflowCommand::CancelRaceLosers { .. } => {}
             // Anything else (activity, activity wait, signal wait, external
             // activity/signal/cancel, detached spawn, arm/cancel timer) → not this
@@ -1962,7 +1971,8 @@ fn split_mixed_signal_batch(
             }
             WorkflowCommand::RecordUpdateResult { .. }
             | WorkflowCommand::UpsertSearchAttributes { .. }
-            | WorkflowCommand::SetCurrentDetails { .. } => {}
+            | WorkflowCommand::SetCurrentDetails { .. }
+            | WorkflowCommand::PublishProgress { .. } => {}
             other => remaining.push(other),
         }
     }
@@ -4341,6 +4351,43 @@ async fn persist_current_details_from_commands(
         }
     }
     Ok(())
+}
+
+/// Fire a best-effort `pg_notify` for each [`WorkflowCommand::PublishProgress`]
+/// command in this decision cycle (issue #791).
+///
+/// Progress chunks are an **ephemeral** live-output side channel: they are never
+/// recorded to `harvest_events` and never replayed. Fired on the worker's
+/// persist connection alongside [`persist_current_details_from_commands`], so a
+/// rolled-back cycle's `NOTIFY` is discarded (pg delivers only on commit) and
+/// the retried cycle re-fires live — a committed chunk is never double-delivered.
+///
+/// One `pg_notify` per chunk (O(chunks) per cycle) preserves each chunk's
+/// distinct `seq` and payload. The context suppresses `publish_progress` during
+/// replay, so this only ever sees live-frontier chunks.
+///
+/// **Best-effort**: a notify failure is logged and swallowed, never failing the
+/// workflow — a progress chunk is disposable. The context caps each chunk below
+/// the Postgres 8000-byte `NOTIFY` limit, so a size-driven failure cannot occur.
+async fn notify_progress_from_commands(
+    conn: &mut AsyncPgConnection,
+    exec_id: ExecutionId,
+    commands: &[WorkflowCommand],
+) {
+    for cmd in commands {
+        if let WorkflowCommand::PublishProgress { seq, chunk } = cmd {
+            if let Err(e) =
+                crate::notify::notify_workflow_progress(conn, exec_id.as_uuid(), *seq, chunk).await
+            {
+                tracing::warn!(
+                    workflow_exec_id = %exec_id.as_uuid(),
+                    seq = *seq,
+                    error = %e,
+                    "failed to publish progress chunk (best-effort, dropped)"
+                );
+            }
+        }
+    }
 }
 
 async fn persist_signal_wait_park(
@@ -8892,6 +8939,8 @@ async fn handle_suspended_workflow(
         )
         .await;
     }
+    // Fire ephemeral progress chunks (issue #791) — best-effort, never fails the cycle.
+    notify_progress_from_commands(conn, context.persistence.exec_id, commands).await;
 
     let sticky = context.persistence.sticky_hint();
     let detached_spawns = DetachedSpawnPersistence {
@@ -9833,6 +9882,8 @@ async fn persist_terminal_outcome_commands(
         .await?;
     persist_search_attrs_from_commands(conn, persistence.exec_id, pending_cmds).await?;
     persist_current_details_from_commands(conn, persistence.exec_id, pending_cmds).await?;
+    // Fire ephemeral progress chunks (issue #791) — best-effort, never fails the cycle.
+    notify_progress_from_commands(conn, persistence.exec_id, pending_cmds).await;
 
     // Cancellable/renewable timer bookkeeping (issue #768) on a terminal cycle.
     // A sealing execution never awaits, so any `ArmTimer` here is a fresh arm
@@ -10564,6 +10615,8 @@ async fn process_workflow_task(
                 persist_search_attrs_from_commands(conn, prepared.exec_id, &commands).await?;
                 // Persist the current_details breadcrumb before inline execution (issue #473).
                 persist_current_details_from_commands(conn, prepared.exec_id, &commands).await?;
+                // Fire ephemeral progress chunks (issue #791) — best-effort, before inline run.
+                notify_progress_from_commands(conn, prepared.exec_id, &commands).await;
                 // Sync in-memory snapshot so a subsequent continue_as_new in the
                 // same task copies the patched attrs to the successor row.
                 prepared.execution.search_attrs = apply_search_attrs_patch_in_memory(
@@ -10743,6 +10796,7 @@ async fn process_workflow_task(
                             | WorkflowCommand::RecordUpdateResult { .. }
                             | WorkflowCommand::UpsertSearchAttributes { .. }
                             | WorkflowCommand::SetCurrentDetails { .. }
+                            | WorkflowCommand::PublishProgress { .. }
                     )
                 }) =>
             {
@@ -10807,6 +10861,8 @@ async fn process_workflow_task(
                     )
                     .await;
                 }
+                // Fire ephemeral progress chunks (issue #791) — best-effort, never fails the cycle.
+                notify_progress_from_commands(conn, prepared.exec_id, &commands).await;
                 prepared.execution.search_attrs = apply_search_attrs_patch_in_memory(
                     prepared.execution.search_attrs.take(),
                     &commands,
@@ -11012,6 +11068,8 @@ async fn process_workflow_task(
                     )
                     .await;
                 }
+                // Fire ephemeral progress chunks (issue #791) — best-effort, never fails the cycle.
+                notify_progress_from_commands(conn, prepared.exec_id, &commands).await;
                 prepared.execution.search_attrs = apply_search_attrs_patch_in_memory(
                     prepared.execution.search_attrs.take(),
                     &commands,

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -4369,13 +4369,27 @@ async fn persist_current_details_from_commands(
 /// **Best-effort**: a notify failure is logged and swallowed, never failing the
 /// workflow — a progress chunk is disposable. The context caps each chunk below
 /// the Postgres 8000-byte `NOTIFY` limit, so a size-driven failure cannot occur.
+///
+/// **Per-cycle ceiling**: each chunk is one `SELECT pg_notify(...)` round-trip
+/// in the persist transaction, so a pathological publish loop (thousands of
+/// chunks in one decision cycle) would fire thousands of serial round-trips and
+/// burst into Postgres' shared async NOTIFY queue. Chunks beyond
+/// [`PROGRESS_MAX_CHUNKS_PER_CYCLE`] are DROPPED best-effort for that cycle with
+/// a single aggregated `tracing::warn!` (not one per dropped chunk).
 async fn notify_progress_from_commands(
     conn: &mut AsyncPgConnection,
     exec_id: ExecutionId,
     commands: &[WorkflowCommand],
 ) {
+    let mut fired = 0usize;
+    let mut dropped_over_cap = 0usize;
     for cmd in commands {
         if let WorkflowCommand::PublishProgress { seq, chunk } = cmd {
+            if fired >= PROGRESS_MAX_CHUNKS_PER_CYCLE {
+                dropped_over_cap += 1;
+                continue;
+            }
+            fired += 1;
             if let Err(e) =
                 crate::notify::notify_workflow_progress(conn, exec_id.as_uuid(), *seq, chunk).await
             {
@@ -4388,7 +4402,23 @@ async fn notify_progress_from_commands(
             }
         }
     }
+    if dropped_over_cap > 0 {
+        tracing::warn!(
+            workflow_exec_id = %exec_id.as_uuid(),
+            dropped = dropped_over_cap,
+            cap = PROGRESS_MAX_CHUNKS_PER_CYCLE,
+            "progress chunks exceeded per-cycle ceiling; excess dropped (best-effort)"
+        );
+    }
 }
+
+/// Per-decision-cycle ceiling on the number of `ctx.publish_progress` chunks the
+/// worker forwards as `pg_notify` round-trips (issue #791). Each chunk is one
+/// serial `SELECT pg_notify(...)` in the persist transaction; this bounds a
+/// pathological publish loop's round-trips and its burst into the shared
+/// Postgres async NOTIFY queue. Excess chunks in a single cycle are dropped
+/// best-effort (progress is disposable).
+const PROGRESS_MAX_CHUNKS_PER_CYCLE: usize = 10_000;
 
 async fn persist_signal_wait_park(
     conn: &mut AsyncPgConnection,

--- a/autumn-harvest/tests/integration/mod.rs
+++ b/autumn-harvest/tests/integration/mod.rs
@@ -73,6 +73,7 @@ mod payload_offload_db_tests;
 mod payload_offload_replay_tests;
 mod poison_pill_tests;
 mod priority_tests;
+mod publish_progress_tests;
 mod query_deadlock;
 mod query_terminal_tests;
 mod query_tests;

--- a/autumn-harvest/tests/integration/publish_progress_tests.rs
+++ b/autumn-harvest/tests/integration/publish_progress_tests.rs
@@ -10,7 +10,7 @@
 //!
 //! Run with:
 //!   cargo test -p autumn-harvest --test integration --features testing \
-//!     --no-default-features -- publish_progress
+//!     --no-default-features -- `publish_progress`
 
 use std::future::Future;
 use std::pin::Pin;

--- a/autumn-harvest/tests/integration/publish_progress_tests.rs
+++ b/autumn-harvest/tests/integration/publish_progress_tests.rs
@@ -1,0 +1,206 @@
+//! Integration tests for `ctx.publish_progress` (issue #791).
+//!
+//! Progress chunks are an EPHEMERAL, best-effort live-output side channel:
+//! replay-neutral, **zero `harvest_events` footprint, NO new `WorkflowEvent`
+//! variant, NO migration**. Chunk content MAY be non-deterministic precisely
+//! because it is never recorded or replayed.
+//!
+//! These tests pin the falsifiable AC2 bar — 0 bytes to `harvest_events`, 0
+//! replay divergence — using the in-process harnesses (no DB required).
+//!
+//! Run with:
+//!   cargo test -p autumn-harvest --test integration --features testing \
+//!     --no-default-features -- publish_progress
+
+use std::future::Future;
+use std::pin::Pin;
+
+use autumn_harvest::context::WorkflowContext;
+use autumn_harvest::event::WorkflowEvent;
+use autumn_harvest::testing::{ReplayStatus, WorkflowReplayer, WorkflowTestEnv};
+use autumn_harvest::types::{ActivityExecId, ExecutionId};
+use chrono::Utc;
+use serde_json::{Value, json};
+
+// ---------------------------------------------------------------------------
+// Test workflow handlers
+// ---------------------------------------------------------------------------
+
+/// Two sequential activities with a `publish_progress` chunk emitted before,
+/// between, and after them. Because progress leaves **zero** footprint in
+/// `harvest_events`, this workflow must replay identically against a history
+/// containing ONLY the two activity pairs — the same history a workflow that
+/// never published progress would produce.
+fn publish_progress_workflow<'a>(
+    ctx: &'a WorkflowContext,
+    _input: Value,
+) -> Pin<Box<dyn Future<Output = Result<Value, String>> + Send + 'a>> {
+    Box::pin(async move {
+        ctx.publish_progress(json!({"phase": "starting", "pct": 0}))
+            .map_err(|e| e.to_string())?;
+        let r1 = ctx
+            .execute_activity_raw("step_one", Value::Null, "default")
+            .await
+            .map_err(|e| e.to_string())?;
+        ctx.publish_progress(json!({"phase": "mid", "pct": 50}))
+            .map_err(|e| e.to_string())?;
+        let r2 = ctx
+            .execute_activity_raw("step_two", Value::Null, "default")
+            .await
+            .map_err(|e| e.to_string())?;
+        ctx.publish_progress(json!({"phase": "done", "pct": 100}))
+            .map_err(|e| e.to_string())?;
+        Ok(json!({"first": r1, "second": r2}))
+    })
+}
+
+/// Identical shape but with NO `publish_progress` calls. Its produced event
+/// history must be byte-for-byte identical (by event-type sequence) to the
+/// progress-publishing sibling above.
+fn no_progress_workflow<'a>(
+    ctx: &'a WorkflowContext,
+    _input: Value,
+) -> Pin<Box<dyn Future<Output = Result<Value, String>> + Send + 'a>> {
+    Box::pin(async move {
+        let r1 = ctx
+            .execute_activity_raw("step_one", Value::Null, "default")
+            .await
+            .map_err(|e| e.to_string())?;
+        let r2 = ctx
+            .execute_activity_raw("step_two", Value::Null, "default")
+            .await
+            .map_err(|e| e.to_string())?;
+        Ok(json!({"first": r1, "second": r2}))
+    })
+}
+
+// ---------------------------------------------------------------------------
+// History fixtures (activity-only — progress records nothing)
+// ---------------------------------------------------------------------------
+
+fn two_activity_history() -> (ExecutionId, Vec<WorkflowEvent>) {
+    let exec_id = ExecutionId::new();
+    let id1 = ActivityExecId::new();
+    let id2 = ActivityExecId::new();
+    let events = vec![
+        WorkflowEvent::WorkflowStarted {
+            input: Value::Null,
+            timestamp: Utc::now(),
+            last_completion_result: None,
+            last_error: None,
+            scheduled_time: None,
+        },
+        WorkflowEvent::ActivityScheduled {
+            activity_id: id1,
+            name: "step_one".into(),
+            input: Value::Null,
+            queue: "default".into(),
+        },
+        WorkflowEvent::ActivityCompleted {
+            activity_id: id1,
+            output: json!("result_one"),
+        },
+        WorkflowEvent::ActivityScheduled {
+            activity_id: id2,
+            name: "step_two".into(),
+            input: Value::Null,
+            queue: "default".into(),
+        },
+        WorkflowEvent::ActivityCompleted {
+            activity_id: id2,
+            output: json!("result_two"),
+        },
+    ];
+    (exec_id, events)
+}
+
+// ---------------------------------------------------------------------------
+// AC2 (a): zero `harvest_events` footprint — a progress-publishing workflow
+//          produces byte-for-byte the same event history as one that does not.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn publish_progress_leaves_zero_event_footprint() {
+    let progress_outcome = WorkflowTestEnv::new()
+        .mock_activity("step_one", |_| Ok(json!("result_one")))
+        .mock_activity("step_two", |_| Ok(json!("result_two")))
+        .run(publish_progress_workflow, json!(null))
+        .await;
+
+    let plain_outcome = WorkflowTestEnv::new()
+        .mock_activity("step_one", |_| Ok(json!("result_one")))
+        .mock_activity("step_two", |_| Ok(json!("result_two")))
+        .run(no_progress_workflow, json!(null))
+        .await;
+
+    // The workflow completes normally — publish_progress never fails it.
+    assert_eq!(
+        progress_outcome.result,
+        Ok(json!({"first": "result_one", "second": "result_two"})),
+        "publish_progress must not alter the workflow result"
+    );
+
+    let progress_types: Vec<&'static str> = progress_outcome
+        .events()
+        .iter()
+        .map(WorkflowEvent::type_name)
+        .collect();
+    let plain_types: Vec<&'static str> = plain_outcome
+        .events()
+        .iter()
+        .map(WorkflowEvent::type_name)
+        .collect();
+
+    assert_eq!(
+        progress_types, plain_types,
+        "publish_progress must leave ZERO footprint in harvest_events: the \
+         event-type sequence must equal the no-progress sibling's, got \
+         {progress_types:?} vs {plain_types:?}"
+    );
+
+    // Belt-and-braces: no event type name mentions "progress" — there is no
+    // progress WorkflowEvent variant at all.
+    assert!(
+        progress_outcome
+            .events()
+            .iter()
+            .all(|e| !e.type_name().to_ascii_lowercase().contains("progress")),
+        "no progress-related WorkflowEvent may ever be recorded"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// AC2 (b): replay-neutrality — a workflow that publishes progress replays
+//          cleanly (ReplaySucceeded) against a history with zero corresponding
+//          events, exactly like the `set_current_details` (#593) precedent.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn publish_progress_replays_with_zero_divergence() {
+    let (exec_id, events) = two_activity_history();
+    let replayer =
+        WorkflowReplayer::new().register_fn("publish_progress_workflow", publish_progress_workflow);
+
+    let report = replayer
+        .replay_from_snapshot(autumn_harvest::testing::HistorySnapshot {
+            workflow_name: "publish_progress_workflow".to_string(),
+            execution_id: exec_id,
+            events,
+            context_headers: None,
+            execution_timeout: None,
+            deadline_at: None,
+            parent_execution_id: None,
+            workflow_id: None,
+        })
+        .await;
+
+    assert!(
+        matches!(report.status, ReplayStatus::ReplaySucceeded),
+        "a workflow calling publish_progress must replay against a history with \
+         zero corresponding events (progress is replay-neutral), got: {report}"
+    );
+    assert!(
+        report.events_replayed > 0,
+        "events_replayed must be positive"
+    );
+}

--- a/docs/api-contract.json
+++ b/docs/api-contract.json
@@ -683,7 +683,7 @@
       "path": "/workflows/{id}/stream",
       "category": "workflow",
       "read_only": true,
-      "description": "Server-Sent Events stream of the EPHEMERAL live-output progress chunks a running workflow publishes via ctx.publish_progress (issue #791). Chunks are ordered over Postgres LISTEN/NOTIFY with sub-second delivery. This is a best-effort side channel: chunks are never recorded in harvest_events, never replayed, and there is NO backfill on (re)connect — a subscriber that connects after a chunk was published will not see it (chunk content may be non-deterministic precisely because it is never stored). Each SSE message carries id (a monotonic, epoch-prefixed seq — a gap means a missed chunk) plus event:progress and data (the raw chunk JSON, NOT re-wrapped). A final event:end frame is emitted when the execution reaches a terminal state and the stream then closes; event:error is sent if the LISTEN connection drops. Keepalive :ping comments keep proxies from idling the connection; the terminal-close poll cadence is a modest default bounded by the configured SSE keepalive interval. AUTH: this route inherits the management API's configured auth middleware (HarvestPlugin::api_with_auth); it is deliberately NOT admin-gated (AC5 — end-users stream their own workflows). If no api_with_auth middleware is configured the route is open — embedders exposing streams to untrusted end-users should configure api_with_auth or front it with their own auth.",
+      "description": "Server-Sent Events stream of the EPHEMERAL live-output progress chunks a running workflow publishes via ctx.publish_progress (issue #791). Chunks are ordered over Postgres LISTEN/NOTIFY with sub-second delivery. This is a best-effort side channel: chunks are never recorded in harvest_events, never replayed, and there is NO backfill on (re)connect — a subscriber that connects after a chunk was published will not see it (chunk content may be non-deterministic precisely because it is never stored). Each SSE message carries id (a monotonic, epoch-prefixed seq — a gap means a missed chunk) plus event:progress and data (the raw chunk JSON, NOT re-wrapped). A final event:end frame is emitted when the execution reaches a terminal state and the stream then closes; event:error is sent if the LISTEN connection drops. Keepalive :ping comments keep proxies from idling the connection; the terminal-close poll cadence is a modest default bounded by the configured SSE keepalive interval. AUTH: this route inherits the management API's configured auth middleware (HarvestPlugin::api_with_auth); it is deliberately NOT admin-gated (AC5 — end-users stream their own workflows). If no api_with_auth middleware is configured the route is open — embedders exposing streams to untrusted end-users should configure api_with_auth or front it with their own auth. The engine only checks that the execution exists (else 404) — exec_id is effectively a bearer capability for this run's live chunk CONTENT, so embedders exposing sensitive output MUST add per-execution authorization. Each subscriber holds one dedicated (non-pooled) Postgres LISTEN connection for the stream's lifetime; embedders should rate-limit and/or cap concurrent streams per user to avoid DB connection exhaustion (a global concurrent-stream cap is a possible future enhancement).",
       "params": [
         {
           "name": "id",
@@ -695,7 +695,7 @@
       "request_body": null,
       "success_response": {
         "status": 200,
-        "note": "Content-Type: text/event-stream. Frames: event:progress (data = the published chunk JSON, id = monotonic seq), a terminal event:end, or event:error. If the execution is already terminal at connect, a single event:end frame is sent and the stream closes.",
+        "note": "Content-Type: text/event-stream. Frames: event:progress (data = the published chunk JSON, id = monotonic seq), a terminal event:end, or event:error. If the execution is already terminal at connect, a single event:end frame is sent and the stream closes. SEQ CLIENT CONTRACT: id is a monotonic per-execution LOGICAL-POSITION identity (not a per-chunk counter). Subscribers should dedupe by seq (keep-first) for at-most-once-per-position display, and use forward seq JUMPS to detect gaps after reconnect. A re-driven workflow position re-emits the SAME seq (best-effort); a re-emitted chunk MAY carry different content for non-deterministic chunks — the first-delivered is canonical. seq is per exec_id; a continue-as-new successor is a new exec_id on a new stream whose seq restarts. Chunks may be DROPPED best-effort under back-pressure (slow client) — the monotonic seq lets the client detect the resulting gap.",
         "free_form": true
       },
       "error_responses": [
@@ -709,7 +709,7 @@
         },
         {
           "status": 503,
-          "description": "SSE notification URL not configured."
+          "description": "Progress streaming is unavailable server-side (retriable): either the LISTEN/NOTIFY notification URL is not configured, or that notification database is unreachable (LISTEN connect failed)."
         }
       ],
       "idempotency": "Fully idempotent; read-only."

--- a/docs/api-contract.json
+++ b/docs/api-contract.json
@@ -679,6 +679,42 @@
       "idempotency": "Fully idempotent; read-only."
     },
     {
+      "method": "GET",
+      "path": "/workflows/{id}/stream",
+      "category": "workflow",
+      "read_only": true,
+      "description": "Server-Sent Events stream of the EPHEMERAL live-output progress chunks a running workflow publishes via ctx.publish_progress (issue #791). Chunks are ordered over Postgres LISTEN/NOTIFY with sub-second delivery. This is a best-effort side channel: chunks are never recorded in harvest_events, never replayed, and there is NO backfill on (re)connect — a subscriber that connects after a chunk was published will not see it (chunk content may be non-deterministic precisely because it is never stored). Each SSE message carries id (a monotonic, epoch-prefixed seq — a gap means a missed chunk) plus event:progress and data (the raw chunk JSON, NOT re-wrapped). A final event:end frame is emitted when the execution reaches a terminal state and the stream then closes; event:error is sent if the LISTEN connection drops. Keepalive :ping comments keep proxies from idling the connection; the terminal-close poll cadence is a modest default bounded by the configured SSE keepalive interval. AUTH: this route inherits the management API's configured auth middleware (HarvestPlugin::api_with_auth); it is deliberately NOT admin-gated (AC5 — end-users stream their own workflows). If no api_with_auth middleware is configured the route is open — embedders exposing streams to untrusted end-users should configure api_with_auth or front it with their own auth.",
+      "params": [
+        {
+          "name": "id",
+          "in": "path",
+          "required": true,
+          "description": "Execution UUID."
+        }
+      ],
+      "request_body": null,
+      "success_response": {
+        "status": 200,
+        "note": "Content-Type: text/event-stream. Frames: event:progress (data = the published chunk JSON, id = monotonic seq), a terminal event:end, or event:error. If the execution is already terminal at connect, a single event:end frame is sent and the stream closes.",
+        "free_form": true
+      },
+      "error_responses": [
+        {
+          "status": 400,
+          "description": "Malformed execution ID."
+        },
+        {
+          "status": 404,
+          "description": "Execution not found."
+        },
+        {
+          "status": 503,
+          "description": "SSE notification URL not configured."
+        }
+      ],
+      "idempotency": "Fully idempotent; read-only."
+    },
+    {
       "method": "POST",
       "path": "/workflows/{workflow_name}/start",
       "category": "workflow",

--- a/docs/changelog.d/pr-1098-publish-progress.md
+++ b/docs/changelog.d/pr-1098-publish-progress.md
@@ -1,0 +1,123 @@
+## Phase 3.57 — Live workflow output streaming via `ctx.publish_progress` (issue #791)
+
+**Before:** a workflow author building an AI agent, a long-running import, or any
+interactive flow had **no way to push incremental, author-defined business
+output** to a waiting client while the run is in flight. The only surfaces were a
+query handler (pull, snapshot-only), `set_current_details` (a single overwriting
+status string, #473/#593), or — for operators only — the admin-gated engine-event
+SSE tail (#324), which streams `ActivityScheduled`/`ActivityCompleted` *machinery*,
+not the author's content. Streaming tokens / reasoning steps / per-item progress
+to an end user meant standing up an external message bus.
+
+**After:** one replay-safe method — `WorkflowContext::publish_progress(chunk: impl
+serde::Serialize) -> HarvestResult<()>` — emits an ordered, author-defined chunk
+from live workflow code, delivered to a subscriber on the new SSE route
+`GET /api/harvest/workflows/{id}/stream` over the existing Postgres LISTEN/NOTIFY
+plumbing. **Ephemeral, best-effort, product-UX channel** — not an audit record:
+chunks are dropped when no subscriber is connected; the durable workflow *result*
+remains authoritative.
+
+**Determinism / append-only invariant — the load-bearing property.** The call is a
+**pure side effect gated on `is_replaying()`**: on a replay pass it returns
+`Ok(())` immediately with **no `WorkflowCommand` pushed and no seq consumed**
+(mirrors `set_current_details`), so a workflow that publishes N chunks produces a
+**byte-for-byte identical `harvest_events` history** to one that publishes none.
+Chunk content **MAY be non-deterministic** (LLM tokens, wall-clock timestamps,
+sampled values) *precisely because* it is never recorded or replayed. **No new
+`WorkflowEvent` variant, no migration, no shard-routing change.**
+
+**Core (`context.rs`).** Live path: serialize the chunk to `serde_json::Value`
+(serialize error → `Err`), cap serialized bytes at `PROGRESS_CHUNK_MAX_BYTES = 7000`
+(Postgres `NOTIFY` hard limit 8000, with envelope headroom); an oversize chunk is
+**replaced** — never silently dropped — with the truncation marker
+`{"_harvest_progress_truncated": true, "bytes": <original_len>}`, preserving the
+ordered slot and signalling truncation to the client. Pushes a **bookkeeping**
+`WorkflowCommand::PublishProgress { seq: u64, chunk: Value }` (no `result_tx`,
+non-suspending; joins the `SetCurrentDetails` family at every exhaustive-match and
+bookkeeping-classifier site in `worker.rs`, excluded from
+`executor.rs::is_replay_significant_command`, `Ok(false)` no-op in
+`testing.rs::apply_command`). **Monotonic seq (AC6):** `seq = (epoch << 24) |
+(local_index & 0xFF_FFFF)` (`encode_progress_seq`), where `epoch` is the
+loaded-history length at cycle start (read by locking the matcher directly, the
+`info()` trick, to avoid the `pump_signal_handlers` side effect) — constant within a
+cycle and strictly growing across cycles — and `local_index` is a per-cycle
+`AtomicU64`. seq is therefore lifetime-monotonic (reconnect gap detection) and
+**idempotent on a crash-retry of the same cycle** (best-effort duplicates are
+dedupable by seq). Epoch shift uses `saturating_mul`; `local_index` saturates at
+`2^24 - 1` (no overflow panic).
+
+**Notify (`worker.rs` + `notify.rs`).** `notify_progress_from_commands(conn,
+exec_id, &commands)` fires `notify::notify_workflow_progress(...)` on the worker's
+**persist connection**, co-located right after every
+`persist_current_details_from_commands` call site (5 sites: suspension, terminal,
+local-activity pre-run, 2 panic-strike paths) — so progress flushes on both
+suspension and terminal cycles, in the same transactional context as the
+`current_details` write (pg NOTIFY delivers on commit → a rolled-back+retried cycle
+re-fires live; the deterministic seq makes any autocommit-mode duplicate dedupable).
+A notify failure is **logged and swallowed**, never fails the workflow — progress
+is disposable. `notify.rs` adds the per-execution channel
+`workflow_progress_channel(exec_id)` (`harvest_progress_{32-hex}`, < 63-char
+`NAMEDATALEN`), `ProgressNotifyPayload { seq, chunk }`, `notify_workflow_progress`,
+and `WorkflowProgressListener` (`connect` / `wait_for_progress` /
+`wait_for_progress_timeout` → `ProgressWaitOutcome::{Chunk, TimedOut,
+ChannelClosed}`), mirroring `WorkflowEventListener` (tokio-postgres driver task +
+mpsc). All `pub` under `autumn_harvest::notify`.
+
+**Plugin SSE route (`api.rs`).** `GET /api/harvest/workflows/{id}/stream`
+(`text/event-stream`). Frames: `event: progress` (`id:` = seq, `data:` = the raw
+chunk JSON, **not** re-wrapped in the adjacently-tagged envelope) in publish order;
+`event: end` (`data: {"reason": <terminal-state>}`) on terminal; `event: error`
+(`data: {"error": "listen_connection_closed"}`) on channel loss. **Auth (AC5):
+deliberately NOT `require_admin`** — it is an end-user-facing read path (an app's
+users stream their own workflows), distinct from the admin engine-event tail (#324).
+It inherits the general `api_with_auth` middleware the other management routes use;
+**open if no auth is configured** — the default posture is documented in
+`docs/streaming-progress.md`, and embedders MUST front untrusted end-users.
+Clean-close mechanics: `LISTEN` is established **before** the existence check (so a
+chunk published in the check→listen window is not missed); the pooled DB connection
+is **dropped** before streaming (SSE streams never hold pool connections — the
+listener owns its own dedicated `tokio-postgres` connection, shard-resolved via
+`sse_notification_url(shard)`); an already-terminal execution emits a single `end`
+frame and closes immediately; on each keepalive `TimedOut` tick the producer polls
+terminal state (bounding close latency to one keepalive) and detects an
+idle-disconnected client via `tx.is_closed()`; `ChannelClosed` emits `error` and
+ends rather than hanging. Read-path decode (#608) does **not** apply — progress
+chunks are ephemeral author-supplied JSON, never codec-encoded.
+
+**Contract / audit registration (AC9).** Route registered in `harvest_api_router`,
+`management_api_routes()`, `management_api_response_fields()`, `docs/api-contract.json`,
+and `autumn_harvest::audit`: `CLASSIFIED_ROUTES` (**ReadOnly**), `ALL_MUTATION_ROUTES`
+(op **None**), `EXCLUDED_ROUTES`. Pinned classification tests in **both** `audit.rs`
+and plugin `contract_regression.rs` (the audit exhaustiveness cross-check stays green
+if a route is dropped from BOTH lists, so both are pinned independently).
+
+**Out of scope (per issue):** durable persistence / replay of chunks (that is the
+durable per-execution logs primitive, #790); at-least-once / exactly-once delivery,
+cross-reconnect ordering guarantees, or buffering for late subscribers (best-effort
+only); final-result delivery (#527) and snapshot reads (query handlers /
+`set_current_details`); client→workflow streaming (that is signals/updates);
+cross-shard fan-in of one logical stream (a stream is scoped to a single `exec_id`
+on its owning shard).
+
+**Docs / example.** `docs/streaming-progress.md` (API, determinism contract,
+best-effort delivery model, SSE wire format + `seq` semantics, auth default posture,
+7000-byte cap + truncation marker, out-of-scope list, cross-links to #473/#593/#324/#527).
+`autumn-harvest/examples/streaming_agent.rs` (an AI-agent-shaped workflow publishing
+per-step chunks interleaved with a mock activity across decision cycles, one
+intentionally non-deterministic chunk with a SAFE-because-never-replayed comment, a
+documented `curl -N` consumer, and embedded `WorkflowTestEnv` tests asserting
+completion + zero-event-footprint + `ReplaySucceeded`).
+
+**Tests, TDD red→green.** Core: 5 inline `context.rs` unit tests
+(replay-suppressed, live-emits-bookkeeping-command, per-cycle local-index increase,
+oversize→truncation-marker); 2 no-DB integration tests
+(`publish_progress_leaves_zero_event_footprint` — identical event-type sequence to a
+no-progress sibling; `publish_progress_replays_with_zero_divergence` — ReplaySucceeded
+against an activity-only history, AC2); 2 new `notify::` unit tests (progress channel
++ payload round-trip). Plugin: DB integration
+(`progress_stream_delivers_ordered_chunks_and_ends_on_terminal`,
+`progress_stream_on_already_terminal_execution_closes_immediately`,
+`progress_stream_unknown_execution_returns_404`) and no-DB registration/auth-posture
+tests (`sse_stream_tests.rs`), plus the pinned classification tests. All core no-DB
+surfaces run green in-sandbox; DB/HTTP suites (`progress_stream_integration`) run
+under the Docker-backed CI step registered in `.github/ci/integration-suites.txt`.

--- a/docs/streaming-progress.md
+++ b/docs/streaming-progress.md
@@ -93,6 +93,12 @@ This is a **product-UX channel, not an audit record.**
   connects late does not receive earlier chunks. There is no buffering for late
   subscribers and no gap-filling across a reconnect — durable per-execution logs
   (#790) are the separate primitive for a persisted, replayable record.
+- **Dropped under back-pressure from a slow-but-connected client.** The SSE
+  producer sends chunks **non-blocking**: if a slow subscriber lets the bounded
+  per-stream buffer fill, the *excess* chunks are **dropped** rather than
+  buffered unboundedly or back-pressured into Postgres' shared `NOTIFY` queue.
+  The monotonic `seq` lets the client detect the resulting gap. Only a
+  *disconnected* client ends the stream.
 - **Best-effort by construction.** A `NOTIFY` failure at the worker is logged and
   **swallowed** — publishing can never fail or slow a workflow. A published chunk
   is capped at **7000 serialized bytes** (Postgres' `NOTIFY` payload limit is
@@ -143,19 +149,31 @@ one keepalive interval; an idle client disconnect and a dropped `LISTEN`
 connection both end the stream rather than hanging. A malformed execution id
 returns `400`; an unknown execution returns `404`.
 
-### Monotonic `seq` and reconnect gap detection (AC6)
+### Monotonic `seq` — the client contract (AC6)
 
 Each chunk carries a **strictly increasing, execution-lifetime-monotonic**
 sequence number, surfaced as the SSE `id:`. It is `epoch`-prefixed — the high
 bits encode the workflow's loaded-history length at the start of the decision
 cycle that published the chunk, and the low bits are a per-cycle counter — so the
-number always grows across decision cycles as well as within one. A client that
-reconnects and sees the first new `id:` jump past `last_seen_id + 1` knows chunks
-were missed in the gap (delivery is best-effort; **the engine does not fill the
-gap** — refetch authoritative state from the workflow result or a query handler
-if you need completeness). Because the same inputs produce the same `seq`, a
-best-effort duplicate delivered after a crash-retry of the same cycle is
-**dedupable by `seq`**.
+number grows across decision cycles as well as within one. Crucially, `seq` is a
+**logical-position identity, not a per-chunk counter**: a re-driven workflow
+position (a spurious wake, or a rolled-back cycle that re-runs) deterministically
+re-emits the **same** `seq`.
+
+What a subscriber should do:
+
+- **Dedupe by `seq`, keep-first.** For at-most-once-per-position display, ignore
+  a chunk whose `seq` you have already seen. A re-emitted chunk MAY carry
+  *different content* for a non-deterministic chunk (an LLM token stream, a live
+  metric) — **the first-delivered is canonical**.
+- **Detect gaps via forward `seq` jumps.** After a reconnect, if the first new
+  `id:` jumps past the last seen `seq`, chunks were missed in the gap (delivery
+  is best-effort — a slow-consumer drop, a late connect, or a reconnect window).
+  **The engine does not fill the gap**; refetch authoritative state from the
+  workflow result or a query handler if you need completeness.
+- **`seq` is per `exec_id`.** A continue-as-new successor is a **new `exec_id` on
+  a new stream** whose `seq` restarts — subscribe to the successor's stream to
+  follow the chain.
 
 ## Auth — default posture (AC5)
 
@@ -169,6 +187,21 @@ route is open.** Embedders surfacing streams to untrusted end-users **must** fro
 this route with their own authentication and per-execution authorization
 (typically your app already knows which `exec_id` belongs to the requesting
 user). Do not expose an unauthenticated `/stream` to the public internet.
+
+**`exec_id` is a bearer capability for live chunk content.** The engine only
+checks that the execution *exists* (returning `404` otherwise) — it performs **no
+authorization**. Anyone who presents a valid `exec_id` receives that run's live
+chunk **content**, which may include sensitive workflow output. If your chunks
+carry anything sensitive, you **must** add a per-execution authorization check in
+your own middleware. `exec_id` is a random UUIDv4 (not enumerable), which
+mitigates blind probing but is **not** an access-control substitute.
+
+**Cap concurrent streams (DoS).** Each subscriber holds **one dedicated,
+non-pooled Postgres `LISTEN` connection** for the lifetime of the stream. A flood
+of concurrent `/stream` requests can therefore exhaust database connections.
+Embedders should rate-limit stream opens and/or cap concurrent streams per user.
+A global concurrent-stream cap is a possible future enhancement; today it is the
+embedder's responsibility.
 
 ## Out of scope
 

--- a/docs/streaming-progress.md
+++ b/docs/streaming-progress.md
@@ -1,0 +1,195 @@
+# Live workflow output streaming — `ctx.publish_progress`
+
+*Issue #791.* An **ephemeral, best-effort live-output side channel** for workflow
+authors: an AI agent streaming tokens, a long import reporting per-item progress,
+any interactive flow that wants to push incremental, author-defined output to a
+waiting client while the durable run is still executing — **without** standing up
+an external message bus and **without** bloating the event log.
+
+```rust
+use autumn_harvest::prelude::*;
+
+#[workflow]
+async fn summarize(ctx: &WorkflowContext, doc: Document) -> Result<Summary, String> {
+    for (i, section) in doc.sections.iter().enumerate() {
+        // Emit an author-defined chunk to any connected subscriber. Fire-and-forget:
+        // returns immediately, never blocks on a subscriber, never fails the workflow.
+        ctx.publish_progress(serde_json::json!({
+            "step": i,
+            "status": "summarizing",
+            "section": section.title,
+        })).map_err(|e| e.to_string())?;
+
+        let _ = ctx.execute_activity(&summarize_section_info(), section.clone()).await;
+    }
+    Ok(Summary::default())
+}
+```
+
+## The API
+
+```rust
+impl WorkflowContext {
+    pub fn publish_progress(&self, chunk: impl serde::Serialize) -> HarvestResult<()>;
+}
+```
+
+`chunk` is **any** serializable value — the shape is entirely author-defined
+(it is your product's stream contract, not the engine's). The call is
+synchronous and non-suspending: it does not `.await`, does not wait for a
+subscriber, and does not participate in any suspension batch. `Err` is returned
+only if the chunk fails to serialize.
+
+Where it fits among the neighboring read surfaces:
+
+| Surface | Direction | Shape | Audience | Durable? |
+|---|---|---|---|---|
+| **`ctx.publish_progress` + `GET /stream`** (this) | push | ordered author-defined chunks, live | end-user | no (ephemeral) |
+| [`set_current_details`](../CLAUDE.md) (#473/#593) | pull | one overwriting status string | operator/end-user | yes (a column) |
+| Engine-event SSE tail (#324) | push | engine machinery (`ActivityScheduled`/…) | **operator only** (admin-gated) | reads durable events |
+| Await-completion long-poll (#527) | pull | terminal result only | end-user | yes (the result) |
+| Durable per-execution logs (#790) | pull | persisted triage record | operator | yes |
+
+Use `publish_progress` when you want **live, incremental, author-defined
+content** streamed to a client. Use `set_current_details` for a single
+"what am I doing right now" status an operator reads on demand; use the
+await-completion long-poll for the final result.
+
+## Determinism contract
+
+`publish_progress` is a **pure side effect**, and that is the whole design:
+
+- **Replay-neutral.** The call is a **no-op when `ctx.is_replaying()` is true** —
+  it returns `Ok(())` immediately, pushes **no `WorkflowCommand`**, and consumes
+  **no sequence number** (mirroring `set_current_details`).
+- **Zero event-log footprint.** It writes **nothing** to `harvest_events`. A
+  workflow that publishes N chunks produces a **byte-for-byte identical history**
+  to one that publishes none — verified by a replay test
+  (`publish_progress_replays_with_zero_divergence`) and a footprint test
+  (`publish_progress_leaves_zero_event_footprint`, which compares the recorded
+  event-type sequence against a no-progress sibling workflow).
+- **No new `WorkflowEvent` variant. No migration. No shard-routing change.**
+- **Chunk content MAY be non-deterministic.** Because a chunk is never recorded
+  and never replayed, it is *safe* to publish values that would break replay if
+  they entered the event log — LLM tokens, `chrono::Utc::now()`, a sampled
+  metric, a random id. This is the opposite of an activity input or a workflow
+  command, where non-determinism corrupts replay. Publish freely.
+
+Internally the live path pushes a **bookkeeping** `WorkflowCommand::PublishProgress`
+that the worker translates into a per-execution `pg_notify` at persist time and
+then discards — it is never appended to the durable log. Publishing from a
+throwaway `WorkflowContext` (inside a query or update handler) is a harmless
+no-op: that context is never drained by the worker persist path.
+
+## Delivery model — ephemeral, best-effort
+
+This is a **product-UX channel, not an audit record.**
+
+- **Dropped when nobody is listening.** Chunks ride Postgres `LISTEN`/`NOTIFY`.
+  If no subscriber is connected to the execution's channel at publish time, the
+  chunk is **dropped**. The durable workflow **result** remains authoritative —
+  the stream is a convenience, never the source of truth.
+- **No backfill, no replay of chunks, no at-least-once.** A subscriber that
+  connects late does not receive earlier chunks. There is no buffering for late
+  subscribers and no gap-filling across a reconnect — durable per-execution logs
+  (#790) are the separate primitive for a persisted, replayable record.
+- **Best-effort by construction.** A `NOTIFY` failure at the worker is logged and
+  **swallowed** — publishing can never fail or slow a workflow. A published chunk
+  is capped at **7000 serialized bytes** (Postgres' `NOTIFY` payload limit is
+  8000, with headroom reserved for the delivery envelope); an oversize chunk is
+  **replaced** — never silently dropped — with the marker
+  `{"_harvest_progress_truncated": true, "bytes": <original_len>}`, so the client
+  still sees an ordered slot and knows truncation occurred. Keep chunks small;
+  stream many small ones rather than one large one.
+
+## The SSE route
+
+```
+GET /api/harvest/workflows/{id}/stream
+```
+
+Returns `text/event-stream`. Frames, in publish order:
+
+| Frame | `id:` | `data:` | Meaning |
+|---|---|---|---|
+| `event: progress` | the chunk's `seq` | the raw chunk JSON (exactly what you published) | one published chunk |
+| `event: end` | — | `{"reason": "<terminal-state>"}` | the workflow reached a terminal state; stream closes |
+| `event: error` | — | `{"error": "listen_connection_closed"}` | the underlying `LISTEN` connection dropped; stream closes |
+
+The `data:` of a `progress` frame is the chunk **verbatim** — it is *not*
+re-wrapped in any envelope; the sequence number rides the SSE `id:` field
+instead. The stream also emits periodic `: ping` keepalive comments.
+
+Consume it with any SSE client. With `curl`:
+
+```console
+$ curl -N http://localhost:8080/api/harvest/workflows/{exec_id}/stream
+event: progress
+id: 42
+data: {"step":0,"status":"summarizing","section":"Intro"}
+
+event: progress
+id: 43
+data: {"step":1,"status":"summarizing","section":"Body"}
+
+event: end
+data: {"reason":"completed"}
+```
+
+**Clean close (AC4).** The stream ends promptly on terminal state: an
+already-terminal execution emits a single `end` frame and closes immediately; a
+running execution is polled on each keepalive tick so close latency is bounded to
+one keepalive interval; an idle client disconnect and a dropped `LISTEN`
+connection both end the stream rather than hanging. A malformed execution id
+returns `400`; an unknown execution returns `404`.
+
+### Monotonic `seq` and reconnect gap detection (AC6)
+
+Each chunk carries a **strictly increasing, execution-lifetime-monotonic**
+sequence number, surfaced as the SSE `id:`. It is `epoch`-prefixed — the high
+bits encode the workflow's loaded-history length at the start of the decision
+cycle that published the chunk, and the low bits are a per-cycle counter — so the
+number always grows across decision cycles as well as within one. A client that
+reconnects and sees the first new `id:` jump past `last_seen_id + 1` knows chunks
+were missed in the gap (delivery is best-effort; **the engine does not fill the
+gap** — refetch authoritative state from the workflow result or a query handler
+if you need completeness). Because the same inputs produce the same `seq`, a
+best-effort duplicate delivered after a crash-retry of the same cycle is
+**dedupable by `seq`**.
+
+## Auth — default posture (AC5)
+
+The stream route is **deliberately not** `require_admin`. It is an
+**end-user-facing** read path — an app's users stream their own workflows —
+distinct from the admin-only engine-event tail (#324).
+
+It inherits the general `api_with_auth` middleware you configure on the Harvest
+API, exactly like the other management routes. **If you configure no auth, the
+route is open.** Embedders surfacing streams to untrusted end-users **must** front
+this route with their own authentication and per-execution authorization
+(typically your app already knows which `exec_id` belongs to the requesting
+user). Do not expose an unauthenticated `/stream` to the public internet.
+
+## Out of scope
+
+Explicitly **not** provided by this feature (see the issue for rationale):
+
+- **Durable persistence or replay of chunks** — that is the durable per-execution
+  logs primitive (#790). Progress chunks are ephemeral.
+- **At-least-once / exactly-once delivery, cross-reconnect ordering guarantees,
+  or buffering for late subscribers** — best-effort only.
+- **Final-result delivery** — use the await-completion long-poll (#527).
+- **Snapshot state reads** — use a query handler or `set_current_details`
+  (#473/#593).
+- **Client → workflow streaming** — that is signals and updates.
+- **Cross-shard fan-in of one logical stream** — a stream is scoped to a single
+  `exec_id` on its owning shard.
+
+## See also
+
+- `autumn-harvest/examples/streaming_agent.rs` — a worked AI-agent-shaped example
+  that publishes per-step chunks and documents the `curl -N` consumer.
+- [`set_current_details`](../CLAUDE.md) (#473/#593) — the single-value pull status
+  companion.
+- Engine-event SSE tail (#324) — the admin-only operator triage stream.
+- Await-completion long-poll (#527) — terminal result delivery.


### PR DESCRIPTION
## Before / After

**Before.** A workflow author building an AI agent, a long-running import, or any interactive flow had **no way to push incremental, author-defined business output** to a waiting client while the run is in flight. The only options were to poll a query handler (pull, snapshot-only), read `set_current_details` (a single overwriting status string, #473/#593), or — for operators only — subscribe to the admin-gated engine-event SSE tail (#324), which streams `ActivityScheduled`/`ActivityCompleted` machinery, not the author's content. Streaming tokens, reasoning steps, or per-item progress to an end user meant bolting on an external message bus.

**After.** `ctx.publish_progress(chunk)` lets live workflow code emit an ordered, author-defined chunk that is delivered to a subscriber on `GET /api/harvest/workflows/{id}/stream` (SSE) over the existing Postgres LISTEN/NOTIFY plumbing. It is **replay-neutral** — a no-op during replay with **zero `harvest_events` footprint**, so a workflow that publishes N chunks produces a byte-for-byte identical history to one that publishes none. Delivery is **ephemeral and best-effort**: chunks are dropped when no subscriber is connected; the durable workflow *result* remains authoritative. No external broker required.

## How

- **Publish (`context.rs`).** `publish_progress` returns early (`Ok(())`, no command, no seq consumed) while `ctx.is_replaying()`. Live, it serializes the chunk, caps it at `PROGRESS_CHUNK_MAX_BYTES` (7000 — Postgres NOTIFY headroom; oversize is *replaced* with `{"_harvest_progress_truncated": true, "bytes": N}`, never silently dropped), assigns an epoch-prefixed monotonic `seq`, and pushes a **bookkeeping** `WorkflowCommand::PublishProgress { seq, chunk }`.
- **Notify (`worker.rs` + `notify.rs`).** At worker persist, `notify_progress_from_commands` fires a per-execution `pg_notify` on the persist connection (co-located with the `set_current_details` write, on both suspension and terminal cycles). A notify failure is logged and swallowed — progress is disposable and can never fail a workflow.
- **Relay (`api.rs`).** `stream_workflow_progress` establishes a dedicated `WorkflowProgressListener` (its own `tokio-postgres` connection, shard-resolved, no pooled diesel conn held across the stream), then relays each chunk as SSE `event: progress` (`id:` = seq, `data:` = raw chunk JSON), emits `event: end` on terminal, and `event: error` on channel loss.

**No new `WorkflowEvent` variant. No migration. No shard-routing change. Replay-determinism preserved by construction** (the chunk is a pure side effect gated on `is_replaying()` and never enters the event log).

## Acceptance criteria

- [x] **AC1** — new `WorkflowContext::publish_progress(impl Serialize)` (`context.rs`).
- [x] **AC2** — replay-neutral, zero `harvest_events` footprint, byte-identical history; verified by `publish_progress_leaves_zero_event_footprint` + `publish_progress_replays_with_zero_divergence` (`tests/integration/publish_progress_tests.rs`) and inline `publish_progress_suppressed_during_replay` (`context.rs`). No new event variant, no migration.
- [x] **AC3** — ephemeral, best-effort over LISTEN/NOTIFY; dropped with no subscriber; worker swallows notify failures (`notify.rs`, `worker.rs`).
- [x] **AC4** — `GET /api/harvest/workflows/{id}/stream` SSE, publish-order frames, closes on terminal (`stream_workflow_progress`, `api.rs`); `progress_stream_delivers_ordered_chunks_and_ends_on_terminal`.
- [x] **AC5** — route is **not** `require_admin`; inherits `api_with_auth`; open if none configured; default posture documented (`sse_stream_tests.rs` auth-posture test + `docs/streaming-progress.md`).
- [x] **AC6** — monotonic epoch-prefixed `seq` (`encode_progress_seq`) surfaced as the SSE `id:` for reconnect gap detection.
- [x] **AC7** — determinism contract documented: chunk content MAY be non-deterministic because it is never recorded/replayed (`docs/streaming-progress.md`, example comment).
- [x] **AC8** — worked example `examples/streaming_agent.rs` (publish + documented `curl -N` consumption) with embedded `WorkflowTestEnv` tests.
- [x] **AC9** — contract surfaces updated: `management_api_routes()` / `management_api_response_fields()` / `docs/api-contract.json`, plus `audit` `CLASSIFIED_ROUTES` (ReadOnly) / `ALL_MUTATION_ROUTES` (None) / `EXCLUDED_ROUTES` with pinned classification tests in `audit.rs` and `contract_regression.rs`.

## Related surfaces (complementary, not overlapping)

- `set_current_details` (#473/#593) — single overwriting pull status.
- Admin engine-event tail (#324) — operator triage, engine events, admin-only.
- Await-completion long-poll (#527) — terminal result only.
- Durable per-execution logs (#790) — persisted triage record (out of scope here).

Closes #791

---
_Generated by [Claude Code](https://claude.ai/code/session_01UV8EQN53U6k7jRDVFnPaG8)_