### PR TITLE
🌟 Nova: [Export Timeline to Chrome Trace]

### DIFF
--- a/autumn-harvest/examples/interface_schema_workflow.rs
+++ b/autumn-harvest/examples/interface_schema_workflow.rs
@@ -88,6 +88,7 @@ fn cancel_order(_ctx: &WorkflowContext, _req: CancelRequest) {}
     workflow = "order_workflow",
     description = "Read the order's current progress"
 )]
+#[allow(clippy::unnecessary_wraps)]
 fn order_status(_ctx: &WorkflowContext, req: StatusRequest) -> Result<StatusResponse, String> {
     Ok(StatusResponse {
         state: if req.verbose {

--- a/autumn-harvest/examples/signal_with_start_webhook.rs
+++ b/autumn-harvest/examples/signal_with_start_webhook.rs
@@ -89,6 +89,7 @@ async fn handle_webhook_after(
             execution_timeout: None,
             memo: None,
             search_attrs: None,
+            start_source_override: None,
             // Idempotent attach to an existing live run; reject if duplicate
             // starts must never happen (e.g., financial onboarding flows).
             reuse_policy: WorkflowIdReusePolicy::AllowDuplicate,

--- a/autumn-harvest/src/lib.rs
+++ b/autumn-harvest/src/lib.rs
@@ -198,7 +198,6 @@ pub mod testing;
 pub mod throttle;
 /// Per-execution timeline read model (issue #739).
 pub mod timeline;
-#[cfg(any(test, feature = "testing"))]
 pub mod trace_export;
 pub mod types;
 pub mod update;
@@ -439,6 +438,7 @@ pub use timeline::{
 };
 #[cfg(any(test, feature = "testing"))]
 pub use trace_export::export_chrome_trace;
+pub use trace_export::export_timeline_chrome_trace;
 pub use types::{
     ActivityExecId, BuildId, DeploymentName, ExecutionId, ExternalActivityToken, ExternalCancelId,
     ExternalSignalId, ParentClosePolicy, Priority, SessionId, ShardId, StartSource, TimerId,

--- a/autumn-harvest/src/trace_export.rs
+++ b/autumn-harvest/src/trace_export.rs
@@ -3,8 +3,11 @@
 //! Converts a `DagProfile` into a JSON structure compatible with trace viewers
 //! like `chrome://tracing` or `ui.perfetto.dev`.
 
+#[cfg(any(test, feature = "testing"))]
 use crate::dag_profiler::{DagProfile, ProfilerEventKind};
+use crate::timeline::Timeline;
 use serde_json::{Value, json};
+#[cfg(any(test, feature = "testing"))]
 use std::collections::HashMap;
 
 /// Exports a `DagProfile` to Chrome Trace Event Format.
@@ -15,6 +18,7 @@ use std::collections::HashMap;
 ///
 /// # Returns
 /// A JSON `Value` representing the trace events array.
+#[cfg(any(test, feature = "testing"))]
 #[must_use]
 pub fn export_chrome_trace(profile: &DagProfile) -> Value {
     let mut events = Vec::new();
@@ -48,11 +52,104 @@ pub fn export_chrome_trace(profile: &DagProfile) -> Value {
     json!(events)
 }
 
+#[must_use]
+pub fn export_timeline_chrome_trace(timeline: &Timeline) -> Value {
+    let mut events = Vec::new();
+
+    for (idx, step) in timeline.steps.iter().enumerate() {
+        let name = step
+            .name
+            .clone()
+            .unwrap_or_else(|| step.step_kind.as_str().to_string());
+        let ts_micros = step.scheduled_at.timestamp_micros();
+        // total_ms could be negative if clocks are weird, but clamped >= 0 in timeline
+        let dur_micros = step.total_ms.max(0) * 1000;
+
+        let mut args = serde_json::Map::new();
+        args.insert("step_index".to_string(), json!(idx));
+        args.insert("outcome".to_string(), json!(step.outcome));
+        if let Some(attempt) = step.attempt {
+            args.insert("attempt".to_string(), json!(attempt));
+        }
+        if let Some(wait_ms) = step.wait_ms {
+            args.insert("wait_ms".to_string(), json!(wait_ms));
+        }
+        if let Some(exec_ms) = step.exec_ms {
+            args.insert("exec_ms".to_string(), json!(exec_ms));
+        }
+
+        events.push(json!({
+            "name": name,
+            "cat": step.step_kind.as_str(),
+            "ph": "X",
+            "ts": ts_micros,
+            "dur": dur_micros,
+            "pid": timeline.exec_id,
+            "tid": step.step_kind.as_str(),
+            "args": args
+        }));
+    }
+
+    json!(events)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::dag_profiler::{ProfilerEvent, ProfilerEventKind};
     use std::time::Duration;
+
+    use crate::timeline::{StepKind, StepOutcome, Timeline, TimelineRollup, TimelineStep};
+    use chrono::Utc;
+
+    #[test]
+    fn test_export_timeline_chrome_trace() {
+        let now = Utc::now();
+        let step = TimelineStep {
+            step_kind: StepKind::Activity,
+            name: Some("test_activity".to_string()),
+            scheduled_at: now,
+            ended_at: Some(now + std::time::Duration::from_millis(150)),
+            total_ms: 150,
+            wait_ms: Some(50),
+            exec_ms: Some(100),
+            outcome: StepOutcome::Completed,
+            attempt: Some(1),
+        };
+
+        let timeline = Timeline {
+            exec_id: "exec-1".to_string(),
+            workflow_id: "wf-1".to_string(),
+            workflow_name: "TestWorkflow".to_string(),
+            state: "COMPLETED".to_string(),
+            steps: vec![step],
+            rollup: TimelineRollup {
+                total_wall_clock_ms: 150,
+                busy_ms: 100,
+                wait_ms: 50,
+                slowest_step: None,
+                step_count_by_kind: std::collections::BTreeMap::default(),
+            },
+        };
+
+        let trace = export_timeline_chrome_trace(&timeline);
+        let arr = trace.as_array().expect("Expected JSON array");
+        assert_eq!(arr.len(), 1);
+
+        let event = &arr[0];
+        assert_eq!(event["name"], "test_activity");
+        assert_eq!(event["cat"], "activity");
+        assert_eq!(event["ph"], "X");
+        assert_eq!(event["ts"], now.timestamp_micros());
+        assert_eq!(event["dur"], 150_000);
+        assert_eq!(event["pid"], "exec-1");
+        assert_eq!(event["tid"], "activity");
+        assert_eq!(event["args"]["step_index"], 0);
+        assert_eq!(event["args"]["outcome"], "completed");
+        assert_eq!(event["args"]["attempt"], 1);
+        assert_eq!(event["args"]["wait_ms"], 50);
+        assert_eq!(event["args"]["exec_ms"], 100);
+    }
 
     #[test]
     fn test_export_chrome_trace() {


### PR DESCRIPTION
💡 **The Spark:** "I noticed we can export `DagProfile` to Chrome traces, but we can't do the same for the actual, real-world execution `Timeline`!" 
🚀 **The Feature:** "Implemented `export_timeline_chrome_trace(timeline: &Timeline)` to convert actual workflow execution timelines into Chrome Trace Events." 
🔮 **The Potential:** "This allows operators to take a production `Timeline` output and drag-and-drop it into `ui.perfetto.dev` to instantly visualize exact wait times, slow activities, and orchestration bottlenecks." 
⚠️ **Risk:** "Low. Isolated in `src/trace_export.rs`. Moved module from strictly `#[cfg(any(test, feature = "testing"))]` to unconditional compilation, but carefully preserved test-only gates for `DagProfile` functionality so production code doesn't inherit testing features."

---
*PR created automatically by Jules for task [12940528368624718095](https://jules.google.com/task/12940528368624718095) started by @madmax983*