### PR TITLE
fix(#1092): short-circuit committed keyed with-start replays before validation

### DIFF
--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -10892,7 +10892,7 @@ async fn probe_committed_start_replay(
 /// plain signal route, PR #1092): a retry of an already-committed keyed
 /// signal-with-start must replay to its documented `200 signal_delivered: false`
 /// no-op BEFORE any fresh-start-only validation runs (the #610 signal-payload
-/// schema gate, the #373 start_input schema gate, the #252 cap). Otherwise a
+/// schema gate, the #373 `start_input` schema gate, the #252 cap). Otherwise a
 /// tightened schema/cap between the original delivery and the retry would
 /// wrongly reject a retry that creates no new work. This probe runs only when an
 /// `idempotency_key` is present; on a miss the caller falls through to the
@@ -10906,6 +10906,7 @@ async fn probe_committed_start_replay(
 /// fresh-start arm's 503-on-audit-failure: the original start was already
 /// audited, so a failed dedup audit is a no-op read that never fails the reply)
 /// and returns the documented `200` response.
+#[allow(clippy::too_many_arguments)]
 async fn probe_committed_sws_replay(
     api_state: &HarvestApiState,
     workflow_name: &str,
@@ -10919,12 +10920,11 @@ async fn probe_committed_sws_replay(
     use axum::response::IntoResponse as _;
     let pool = api_state.storage_pool().ok()?;
     for (shard, shard_pool) in pool.iter_shards() {
-        let mut probe_conn = match acquire_conn(shard_pool).await {
-            Ok(c) => c,
-            // A transient probe-connection failure must not masquerade as a
-            // dedup miss (which would fall through to a fresh start); skip this
-            // shard and let a genuine all-shard miss fall through instead.
-            Err(_) => continue,
+        // A transient probe-connection failure must not masquerade as a dedup
+        // miss (which would fall through to a fresh start); skip this shard and
+        // let a genuine all-shard miss fall through instead.
+        let Ok(mut probe_conn) = acquire_conn(shard_pool).await else {
+            continue;
         };
         let Some(existing) = autumn_harvest::execution::lookup_idempotent_signal_dedupe(
             &mut probe_conn,
@@ -10975,7 +10975,7 @@ async fn probe_committed_sws_replay(
 ///
 /// INVARIANT (mirrors [`probe_committed_sws_replay`]): a retry of an
 /// already-committed keyed update-with-start must replay to its cached admission
-/// BEFORE any fresh-start-only validation runs (the #373 start_input schema
+/// BEFORE any fresh-start-only validation runs (the #373 `start_input` schema
 /// gate, the #610 update-arg schema gate, the #684 semantic validator).
 /// Otherwise a tightened schema — or a validator that would now reject the same
 /// args — would wrongly reject a retry that admits no new update. Keyed-only; a
@@ -10995,9 +10995,8 @@ async fn probe_committed_uws_replay(
 ) -> Option<UpdateWithStartOutcome> {
     let pool = api_state.storage_pool().ok()?;
     for (_shard, shard_pool) in pool.iter_shards() {
-        let mut probe_conn = match acquire_conn(shard_pool).await {
-            Ok(c) => c,
-            Err(_) => continue,
+        let Ok(mut probe_conn) = acquire_conn(shard_pool).await else {
+            continue;
         };
         let Some(row) = autumn_harvest::execution::lookup_idempotent_update_dedupe(
             &mut probe_conn,

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -10919,23 +10919,38 @@ async fn probe_committed_sws_replay(
 ) -> Option<axum::response::Response> {
     use axum::response::IntoResponse as _;
     let pool = api_state.storage_pool().ok()?;
+    // Fail CLOSED on an inconclusive shard error (three-state: hit / clean-miss /
+    // inconclusive). A transient conn-acquire or lookup failure on the shard that
+    // owns a committed key must NOT masquerade as a dedup miss — that would fall
+    // through to fresh-start validation and could wrongly reject THIS PR's core
+    // invariant (a committed replay is never rejected by tightened validation)
+    // under a transient error. Deliberately MORE conservative than #808's
+    // plain-start probe (which swallows): (a) the sibling `found_shard` scan in
+    // this handler already fails closed (503) on the same error class, and (b)
+    // fail-closed preserves the never-reject invariant even under a transient
+    // owning-shard error; a keyed client retries 503 idempotently. Keep scanning
+    // the remaining shards first — a later shard may hold the hit — and only 503
+    // when the whole fan-out found no hit at all.
+    let mut had_error = false;
     for (shard, shard_pool) in pool.iter_shards() {
-        // A transient probe-connection failure must not masquerade as a dedup
-        // miss (which would fall through to a fresh start); skip this shard and
-        // let a genuine all-shard miss fall through instead.
         let Ok(mut probe_conn) = acquire_conn(shard_pool).await else {
+            had_error = true;
             continue;
         };
-        let Some(existing) = autumn_harvest::execution::lookup_idempotent_signal_dedupe(
+        let existing = match autumn_harvest::execution::lookup_idempotent_signal_dedupe(
             &mut probe_conn,
             workflow_name,
             workflow_id,
             key,
         )
         .await
-        .ok()
-        .flatten() else {
-            continue;
+        {
+            Ok(Some(existing)) => existing,
+            Ok(None) => continue,
+            Err(_) => {
+                had_error = true;
+                continue;
+            }
         };
         let outcome = SignalWithStartOutcome {
             exec_id: ExecutionId::from_uuid(existing.id),
@@ -10968,6 +10983,18 @@ async fn probe_committed_sws_replay(
                 .into_response(),
         );
     }
+    // No hit. If any shard was inconclusive (conn/lookup error), fail closed with
+    // a 503 rather than let a committed replay fall through to (possibly tightened)
+    // fresh-start validation. A clean all-shard miss returns `None` so the caller
+    // runs the authoritative in-lock path.
+    if had_error {
+        return Some(
+            AutumnError::service_unavailable_msg(
+                "signal-with-start committed-replay probe: shard lookup failed; retry",
+            )
+            .into_response(),
+        );
+    }
     None
 }
 
@@ -10987,29 +11014,51 @@ async fn probe_committed_sws_replay(
 /// "completed"` and writes the SUCCEEDED audit — giving a committed replay the
 /// SAME behavior as a fresh admission. `update_admitted: false` marks the cache
 /// hit.
+///
+/// Three-state result: `Ok(Some(outcome))` = committed-replay HIT (flows through
+/// the handler's `Ok` arm); `Ok(None)` = a genuine clean all-shard MISS (falls
+/// through to the authoritative in-lock path); `Err(resp)` = an INCONCLUSIVE
+/// shard error (fail closed with a 503). Failing closed on a transient conn/lookup
+/// error is deliberately MORE conservative than #808's plain-start probe (which
+/// swallows): (a) the sibling `found_shard` scan in this handler already fails
+/// closed (503) on the same error class, and (b) fail-closed preserves THIS PR's
+/// core invariant — a committed replay is never rejected by tightened validation —
+/// even under a transient owning-shard error; a keyed client retries 503
+/// idempotently.
 async fn probe_committed_uws_replay(
     api_state: &HarvestApiState,
     workflow_name: &str,
     workflow_id: &str,
     update_id: UpdateId,
-) -> Option<UpdateWithStartOutcome> {
-    let pool = api_state.storage_pool().ok()?;
+) -> Result<Option<UpdateWithStartOutcome>, axum::response::Response> {
+    use axum::response::IntoResponse as _;
+    let Ok(pool) = api_state.storage_pool() else {
+        // No storage pool at all → clean miss; the handler's own `storage_pool()`
+        // call fails closed for genuinely-fresh work.
+        return Ok(None);
+    };
+    let mut had_error = false;
     for (_shard, shard_pool) in pool.iter_shards() {
         let Ok(mut probe_conn) = acquire_conn(shard_pool).await else {
+            had_error = true;
             continue;
         };
-        let Some(row) = autumn_harvest::execution::lookup_idempotent_update_dedupe(
+        let row = match autumn_harvest::execution::lookup_idempotent_update_dedupe(
             &mut probe_conn,
             workflow_name,
             workflow_id,
             &update_id,
         )
         .await
-        .ok()
-        .flatten() else {
-            continue;
+        {
+            Ok(Some(row)) => row,
+            Ok(None) => continue,
+            Err(_) => {
+                had_error = true;
+                continue;
+            }
         };
-        return Some(UpdateWithStartOutcome {
+        return Ok(Some(UpdateWithStartOutcome {
             exec_id: row.exec_id,
             workflow_name: row.workflow_name,
             workflow_id: row.workflow_id,
@@ -11017,9 +11066,19 @@ async fn probe_committed_uws_replay(
             started_fresh: false,
             update_id,
             update_admitted: false,
-        });
+        }));
     }
-    None
+    // No hit. If any shard was inconclusive (conn/lookup error), fail closed with a
+    // 503 rather than let a committed replay fall through to (possibly tightened)
+    // fresh-start validation. A clean all-shard miss returns `Ok(None)` so the
+    // caller runs the authoritative in-lock path.
+    if had_error {
+        return Err(AutumnError::service_unavailable_msg(
+            "update-with-start committed-replay probe: shard lookup failed; retry",
+        )
+        .into_response());
+    }
+    Ok(None)
 }
 
 /// Handle a `start_workflow` request whose JSON body failed to deserialize
@@ -15681,7 +15740,14 @@ async fn update_with_start_workflow(
     // SAME behavior as a fresh admission. Mirrors #808 (plain start) and #1092
     // (plain signal route).
     let probe_outcome = if request.idempotency_key.is_some() {
-        probe_committed_uws_replay(&api_state, &workflow_name, &workflow_id, update_id).await
+        // `Err(resp)` = an inconclusive shard error → fail closed (503) rather than
+        // risk a spurious fresh-start rejection of a committed replay; `Ok(outcome)`
+        // = hit (Some) or clean miss (None).
+        match probe_committed_uws_replay(&api_state, &workflow_name, &workflow_id, update_id).await
+        {
+            Ok(outcome) => outcome,
+            Err(resp) => return resp,
+        }
     } else {
         None
     };

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -15650,6 +15650,42 @@ async fn update_with_start_workflow(
     let start_input = request.start_input.unwrap_or(Value::Null);
     let update_args = request.update_args.unwrap_or(Value::Null);
 
+    // Derive update_id — deterministic from idempotency_key if provided. Hoisted
+    // here (mirroring the signal-with-start probe placement) so the committed-
+    // replay probe below can run BEFORE the #377 admission gate and the
+    // found-shard scan, as well as before the #373/#610/#684 validation blocks.
+    let update_id = request
+        .idempotency_key
+        .as_ref()
+        .map_or_else(UpdateId::new, |key| {
+            let namespace = uuid::Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+                .expect("static namespace UUID is valid");
+            UpdateId::from_uuid(uuid::Uuid::new_v5(&namespace, key.as_bytes()))
+        });
+
+    // INVARIANT (this PR + #377): keyed committed-replay short-circuit. A retry of
+    // an already-committed keyed update-with-start must replay to its cached
+    // admission BEFORE any fresh-start-only rejection — the #373 start_input schema
+    // gate, the #610 update-arg schema gate + #684 validator further down, AND the
+    // #377 admission gate below. This mirrors both the signal-with-start route
+    // (whose probe likewise precedes the found-shard scan and the admission gate)
+    // and the #808 invariant that a committed replay precedes ALL fresh-start-only
+    // rejections, INCLUDING a raised admission gate: otherwise a retry that admits
+    // no new update — but hits an operator-raised gate or a schema/validator
+    // tightened since the original delivery — would wrongly return 503/400/422.
+    // Keyed-only; a miss (`None`) falls through to the untouched authoritative
+    // in-lock path (`update_with_start_workflow_execution_with_metrics`), which
+    // reserves the exactly-once update and remains the source of truth. On a hit
+    // the outcome flows through the existing `Ok` arm (which polls for the cached
+    // update result and writes the SUCCEEDED audit), giving a committed replay the
+    // SAME behavior as a fresh admission. Mirrors #808 (plain start) and #1092
+    // (plain signal route).
+    let probe_outcome = if request.idempotency_key.is_some() {
+        probe_committed_uws_replay(&api_state, &workflow_name, &workflow_id, update_id).await
+    } else {
+        None
+    };
+
     // Debounce admission is owned by POST /workflows/{name}/start. Ask the core
     // primitive to reject only a *fresh start* under its lock so an attach /
     // idempotent update-with-start to a live run still succeeds (issue #499).
@@ -15732,8 +15768,15 @@ async fn update_with_start_workflow(
         (shard, conn, ExecutionId::new_for_shard(shard))
     };
 
-    // Admission gate check (unconditional — same rationale as signal-with-start).
-    {
+    // issue #377: admission gate. Skipped on a committed-replay hit
+    // (`probe_outcome.is_some()`): a retry admits no new update, so — per the #808
+    // invariant, mirroring the fresh-start-only validation gates below — a
+    // committed replay must return its cached admission even while an operator has
+    // raised a gate, rather than a spurious 503. On a miss the gate runs
+    // unconditionally for genuinely-fresh work (same rationale as
+    // signal-with-start: the pre-scan is unlocked, so the resolver may still
+    // create fresh even when we observed an existing RUNNING execution).
+    if probe_outcome.is_none() {
         let wf_owner = runtime
             .registry
             .workflows
@@ -15780,38 +15823,6 @@ async fn update_with_start_workflow(
                 .into_response();
         }
     }
-
-    // Derive update_id — deterministic from idempotency_key if provided.
-    // Hoisted ABOVE the #373/#610/#684 validation blocks so the committed-replay
-    // probe below can key on it.
-    let update_id = request
-        .idempotency_key
-        .as_ref()
-        .map_or_else(UpdateId::new, |key| {
-            let namespace = uuid::Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
-                .expect("static namespace UUID is valid");
-            UpdateId::from_uuid(uuid::Uuid::new_v5(&namespace, key.as_bytes()))
-        });
-
-    // INVARIANT (this PR): keyed committed-replay short-circuit. A retry of an
-    // already-committed keyed update-with-start must replay to its cached
-    // admission BEFORE any fresh-start-only validation (the #373 start_input
-    // schema gate immediately below, and the #610 update-arg schema gate + #684
-    // validator further down). Otherwise a schema tightened — or a validator that
-    // would now reject the same args — between the original delivery and the
-    // retry would wrongly reject a retry that admits no new update. Keyed-only; a
-    // miss (`None`) falls through to the untouched authoritative in-lock path
-    // (`update_with_start_workflow_execution_with_metrics`), which reserves the
-    // exactly-once update and remains the source of truth. On a hit the outcome
-    // flows through the existing `Ok` arm (which polls for the cached update
-    // result and writes the SUCCEEDED audit), giving a committed replay the SAME
-    // behavior as a fresh admission. Mirrors #808 (plain start) and #1092 (plain
-    // signal route).
-    let probe_outcome = if request.idempotency_key.is_some() {
-        probe_committed_uws_replay(&api_state, &workflow_name, &workflow_id, update_id).await
-    } else {
-        None
-    };
 
     // issue #373: start_input schema validation (fresh-start-only; skipped on a
     // committed-replay hit).

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -15767,71 +15767,102 @@ async fn update_with_start_workflow(
             per_wf.max(runtime.registry.max_workflow_input_bytes)
         });
 
-    // Multi-shard scan: find any existing non-terminal execution for
-    // (workflow_name, workflow_id) to determine the target shard and exec_id.
+    // `pool` is needed by BOTH paths: the fresh/miss multi-shard scan below and
+    // the `Ok`-arm long-poll (`poll_update_result`), which routes by exec_id.
     let pool = match api_state.storage_pool() {
         Ok(p) => p,
         Err(e) => return map_error(e).into_response(),
     };
-    let mut found_shard: Option<(ShardId, PoolConn, ExecutionId)> = None;
-    for (candidate_shard, shard_pool) in pool.iter_shards() {
-        let mut shard_conn = match acquire_conn(shard_pool).await {
-            Ok(c) => c,
-            Err(e) => return e.into_response(),
-        };
-        let hit = match harvest_workflow_executions::table
-            .filter(harvest_workflow_executions::workflow_name.eq(&workflow_name))
-            .filter(harvest_workflow_executions::workflow_id.eq(&workflow_id))
-            .filter(harvest_workflow_executions::state.ne_all(["CONTINUED_AS_NEW", "TERMINATED"]))
-            .select((
-                harvest_workflow_executions::id,
-                harvest_workflow_executions::state,
-            ))
-            .first::<(uuid::Uuid, String)>(&mut shard_conn)
-            .await
-            .optional()
-        {
-            Ok(hit) => hit,
-            Err(e) => {
-                return AutumnError::service_unavailable_msg(format!(
-                    "shard {} lookup failed: {e}",
-                    candidate_shard.as_i32()
-                ))
-                .into_response();
-            }
-        };
-        if let Some((existing_uuid, existing_state)) = hit {
-            // Reuse the execution UUID only when attaching to a live RUNNING or
-            // SUSPENDED run under a non-rejecting policy. All other paths (terminal
-            // prior, PAUSED, TerminateIfRunning) go through replace_execution and
-            // need a fresh exec_id to avoid a primary-key conflict.
-            let will_attach = matches!(existing_state.as_str(), "RUNNING" | "SUSPENDED")
-                && matches!(
-                    reuse_policy,
-                    WorkflowIdReusePolicy::AllowDuplicate
-                        | WorkflowIdReusePolicy::AllowDuplicateFailedOnly
-                );
-            let exec_id = if will_attach {
-                ExecutionId::from_uuid(existing_uuid)
-            } else {
-                ExecutionId::new_for_shard(candidate_shard)
-            };
-            found_shard = Some((candidate_shard, shard_conn, exec_id));
-            break;
-        }
-    }
 
-    let (shard, mut conn, exec_id) = if let Some(tuple) = found_shard {
-        tuple
-    } else {
-        let shard = runtime
-            .router
-            .pick_for_new_workflow(&workflow_name, &workflow_id);
-        let conn = match db_conn_for_shard(&api_state, shard).await {
+    // Resolve the `(shard, conn, exec_id)` the rest of the handler consumes.
+    //
+    // On a committed-replay HIT (`probe_outcome.is_some()`) there is NO
+    // fresh-start work, so a committed replay needs no fresh-start routing:
+    // audit + polling run on the hit execution's OWN shard, resolvable O(1) from
+    // `outcome.exec_id`. Acquire ONLY that shard's connection and SKIP the
+    // multi-shard scan, the admission gate, and `pick_for_new_workflow` entirely.
+    // This closes a residual undoing of the earlier admission-gate hoist: a
+    // fresh-shard partial outage — a shard-scan `Err`, or `pick_for_new_workflow`
+    // selecting an unavailable shard (multi-shard partial outage / terminal-prior
+    // case) — could otherwise still return 503 on a dedupe hit that does no fresh
+    // work (Codex P2 / #808 invariant: a committed replay is never rejected by
+    // fresh-start-only infrastructure).
+    //
+    // On a MISS the full fresh-start routing runs exactly as before
+    // (byte-identical): find any existing non-terminal execution for
+    // (workflow_name, workflow_id) to determine the target shard and exec_id,
+    // else `pick_for_new_workflow`.
+    let (shard, mut conn, exec_id) = if let Some(outcome) = probe_outcome.as_ref() {
+        let hit_exec_id = outcome.exec_id;
+        let conn = match db_conn_for_execution(&api_state, hit_exec_id).await {
             Ok(c) => c,
             Err(e) => return e.into_response(),
         };
-        (shard, conn, ExecutionId::new_for_shard(shard))
+        (hit_exec_id.shard(), conn, hit_exec_id)
+    } else {
+        let mut found_shard: Option<(ShardId, PoolConn, ExecutionId)> = None;
+        for (candidate_shard, shard_pool) in pool.iter_shards() {
+            let mut shard_conn = match acquire_conn(shard_pool).await {
+                Ok(c) => c,
+                Err(e) => return e.into_response(),
+            };
+            let hit = match harvest_workflow_executions::table
+                .filter(harvest_workflow_executions::workflow_name.eq(&workflow_name))
+                .filter(harvest_workflow_executions::workflow_id.eq(&workflow_id))
+                .filter(
+                    harvest_workflow_executions::state.ne_all(["CONTINUED_AS_NEW", "TERMINATED"]),
+                )
+                .select((
+                    harvest_workflow_executions::id,
+                    harvest_workflow_executions::state,
+                ))
+                .first::<(uuid::Uuid, String)>(&mut shard_conn)
+                .await
+                .optional()
+            {
+                Ok(hit) => hit,
+                Err(e) => {
+                    return AutumnError::service_unavailable_msg(format!(
+                        "shard {} lookup failed: {e}",
+                        candidate_shard.as_i32()
+                    ))
+                    .into_response();
+                }
+            };
+            if let Some((existing_uuid, existing_state)) = hit {
+                // Reuse the execution UUID only when attaching to a live RUNNING or
+                // SUSPENDED run under a non-rejecting policy. All other paths
+                // (terminal prior, PAUSED, TerminateIfRunning) go through
+                // replace_execution and need a fresh exec_id to avoid a
+                // primary-key conflict.
+                let will_attach = matches!(existing_state.as_str(), "RUNNING" | "SUSPENDED")
+                    && matches!(
+                        reuse_policy,
+                        WorkflowIdReusePolicy::AllowDuplicate
+                            | WorkflowIdReusePolicy::AllowDuplicateFailedOnly
+                    );
+                let exec_id = if will_attach {
+                    ExecutionId::from_uuid(existing_uuid)
+                } else {
+                    ExecutionId::new_for_shard(candidate_shard)
+                };
+                found_shard = Some((candidate_shard, shard_conn, exec_id));
+                break;
+            }
+        }
+
+        if let Some(tuple) = found_shard {
+            tuple
+        } else {
+            let shard = runtime
+                .router
+                .pick_for_new_workflow(&workflow_name, &workflow_id);
+            let conn = match db_conn_for_shard(&api_state, shard).await {
+                Ok(c) => c,
+                Err(e) => return e.into_response(),
+            };
+            (shard, conn, ExecutionId::new_for_shard(shard))
+        }
     };
 
     // issue #377: admission gate. Skipped on a committed-replay hit

--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -10886,6 +10886,143 @@ async fn probe_committed_start_replay(
     )
 }
 
+/// Read-only committed-replay probe for `signal-with-start` (keyed requests only).
+///
+/// INVARIANT (mirrors the plain `start_workflow` probe, issue #808, and the
+/// plain signal route, PR #1092): a retry of an already-committed keyed
+/// signal-with-start must replay to its documented `200 signal_delivered: false`
+/// no-op BEFORE any fresh-start-only validation runs (the #610 signal-payload
+/// schema gate, the #373 start_input schema gate, the #252 cap). Otherwise a
+/// tightened schema/cap between the original delivery and the retry would
+/// wrongly reject a retry that creates no new work. This probe runs only when an
+/// `idempotency_key` is present; on a miss the caller falls through to the
+/// untouched authoritative in-lock path (which reserves the exactly-once row and
+/// remains the source of truth for the concurrent-first-delivery race). It never
+/// starts, attaches, or enqueues anything — it is a read-only fast path.
+///
+/// Fans out across shards using the SAME `lookup_idempotent_signal_dedupe` the
+/// in-lock authoritative dedup uses, so the two can never drift. On the first
+/// hit it writes a best-effort SUCCEEDED audit (intentional asymmetry with the
+/// fresh-start arm's 503-on-audit-failure: the original start was already
+/// audited, so a failed dedup audit is a no-op read that never fails the reply)
+/// and returns the documented `200` response.
+async fn probe_committed_sws_replay(
+    api_state: &HarvestApiState,
+    workflow_name: &str,
+    workflow_id: &str,
+    key: &str,
+    actor: &str,
+    source: &str,
+    request_id: Option<&str>,
+    route: &'static str,
+) -> Option<axum::response::Response> {
+    use axum::response::IntoResponse as _;
+    let pool = api_state.storage_pool().ok()?;
+    for (shard, shard_pool) in pool.iter_shards() {
+        let mut probe_conn = match acquire_conn(shard_pool).await {
+            Ok(c) => c,
+            // A transient probe-connection failure must not masquerade as a
+            // dedup miss (which would fall through to a fresh start); skip this
+            // shard and let a genuine all-shard miss fall through instead.
+            Err(_) => continue,
+        };
+        let Some(existing) = autumn_harvest::execution::lookup_idempotent_signal_dedupe(
+            &mut probe_conn,
+            workflow_name,
+            workflow_id,
+            key,
+        )
+        .await
+        .ok()
+        .flatten() else {
+            continue;
+        };
+        let outcome = SignalWithStartOutcome {
+            exec_id: ExecutionId::from_uuid(existing.id),
+            workflow_name: existing.workflow_name,
+            workflow_id: existing.workflow_id,
+            state: existing.state,
+            started_fresh: false,
+            signal_delivered: false,
+        };
+        let exec_id_str = outcome.exec_id.to_string();
+        let ar = NewAuditRecord {
+            actor,
+            operation: OP_WORKFLOW_SIGNAL_WITH_START,
+            target_type: TARGET_WORKFLOW,
+            target_id: Some(exec_id_str.as_str()),
+            route_or_command: route,
+            request_id,
+            idempotency_key: Some(key),
+            status: STATUS_SUCCEEDED,
+            error_summary: None,
+            shard_id: Some(shard.as_i32()),
+            source,
+        };
+        let _ = audit::insert_audit(&mut probe_conn, &ar).await;
+        return Some(
+            (
+                axum::http::StatusCode::OK,
+                Json(SignalWithStartResponse::from_outcome(outcome)),
+            )
+                .into_response(),
+        );
+    }
+    None
+}
+
+/// Read-only committed-replay probe for `update-with-start` (keyed requests only).
+///
+/// INVARIANT (mirrors [`probe_committed_sws_replay`]): a retry of an
+/// already-committed keyed update-with-start must replay to its cached admission
+/// BEFORE any fresh-start-only validation runs (the #373 start_input schema
+/// gate, the #610 update-arg schema gate, the #684 semantic validator).
+/// Otherwise a tightened schema — or a validator that would now reject the same
+/// args — would wrongly reject a retry that admits no new update. Keyed-only; a
+/// miss falls through to the authoritative in-lock path.
+///
+/// Unlike the signal probe it returns the resolved [`UpdateWithStartOutcome`]
+/// (not a full response) so the outcome flows through the handler's existing
+/// `Ok` arm — which polls for the cached update result under `wait_for_stage =
+/// "completed"` and writes the SUCCEEDED audit — giving a committed replay the
+/// SAME behavior as a fresh admission. `update_admitted: false` marks the cache
+/// hit.
+async fn probe_committed_uws_replay(
+    api_state: &HarvestApiState,
+    workflow_name: &str,
+    workflow_id: &str,
+    update_id: UpdateId,
+) -> Option<UpdateWithStartOutcome> {
+    let pool = api_state.storage_pool().ok()?;
+    for (_shard, shard_pool) in pool.iter_shards() {
+        let mut probe_conn = match acquire_conn(shard_pool).await {
+            Ok(c) => c,
+            Err(_) => continue,
+        };
+        let Some(row) = autumn_harvest::execution::lookup_idempotent_update_dedupe(
+            &mut probe_conn,
+            workflow_name,
+            workflow_id,
+            &update_id,
+        )
+        .await
+        .ok()
+        .flatten() else {
+            continue;
+        };
+        return Some(UpdateWithStartOutcome {
+            exec_id: row.exec_id,
+            workflow_name: row.workflow_name,
+            workflow_id: row.workflow_id,
+            state: row.state,
+            started_fresh: false,
+            update_id,
+            update_admitted: false,
+        });
+    }
+    None
+}
+
 /// Handle a `start_workflow` request whose JSON body failed to deserialize
 /// (issue #808, Codex P2). axum rejects a malformed `Json<T>` body before the
 /// handler runs, but a retry that carries its exactly-once key in the
@@ -14920,6 +15057,35 @@ pub(crate) async fn signal_with_start_workflow(
     let start_input = request.start_input.unwrap_or(Value::Null);
     let signal_payload = request.signal_payload.unwrap_or(Value::Null);
 
+    // INVARIANT (this PR): keyed committed-replay short-circuit. A retry of an
+    // already-committed keyed signal-with-start must replay to its documented
+    // `200 signal_delivered: false` no-op BEFORE any fresh-start-only validation
+    // (the #610 signal-payload schema gate immediately below, the #252 cap, and
+    // the #373 start_input schema enforced inside the core primitive). Otherwise
+    // a schema/cap tightened between the original delivery and the retry would
+    // wrongly reject a retry that creates no new work. Keyed-only; a miss falls
+    // through to the untouched authoritative in-lock path
+    // (`signal_with_start_workflow_execution_with_metrics`), which reserves the
+    // exactly-once signal row and remains the source of truth for the
+    // concurrent-first-delivery race — this probe is an additive fast path for
+    // COMMITTED replays only, never a replacement. Mirrors #808 (plain start)
+    // and #1092 (plain signal route).
+    if let Some(key) = request.idempotency_key.as_deref()
+        && let Some(resp) = probe_committed_sws_replay(
+            &api_state,
+            &workflow_name,
+            &workflow_id,
+            key,
+            &actor,
+            &source,
+            request_id.as_deref(),
+            route,
+        )
+        .await
+    {
+        return resp;
+    }
+
     // issue #610: structural schema validation of the signal payload against
     // the signal handler's published `arg_schema` (if any). Runs before any
     // durable start/attach so a malformed signal is rejected at the edge with a
@@ -15616,8 +15782,42 @@ async fn update_with_start_workflow(
         }
     }
 
-    // Validate start_input against the workflow's published JSON Schema (if any).
-    if let Some(info) = runtime.registry.workflows.get(&workflow_name)
+    // Derive update_id — deterministic from idempotency_key if provided.
+    // Hoisted ABOVE the #373/#610/#684 validation blocks so the committed-replay
+    // probe below can key on it.
+    let update_id = request
+        .idempotency_key
+        .as_ref()
+        .map_or_else(UpdateId::new, |key| {
+            let namespace = uuid::Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+                .expect("static namespace UUID is valid");
+            UpdateId::from_uuid(uuid::Uuid::new_v5(&namespace, key.as_bytes()))
+        });
+
+    // INVARIANT (this PR): keyed committed-replay short-circuit. A retry of an
+    // already-committed keyed update-with-start must replay to its cached
+    // admission BEFORE any fresh-start-only validation (the #373 start_input
+    // schema gate immediately below, and the #610 update-arg schema gate + #684
+    // validator further down). Otherwise a schema tightened — or a validator that
+    // would now reject the same args — between the original delivery and the
+    // retry would wrongly reject a retry that admits no new update. Keyed-only; a
+    // miss (`None`) falls through to the untouched authoritative in-lock path
+    // (`update_with_start_workflow_execution_with_metrics`), which reserves the
+    // exactly-once update and remains the source of truth. On a hit the outcome
+    // flows through the existing `Ok` arm (which polls for the cached update
+    // result and writes the SUCCEEDED audit), giving a committed replay the SAME
+    // behavior as a fresh admission. Mirrors #808 (plain start) and #1092 (plain
+    // signal route).
+    let probe_outcome = if request.idempotency_key.is_some() {
+        probe_committed_uws_replay(&api_state, &workflow_name, &workflow_id, update_id).await
+    } else {
+        None
+    };
+
+    // issue #373: start_input schema validation (fresh-start-only; skipped on a
+    // committed-replay hit).
+    if probe_outcome.is_none()
+        && let Some(info) = runtime.registry.workflows.get(&workflow_name)
         && let Err(violations) = info.validate_input(&start_input)
     {
         let ar = NewAuditRecord {
@@ -15643,16 +15843,6 @@ async fn update_with_start_workflow(
         )
             .into_response();
     }
-
-    // Derive update_id — deterministic from idempotency_key if provided.
-    let update_id = request
-        .idempotency_key
-        .as_ref()
-        .map_or_else(UpdateId::new, |key| {
-            let namespace = uuid::Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
-                .expect("static namespace UUID is valid");
-            UpdateId::from_uuid(uuid::Uuid::new_v5(&namespace, key.as_bytes()))
-        });
 
     let trace_ctx = tracing::info_span!(
         "harvest.workflow.schedule",
@@ -15696,11 +15886,14 @@ async fn update_with_start_workflow(
     // Resolve the registered update handler once and reuse it for both the
     // #610 schema-400 check and the #684 validator-422 check, mirroring the
     // plain `admit_update` route so the two entry points stay consistent.
-    if let Some(update_info) = runtime
-        .registry
-        .update_handlers
-        .iter()
-        .find(|h| h.workflow == workflow_name && h.name == request.update_name)
+    // Skipped entirely on a committed-replay hit (`probe_outcome.is_some()`):
+    // both gates are fresh-start-only, and a retry admits no new update.
+    if probe_outcome.is_none()
+        && let Some(update_info) = runtime
+            .registry
+            .update_handlers
+            .iter()
+            .find(|h| h.workflow == workflow_name && h.name == request.update_name)
     {
         // issue #610: structural schema validation of the update argument
         // against the handler's published `arg_schema` (if any). Runs *before*
@@ -15797,17 +15990,28 @@ async fn update_with_start_workflow(
         reject_fresh_if_debounced,
     };
 
-    let result = update_with_start_workflow_execution_with_metrics(
-        &mut conn,
-        params,
-        Some(runtime.registry.telemetry().metrics.as_ref()),
-        // issue #618 (PR #1014): gate a FRESH create AUTHORITATIVELY under the
-        // primitive's lock (see the sibling comment on the signal-with-start
-        // route). Closes the residual pre-check→locked-create TOCTOU; a pre-check
-        // block short-circuits before this call, so no double-count.
-        Some(autumn_harvest::admission_gate::GateMode::Check),
-    )
-    .await;
+    // A committed-replay hit short-circuits the authoritative in-lock call and
+    // feeds the cached outcome straight through the shared result match below
+    // (whose `Ok` arm polls for the cached update result and audits). A miss runs
+    // the authoritative path, which reserves the exactly-once update and stays
+    // the source of truth for the concurrent-first-delivery race.
+    let result = match probe_outcome {
+        Some(outcome) => Ok(outcome),
+        None => {
+            update_with_start_workflow_execution_with_metrics(
+                &mut conn,
+                params,
+                Some(runtime.registry.telemetry().metrics.as_ref()),
+                // issue #618 (PR #1014): gate a FRESH create AUTHORITATIVELY under
+                // the primitive's lock (see the sibling comment on the
+                // signal-with-start route). Closes the residual pre-check→locked-
+                // create TOCTOU; a pre-check block short-circuits before this call,
+                // so no double-count.
+                Some(autumn_harvest::admission_gate::GateMode::Check),
+            )
+            .await
+        }
+    };
 
     if let Err(HarvestError::DebounceFreshStart { .. }) = &result {
         // Failed-start audit (parity with the match arms below).

--- a/autumn-harvest-plugin/tests/interface_schema_integration.rs
+++ b/autumn-harvest-plugin/tests/interface_schema_integration.rs
@@ -477,11 +477,7 @@ async fn seed_running_execution(pool: &DbPool, workflow_name: &str) -> Execution
 /// route correctly — and the read-only committed-replay probes join
 /// `harvest_signals`/`harvest_events` with no state filter at all, so they
 /// resolve a dedup hit against a terminal prior too.
-async fn seed_execution_in_state(
-    pool: &DbPool,
-    workflow_name: &str,
-    state: &str,
-) -> ExecutionId {
+async fn seed_execution_in_state(pool: &DbPool, workflow_name: &str, state: &str) -> ExecutionId {
     let mut conn = pool.get().await.expect("pooled conn");
     let exec_id = ExecutionId::new();
     diesel::sql_query(

--- a/autumn-harvest-plugin/tests/interface_schema_integration.rs
+++ b/autumn-harvest-plugin/tests/interface_schema_integration.rs
@@ -508,12 +508,13 @@ async fn seed_execution_in_state(pool: &DbPool, workflow_name: &str, state: &str
 }
 
 // Reproduce the deterministic update_id the update-with-start handler derives
-// from an idempotency key (UUIDv5 over the OID namespace), so a test can seed a
+// from an idempotency key (UUIDv5 over the DNS namespace), so a test can seed a
 // matching UpdateAdmitted event that the committed-replay probe will find.
 fn derive_uws_update_id(key: &str) -> UpdateId {
-    let namespace = uuid::Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
-        .expect("static namespace UUID is valid");
-    UpdateId::from_uuid(uuid::Uuid::new_v5(&namespace, key.as_bytes()))
+    UpdateId::from_uuid(uuid::Uuid::new_v5(
+        &uuid::Uuid::NAMESPACE_DNS,
+        key.as_bytes(),
+    ))
 }
 
 /// Seed an `UpdateAdmitted` event for `(exec_id, update_id)` directly, simulating

--- a/autumn-harvest-plugin/tests/interface_schema_integration.rs
+++ b/autumn-harvest-plugin/tests/interface_schema_integration.rs
@@ -32,6 +32,7 @@ use std::pin::Pin;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicU64, Ordering};
 
+use autumn_harvest::admission_gate::{AdmissionGate, AdmissionGateId, GateScope};
 use autumn_harvest::context::WorkflowContext;
 use autumn_harvest::event::WorkflowEvent;
 use autumn_harvest::info::{QueryHandlerInfo, SignalHandlerInfo, UpdateHandlerInfo, WorkflowInfo};
@@ -376,6 +377,13 @@ fn build_pool(url: &str) -> DbPool {
 }
 
 fn build_app(pool: &DbPool) -> HarvestApiApp {
+    build_app_with_state(pool).0
+}
+
+/// Like [`build_app`] but also returns the `HarvestApiState` the router reads,
+/// so a test can reach into `api_state.gate_cache()` to raise an admission gate
+/// (the route consults the state's own per-instance cache, not the global one).
+fn build_app_with_state(pool: &DbPool) -> (HarvestApiApp, HarvestApiState) {
     let api_state = HarvestApiState::new();
     api_state.set_admin_auth_boundary(true);
     api_state.install_storage_pool(HarvestDbPool::from(pool.clone()));
@@ -391,7 +399,9 @@ fn build_app(pool: &DbPool) -> HarvestApiApp {
         HarvestRetentionRuntime::disabled(autumn_harvest::RetentionConfig::default()),
         ShardRouter::default(),
     ));
-    harvest_api_router(api_state).with_state(AppState::for_test().with_profile("test"))
+    let app =
+        harvest_api_router(api_state.clone()).with_state(AppState::for_test().with_profile("test"));
+    (app, api_state)
 }
 
 async fn get(app: &HarvestApiApp, uri: &str) -> (StatusCode, Value) {
@@ -1172,6 +1182,78 @@ async fn signal_with_start_accepts_valid_payload() {
 // #1092 (plain signal route). A probe MISS falls through to the untouched
 // authoritative in-lock path, which stays the source of truth.
 
+// P1 symmetry (PR #1105 review): the signal-with-start probe already precedes
+// the #377 admission gate; lock that in against regression. A committed keyed
+// signal-with-start replay must dedup to 200 even while a `WorkflowName` gate is
+// raised for the workflow — a retry that delivers no new signal must not be
+// blocked by an operator-raised gate. No second signal row is enqueued.
+#[tokio::test]
+async fn sws_committed_keyed_replay_bypasses_a_raised_admission_gate() {
+    let (url, _guard) = setup_database().await;
+    let pool = build_pool(&url);
+    let (app, api_state) = build_app_with_state(&pool);
+    let exec_id = seed_execution_in_state(&pool, "iface_wf", "RUNNING").await;
+    let wid = exec_id.to_string();
+
+    let committed_key = "k-sws-gated-run";
+    seed_signal_row(
+        &pool,
+        exec_id,
+        "approve",
+        json!({ "reason": "ok" }),
+        committed_key,
+    )
+    .await;
+    assert_eq!(
+        count_signal_rows(&pool, exec_id, committed_key).await,
+        1,
+        "precondition: exactly one committed signal row"
+    );
+
+    // Raise an admission gate for this workflow on the router's own cache.
+    api_state.gate_cache().refresh(vec![AdmissionGate {
+        id: AdmissionGateId(uuid::Uuid::new_v4()),
+        scope: GateScope::WorkflowName("iface_wf".to_string()),
+        reason: "p1-sws-gate-incident".to_string(),
+        message: None,
+        created_by: "test".to_string(),
+        created_at: Utc::now(),
+        expires_at: None,
+    }]);
+
+    let (status, body) = post_json(
+        &app,
+        "/workflows/iface_wf/signal-with-start",
+        json!({
+            "workflow_id": wid,
+            "signal_name": "approve",
+            "signal_payload": { "reason": "ok" },
+            "idempotency_key": committed_key
+        }),
+    )
+    .await;
+    assert_ne!(
+        status,
+        StatusCode::SERVICE_UNAVAILABLE,
+        "committed keyed signal-with-start replay must NOT be blocked by a raised admission gate: {body}"
+    );
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "committed keyed replay must dedup to 200 even under a raised gate: {body}"
+    );
+    assert_eq!(
+        body["signal_delivered"],
+        json!(false),
+        "committed replay must report signal_delivered: false: {body}"
+    );
+    assert_eq!(
+        count_signal_rows(&pool, exec_id, committed_key).await,
+        1,
+        "committed replay must NOT enqueue a second signal row"
+    );
+}
+
 /// AC1: a committed keyed signal-with-start that ATTACHED to a live (RUNNING)
 /// run replays to `200 signal_delivered: false` even when the retry payload is
 /// now schema-invalid — the committed-replay probe short-circuits before the
@@ -1341,6 +1423,87 @@ async fn uws_committed_keyed_replay_after_running_short_circuits_before_validati
         body["started_fresh"],
         json!(false),
         "committed replay must report started_fresh: false: {body}"
+    );
+    assert_eq!(
+        count_update_admitted_events(&pool, exec_id).await,
+        1,
+        "committed replay must NOT append a second UpdateAdmitted event"
+    );
+}
+
+// P1 (PR #1105 review): a committed keyed update-with-start replay must short-
+// circuit BEFORE the #377 admission gate, mirroring signal-with-start (whose
+// probe already precedes the gate). Seeded against a RUNNING run with a
+// committed `UpdateAdmitted` event; a `WorkflowName` admission gate is then
+// raised for `iface_wf` on the router's own cache. The retry of the same key
+// must return the cached admission (200, started_fresh: false), NOT a 503 — a
+// retry that admits no new update must not be blocked by an operator-raised gate
+// (the #808 invariant: a committed replay precedes ALL fresh-start-only
+// rejections, including the admission gate). No second `UpdateAdmitted` event.
+#[tokio::test]
+async fn uws_committed_keyed_replay_bypasses_a_raised_admission_gate() {
+    let (url, _guard) = setup_database().await;
+    let pool = build_pool(&url);
+    let (app, api_state) = build_app_with_state(&pool);
+    let exec_id = seed_execution_in_state(&pool, "iface_wf", "RUNNING").await;
+    let wid = exec_id.to_string();
+
+    let committed_key = "k-uws-gated-run";
+    let update_id = derive_uws_update_id(committed_key);
+    seed_update_admitted_event(&pool, exec_id, update_id, "set_priority").await;
+    assert_eq!(
+        count_update_admitted_events(&pool, exec_id).await,
+        1,
+        "precondition: exactly one committed UpdateAdmitted event"
+    );
+
+    // Raise an admission gate for this workflow on the router's own cache. On a
+    // FRESH keyed start this would 503; the committed replay must bypass it.
+    api_state.gate_cache().refresh(vec![AdmissionGate {
+        id: AdmissionGateId(uuid::Uuid::new_v4()),
+        scope: GateScope::WorkflowName("iface_wf".to_string()),
+        reason: "p1-gate-incident".to_string(),
+        message: None,
+        created_by: "test".to_string(),
+        created_at: Utc::now(),
+        expires_at: None,
+    }]);
+
+    // Valid args — the ONLY potential blocker under test is the raised gate.
+    let (status, body) = post_json(
+        &app,
+        "/workflows/iface_wf/update-with-start",
+        json!({
+            "workflow_id": wid,
+            "update_name": "set_priority",
+            "update_args": { "priority": 7 },
+            "idempotency_key": committed_key,
+            "wait_for_stage": "admitted"
+        }),
+    )
+    .await;
+    assert_ne!(
+        status,
+        StatusCode::SERVICE_UNAVAILABLE,
+        "committed keyed update-with-start replay must NOT be blocked by a raised admission gate: {body}"
+    );
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "committed keyed replay must return the cached admission (200) even under a raised gate: {body}"
+    );
+    // `update_admitted: false` is the internal outcome marker; on the wire it
+    // surfaces as `started_fresh: false` (the response omits `update_admitted`),
+    // matching the sibling committed-replay tests.
+    assert_eq!(
+        body["started_fresh"],
+        json!(false),
+        "committed replay must report started_fresh: false: {body}"
+    );
+    assert_eq!(
+        body["update_id"],
+        json!(update_id.to_string()),
+        "committed replay must return the derived update_id (cache-hit evidence): {body}"
     );
     assert_eq!(
         count_update_admitted_events(&pool, exec_id).await,

--- a/autumn-harvest-plugin/tests/interface_schema_integration.rs
+++ b/autumn-harvest-plugin/tests/interface_schema_integration.rs
@@ -38,7 +38,7 @@ use autumn_harvest::info::{QueryHandlerInfo, SignalHandlerInfo, UpdateHandlerInf
 use autumn_harvest::scheduler::{DagCatalog, SchedulerMonitor};
 use autumn_harvest::shard::ShardRouter;
 use autumn_harvest::store;
-use autumn_harvest::types::ExecutionId;
+use autumn_harvest::types::{ExecutionId, UpdateId};
 use autumn_harvest::worker::{DbPool, HandlerRegistry};
 use autumn_harvest_plugin::HarvestDbPool;
 use autumn_harvest_plugin::api::{
@@ -468,17 +468,32 @@ async fn get_raw(app: &HarvestApiApp, uri: &str) -> (StatusCode, Vec<u8>) {
 /// given workflow type so `load_execution`/`admit_update`/`send_signal`
 /// succeed. Returns the execution id.
 async fn seed_running_execution(pool: &DbPool, workflow_name: &str) -> ExecutionId {
+    seed_execution_in_state(pool, workflow_name, "RUNNING").await
+}
+
+/// State-parameterized variant of [`seed_running_execution`]. The multi-shard
+/// `found_shard` scan in signal-/update-with-start excludes only
+/// `CONTINUED_AS_NEW`/`TERMINATED`, so `COMPLETED`/`PAUSED` rows are found and
+/// route correctly — and the read-only committed-replay probes join
+/// `harvest_signals`/`harvest_events` with no state filter at all, so they
+/// resolve a dedup hit against a terminal prior too.
+async fn seed_execution_in_state(
+    pool: &DbPool,
+    workflow_name: &str,
+    state: &str,
+) -> ExecutionId {
     let mut conn = pool.get().await.expect("pooled conn");
     let exec_id = ExecutionId::new();
     diesel::sql_query(
         "INSERT INTO harvest_workflow_executions \
          (id, workflow_name, workflow_id, shard_id, input, queue_name, state) \
-         VALUES ($1, $2, $3, 0, $4, 'default', 'RUNNING')",
+         VALUES ($1, $2, $3, 0, $4, 'default', $5)",
     )
     .bind::<diesel::sql_types::Uuid, _>(exec_id.as_uuid())
     .bind::<diesel::sql_types::Text, _>(workflow_name)
     .bind::<diesel::sql_types::Text, _>(exec_id.to_string())
     .bind::<diesel::sql_types::Jsonb, _>(json!({}))
+    .bind::<diesel::sql_types::Text, _>(state)
     .execute(&mut conn)
     .await
     .expect("seed execution");
@@ -494,6 +509,58 @@ async fn seed_running_execution(pool: &DbPool, workflow_name: &str) -> Execution
         .await
         .expect("seed history");
     exec_id
+}
+
+/// Reproduce the deterministic `update_id` the `update-with-start` handler
+/// derives from an idempotency key (UUIDv5 over the OID namespace), so a test
+/// can seed a matching `UpdateAdmitted` event that the committed-replay probe
+/// will find.
+fn derive_uws_update_id(key: &str) -> UpdateId {
+    let namespace = uuid::Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+        .expect("static namespace UUID is valid");
+    UpdateId::from_uuid(uuid::Uuid::new_v5(&namespace, key.as_bytes()))
+}
+
+/// Seed an `UpdateAdmitted` event for `(exec_id, update_id)` directly, simulating
+/// an update that was admitted on a prior committed delivery. `lookup_idempotent_
+/// update_dedupe` matches on `event_data->'data'->>'update_id'`, so the seeded
+/// event's `update_id` must serialize to the same UUID string the probe binds.
+async fn seed_update_admitted_event(
+    pool: &DbPool,
+    exec_id: ExecutionId,
+    update_id: UpdateId,
+    update_name: &str,
+) {
+    let mut conn = pool.get().await.expect("pooled conn");
+    let events = vec![WorkflowEvent::UpdateAdmitted {
+        update_id,
+        name: update_name.to_string(),
+        input: json!({}),
+        timestamp: Utc::now(),
+    }];
+    // WorkflowStarted was appended at event_id 0 by the seed helper; continue at 1.
+    store::append_events(&mut conn, exec_id, &events, 1)
+        .await
+        .expect("seed UpdateAdmitted event");
+}
+
+/// Count `UpdateAdmitted` events for a given execution.
+async fn count_update_admitted_events(pool: &DbPool, exec_id: ExecutionId) -> i64 {
+    #[derive(diesel::QueryableByName)]
+    struct Cnt {
+        #[diesel(sql_type = diesel::sql_types::BigInt)]
+        n: i64,
+    }
+    let mut conn = pool.get().await.expect("pooled conn");
+    let row: Cnt = diesel::sql_query(
+        "SELECT COUNT(*) AS n FROM harvest_events \
+         WHERE workflow_exec_id = $1 AND event_type = 'UpdateAdmitted'",
+    )
+    .bind::<diesel::sql_types::Uuid, _>(exec_id.as_uuid())
+    .get_result(&mut conn)
+    .await
+    .expect("count UpdateAdmitted events");
+    row.n
 }
 
 fn names(arr: &Value) -> Vec<String> {
@@ -1095,5 +1162,399 @@ async fn signal_with_start_accepts_valid_payload() {
     assert!(
         status.is_success(),
         "valid signal-with-start should proceed (2xx), got {status}: {body}"
+    );
+}
+
+// ── with-start keyed committed-replay: validation ordering (this PR) ─────────
+//
+// A retry of an already-committed keyed signal-/update-with-start must replay to
+// its documented no-op BEFORE any fresh-start-only validation runs (#610 schema
+// gate, #373 start_input schema, #684 validator). Otherwise, if validation
+// TIGHTENED between the original delivery and the retry (schema published/made
+// stricter, payload cap lowered), the retry is wrongly rejected 400/422 instead
+// of returning the cached outcome. This mirrors #808 (plain start route) and
+// #1092 (plain signal route). A probe MISS falls through to the untouched
+// authoritative in-lock path, which stays the source of truth.
+
+/// AC1: a committed keyed signal-with-start that ATTACHED to a live (RUNNING)
+/// run replays to `200 signal_delivered: false` even when the retry payload is
+/// now schema-invalid — the committed-replay probe short-circuits before the
+/// #610 signal-payload schema gate. No second signal row is enqueued.
+#[tokio::test]
+async fn sws_committed_keyed_replay_after_attach_short_circuits_before_schema_gate() {
+    let (url, _guard) = setup_database().await;
+    let pool = build_pool(&url);
+    let app = build_app(&pool);
+    let exec_id = seed_execution_in_state(&pool, "iface_wf", "RUNNING").await;
+    let wid = exec_id.to_string();
+
+    // Simulate a signal-with-start that committed before the `approve` schema
+    // was published: seed a matching signal row whose payload is now invalid.
+    let committed_key = "k-sws-attach";
+    seed_signal_row(
+        &pool,
+        exec_id,
+        "approve",
+        json!({ "reason": 123 }),
+        committed_key,
+    )
+    .await;
+    assert_eq!(
+        count_signal_rows(&pool, exec_id, committed_key).await,
+        1,
+        "precondition: exactly one committed signal row"
+    );
+
+    // Same-key retry with a now-schema-invalid signal payload (`{}`, missing the
+    // required string `reason`) → committed-replay no-op, NOT the schema 400.
+    let (status, body) = post_json(
+        &app,
+        "/workflows/iface_wf/signal-with-start",
+        json!({
+            "workflow_id": wid,
+            "signal_name": "approve",
+            "signal_payload": {},
+            "idempotency_key": committed_key
+        }),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "committed keyed signal-with-start replay must dedup to 200, not be rejected by the \
+         schema gate: {body}"
+    );
+    assert_eq!(
+        body["signal_delivered"],
+        json!(false),
+        "committed replay must report signal_delivered: false: {body}"
+    );
+    assert_eq!(
+        body["execution_id"],
+        json!(exec_id.to_string()),
+        "committed replay must return the original execution_id: {body}"
+    );
+    assert_eq!(
+        count_signal_rows(&pool, exec_id, committed_key).await,
+        1,
+        "committed replay must NOT enqueue a second signal row"
+    );
+}
+
+/// AC2: the same short-circuit holds when the committed prior is TERMINAL
+/// (COMPLETED). The in-lock path would escalate a terminal prior to a fresh
+/// start, but the idempotency-key dedup (and the probe mirroring it) recognizes
+/// the committed key first and replays the no-op. Payload again now-invalid.
+#[tokio::test]
+async fn sws_committed_keyed_replay_after_terminal_fresh_start_short_circuits() {
+    let (url, _guard) = setup_database().await;
+    let pool = build_pool(&url);
+    let app = build_app(&pool);
+    let exec_id = seed_execution_in_state(&pool, "iface_wf", "COMPLETED").await;
+    let wid = exec_id.to_string();
+
+    let committed_key = "k-sws-fresh";
+    seed_signal_row(
+        &pool,
+        exec_id,
+        "approve",
+        json!({ "reason": 123 }),
+        committed_key,
+    )
+    .await;
+
+    let (status, body) = post_json(
+        &app,
+        "/workflows/iface_wf/signal-with-start",
+        json!({
+            "workflow_id": wid,
+            "signal_name": "approve",
+            "signal_payload": {},
+            "idempotency_key": committed_key
+        }),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "committed keyed replay against a terminal prior must dedup to 200: {body}"
+    );
+    assert_eq!(
+        body["signal_delivered"],
+        json!(false),
+        "committed replay must report signal_delivered: false: {body}"
+    );
+    assert_eq!(
+        count_signal_rows(&pool, exec_id, committed_key).await,
+        1,
+        "committed replay must NOT enqueue a second signal row"
+    );
+}
+
+/// AC3: a committed keyed update-with-start replay against a RUNNING run
+/// short-circuits before the #610 update-arg schema gate (and the #373
+/// start_input gate). Retry args are now schema-invalid; the response is the
+/// cached admission (`200`, `started_fresh: false`), NOT a 400. No second
+/// `UpdateAdmitted` event is appended.
+#[tokio::test]
+async fn uws_committed_keyed_replay_after_running_short_circuits_before_validation() {
+    let (url, _guard) = setup_database().await;
+    let pool = build_pool(&url);
+    let app = build_app(&pool);
+    let exec_id = seed_execution_in_state(&pool, "iface_wf", "RUNNING").await;
+    let wid = exec_id.to_string();
+
+    let committed_key = "k-uws-run";
+    let update_id = derive_uws_update_id(committed_key);
+    seed_update_admitted_event(&pool, exec_id, update_id, "set_priority").await;
+    assert_eq!(
+        count_update_admitted_events(&pool, exec_id).await,
+        1,
+        "precondition: exactly one committed UpdateAdmitted event"
+    );
+
+    // Retry with a now-schema-invalid update arg (`priority` string, not int).
+    let (status, body) = post_json(
+        &app,
+        "/workflows/iface_wf/update-with-start",
+        json!({
+            "workflow_id": wid,
+            "update_name": "set_priority",
+            "update_args": { "priority": "high" },
+            "idempotency_key": committed_key,
+            "wait_for_stage": "admitted"
+        }),
+    )
+    .await;
+    assert_ne!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "committed keyed update-with-start replay must NOT be rejected by the schema gate: {body}"
+    );
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "committed keyed replay must return the cached admission (200): {body}"
+    );
+    assert_eq!(
+        body["update_id"],
+        json!(update_id.to_string()),
+        "committed replay must return the derived update_id: {body}"
+    );
+    assert_eq!(
+        body["started_fresh"],
+        json!(false),
+        "committed replay must report started_fresh: false: {body}"
+    );
+    assert_eq!(
+        count_update_admitted_events(&pool, exec_id).await,
+        1,
+        "committed replay must NOT append a second UpdateAdmitted event"
+    );
+}
+
+/// AC4: a committed keyed update-with-start replay does not re-run the #684
+/// semantic validator. Seeded against a COMPLETED prior with `set_priority_gated`
+/// (validator rejects `priority > 10`); the retry carries `priority: 99` which
+/// would 422, but the committed-replay probe returns the cached outcome (200)
+/// before the validator runs.
+#[tokio::test]
+async fn uws_committed_keyed_replay_validator_not_rerun() {
+    let (url, _guard) = setup_database().await;
+    let pool = build_pool(&url);
+    let app = build_app(&pool);
+    let exec_id = seed_execution_in_state(&pool, "iface_wf", "COMPLETED").await;
+    let wid = exec_id.to_string();
+
+    let committed_key = "k-uws-gated";
+    let update_id = derive_uws_update_id(committed_key);
+    seed_update_admitted_event(&pool, exec_id, update_id, "set_priority_gated").await;
+
+    let (status, body) = post_json(
+        &app,
+        "/workflows/iface_wf/update-with-start",
+        json!({
+            "workflow_id": wid,
+            "update_name": "set_priority_gated",
+            "update_args": { "priority": 99 },
+            "idempotency_key": committed_key,
+            "wait_for_stage": "admitted"
+        }),
+    )
+    .await;
+    assert_ne!(
+        status,
+        StatusCode::UNPROCESSABLE_ENTITY,
+        "committed keyed replay must NOT re-run the validator (422): {body}"
+    );
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "committed keyed replay must return the cached admission (200): {body}"
+    );
+    assert_eq!(
+        body["update_id"],
+        json!(update_id.to_string()),
+        "committed replay must return the derived update_id: {body}"
+    );
+    assert_eq!(
+        count_update_admitted_events(&pool, exec_id).await,
+        1,
+        "committed replay must NOT append a second UpdateAdmitted event"
+    );
+}
+
+/// AC5a: a FRESH keyed signal-with-start with a malformed payload (key never
+/// seen) is still validated at the edge → 400. The probe misses, so the #610
+/// schema gate runs as before.
+#[tokio::test]
+async fn sws_fresh_keyed_malformed_still_400() {
+    let (url, _guard) = setup_database().await;
+    let pool = build_pool(&url);
+    let app = build_app(&pool);
+
+    let (status, body) = post_json(
+        &app,
+        "/workflows/iface_wf/signal-with-start",
+        json!({
+            "workflow_id": "sws-fresh-bad",
+            "signal_name": "approve",
+            "signal_payload": {},
+            "idempotency_key": "k-sws-fresh-bad"
+        }),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "a fresh keyed malformed signal-with-start must still be validated: {body}"
+    );
+    assert_field_violation(&body, "signal payload validation failed", "/reason");
+}
+
+/// AC5b: a FRESH keyed update-with-start with a malformed payload is still
+/// validated at the edge → 400.
+#[tokio::test]
+async fn uws_fresh_keyed_malformed_still_400() {
+    let (url, _guard) = setup_database().await;
+    let pool = build_pool(&url);
+    let app = build_app(&pool);
+
+    let (status, body) = post_json(
+        &app,
+        "/workflows/iface_wf/update-with-start",
+        json!({
+            "workflow_id": "uws-fresh-bad",
+            "update_name": "set_priority",
+            "update_args": { "priority": "high" },
+            "idempotency_key": "k-uws-fresh-bad",
+            "wait_for_stage": "admitted"
+        }),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "a fresh keyed malformed update-with-start must still be validated: {body}"
+    );
+    assert_field_violation(&body, "update payload validation failed", "/priority");
+}
+
+/// AC6: the UNKEYED path is byte-for-byte unchanged — a valid unkeyed
+/// signal-/update-with-start still proceeds (2xx), and a malformed unkeyed one
+/// is still rejected 400. The probe is keyed-only, so it never runs here.
+#[tokio::test]
+async fn sws_uws_unkeyed_behavior_unchanged() {
+    let (url, _guard) = setup_database().await;
+    let pool = build_pool(&url);
+    let app = build_app(&pool);
+
+    // Valid unkeyed signal-with-start → proceeds (2xx).
+    let (status, body) = post_json(
+        &app,
+        "/workflows/iface_wf/signal-with-start",
+        json!({
+            "workflow_id": "sws-unkeyed-ok",
+            "signal_name": "approve",
+            "signal_payload": { "reason": "ok" }
+        }),
+    )
+    .await;
+    assert!(
+        status.is_success(),
+        "valid unkeyed signal-with-start must still proceed (2xx): {status} {body}"
+    );
+
+    // Malformed unkeyed signal-with-start → still 400.
+    let (status, body) = post_json(
+        &app,
+        "/workflows/iface_wf/signal-with-start",
+        json!({
+            "workflow_id": "sws-unkeyed-bad",
+            "signal_name": "approve",
+            "signal_payload": {}
+        }),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "malformed unkeyed signal-with-start must still be validated: {body}"
+    );
+
+    // Malformed unkeyed update-with-start → still 400.
+    let (status, body) = post_json(
+        &app,
+        "/workflows/iface_wf/update-with-start",
+        json!({
+            "workflow_id": "uws-unkeyed-bad",
+            "update_name": "set_priority",
+            "update_args": { "priority": "high" },
+            "wait_for_stage": "admitted"
+        }),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::BAD_REQUEST,
+        "malformed unkeyed update-with-start must still be validated: {body}"
+    );
+}
+
+/// AC7: a genuine FRESH keyed update-with-start against a PAUSED prior still
+/// returns 409 WorkflowPaused. This confirms the authoritative in-lock path is
+/// preserved for non-committed requests: probe MISSES → validation runs (payload
+/// valid) → authoritative call → WorkflowPaused.
+#[tokio::test]
+async fn uws_paused_fresh_keyed_still_409() {
+    let (url, _guard) = setup_database().await;
+    let pool = build_pool(&url);
+    let app = build_app(&pool);
+    let exec_id = seed_execution_in_state(&pool, "iface_wf", "PAUSED").await;
+    let wid = exec_id.to_string();
+
+    // Fresh key (never committed) + a schema-valid update arg + AllowDuplicate
+    // (default). Probe misses; validation passes; the authoritative resolver
+    // rejects an update to a PAUSED prior with WorkflowPaused (409).
+    let (status, body) = post_json(
+        &app,
+        "/workflows/iface_wf/update-with-start",
+        json!({
+            "workflow_id": wid,
+            "update_name": "set_priority",
+            "update_args": { "priority": 3 },
+            "idempotency_key": "k-uws-paused-fresh",
+            "wait_for_stage": "admitted"
+        }),
+    )
+    .await;
+    assert_eq!(
+        status,
+        StatusCode::CONFLICT,
+        "a fresh keyed update-with-start to a PAUSED prior must still 409: {body}"
+    );
+    assert_eq!(
+        body["error"], "workflow is paused",
+        "409 body must carry the paused error: {body}"
     );
 }

--- a/autumn-harvest-plugin/tests/interface_schema_integration.rs
+++ b/autumn-harvest-plugin/tests/interface_schema_integration.rs
@@ -37,9 +37,9 @@ use autumn_harvest::context::WorkflowContext;
 use autumn_harvest::event::WorkflowEvent;
 use autumn_harvest::info::{QueryHandlerInfo, SignalHandlerInfo, UpdateHandlerInfo, WorkflowInfo};
 use autumn_harvest::scheduler::{DagCatalog, SchedulerMonitor};
-use autumn_harvest::shard::ShardRouter;
+use autumn_harvest::shard::{ShardRouter, ShardedDbPool};
 use autumn_harvest::store;
-use autumn_harvest::types::{ExecutionId, UpdateId};
+use autumn_harvest::types::{ExecutionId, ShardId, UpdateId};
 use autumn_harvest::worker::{DbPool, HandlerRegistry};
 use autumn_harvest_plugin::HarvestDbPool;
 use autumn_harvest_plugin::api::{
@@ -402,6 +402,44 @@ fn build_app_with_state(pool: &DbPool) -> (HarvestApiApp, HarvestApiState) {
     let app =
         harvest_api_router(api_state.clone()).with_state(AppState::for_test().with_profile("test"));
     (app, api_state)
+}
+
+/// Build the interface-schema app on a TWO-shard pool: shard 0 is the live test
+/// DB, shard 1 points at an unreachable URL (connection refused). Mirrors the
+/// partial-outage harness in `workflow_reachability_integration.rs`. Used to
+/// prove the committed-replay HIT path never touches fresh-start shard routing:
+/// the pre-fix `found_shard` scan / `pick_for_new_workflow` would reach the dead
+/// shard and 503, whereas a dedupe hit resolves audit + polling on its own
+/// (live) shard via `db_conn_for_execution`.
+fn build_app_two_shard_dead_second(live_pool: &DbPool) -> HarvestApiApp {
+    let mut shard_pools = std::collections::BTreeMap::new();
+    shard_pools.insert(ShardId::new(0), live_pool.clone());
+    shard_pools.insert(
+        ShardId::new(1),
+        build_pool("postgres://postgres:postgres@127.0.0.1:1/nonexistent"),
+    );
+    let storage = HarvestDbPool::sharded(ShardedDbPool::from_map(shard_pools, ShardId::new(0)));
+
+    let api_state = HarvestApiState::new();
+    api_state.set_admin_auth_boundary(true);
+    api_state.install_storage_pool(storage);
+    let registry = HandlerRegistry::new(vec![iface_info(), plain_info(), empty_info()], vec![])
+        .with_handler_infos(query_handlers(), update_handlers(), signal_handlers());
+    api_state.install(HarvestApiRuntime::new(
+        Arc::new(registry),
+        Arc::new(DagCatalog::default()),
+        Arc::new(Vec::new()),
+        Some("iface-test".to_string()),
+        vec!["default".to_string()],
+        SchedulerMonitor::offline(),
+        HarvestRetentionRuntime::disabled(autumn_harvest::RetentionConfig::default()),
+        ShardRouter::new(
+            vec![ShardId::new(0), ShardId::new(1)],
+            vec![ShardId::new(0), ShardId::new(1)],
+            ShardId::new(0),
+        ),
+    ));
+    harvest_api_router(api_state).with_state(AppState::for_test().with_profile("test"))
 }
 
 async fn get(app: &HarvestApiApp, uri: &str) -> (StatusCode, Value) {
@@ -1504,6 +1542,83 @@ async fn uws_committed_keyed_replay_bypasses_a_raised_admission_gate() {
         body["update_id"],
         json!(update_id.to_string()),
         "committed replay must return the derived update_id (cache-hit evidence): {body}"
+    );
+    assert_eq!(
+        count_update_admitted_events(&pool, exec_id).await,
+        1,
+        "committed replay must NOT append a second UpdateAdmitted event"
+    );
+}
+
+// P2 (PR #1105 review, Codex): a committed keyed update-with-start replay HIT
+// must NOT be rejected by fresh-start-only shard routing. Pre-fix, on a hit the
+// handler still ran the multi-shard `found_shard` scan / `pick_for_new_workflow`
+// before the `match probe_outcome`, so a dead fresh-start shard returned a
+// spurious 503 even though the dedupe hit was already found and no fresh work is
+// needed — partially undoing the admission-gate hoist via fresh-start infra.
+//
+// Reproduction (the "terminal prior" case Codex named): a TERMINATED prior on
+// the live shard 0 with a committed `UpdateAdmitted` event. The read-only probe
+// (no state filter) resolves the hit on shard 0; the `found_shard` scan EXCLUDES
+// `TERMINATED`, so pre-fix it finds nothing on shard 0 and proceeds to the dead
+// shard 1 (connection refused) → 503. Post-fix the hit path acquires ONLY the
+// hit execution's own (live) shard via `db_conn_for_execution` and skips the
+// scan entirely → 200 with the cached admission (`started_fresh: false`). This
+// is the #808 invariant: a committed replay is never rejected by fresh-start-only
+// infrastructure. `signal-with-start` is already clean here (its probe returns a
+// finished response before the routing scan), so this guard is uws-only.
+#[tokio::test]
+async fn uws_committed_keyed_replay_hit_never_503s_on_dead_fresh_start_shard() {
+    let (url, _guard) = setup_database().await;
+    let pool = build_pool(&url);
+    // TERMINATED prior on the live shard: the read-only probe still resolves it
+    // (no state filter), but the fresh-start `found_shard` scan excludes it,
+    // forcing the pre-fix path onward to the dead shard.
+    let exec_id = seed_execution_in_state(&pool, "iface_wf", "TERMINATED").await;
+    let wid = exec_id.to_string();
+    let committed_key = "k-uws-dead-shard";
+    let update_id = derive_uws_update_id(committed_key);
+    seed_update_admitted_event(&pool, exec_id, update_id, "set_priority").await;
+    assert_eq!(
+        count_update_admitted_events(&pool, exec_id).await,
+        1,
+        "precondition: exactly one committed UpdateAdmitted event"
+    );
+
+    // The app's storage pool has a live shard 0 (holding the seeded execution)
+    // and a dead shard 1. On a HIT the handler must resolve everything on shard 0.
+    let app = build_app_two_shard_dead_second(&pool);
+    let (status, body) = post_json(
+        &app,
+        "/workflows/iface_wf/update-with-start",
+        json!({
+            "workflow_id": wid,
+            "update_name": "set_priority",
+            "update_args": { "priority": 3 },
+            "idempotency_key": committed_key,
+            "wait_for_stage": "admitted"
+        }),
+    )
+    .await;
+    assert_ne!(
+        status,
+        StatusCode::SERVICE_UNAVAILABLE,
+        "committed keyed replay HIT must NOT 503 on a dead fresh-start shard: {body}"
+    );
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "committed keyed replay HIT must return the cached admission (200): {body}"
+    );
+    assert_eq!(
+        body["update_id"],
+        json!(update_id.to_string()),
+        "committed replay must return the derived update_id (cache-hit evidence): {body}"
+    );
+    assert_eq!(
+        body["started_fresh"],
+        json!(false),
+        "committed replay must report started_fresh: false: {body}"
     );
     assert_eq!(
         count_update_admitted_events(&pool, exec_id).await,

--- a/autumn-harvest-plugin/tests/interface_schema_integration.rs
+++ b/autumn-harvest-plugin/tests/interface_schema_integration.rs
@@ -507,10 +507,9 @@ async fn seed_execution_in_state(pool: &DbPool, workflow_name: &str, state: &str
     exec_id
 }
 
-/// Reproduce the deterministic `update_id` the `update-with-start` handler
-/// derives from an idempotency key (UUIDv5 over the OID namespace), so a test
-/// can seed a matching `UpdateAdmitted` event that the committed-replay probe
-/// will find.
+// Reproduce the deterministic update_id the update-with-start handler derives
+// from an idempotency key (UUIDv5 over the OID namespace), so a test can seed a
+// matching UpdateAdmitted event that the committed-replay probe will find.
 fn derive_uws_update_id(key: &str) -> UpdateId {
     let namespace = uuid::Uuid::parse_str("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
         .expect("static namespace UUID is valid");
@@ -1287,11 +1286,11 @@ async fn sws_committed_keyed_replay_after_terminal_fresh_start_short_circuits() 
     );
 }
 
-/// AC3: a committed keyed update-with-start replay against a RUNNING run
-/// short-circuits before the #610 update-arg schema gate (and the #373
-/// start_input gate). Retry args are now schema-invalid; the response is the
-/// cached admission (`200`, `started_fresh: false`), NOT a 400. No second
-/// `UpdateAdmitted` event is appended.
+// AC3: a committed keyed update-with-start replay against a RUNNING run
+// short-circuits before the #610 update-arg schema gate (and the #373
+// start_input gate). Retry args are now schema-invalid; the response is the
+// cached admission (200, started_fresh: false), NOT a 400. No second
+// UpdateAdmitted event is appended.
 #[tokio::test]
 async fn uws_committed_keyed_replay_after_running_short_circuits_before_validation() {
     let (url, _guard) = setup_database().await;
@@ -1400,9 +1399,9 @@ async fn uws_committed_keyed_replay_validator_not_rerun() {
     );
 }
 
-/// AC5a: a FRESH keyed signal-with-start with a malformed payload (key never
-/// seen) is still validated at the edge → 400. The probe misses, so the #610
-/// schema gate runs as before.
+// AC5a: a FRESH keyed signal-with-start with a malformed payload (key never
+// seen) is still validated at the edge → 400. The probe misses, so the #610
+// schema gate runs as before.
 #[tokio::test]
 async fn sws_fresh_keyed_malformed_still_400() {
     let (url, _guard) = setup_database().await;
@@ -1428,8 +1427,8 @@ async fn sws_fresh_keyed_malformed_still_400() {
     assert_field_violation(&body, "signal payload validation failed", "/reason");
 }
 
-/// AC5b: a FRESH keyed update-with-start with a malformed payload is still
-/// validated at the edge → 400.
+// AC5b: a FRESH keyed update-with-start with a malformed payload is still
+// validated at the edge → 400.
 #[tokio::test]
 async fn uws_fresh_keyed_malformed_still_400() {
     let (url, _guard) = setup_database().await;
@@ -1517,10 +1516,10 @@ async fn sws_uws_unkeyed_behavior_unchanged() {
     );
 }
 
-/// AC7: a genuine FRESH keyed update-with-start against a PAUSED prior still
-/// returns 409 WorkflowPaused. This confirms the authoritative in-lock path is
-/// preserved for non-committed requests: probe MISSES → validation runs (payload
-/// valid) → authoritative call → WorkflowPaused.
+// AC7: a genuine FRESH keyed update-with-start against a PAUSED prior still
+// returns 409 WorkflowPaused. This confirms the authoritative in-lock path is
+// preserved for non-committed requests: probe MISSES → validation runs (payload
+// valid) → authoritative call → WorkflowPaused.
 #[tokio::test]
 async fn uws_paused_fresh_keyed_still_409() {
     let (url, _guard) = setup_database().await;

--- a/autumn-harvest/src/execution.rs
+++ b/autumn-harvest/src/execution.rs
@@ -4250,7 +4250,13 @@ async fn try_load_active_execution_for_update(
 /// logical workflow so a webhook retry that arrives after the prior signal
 /// drove its execution to a terminal state is recognised as a duplicate and
 /// short-circuited before any fresh start / replacement happens.
-async fn lookup_idempotent_signal_dedupe(
+/// Read-only shared committed-replay lookup for `signal_with_start`
+/// idempotency, scoped `(workflow_name, workflow_id, idempotency_key)`, joining
+/// `harvest_signals` → `harvest_workflow_executions` (no state filter, newest
+/// signal first). Used by BOTH the in-lock authoritative dedup and the
+/// read-only handler-edge fast-path probe — single source of truth so the two
+/// can never drift.
+pub async fn lookup_idempotent_signal_dedupe(
     conn: &mut AsyncPgConnection,
     workflow_name: &str,
     workflow_id: &str,
@@ -4775,12 +4781,22 @@ pub async fn update_with_start_workflow_execution_with_metrics(
     Ok(outcome)
 }
 
-/// Minimal row returned by the idempotency dedupe query.
-struct UpdateDedupeRow {
-    exec_id: ExecutionId,
-    workflow_name: String,
-    workflow_id: String,
-    state: String,
+/// Minimal row returned by the `update_with_start` idempotency dedupe query.
+///
+/// Public so the plugin's read-only handler-edge committed-replay probe can
+/// build an [`UpdateWithStartOutcome`] from a dedupe hit, sharing the exact
+/// lookup ([`lookup_idempotent_update_dedupe`]) the in-lock authoritative path
+/// uses — single source of truth so the two can never drift.
+#[derive(Debug, Clone)]
+pub struct UpdateDedupeRow {
+    /// The execution that already admitted the update for this key.
+    pub exec_id: ExecutionId,
+    /// The owning workflow type.
+    pub workflow_name: String,
+    /// The owning `workflow_id`.
+    pub workflow_id: String,
+    /// The execution's current state string.
+    pub state: String,
 }
 
 /// Cross-execution idempotency dedupe for `update_with_start`.
@@ -4792,7 +4808,11 @@ struct UpdateDedupeRow {
 ///
 /// The lookup uses JSON operators on `event_data` (Postgres JSONB). This is a
 /// cold-path read (retries only) so index coverage is not critical.
-async fn lookup_idempotent_update_dedupe(
+///
+/// Public so the plugin's read-only handler-edge committed-replay probe shares
+/// the exact lookup the in-lock authoritative dedup uses — single source of
+/// truth so the two can never drift.
+pub async fn lookup_idempotent_update_dedupe(
     conn: &mut AsyncPgConnection,
     workflow_name: &str,
     workflow_id: &str,

--- a/autumn-harvest/tests/integration/mod.rs
+++ b/autumn-harvest/tests/integration/mod.rs
@@ -73,6 +73,7 @@ mod payload_offload_db_tests;
 mod payload_offload_replay_tests;
 mod poison_pill_tests;
 mod priority_tests;
+#[cfg(feature = "testing")]
 mod publish_progress_tests;
 mod query_deadlock;
 mod query_terminal_tests;

--- a/autumn-harvest/tests/integration/rate_limit_key_tests.rs
+++ b/autumn-harvest/tests/integration/rate_limit_key_tests.rs
@@ -442,6 +442,7 @@ fn resolution_start_params(
         memo: None,
         search_attrs: None,
         reuse_policy: WorkflowIdReusePolicy::default(),
+        conflict_policy: autumn_harvest::types::WorkflowIdConflictPolicy::Unspecified,
         trace_context: None,
         max_execution_timeout_ceiling: None,
         concurrency_key: None,

--- a/docs/changelog.d/pr-1105-with-start-keyed-replay.md
+++ b/docs/changelog.d/pr-1105-with-start-keyed-replay.md
@@ -12,10 +12,11 @@ payload cap, or a validator that would now reject the same args). At-least-once
 webhook/event retries broke precisely when a schema change landed. Fixed with an
 early, **read-only** committed-replay probe at each handler's edge (keyed
 requests only) that short-circuits to the documented replay response BEFORE any
-fresh-start-only validation; a probe MISS falls through to the untouched
-authoritative in-lock path, which reserves the exactly-once signal/update and
-remains the source of truth for the concurrent-first-delivery race. Mirrors #808
-(plain start route) and #1092 (plain signal route).
+fresh-start-only *rejection* — validation AND the #377 admission gate; a probe
+MISS falls through to the untouched authoritative in-lock path, which reserves
+the exactly-once signal/update and remains the source of truth for the
+concurrent-first-delivery race. Mirrors #808 (plain start route) and #1092 (plain
+signal route).
 
 - **Core (`execution.rs`)**: promoted the two committed-replay lookups the
   in-lock dedup already uses to `pub` so the probe and the authoritative dedup
@@ -28,15 +29,37 @@ remains the source of truth for the concurrent-first-delivery race. Mirrors #808
   (intentional asymmetry with the fresh-start arm's 503-on-audit-failure: the
   original start was already audited). It runs right after signal-payload
   extraction, keyed-only, before the #610 signal-payload schema gate.
-- **`update-with-start` handler**: the `update_id` derivation (UUIDv5 over the OID
-  namespace of the idempotency key) is hoisted above the #373 gate; new
-  `probe_committed_uws_replay` fans out via `lookup_idempotent_update_dedupe` and
-  returns the resolved `UpdateWithStartOutcome` (`update_admitted: false`) — which
-  flows through the handler's existing `Ok` arm (polling for the cached update
-  result, writing the SUCCEEDED audit), giving a committed replay the SAME
-  behavior as a fresh admission. The #373 and #610+#684 blocks are guarded
-  `if probe_outcome.is_none()`; the authoritative call becomes
-  `match probe_outcome { Some(o) => Ok(o), None => authoritative }`.
+- **`update-with-start` handler**: the `update_id` derivation (UUIDv5 over the DNS
+  namespace of the idempotency key) and `probe_committed_uws_replay` are hoisted
+  **above the found-shard scan and the #377 admission gate** (mirroring
+  signal-with-start, whose probe already precedes both), not merely above the #373
+  gate. The probe fans out via `lookup_idempotent_update_dedupe` and returns the
+  resolved `UpdateWithStartOutcome` (`update_admitted: false`) — which flows
+  through the handler's existing `Ok` arm (polling for the cached update result,
+  writing the SUCCEEDED audit), giving a committed replay the SAME behavior as a
+  fresh admission. The #377 admission gate, the #373 gate, and the #610+#684 blocks
+  are all guarded `if probe_outcome.is_none()` (on a hit the handler short-circuits
+  before the gate; on a miss the gate runs unconditionally for genuinely-fresh
+  work); the authoritative call becomes
+  `match probe_outcome { Some(o) => Ok(o), None => authoritative }`. This closes a
+  P1 review finding: pre-hoist, update-with-start ran the admission gate BEFORE the
+  probe, so a committed keyed replay retried while an operator had RAISED a gate
+  returned a spurious `503` instead of the cached `200`/`update_admitted:false` —
+  divergent from its own signal-with-start sibling and from the #808 invariant.
+- **Fail-closed probes (P2 review finding)**: both probes previously swallowed any
+  per-shard conn-acquire or lookup error into a dedup MISS, then fell through to
+  fresh-start validation — reintroducing the bug under a transient owning-shard
+  error. Both now track a `had_error` flag across the fan-out (three-state: hit /
+  clean-miss / inconclusive): on a hit they short-circuit; a conn/lookup `Err`
+  sets the flag and keeps scanning other shards (a later shard may hold the hit);
+  after a no-hit loop they fail **closed** with a `503` when `had_error`, else
+  return the clean-miss sentinel so the caller runs the authoritative in-lock path.
+  `probe_committed_sws_replay` still returns `Option<Response>` (`Some` now also
+  carries the `503`); `probe_committed_uws_replay` returns
+  `Result<Option<UpdateWithStartOutcome>, Response>` (`Err` = `503`). Deliberately
+  more conservative than #808's plain-start probe — the sibling found-shard scan
+  in both handlers already fails closed on the same error class, and fail-closed
+  preserves the never-reject invariant; a keyed client retries `503` idempotently.
 
 **No new `WorkflowEvent` variant, no migration, no route/contract change.** The
 in-lock exactly-once machinery is untouched — the probe is an additive read-only
@@ -50,8 +73,12 @@ Docker-backed on Linux in CI, manifest line 85; ran green against local Postgres
 `sws_committed_keyed_replay_after_attach_short_circuits_before_schema_gate`,
 `sws_committed_keyed_replay_after_terminal_fresh_start_short_circuits`,
 `uws_committed_keyed_replay_after_running_short_circuits_before_validation`,
-`uws_committed_keyed_replay_validator_not_rerun` — plus the guard tests
-`sws_fresh_keyed_malformed_still_400`, `uws_fresh_keyed_malformed_still_400`,
-`sws_uws_unkeyed_behavior_unchanged`, `uws_paused_fresh_keyed_still_409`
-proving the fresh/unkeyed/paused paths are preserved. Full 26-test suite green,
-no regression.
+`uws_committed_keyed_replay_validator_not_rerun` — plus the two admission-gate
+RED→GREEN proofs `uws_committed_keyed_replay_bypasses_a_raised_admission_gate`
+(new; fails with `503` pre-hoist) and its symmetric guard
+`sws_committed_keyed_replay_bypasses_a_raised_admission_gate` (both raise a
+`WorkflowName` gate on the router's own `gate_cache` and assert `200`, not `503`),
+plus the guard tests `sws_fresh_keyed_malformed_still_400`,
+`uws_fresh_keyed_malformed_still_400`, `sws_uws_unkeyed_behavior_unchanged`,
+`uws_paused_fresh_keyed_still_409` proving the fresh/unkeyed/paused paths are
+preserved. Full 28-test suite green, no regression.

--- a/docs/changelog.d/pr-1105-with-start-keyed-replay.md
+++ b/docs/changelog.d/pr-1105-with-start-keyed-replay.md
@@ -1,0 +1,57 @@
+## Phase 3.51 — with-start keyed committed-replay validation ordering (issue #1092 follow-up)
+
+`signal_with_start_workflow` and `update_with_start_workflow` (the HTTP handlers
+for the atomic start-or-attach + signal (#244) / + update (#479) primitives) ran
+their fresh-start-only validation — the #610 payload/schema gate, and for
+update-with-start the #373 `start_input` schema gate and the #684 semantic
+validator — **before** their idempotency dedup. So a retry of an
+*already-committed keyed with-start* — which must replay to its documented no-op
+— was instead rejected `400`/`422` whenever validation had **tightened** between
+the original delivery and the retry (a schema published/made stricter, a lowered
+payload cap, or a validator that would now reject the same args). At-least-once
+webhook/event retries broke precisely when a schema change landed. Fixed with an
+early, **read-only** committed-replay probe at each handler's edge (keyed
+requests only) that short-circuits to the documented replay response BEFORE any
+fresh-start-only validation; a probe MISS falls through to the untouched
+authoritative in-lock path, which reserves the exactly-once signal/update and
+remains the source of truth for the concurrent-first-delivery race. Mirrors #808
+(plain start route) and #1092 (plain signal route).
+
+- **Core (`execution.rs`)**: promoted the two committed-replay lookups the
+  in-lock dedup already uses to `pub` so the probe and the authoritative dedup
+  share one source of truth (they can never drift): `lookup_idempotent_signal_dedupe`,
+  `lookup_idempotent_update_dedupe`, and the `UpdateDedupeRow` it returns (now a
+  `pub` struct with `pub` fields, deriving `Debug, Clone`).
+- **`signal-with-start` handler**: new `probe_committed_sws_replay` (plugin
+  `api.rs`) fans out across shards via `lookup_idempotent_signal_dedupe`; on a hit
+  it returns `200 { signal_delivered: false }` with a best-effort SUCCEEDED audit
+  (intentional asymmetry with the fresh-start arm's 503-on-audit-failure: the
+  original start was already audited). It runs right after signal-payload
+  extraction, keyed-only, before the #610 signal-payload schema gate.
+- **`update-with-start` handler**: the `update_id` derivation (UUIDv5 over the OID
+  namespace of the idempotency key) is hoisted above the #373 gate; new
+  `probe_committed_uws_replay` fans out via `lookup_idempotent_update_dedupe` and
+  returns the resolved `UpdateWithStartOutcome` (`update_admitted: false`) — which
+  flows through the handler's existing `Ok` arm (polling for the cached update
+  result, writing the SUCCEEDED audit), giving a committed replay the SAME
+  behavior as a fresh admission. The #373 and #610+#684 blocks are guarded
+  `if probe_outcome.is_none()`; the authoritative call becomes
+  `match probe_outcome { Some(o) => Ok(o), None => authoritative }`.
+
+**No new `WorkflowEvent` variant, no migration, no route/contract change.** The
+in-lock exactly-once machinery is untouched — the probe is an additive read-only
+fast path for committed replays only, never a replacement (two simultaneous first
+deliveries both miss the probe and are serialized by the in-lock `ON CONFLICT`
+reserve). The non-keyed and fresh-keyed paths are byte-for-byte unchanged (the
+probe is keyed-only; a fresh key misses and the existing validation +
+authoritative path runs). Tests (`autumn-harvest-plugin/tests/interface_schema_integration.rs`,
+Docker-backed on Linux in CI, manifest line 85; ran green against local Postgres
+16): the 4 committed-replay RED→GREEN proofs —
+`sws_committed_keyed_replay_after_attach_short_circuits_before_schema_gate`,
+`sws_committed_keyed_replay_after_terminal_fresh_start_short_circuits`,
+`uws_committed_keyed_replay_after_running_short_circuits_before_validation`,
+`uws_committed_keyed_replay_validator_not_rerun` — plus the guard tests
+`sws_fresh_keyed_malformed_still_400`, `uws_fresh_keyed_malformed_still_400`,
+`sws_uws_unkeyed_behavior_unchanged`, `uws_paused_fresh_keyed_still_409`
+proving the fresh/unkeyed/paused paths are preserved. Full 26-test suite green,
+no regression.

--- a/docs/changelog.d/pr-1105-with-start-keyed-replay.md
+++ b/docs/changelog.d/pr-1105-with-start-keyed-replay.md
@@ -60,6 +60,35 @@ signal route).
   more conservative than #808's plain-start probe — the sibling found-shard scan
   in both handlers already fails closed on the same error class, and fail-closed
   preserves the never-reject invariant; a keyed client retries `503` idempotently.
+- **Committed uws replay skips fresh-start shard routing (P2 review finding)**:
+  after the admission-gate hoist above, the `update-with-start` handler still ran
+  the storage-pool lookup, the multi-shard `found_shard` scan, AND
+  `pick_for_new_workflow` on a committed-replay HIT before the later
+  `match probe_outcome` — so a dedupe hit could STILL return `503` (a shard-scan
+  `Err`, or `pick_for_new_workflow` selecting an unavailable shard, in a
+  multi-shard partial outage or terminal-prior case), partially undoing the
+  admission-gate hoist via fresh-start infrastructure. The `(shard, conn, exec_id)`
+  resolution now branches on `probe_outcome.as_ref()`: on a HIT it acquires ONLY
+  the hit execution's OWN shard connection (O(1) from `outcome.exec_id` via
+  `db_conn_for_execution`) for the `Ok` arm's audit + result poll, skipping the
+  scan / admission gate / `pick_for_new_workflow` entirely; on a MISS the full
+  fresh-start routing runs byte-identically. A fresh-shard partial outage can now
+  never `503` a dedupe hit (the #808 invariant: a committed replay is never
+  rejected by fresh-start-only infrastructure). `signal-with-start` was already
+  clean here — its probe returns a finished `Response` and `return`s before the
+  routing scan, so this fix is uws-only. New RED→GREEN proof
+  `uws_committed_keyed_replay_hit_never_503s_on_dead_fresh_start_shard`
+  (`interface_schema_integration.rs`) builds a TWO-shard app (shard 0 live, shard 1
+  an unreachable URL — mirroring the `workflow_reachability_integration.rs`
+  partial-outage harness) and seeds a TERMINATED prior + committed `UpdateAdmitted`
+  on shard 0: the read-only probe (no state filter) resolves the hit on shard 0,
+  but the fresh-start `found_shard` scan EXCLUDES `TERMINATED`, so pre-fix it
+  reaches the dead shard 1 and returns `503`; post-fix the hit path resolves audit
+  + polling on shard 0 via `db_conn_for_execution` and returns `200`
+  (`started_fresh: false`, no second `UpdateAdmitted`). The rest of the
+  `interface_schema_integration` suite (every existing uws committed-replay hit
+  test — attach / running / validator-not-rerun / gate-bypass) stays green,
+  proving the hit-shard audit + polling path is unchanged.
 
 **No new `WorkflowEvent` variant, no migration, no route/contract change.** The
 in-lock exactly-once machinery is untouched — the probe is an additive read-only


### PR DESCRIPTION
## Before / After

**Before.** The `signal-with-start` (#244) and `update-with-start` (#479) HTTP
handlers ran their fresh-start-only rejections — the #610 payload/schema gate,
the #377 admission gate, and for `update-with-start` the #373 `start_input`
schema gate and the #684 semantic validator — **before** their idempotency
dedup. So a retry of an *already-committed keyed with-start* — which must replay
to its documented no-op — was instead rejected `400`/`422` whenever validation
had **tightened** between the original delivery and the retry (a schema
published/made stricter, a lowered payload cap, or a validator that would now
reject the same args); and — for `update-with-start` specifically — rejected
`503` whenever an operator had **raised an admission gate**, even though the
retry admits no new work. At-least-once webhook/event retries broke precisely
when a schema change landed or a gate was raised.

**After.** Each handler runs an early, **read-only** committed-replay probe at
its edge (keyed requests only). On a hit it short-circuits to the documented
replay response **before** any fresh-start-only rejection — validation AND the
#377 admission gate. On a miss it falls through to the untouched authoritative
in-lock path, which reserves the exactly-once signal/update and remains the
source of truth. This mirrors #808 (plain start route) and #1092 (plain signal
route).

## How

- **Core (`execution.rs`)** — promoted the two committed-replay lookups the
  in-lock dedup already uses to `pub` so the probe and the authoritative path
  share one source of truth (they can never drift): `lookup_idempotent_signal_dedupe`,
  `lookup_idempotent_update_dedupe`, and the `UpdateDedupeRow` it returns. The
  plugin reaches them via the already-`pub mod execution` path — **no `lib.rs`
  re-export is added** (verified: this branch makes zero changes to `lib.rs`).
- **`signal-with-start` handler** — new `probe_committed_sws_replay` fans out
  across shards using `lookup_idempotent_signal_dedupe`; on a hit it returns
  `200 { signal_delivered: false }` with a best-effort SUCCEEDED audit. It runs
  right after signal-payload extraction, keyed-only, before the #610 gate and
  the #377 admission gate (which the sibling probe already precedes).
- **`update-with-start` handler** — the `update_id` derivation (UUIDv5 of the
  key, DNS namespace) and `probe_committed_uws_replay` are hoisted **above the
  found-shard scan and the #377 admission gate** (mirroring signal-with-start),
  not merely above the #373 gate. The probe returns the resolved
  `UpdateWithStartOutcome` (`update_admitted: false`) which flows through the
  handler's existing `Ok` arm (polling for the cached result, writing the
  SUCCEEDED audit) — the *same* behavior as a fresh admission. The #377 gate, the
  #373 gate, and the #610+#684 blocks are all guarded `if probe_outcome.is_none()`
  (hit → short-circuit before the gate; miss → gate runs for genuinely-fresh
  work); the authoritative call becomes
  `match probe_outcome { Some(o) => Ok(o), None => authoritative }`.
- **Fail-closed probes** — both probes now track a `had_error` flag across the
  shard fan-out (three-state: hit / clean-miss / inconclusive). A per-shard
  conn-acquire or lookup `Err` sets the flag and keeps scanning other shards (a
  later shard may still hold the hit); after a no-hit loop they fail **closed**
  with a `503` when `had_error`, else return the clean-miss sentinel so the caller
  runs the authoritative in-lock path. Deliberately more conservative than #808's
  plain-start probe: the sibling found-shard scan in both handlers already fails
  closed on the same error class, and fail-closed preserves the never-reject
  invariant even under a transient owning-shard error; a keyed client retries
  `503` idempotently. `probe_committed_sws_replay` still returns
  `Option` (`Some` now also carries the `503`); `probe_committed_uws_replay`
  returns `Result<Option, Response>` (`Err` = `503`).

The probe is keyed-only and never starts, attaches, or enqueues anything — a
miss leaves the existing path byte-for-byte unchanged, and the in-lock
`ON CONFLICT` reserve stays the authoritative dedup for the concurrent-first-
delivery race (two simultaneous first deliveries both miss the probe, both
proceed, and the reserve serializes them).

## AC → evidence

| # | Behavior | Test | Status |
|---|----------|------|--------|
| 1 | sws committed keyed replay after **attach** short-circuits the #610 gate → 200 `signal_delivered:false`, no 2nd row | `sws_committed_keyed_replay_after_attach_short_circuits_before_schema_gate` | RED→GREEN, RAN |
| 2 | sws committed keyed replay after **terminal** prior short-circuits → 200, no 2nd row | `sws_committed_keyed_replay_after_terminal_fresh_start_short_circuits` | RED→GREEN, RAN |
| 3 | uws committed keyed replay (RUNNING) short-circuits #373/#610 → 200, no 2nd `UpdateAdmitted` | `uws_committed_keyed_replay_after_running_short_circuits_before_validation` | RED→GREEN, RAN |
| 4 | uws committed keyed replay does not re-run the #684 validator → 200, not 422 | `uws_committed_keyed_replay_validator_not_rerun` | RED→GREEN, RAN |
| 5 | **P1**: uws committed keyed replay bypasses a **raised admission gate** → 200, not 503, no 2nd `UpdateAdmitted` | `uws_committed_keyed_replay_bypasses_a_raised_admission_gate` | RED→GREEN, RAN |
| 6 | **P1** (symmetry): sws committed keyed replay bypasses a raised admission gate → 200, not 503, no 2nd row | `sws_committed_keyed_replay_bypasses_a_raised_admission_gate` | GREEN, RAN |
| 7a | fresh keyed malformed sws still 400 | `sws_fresh_keyed_malformed_still_400` | GREEN, RAN |
| 7b | fresh keyed malformed uws still 400 | `uws_fresh_keyed_malformed_still_400` | GREEN, RAN |
| 8 | unkeyed sws/uws behavior unchanged (valid → 2xx, malformed → 400) | `sws_uws_unkeyed_behavior_unchanged` | GREEN, RAN |
| 9 | fresh keyed uws to a PAUSED prior still 409 (authoritative path preserved) | `uws_paused_fresh_keyed_still_409` | GREEN, RAN |
| 10 | **P2** (this fix): uws committed keyed replay **HIT** never 503s on a dead fresh-start shard — skips the found-shard scan / admission gate / `pick_for_new_workflow` → 200, no 2nd `UpdateAdmitted` | `uws_committed_keyed_replay_hit_never_503s_on_dead_fresh_start_shard` | RED→GREEN, RAN |

All ran green against local Postgres 16, plus the full 29-test
`interface_schema_integration` suite (no regression). The P1 admission-gate proof
was verified **RED→GREEN**: pre-hoist it fails with
`503 {"error":"admission blocked", ...}`; post-hoist it returns `200`. The P2
dead-fresh-start-shard proof (AC 10) was likewise verified **RED→GREEN**: it fails
`1/1` against pre-fix code and passes `29/29` after. The suite is Docker-backed on
Linux in CI (manifest line 85).

## Review hardening (P1 / P2)

- **P1** — `update-with-start` ran the #377 admission gate **before** the
  committed-replay probe, whereas `signal-with-start` already ran its probe
  first. A committed keyed uws replay retried while an operator had raised a gate
  therefore returned a spurious `503` instead of the cached
  `200`/`update_admitted:false` — divergent from its own sibling and from the
  #808 invariant. Fixed by hoisting the `update_id` derivation + probe above the
  found-shard scan and the gate, and guarding the gate with
  `probe_outcome.is_none()`. New RED→GREEN test
  `uws_committed_keyed_replay_bypasses_a_raised_admission_gate` (fails `503`
  pre-hoist) plus a symmetric guard test on the already-correct signal-with-start
  ordering; both raise a `WorkflowName` gate on the router's own `gate_cache`.
- **P2 (fail-closed probes)** — both probes previously swallowed per-shard
  conn/lookup errors into a dedup MISS, then fell through to fresh-start
  validation — reintroducing the bug under a transient owning-shard error. Both
  now fail **closed** (`503`) on an inconclusive shard error (see the
  "Fail-closed probes" bullet above), matching the sibling found-shard scan's
  existing fail-closed posture.
- **P2 (fresh-start shard routing on a hit)** — even after the admission-gate
  hoist, `update-with-start` still ran the storage-pool lookup, the multi-shard
  `found_shard` scan, **and** `pick_for_new_workflow` on a committed-replay
  **hit** before the `match probe_outcome`. So a dedupe hit could **still** return
  `503` (a shard-scan `Err`, or `pick_for_new_workflow` selecting an unavailable
  shard — a multi-shard partial outage or terminal-prior case) even though no
  fresh work is needed, partially undoing the admission-gate hoist via fresh-start
  infrastructure. Fixed by branching the `(shard, conn, exec_id)` resolution on
  `probe_outcome.as_ref()`: a **hit** acquires only the hit execution's own shard
  connection (O(1) via `db_conn_for_execution`) for the `Ok`-arm audit + poll and
  skips the scan / admission gate / `pick_for_new_workflow` entirely; a **miss**
  runs the full fresh-start routing byte-identically. A fresh-shard partial outage
  can now never `503` a dedupe hit (the #808 invariant: a committed replay is
  never rejected by fresh-start-only infrastructure). `signal-with-start` was
  already clean here (its probe returns a finished `Response` and `return`s before
  the routing scan), so this fix is uws-only. New RED→GREEN test
  `uws_committed_keyed_replay_hit_never_503s_on_dead_fresh_start_shard` builds a
  two-shard app (shard 0 live, shard 1 an unreachable URL) with a TERMINATED prior
  + committed `UpdateAdmitted` on shard 0: the read-only probe (no state filter)
  resolves the hit on shard 0, but the fresh-start scan EXCLUDES `TERMINATED`, so
  pre-fix it reaches the dead shard → `503`; post-fix returns `200`. Verified RED
  (`1` failed) against pre-fix code, GREEN (`29/29`) after.

## Invariants

- **No new `WorkflowEvent` variant, no migration, no route/contract change.**
- The **in-lock exactly-once machinery is untouched** — the probe is an additive,
  read-only fast path for committed replays only, never a replacement.
- **Non-keyed and fresh-keyed paths are byte-for-byte identical** (the probe is
  keyed-only; a fresh key misses and the existing validation + authoritative path
  runs, as proven by AC7–AC9).

## Note: two unrelated trunk-heal commits

Two isolated, trivially-revertable heals of **pre-existing** trunk-dev breakages
are carried on this branch. Neither is part of this feature; each is split into
its own commit so it can be dropped if trunk is healed elsewhere first. Both are
parallel-merge-burst semantic conflicts (each contributing PR was green
independently, but the combination breaks a shared CI gate off `ea7394e`).

1. **`fix: heal StartWorkflowParams literal missing conflict_policy (#1100/#1101)`** —
   the `resolution_start_params` `StartWorkflowParams` literal in
   `rate_limit_key_tests.rs` (PR #1101) omits the `conflict_policy` field that PR
   #1100 added to the struct, so `cargo clippy -p autumn-harvest --all-features
   --tests` fails to compile on trunk-dev @ `ea7394e` regardless of this PR.
   Without it the shared clippy gate cannot pass for this (or any) PR off
   `ea7394e`.

2. **`fix: gate publish_progress_tests behind testing feature to heal
   no-default-features trunk (#1098/#791)`** — the `publish_progress_tests`
   module (added by #1098/#791) uses `autumn_harvest::testing`, but its
   `mod publish_progress_tests;` declaration in `tests/integration/mod.rs` lacked
   the `#[cfg(feature = "testing")]` gate that every sibling testing-dependent
   module carries, so `cargo test -p autumn-harvest --no-default-features` fails
   to compile on trunk-dev regardless of this PR. The fix mirrors the sibling
   convention exactly (the module needs only the `testing` feature, per its own
   doc comment: "no DB required"). Without it the no-default-features CI leg is
   red repo-wide.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VuCynLkXeoYZCRRsYLfBTs)_