### PR TITLE
🛡️ Sentry: [test coverage improvement]

### DIFF
--- a/autumn-harvest/examples/interface_schema_workflow.rs
+++ b/autumn-harvest/examples/interface_schema_workflow.rs
@@ -88,6 +88,7 @@ fn cancel_order(_ctx: &WorkflowContext, _req: CancelRequest) {}
     workflow = "order_workflow",
     description = "Read the order's current progress"
 )]
+#[allow(clippy::unnecessary_wraps)]
 fn order_status(_ctx: &WorkflowContext, req: StatusRequest) -> Result<StatusResponse, String> {
     Ok(StatusResponse {
         state: if req.verbose {

--- a/autumn-harvest/examples/signal_with_start_webhook.rs
+++ b/autumn-harvest/examples/signal_with_start_webhook.rs
@@ -80,6 +80,7 @@ async fn handle_webhook_after(
     let outcome = signal_with_start_workflow_execution(
         conn,
         SignalWithStartParams {
+            start_source_override: None,
             workflow_name: "onboarding",
             workflow_id: &customer_id,
             exec_id,

--- a/autumn-harvest/src/batch.rs
+++ b/autumn-harvest/src/batch.rs
@@ -991,4 +991,24 @@ mod tests {
         let back: BatchTargetError = serde_json::from_value(value).unwrap();
         assert_eq!(back, err);
     }
+
+    #[test]
+    fn batch_job_status_from_str_roundtrips() {
+        for status in [
+            BatchJobStatus::Pending,
+            BatchJobStatus::Running,
+            BatchJobStatus::Completed,
+            BatchJobStatus::Failed,
+        ] {
+            let s = status.as_str();
+            let parsed: BatchJobStatus = s.parse().expect("known status must parse");
+            assert_eq!(parsed, status);
+        }
+    }
+
+    #[test]
+    fn batch_job_status_from_str_rejects_unknown() {
+        let err = BatchJobStatus::from_str("Unknown").expect_err("unknown status must fail");
+        assert!(err.contains("unknown batch job status"));
+    }
 }

--- a/autumn-harvest/src/trace_export.rs
+++ b/autumn-harvest/src/trace_export.rs
@@ -81,4 +81,36 @@ mod tests {
         assert_eq!(event["ts"], 1_000_000);
         assert_eq!(event["dur"], 2_000_000);
     }
+
+    #[test]
+    fn test_export_chrome_trace_unmatched_start() {
+        let profile = DagProfile {
+            total_duration: Duration::from_secs(5),
+            peak_concurrency: 1,
+            timeline: vec![ProfilerEvent {
+                time: Duration::from_secs(1),
+                kind: ProfilerEventKind::TaskStarted(0, "activity_a".to_string()),
+            }],
+        };
+
+        let trace = export_chrome_trace(&profile);
+        let arr = trace.as_array().expect("Expected JSON array");
+        assert_eq!(arr.len(), 0);
+    }
+
+    #[test]
+    fn test_export_chrome_trace_unmatched_end() {
+        let profile = DagProfile {
+            total_duration: Duration::from_secs(5),
+            peak_concurrency: 1,
+            timeline: vec![ProfilerEvent {
+                time: Duration::from_secs(1),
+                kind: ProfilerEventKind::TaskCompleted(0, "activity_a".to_string()),
+            }],
+        };
+
+        let trace = export_chrome_trace(&profile);
+        let arr = trace.as_array().expect("Expected JSON array");
+        assert_eq!(arr.len(), 0);
+    }
 }


### PR DESCRIPTION
* 🎯 Target: `autumn-harvest/src/batch.rs` and `autumn-harvest/src/trace_export.rs`.
* 💣 Risk: Prevents regressions on the batch serialization state definitions and `trace_export` trace mismatch edge cases.
* 🧪 Strategy: Added table-driven test cases for serialization states and direct array tests for `export_chrome_trace` mismatches.
* 🔬 Verification: Run `cargo test -p autumn-harvest --lib batch` and `cargo test -p autumn-harvest --lib trace_export`.

---
*PR created automatically by Jules for task [8174112002631270473](https://jules.google.com/task/8174112002631270473) started by @madmax983*