### PR TITLE
fix(#685): enforce start-route cancel-capable admin gate before the fail-closed runtime check

### DIFF
--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -10779,13 +10779,50 @@ pub(crate) async fn start_workflow(
     // A start that can forcibly cancel a live prior requires admin auth. The
     // gate is NARROWED (issue #685 review) to the precise "can cancel a live
     // run" capability — the resolved active-prior behavior being `Terminate` —
-    // rather than a raw-string match on the reuse/conflict wire values. This is
-    // computed AFTER both policies are parsed (below), because the flagship
-    // non-admin idempotent-starter shape `reuse = terminate_if_running` +
-    // `conflict = use_existing` resolves to `Attach` (return the existing
+    // rather than a raw-string match on the reuse/conflict wire values. The
+    // flagship non-admin idempotent-starter shape `reuse = terminate_if_running`
+    // + `conflict = use_existing` resolves to `Attach` (return the existing
     // handle) and provably CANNOT cancel a live run — gating it on the raw
     // `terminate_if_running` string would wrongly force admin and defeat the
-    // non-admin webhook/cron user story. See the gate below the two parses.
+    // non-admin webhook/cron user story.
+    //
+    // This gate is enforced in TWO places:
+    //
+    //  1. EARLY (here) — a lenient evaluation before the fail-closed
+    //     `api_state.runtime()` check below. The auth decision is a pure
+    //     function of the two request-body strings and `api_state` config; it
+    //     needs neither the runtime nor a DB. Evaluating it first means an
+    //     unauthenticated caller that could cancel a live run is rejected with
+    //     `401` regardless of runtime readiness (defense in depth — authorize
+    //     before the fail-closed resource check — and it restores the pre-#685
+    //     property that the gate is observable without a running DB). It is
+    //     LENIENT: an unparseable policy string makes the `Ok`/`Ok` guard fail,
+    //     so it defers to the authoritative gate below (a fresh invalid string
+    //     still `400`s at the real parse; an #808 keyed committed-replay still
+    //     returns its `200` — a non-admin can never have committed a `Terminate`
+    //     start, so no committed replay exists for one to bypass this through).
+    //     A cleanly-parsed non-`Terminate` combo (e.g. the flagship
+    //     `terminate_if_running` + `use_existing` → `Attach`) is a no-op here.
+    //
+    //  2. AUTHORITATIVE (below, after both parses) — the belt-and-suspenders
+    //     backstop on the cleanly-parsed policies. Reachable only for requests
+    //     the early gate already let through (admin, or non-`Terminate`), so it
+    //     never changes a running deployment's outcome.
+    if let (Ok(early_reuse), Ok(early_conflict)) = (
+        parse_reuse_policy(request.reuse_policy.as_deref()),
+        parse_conflict_policy(request.conflict_policy.as_deref()),
+    ) && autumn_harvest::execution::effective_active_conflict_behavior(
+        early_reuse,
+        early_conflict,
+    ) == autumn_harvest::execution::ActiveConflictBehavior::Terminate
+        && !has_harvest_admin_access(
+            &api_state,
+            maybe_session.as_ref().map(|Extension(s)| s.clone()),
+        )
+        .await
+    {
+        return AutumnError::unauthorized_msg("authentication required").into_response();
+    }
 
     let runtime = match api_state.runtime() {
         Ok(r) => r,

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -10776,6 +10776,27 @@ pub(crate) async fn start_workflow(
         .unwrap_or(autumn_harvest::StartSource::Api);
     let effective_start_source_ref = request.start_source_ref_override.clone();
 
+    // issue #685 review (Codex P2): the early gate must NOT pre-empt a request
+    // that carries an idempotency key. The #808 committed-replay claim is keyed
+    // on `(workflow_name, idempotency_key)` ALONE — independent of the
+    // reuse/conflict policy and of the caller's auth — so a committed KEYED
+    // `Terminate` start (which an ADMIN may legitimately have made) can be
+    // replayed by a later NON-admin retry carrying the same key, which must
+    // return the #808 `200` no-op, not a `401`. A presence-only boolean
+    // (below) therefore defers any keyed request past this early gate to the
+    // downstream path. Presence only — no validation/erroring here; the
+    // downstream resolver (`extract_start_idempotency_header_key` /
+    // `validate_start_idempotency_key`) still `400`s an empty/over-long key
+    // unchanged. Header-present counts even if it is empty/invalid: such a key
+    // resolves to a downstream `400`, which is the correct answer for a caller
+    // that signalled idempotent intent — never an early `401` and never a
+    // false `200`.
+    let idempotency_key_present = headers.contains_key(HEADER_IDEMPOTENCY_KEY)
+        || request
+            .idempotency_key
+            .as_deref()
+            .is_some_and(|k| !k.trim().is_empty());
+
     // A start that can forcibly cancel a live prior requires admin auth. The
     // gate is NARROWED (issue #685 review) to the precise "can cancel a live
     // run" capability — the resolved active-prior behavior being `Terminate` —
@@ -10788,26 +10809,32 @@ pub(crate) async fn start_workflow(
     //
     // This gate is enforced in TWO places:
     //
-    //  1. EARLY (here) — a lenient evaluation before the fail-closed
-    //     `api_state.runtime()` check below. The auth decision is a pure
-    //     function of the two request-body strings and `api_state` config; it
-    //     needs neither the runtime nor a DB. Evaluating it first means an
-    //     unauthenticated caller that could cancel a live run is rejected with
-    //     `401` regardless of runtime readiness (defense in depth — authorize
-    //     before the fail-closed resource check — and it restores the pre-#685
-    //     property that the gate is observable without a running DB). It is
-    //     LENIENT: an unparseable policy string makes the `Ok`/`Ok` guard fail,
-    //     so it defers to the authoritative gate below (a fresh invalid string
-    //     still `400`s at the real parse; an #808 keyed committed-replay still
-    //     returns its `200` — a non-admin can never have committed a `Terminate`
-    //     start, so no committed replay exists for one to bypass this through).
+    //  1. EARLY (here) — an observable, KEY-ABSENT-ONLY auth check before the
+    //     fail-closed `api_state.runtime()` check below. The auth decision is a
+    //     pure function of the two request-body strings, the key-presence
+    //     boolean, and `api_state` config; it needs neither the runtime nor a
+    //     DB. Evaluating it first means an unauthenticated caller that could
+    //     cancel a live run with NO idempotency key is rejected with `401`
+    //     regardless of runtime readiness (defense in depth — authorize before
+    //     the fail-closed resource check — and it restores the pre-#685 property
+    //     that the gate is observable without a running DB). It is LENIENT in
+    //     two ways: an unparseable policy string makes the `Ok`/`Ok` guard fail
+    //     (a fresh invalid string still `400`s at the real parse), and a KEYED
+    //     request (`idempotency_key_present`) always defers. Deferring a keyed
+    //     request is what preserves BOTH #808 outcomes: a committed-replay hit
+    //     returns its `200` at the probe below (caller/body-independent), while
+    //     a genuinely-fresh keyed `Terminate` by a non-admin is still rejected
+    //     `401` by the authoritative gate below (which runs AFTER that probe).
     //     A cleanly-parsed non-`Terminate` combo (e.g. the flagship
     //     `terminate_if_running` + `use_existing` → `Attach`) is a no-op here.
     //
-    //  2. AUTHORITATIVE (below, after both parses) — the belt-and-suspenders
-    //     backstop on the cleanly-parsed policies. Reachable only for requests
-    //     the early gate already let through (admin, or non-`Terminate`), so it
-    //     never changes a running deployment's outcome.
+    //  2. AUTHORITATIVE (below, after both parses AND the #808 committed-replay
+    //     probe) — the belt-and-suspenders backstop on the cleanly-parsed
+    //     policies. Reachable for requests the early gate let through: admin,
+    //     non-`Terminate`, OR keyed. For a keyed request it runs after the probe
+    //     that already returned `200` for a committed replay, so it only ever
+    //     sees a genuinely-fresh keyed `Terminate` — which it correctly `401`s
+    //     for a non-admin. It never changes a running deployment's outcome.
     if let (Ok(early_reuse), Ok(early_conflict)) = (
         parse_reuse_policy(request.reuse_policy.as_deref()),
         parse_conflict_policy(request.conflict_policy.as_deref()),
@@ -10815,6 +10842,7 @@ pub(crate) async fn start_workflow(
         early_reuse,
         early_conflict,
     ) == autumn_harvest::execution::ActiveConflictBehavior::Terminate
+        && !idempotency_key_present
         && !has_harvest_admin_access(
             &api_state,
             maybe_session.as_ref().map(|Extension(s)| s.clone()),
@@ -11120,10 +11148,13 @@ pub(crate) async fn start_workflow(
     // equivalent to the already-non-admin `allow_duplicate_failed_only` replace
     // path — so it is correctly not admin-gated. This runs after both parses (an
     // invalid value now returns `400` before reaching the gate, which is more
-    // correct); for a keyed start it also runs after the #808 committed-replay
-    // probe, which is safe because a replay returns the already-committed run and
-    // never performs a NEW cancel, and a non-admin can never commit a Terminate
-    // start in the first place (the fresh path always gates).
+    // correct); for a keyed start it runs AFTER the #808 committed-replay probe,
+    // so a committed replay has already returned its `200` and this gate only
+    // ever sees a genuinely-fresh keyed `Terminate` — which it correctly `401`s
+    // for a non-admin. This is the authoritative backstop for keyed
+    // cancel-capable requests, which the early gate deliberately defers (a keyed
+    // request may be a committed replay of an ADMIN's start, so it must reach the
+    // probe before any auth rejection).
     if autumn_harvest::execution::effective_active_conflict_behavior(reuse_policy, conflict_policy)
         == autumn_harvest::execution::ActiveConflictBehavior::Terminate
         && !has_harvest_admin_access(&api_state, maybe_session.map(|Extension(session)| session))

--- a/autumn-harvest-plugin/tests/progress_stream_integration.rs
+++ b/autumn-harvest-plugin/tests/progress_stream_integration.rs
@@ -219,6 +219,7 @@ fn start_params_named(
         memo: None,
         search_attrs: None,
         reuse_policy: autumn_harvest::WorkflowIdReusePolicy::AllowDuplicate,
+        conflict_policy: autumn_harvest::types::WorkflowIdConflictPolicy::Unspecified,
         trace_context: None,
         max_execution_timeout_ceiling: None,
         concurrency_key: None,

--- a/autumn-harvest-plugin/tests/security.rs
+++ b/autumn-harvest-plugin/tests/security.rs
@@ -215,6 +215,56 @@ async fn eris_unauthenticated_start_workflow_use_existing_conflict_is_allowed() 
     assert_ne!(res.status(), StatusCode::FORBIDDEN);
 }
 
+// issue #685 review (Codex P2): the early cancel-capable admin gate must NOT
+// pre-empt a request that carries an idempotency key. The #808 committed-replay
+// claim is keyed on `(workflow_name, idempotency_key)` ALONE — independent of the
+// reuse/conflict policy and the caller's auth — so an ADMIN may legitimately have
+// committed a keyed `terminate_if_running` start that a later NON-admin retry
+// (same key) must replay as a `200`, not a `401`. A keyed cancel-capable request
+// therefore defers past the early gate to the downstream path. In this no-DB
+// harness the downstream path fails-closed at the runtime-not-started check (a
+// non-`401` status), which is exactly the "no longer early-`401`'d" proof: the
+// UNKEYED `terminate_if_running` case above asserts `401`, this KEYED case must
+// NOT. (A genuinely-fresh keyed `Terminate` by a non-admin is still `401`'d
+// downstream by the authoritative gate, which runs AFTER the committed-replay
+// probe — that requires a DB and is covered by the #808 integration tests.)
+#[tokio::test]
+async fn eris_keyed_terminate_if_running_defers_past_early_gate() {
+    let app = unauthenticated_app();
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/workflows/my-workflow/start")
+        .header("Content-Type", "application/json")
+        .header("Idempotency-Key", "replay-key-1")
+        .body(Body::from(
+            r#"{"reuse_policy": "terminate_if_running"}"#.to_owned(),
+        ))
+        .unwrap();
+    let res = app.oneshot(req).await.unwrap();
+    assert_ne!(res.status(), StatusCode::UNAUTHORIZED);
+    assert_ne!(res.status(), StatusCode::FORBIDDEN);
+}
+
+// Companion narrowing proof for the other cancel-capable shape: a keyed
+// `conflict_policy = terminate_existing` request likewise defers past the early
+// gate (the UNKEYED variant above asserts `401`).
+#[tokio::test]
+async fn eris_keyed_terminate_existing_conflict_defers_past_early_gate() {
+    let app = unauthenticated_app();
+    let req = Request::builder()
+        .method(Method::POST)
+        .uri("/workflows/my-workflow/start")
+        .header("Content-Type", "application/json")
+        .header("Idempotency-Key", "replay-key-2")
+        .body(Body::from(
+            r#"{"conflict_policy": "terminate_existing"}"#.to_owned(),
+        ))
+        .unwrap();
+    let res = app.oneshot(req).await.unwrap();
+    assert_ne!(res.status(), StatusCode::UNAUTHORIZED);
+    assert_ne!(res.status(), StatusCode::FORBIDDEN);
+}
+
 #[tokio::test]
 async fn eris_start_workflow_terminate_if_running_honors_configured_session_key() {
     let api_state = HarvestApiState::new();

--- a/autumn-harvest-plugin/tests/security.rs
+++ b/autumn-harvest-plugin/tests/security.rs
@@ -145,6 +145,76 @@ async fn eris_unauthenticated_start_workflow_terminate_if_running_is_blocked() {
     assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
 }
 
+// A `conflict_policy = terminate_existing` request (with ANY reuse policy)
+// resolves to `Terminate` — it can cancel a live RUNNING/PAUSED prior — so it is
+// admin-gated exactly like `terminate_if_running` with the default conflict.
+#[tokio::test]
+async fn eris_unauthenticated_start_workflow_terminate_existing_conflict_is_blocked() {
+    let app = unauthenticated_app();
+    let res = app
+        .oneshot(post_json(
+            "/workflows/my-workflow/start",
+            r#"{"conflict_policy": "terminate_existing"}"#,
+        ))
+        .await
+        .unwrap();
+    assert_eq!(res.status(), StatusCode::UNAUTHORIZED);
+}
+
+// Narrowing proof (issue #685): the flagship non-admin idempotent-starter shape
+// `reuse = terminate_if_running` + `conflict = use_existing` resolves to
+// `Attach` (return the existing handle) and provably CANNOT cancel a live run,
+// so it must NOT be admin-gated — it is allowed through the auth gate (and then
+// fails later for an unrelated boot-window reason, exactly like every other
+// "allowed through" eris start case, so we assert only "not blocked by auth").
+#[tokio::test]
+async fn eris_unauthenticated_start_workflow_terminate_if_running_plus_use_existing_is_allowed() {
+    let app = unauthenticated_app();
+    let res = app
+        .oneshot(post_json(
+            "/workflows/my-workflow/start",
+            r#"{"reuse_policy": "terminate_if_running", "conflict_policy": "use_existing"}"#,
+        ))
+        .await
+        .unwrap();
+    assert_ne!(res.status(), StatusCode::UNAUTHORIZED);
+    assert_ne!(res.status(), StatusCode::FORBIDDEN);
+}
+
+// Narrowing proof: `reuse = terminate_if_running` + `conflict = fail` resolves to
+// `Fail` (`Err(AlreadyExists)` over a live prior) — it touches no live work — so
+// it is likewise NOT admin-gated.
+#[tokio::test]
+async fn eris_unauthenticated_start_workflow_terminate_if_running_plus_fail_is_allowed() {
+    let app = unauthenticated_app();
+    let res = app
+        .oneshot(post_json(
+            "/workflows/my-workflow/start",
+            r#"{"reuse_policy": "terminate_if_running", "conflict_policy": "fail"}"#,
+        ))
+        .await
+        .unwrap();
+    assert_ne!(res.status(), StatusCode::UNAUTHORIZED);
+    assert_ne!(res.status(), StatusCode::FORBIDDEN);
+}
+
+// Narrowing proof: a `conflict_policy = use_existing` (attach) start with the
+// default reuse policy resolves to `Attach` — non-destructive — and is NOT
+// admin-gated.
+#[tokio::test]
+async fn eris_unauthenticated_start_workflow_use_existing_conflict_is_allowed() {
+    let app = unauthenticated_app();
+    let res = app
+        .oneshot(post_json(
+            "/workflows/my-workflow/start",
+            r#"{"conflict_policy": "use_existing"}"#,
+        ))
+        .await
+        .unwrap();
+    assert_ne!(res.status(), StatusCode::UNAUTHORIZED);
+    assert_ne!(res.status(), StatusCode::FORBIDDEN);
+}
+
 #[tokio::test]
 async fn eris_start_workflow_terminate_if_running_honors_configured_session_key() {
     let api_state = HarvestApiState::new();

--- a/docs/changelog.d/pr-1103-685-start-gate-early-auth.md
+++ b/docs/changelog.d/pr-1103-685-start-gate-early-auth.md
@@ -1,0 +1,57 @@
+## Phase 3.x — Enforce the start-route capability-precise admin gate before the fail-closed runtime check (issue #685 follow-up)
+
+Heals the no-DB plugin security test
+`eris_unauthenticated_start_workflow_terminate_if_running_is_blocked`, which
+began failing on trunk-dev after #1100 (issue #685) narrowed and **reordered**
+the `POST /workflows/{name}/start` admin gate.
+
+**Root cause (not a live-deployment security hole).** Pre-#1100 the admin gate
+was a raw-string match placed at the top of `start_workflow`, before the
+fail-closed `api_state.runtime()` check. #1100 replaced it with the
+capability-precise gate
+`effective_active_conflict_behavior(reuse, conflict) == Terminate && !admin`
+and moved it to *after* both policy parses — which sit after the runtime check
+and the #808 committed-replay probe. In a **running** deployment the gate still
+correctly returns `401` for every request that can cancel a live run, so there
+is no live security hole. But in the no-DB `unauthenticated_app()` harness the
+runtime is unset, so `api_state.runtime()` returns `Config("harvest runtime is
+not started")` → `400` *before* the gate is reached. The test's `401` assertion
+now saw `400`. More importantly the reordering made the start-route auth gate
+**un-observable** in the no-DB harness: a gate-present and a gate-removed build
+both return `400`, so a test that accepted `400` would catch no regression.
+
+**Fix.** Add a surgical, additive, **lenient early auth gate** before the
+runtime check that reproduces the exact capability-precise condition on the two
+pure request-body policy strings (no runtime, no DB needed). It is lenient — an
+unparseable policy string makes the `Ok`/`Ok` guard fail, deferring to the
+authoritative gate (so #808's "committed replay returns `200` despite an invalid
+string" and "fresh invalid string → `400`" are preserved). Only a cleanly-parsed
+`Terminate`-capable combo by a non-admin returns `401`. The authoritative gate
+after the two parses is kept unchanged as a belt-and-suspenders backstop
+(reachable only for requests the early gate let through — admin, or
+non-`Terminate`). This restores the pre-#685 property that a cancel-capable
+unauthenticated start is rejected with `401` regardless of runtime readiness
+(defense in depth: authorize before the fail-closed resource check; `401` now
+precedes the registry `404`, removing an existence oracle — exactly the
+pre-#1100 ordering), and keeps #1100's narrowing intact: the flagship non-admin
+idempotent-starter `reuse = terminate_if_running` + `conflict = use_existing`
+(→ `Attach`) and `+ fail` (→ `Fail`) stay non-admin.
+
+**No new `WorkflowEvent` variant, no migration, no route change.** Running
+deployments are unaffected (same outcomes, `401` merely enforced earlier).
+
+**Tests** (`autumn-harvest-plugin/tests/security.rs`): the previously-failing
+test now asserts a clean `401` again; four new no-DB cases encode the narrowed
+contract so a regression in either direction is caught —
+`conflict_policy = terminate_existing` → `401`; and
+`terminate_if_running + use_existing`, `terminate_if_running + fail`,
+`conflict_policy = use_existing` are each `!= 401 && != 403` (allowed past the
+auth gate).
+
+**Also heals inherited trunk-dev Lint red** (out of this change's scope but
+blocking the `cargo clippy -p autumn-harvest-plugin --all-targets` gate):
+#1100's `StartWorkflowParams` literal sweep missed
+`autumn-harvest-plugin/tests/progress_stream_integration.rs` (added by #1098),
+which failed to compile with `missing field conflict_policy`. Added
+`conflict_policy: WorkflowIdConflictPolicy::Unspecified` matching the sweep's
+convention.

--- a/docs/changelog.d/pr-1103-685-start-gate-early-auth.md
+++ b/docs/changelog.d/pr-1103-685-start-gate-early-auth.md
@@ -55,3 +55,30 @@ blocking the `cargo clippy -p autumn-harvest-plugin --all-targets` gate):
 which failed to compile with `missing field conflict_policy`. Added
 `conflict_policy: WorkflowIdConflictPolicy::Unspecified` matching the sweep's
 convention.
+
+**Post-review hardening (Codex P2): the early gate now defers idempotency-keyed
+requests.** The early gate above rejected any cleanly-parsed `Terminate`-capable
+combo by a non-admin with `401` — with no regard for an idempotency key. But the
+#808 committed-replay claim is keyed on `(workflow_name, idempotency_key)`
+**alone** — independent of the reuse/conflict policy and the caller's auth — so a
+keyed `Terminate` start committed by an **admin** can legitimately be replayed by
+a later **non-admin** retry carrying the same key, which must return the #808
+`200` no-op. The early gate's own comment (and the authoritative gate's) claimed
+"a non-admin can never have committed a `Terminate` start, so no committed replay
+exists" — flawed reasoning, since the committer and the retrier need not be the
+same principal. **Fix:** narrow the early gate to fire only when **no** idempotency
+key is present (a cheap presence-only boolean — header `Idempotency-Key` present,
+or a non-empty body `idempotency_key`; no validation here, so the downstream
+resolver still `400`s an empty/over-long key unchanged). Any keyed request defers
+past the early gate to the downstream path, preserving BOTH #808 outcomes: a
+committed-replay hit returns its `200` at the committed-replay probe
+(caller/body-independent), while a genuinely-fresh keyed `Terminate` by a
+non-admin is still `401`'d by the authoritative gate — which runs **after** that
+probe, so the narrowing opens no hole. Both misleading comments are rewritten to
+state the correct invariant (the early gate is an observable, key-absent-only auth
+check; keyed requests defer downstream). New no-DB regression tests
+(`eris_keyed_terminate_if_running_defers_past_early_gate`,
+`eris_keyed_terminate_existing_conflict_defers_past_early_gate`) assert a keyed
+cancel-capable request is no longer early-`401`'d (in the no-DB harness it
+fails-closed at the runtime check → non-`401`), contrasted against the unkeyed
+cases which still assert `401`.


### PR DESCRIPTION
## Verdict: A — test is stale (no live-deployment security hole)

The no-DB plugin security test `eris_unauthenticated_start_workflow_terminate_if_running_is_blocked` failed on trunk-dev after #1100 (issue #685) narrowed **and reordered** the `POST /workflows/{name}/start` admin gate. This is **not** a live security regression — the running-deployment gate still blocks every cancel-capable request. It is a testability + defense-in-depth regression caused by ordering the auth gate *after* a fail-closed resource check.

### Failing assertion (actual vs expected)
`autumn-harvest-plugin/tests/security.rs:145` — `assert_eq!(res.status(), UNAUTHORIZED)`:
- **actual: `400`** ("harvest runtime is not started")
- **expected: `401`**

Request: unauthenticated `POST /workflows/my-workflow/start` with `{"reuse_policy": "terminate_if_running"}`.

### Request traced through the gate (post-#1100 `start_workflow`, `api.rs`)
1. body parse
2. **`api_state.runtime()` → `Err(Config "harvest runtime is not started")` → `map_error` → `400`** ← fires here in the no-DB `unauthenticated_app()` harness (no runtime installed)
3. registry `404` / DAG `400`
4. idempotency-key extraction; shard resolution (in-memory)
5. #808 committed-replay probe (read-only; **skipped** when no key — the test sends none)
6. `parse_reuse_policy` / `parse_conflict_policy`
7. **capability-precise admin gate:** `effective_active_conflict_behavior(reuse, conflict) == Terminate && !has_harvest_admin_access → 401`

For this request `effective_active_conflict_behavior(TerminateIfRunning, Unspecified) == Terminate` and `has_harvest_admin_access` is `false`, so a **running** deployment correctly returns `401` at step 7. The no-DB harness never reaches it: step 2's fail-closed `400` masks it.

### Why verdict A (no live hole)
Pre-#1100 the gate was a raw-string match at the top of the handler, **before** the runtime check. #1100 moved the (now capability-precise) gate to after both parses — after the runtime check. Between the runtime check and the gate nothing destructive happens (read-only shard resolution, error-path audit inserts, and — only with a key, which the test omits — a read-only replay probe); the actual reserve+start / cancel is *after* the gate. So the narrowed gate still blocks every request that can cancel a live run. The only real regression is that the start-route auth gate became **un-observable** in the no-DB harness: gate-present and gate-removed both return `400`, so a test that accepted `400` would catch no regression.

### Fix
Add a surgical, additive, **lenient early auth gate** before the runtime check that reproduces the exact capability-precise condition on the two pure request-body policy strings (needs no runtime/DB):
- **Lenient** — an unparseable policy string makes the `Ok`/`Ok` guard fail, deferring to the authoritative gate (so #808's "committed replay returns `200` despite an invalid string" and "fresh invalid string → `400`" are preserved).
- Only a cleanly-parsed `Terminate`-capable combo by a non-admin returns `401`.
- The authoritative gate after the two parses is kept unchanged as a belt-and-suspenders backstop (reachable only for requests the early gate let through — admin, or non-`Terminate`).

This restores the pre-#685 property that a cancel-capable unauthenticated start is `401` regardless of runtime readiness (authorize before the fail-closed resource check; `401` now precedes the registry `404`, removing an existence oracle — exactly the pre-#1100 ordering), while preserving #1100's narrowing: the non-admin idempotent-starter `terminate_if_running` + `use_existing` (→ `Attach`) / `+ fail` (→ `Fail`) stay non-admin. **No new `WorkflowEvent` variant, no migration, no route change**; running deployments are unaffected (same outcomes, `401` merely enforced earlier).

### Tests (encode the narrowed contract; catch regressions in either direction)
- **kept:** `terminate_if_running` (omitted conflict) → `401`
- **added:** `conflict_policy = terminate_existing` (any reuse) → `401`
- **added (narrowing proof, allowed through):** `terminate_if_running + use_existing`, `terminate_if_running + fail`, and `conflict_policy = use_existing` → `!= 401 && != 403`

### Red → green
- Before: `eris_unauthenticated_start_workflow_terminate_if_running_is_blocked` — `assertion left == right failed: left: 400, right: 401`.
- After: `cargo test -p autumn-harvest-plugin --test security` → **74 passed; 0 failed**.

### Also heals inherited trunk-dev Lint red (blocking the plugin clippy gate)
#1100's `StartWorkflowParams` literal sweep missed `autumn-harvest-plugin/tests/progress_stream_integration.rs` (added by #1098), which failed to compile with `missing field conflict_policy` on **pristine trunk-dev** (verified via `git stash`). Added `conflict_policy: WorkflowIdConflictPolicy::Unspecified` matching the sweep's convention. Unrelated to #1101/#1102 (rate limits / api tokens); not touched.

### CI mirror run locally (stable toolchain, matching ci.yml)
- `cargo fmt --all -- --check` — clean
- `cargo clippy -p autumn-harvest-plugin --all-targets -- -D warnings` — clean
- `cargo clippy -p autumn-harvest-plugin --all-targets --features webhooks -- -D warnings` — clean
- `cargo check --workspace` — clean
- `cargo test -p autumn-harvest-plugin --lib` — 604 passed
- `cargo test -p autumn-harvest-plugin --test security` — 74 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012kHwVjVbFy7RampL1AusmA)_