### PR TITLE
fix(#614): replay-diagnosis decode-audit gate + strict history-policy threading (Codex follow-up)

### DIFF
--- a/autumn-harvest-plugin/src/api.rs
+++ b/autumn-harvest-plugin/src/api.rs
@@ -25976,6 +25976,10 @@ async fn run_replay_canary_handler(
 async fn replay_diagnosis(
     Extension(api_state): Extension<HarvestApiState>,
     Path(id): Path<String>,
+    // Issue #608 (PR #1107 Codex review): needed to gate + audit read-path codec
+    // decoding of this execution's payloads (see the load block below).
+    headers: axum::http::HeaderMap,
+    maybe_session: Option<Extension<Session>>,
 ) -> Result<Json<crate::replay_diagnosis::ReplayDiagnosisResponse>, AutumnError> {
     let exec_id = parse_execution_id(&id)?;
     let runtime = api_state.runtime().map_err(map_error)?;
@@ -26038,30 +26042,103 @@ async fn replay_diagnosis(
         .handler;
 
     // Load the recorded history exactly as the live worker loads it for replay:
-    // decode with the runtime's own codecs (#608) and inflate offloaded payloads
-    // via the registry's offloader (#524), so an encrypted or offloaded history
-    // replays faithfully rather than hard-500ing on ciphertext / false-diverging
-    // on an offload reference envelope. When neither is configured (the default),
-    // `load_history_inflated` with a `None` offloader + identity codecs is
-    // behaviorally identical to `load_history`. Then DROP the DB connection before
-    // driving user code — WorkflowReplayer needs no DB, and holding a pool slot
-    // for the whole replay would starve other management/worker DB operations (the
-    // #612 pool-slot discipline).
+    // codec-decode payloads (#608) and inflate offloaded payloads via the
+    // registry's offloader (#524), so an encrypted or offloaded history replays
+    // faithfully rather than hard-erroring on ciphertext / false-diverging on an
+    // offload reference envelope. Then DROP the DB connection before driving user
+    // code — WorkflowReplayer needs no DB, and holding a pool slot for the whole
+    // replay would starve other management/worker DB operations (the #612
+    // pool-slot discipline).
     //
-    // Design choice: build a HistorySnapshot from the already-loaded execution row
-    // + this history and replay via `replay_canary_snapshot` (drop-first), rather
-    // than `WorkflowReplayer::replay_from_db`, which reloads history + meta and
-    // holds its connection across the whole replay. Both are correct; drop-first
-    // keeps the pool slot free for the ~bounded replay duration.
-    let history = store::load_history_inflated(
-        &mut conn,
-        exec_id,
-        &api_state.payload_codecs(),
-        runtime.registry.payload_offloader(),
-    )
-    .await
-    .map_err(map_error)?;
-    drop(conn);
+    // #608 read-path decode gate (PR #1107 Codex review): decoding is gated
+    // behind the deployment opt-in (`decode_payloads_on_read`) + admin — the
+    // exact `read_path_decoder` predicate every other #608 read surface uses.
+    // The merged endpoint decoded with the runtime's codecs UNCONDITIONALLY,
+    // which on a non-identity-codec deployment (a) decoded — and surfaced, via
+    // `failure.error` / `divergence.expected` / `divergence.actual` — encrypted
+    // payloads even with the operator's decode gate OFF, and (b) dropped the
+    // connection without writing the required `payload.decode_read` audit row.
+    // This route is already admin-gated (`require_admin`), so the gate resolves
+    // to the `decode_payloads_on_read` flag in practice. Offload inflation (#524)
+    // is NOT a #608 concern (a storage indirection, not decryption) and is kept
+    // in BOTH branches so an offloaded history replays faithfully regardless of
+    // the decode gate — matching the closest #608 replay-driving sibling.
+    //
+    // Design choice: build a HistorySnapshot from the already-loaded execution
+    // row + this history and replay via `replay_canary_snapshot` (drop-first),
+    // rather than `WorkflowReplayer::replay_from_db`, which reloads history + meta
+    // and holds its connection across the whole replay. Both are correct;
+    // drop-first keeps the pool slot free for the ~bounded replay duration.
+    let offloader = runtime.registry.payload_offloader();
+    // Decode ON (deployment opt-in + admin): decode with the runtime's real
+    // codecs exactly as the live worker does, and write the audit row when ≥1
+    // codec envelope was decoded. `load_history_inflated` strict-decodes
+    // (matching the worker's replay fidelity); the audit count is derived from a
+    // lossy scan of the raw stored payloads (never used for the replay itself).
+    // Offloaded-then-encrypted payloads (PayloadStore + non-identity codec both
+    // configured) are not offload-inflated for the count, so the audit
+    // conservatively counts inline-encrypted envelopes only — a rare-combo edge
+    // that under-counts, never a leak.
+    let history = if let Some(codecs) =
+        read_path_decoder(&api_state, extension_session(maybe_session)).await
+    {
+        let history = store::load_history_inflated(&mut conn, exec_id, &codecs, offloader)
+            .await
+            .map_err(map_error)?;
+        let mut outcome = LossyDecodeOutcome::default();
+        if let Ok(raw) = store::load_history_undecoded(&mut conn, exec_id).await {
+            for event in &raw.events {
+                if let Ok(mut value) = serde_json::to_value(event) {
+                    outcome = outcome.merged(codecs.decode_value_lossy(&mut value));
+                }
+            }
+        }
+        let target = exec_id.to_string();
+        // Reuse the handler's own (execution-shard) connection, mirroring the
+        // history-export audit — a second pool acquire while it is live can
+        // stall a size-1 pool (PR #936 review).
+        audit_decoded_read(
+            &api_state,
+            Some(&mut conn),
+            &headers,
+            TARGET_WORKFLOW,
+            Some(&target),
+            "POST /workflows/{id}/replay-diagnosis",
+            Some(exec_id.shard()),
+            outcome,
+            None,
+        )
+        .await;
+        drop(conn);
+        history
+    } else {
+        // Decode OFF (or non-admin): do NOT codec-decode. Load with the identity
+        // codec (still inflating offloaded refs). On an identity-codec deployment
+        // this is byte-identical to the merged behavior — no envelopes exist, so
+        // all 16 identity-deployment integration tests are unaffected. On a
+        // non-identity deployment the identity decode hard-errors
+        // `UnknownPayloadCodec` on the first encrypted envelope; map that to an
+        // HONEST 410 (via `HistoryUnavailable`, the endpoint's existing "history
+        // not diagnosable" contract) rather than leaking ciphertext into the
+        // verdict, false-diverging, or 503-ing — the operator must enable
+        // read-path decoding (admin) to diagnose an encrypted execution.
+        let identity = PayloadCodecs::default();
+        match store::load_history_inflated(&mut conn, exec_id, &identity, offloader).await {
+            Ok(history) => {
+                drop(conn);
+                history
+            }
+            Err(HarvestError::UnknownPayloadCodec { .. }) => {
+                return Err(map_error(HarvestError::HistoryUnavailable {
+                    exec_id,
+                    reason: "payload decoding is required to diagnose this execution; \
+                             enable decode-on-read (admin)"
+                        .to_string(),
+                }));
+            }
+            Err(error) => return Err(map_error(error)),
+        }
+    };
 
     // Whether the recorded history reached its terminal seal — needed by the
     // sealed-mid-await reclassification below, computed before `history.events`

--- a/autumn-harvest-plugin/tests/replay_diagnosis_integration.rs
+++ b/autumn-harvest-plugin/tests/replay_diagnosis_integration.rs
@@ -46,6 +46,7 @@ use autumn_harvest::context::WorkflowContext;
 use autumn_harvest::erase;
 use autumn_harvest::event::WorkflowEvent;
 use autumn_harvest::info::WorkflowInfo;
+use autumn_harvest::payload_codec::{CodecError, PayloadCodec, PayloadCodecs};
 use autumn_harvest::scheduler::{DagCatalog, SchedulerMonitor};
 use autumn_harvest::shard::ShardRouter;
 use autumn_harvest::store;
@@ -1075,4 +1076,223 @@ async fn policy_branching_workflow_diagnoses_clean_with_registry_history_policy(
     assert_eq!(body["diagnosis"], json!("clean"), "body={body}");
     assert!(body.get("divergence").is_none(), "clean has no divergence");
     assert!(body.get("failure").is_none(), "clean has no failure");
+}
+
+// ─── Issue #608 read-path decode gate (PR #1107 Codex review, finding #5) ─────
+//
+// The merged endpoint decoded history with the runtime's codecs UNCONDITIONALLY,
+// so on a non-identity-codec deployment it (a) decoded encrypted payloads even
+// with the operator's read-path decode gate OFF (surfacing plaintext via
+// failure/divergence fields) and (b) wrote no `payload.decode_read` audit row.
+// The fix gates the codec decode behind `read_path_decoder`
+// (`decode_payloads_on_read` + admin) and audits when it decodes. These tests
+// exercise a genuine non-identity codec + both decode-flag states. Identity
+// deployments (all the tests above) hit the decode-OFF identity-load branch and
+// are byte-identical to the merged behavior — confirmed by their unchanged pass.
+
+/// A trivial invertible non-identity codec (byte reversal). Encoding a payload
+/// produces a `_harvest_codec_envelope` with `codec_id = "test-reverse"`, so a
+/// history seeded with it is only decodable by a `PayloadCodecs` that has this
+/// codec registered — the identity default hard-errors `UnknownPayloadCodec`.
+#[derive(Clone, Copy)]
+struct ReverseCodec;
+
+impl PayloadCodec for ReverseCodec {
+    fn codec_id(&self) -> &'static str {
+        "test-reverse"
+    }
+    fn encode(&self, raw: &[u8]) -> Result<Vec<u8>, CodecError> {
+        Ok(raw.iter().rev().copied().collect())
+    }
+    fn decode(&self, encoded: &[u8]) -> Result<Vec<u8>, CodecError> {
+        Ok(encoded.iter().rev().copied().collect())
+    }
+}
+
+fn reverse_codecs() -> PayloadCodecs {
+    let mut codecs = PayloadCodecs::default();
+    codecs.set_default(Arc::new(ReverseCodec));
+    codecs
+}
+
+/// Like [`build_app`] but installs a non-identity codec registry and toggles the
+/// `decode_payloads_on_read` gate — the two levers finding #5 exercises.
+fn build_app_with_codecs(pool: &DbPool, decode_on: bool, codecs: PayloadCodecs) -> HarvestApiApp {
+    let api_state = HarvestApiState::new();
+    api_state.set_admin_auth_boundary(true);
+    api_state.install_storage_pool(HarvestDbPool::from(pool.clone()));
+    api_state.set_payload_codecs(codecs);
+    api_state.set_decode_payloads_on_read(decode_on);
+    let runtime = HarvestApiRuntime::new(
+        Arc::new(HandlerRegistry::new(vec![progress_info()], vec![])),
+        Arc::new(DagCatalog::default()),
+        Arc::new(Vec::new()),
+        Some("replay-diagnosis-test".to_string()),
+        vec!["default".to_string()],
+        SchedulerMonitor::offline(),
+        HarvestRetentionRuntime::disabled(autumn_harvest::RetentionConfig::default()),
+        ShardRouter::default(),
+    );
+    api_state.install(runtime);
+    harvest_api_router(api_state).with_state(AppState::for_test().with_profile("test"))
+}
+
+/// Seed an execution whose event payloads are codec-ENCODED (envelopes), using
+/// [`PayloadCodecs::encode_event`] — the same encoding the live write path
+/// produces for a non-identity deployment. The execution row `input` is left
+/// plaintext (the diagnosis reads `history.events`, not the row input, and the
+/// erased-guard only looks for the tombstone marker).
+async fn seed_encoded_execution(
+    pool: &DbPool,
+    workflow_name: &str,
+    state: &str,
+    input: Value,
+    events: Vec<WorkflowEvent>,
+    codecs: &PayloadCodecs,
+) -> ExecutionId {
+    let mut conn = pool.get().await.expect("pooled conn");
+    let exec_id = ExecutionId::new();
+    diesel::sql_query(
+        "INSERT INTO harvest_workflow_executions \
+         (id, workflow_name, workflow_id, shard_id, input, queue_name, state) \
+         VALUES ($1, $2, $3, 0, $4, 'default', $5)",
+    )
+    .bind::<diesel::sql_types::Uuid, _>(exec_id.as_uuid())
+    .bind::<diesel::sql_types::Text, _>(workflow_name)
+    .bind::<diesel::sql_types::Text, _>(exec_id.to_string())
+    .bind::<diesel::sql_types::Jsonb, _>(input)
+    .bind::<diesel::sql_types::Text, _>(state)
+    .execute(&mut conn)
+    .await
+    .expect("seed execution");
+
+    for (i, event) in events.iter().enumerate() {
+        let encoded = codecs
+            .encode_event(event)
+            .expect("encode event into envelope");
+        #[allow(clippy::cast_possible_truncation, clippy::cast_possible_wrap)]
+        let event_id = i as i32;
+        diesel::sql_query(
+            "INSERT INTO harvest_events \
+             (workflow_exec_id, event_id, event_type, event_data, timestamp) \
+             VALUES ($1, $2, $3, $4, now())",
+        )
+        .bind::<diesel::sql_types::Uuid, _>(exec_id.as_uuid())
+        .bind::<diesel::sql_types::Integer, _>(event_id)
+        .bind::<diesel::sql_types::Text, _>(event.type_name())
+        .bind::<diesel::sql_types::Jsonb, _>(encoded)
+        .execute(&mut conn)
+        .await
+        .expect("seed encoded event");
+    }
+    exec_id
+}
+
+/// Count `payload.decode_read` audit rows recorded for an execution (issue #608
+/// AC8).
+async fn count_decode_audit_rows(pool: &DbPool, exec_id: ExecutionId) -> i64 {
+    use diesel::sql_types::BigInt;
+    #[derive(diesel::QueryableByName)]
+    struct Count {
+        #[diesel(sql_type = BigInt)]
+        n: i64,
+    }
+    let mut conn = pool.get().await.expect("pooled conn");
+    let rows: Vec<Count> = diesel::sql_query(
+        "SELECT COUNT(*) AS n FROM harvest_audit_log \
+         WHERE operation = 'payload.decode_read' AND target_id = $1",
+    )
+    .bind::<diesel::sql_types::Text, _>(exec_id.to_string())
+    .load(&mut conn)
+    .await
+    .expect("count audit rows");
+    rows.into_iter().next().map_or(0, |c| c.n)
+}
+
+#[tokio::test]
+async fn encrypted_history_decode_on_diagnoses_clean_and_writes_audit_row() {
+    // Encrypted deployment + decode-on-read ENABLED (admin): the endpoint decodes
+    // the codec-encoded history exactly as the live worker does, so it replays
+    // clean, AND writes a `payload.decode_read` audit row (issue #608 AC8).
+    let (url, _c) = setup_database().await;
+    let pool = build_pool(&url);
+
+    let (input, mut events) = progress_history(&["a"], false);
+    // A real COMPLETED run seals its history; the seal-gate (issue #614) 410s a
+    // terminal execution truncated before its seal, so seed the realistic
+    // terminal history (encoded, like every other event).
+    events.push(WorkflowEvent::WorkflowCompleted {
+        output: Value::Null,
+    });
+    let exec = seed_encoded_execution(
+        &pool,
+        "progress_wf",
+        "COMPLETED",
+        input,
+        events,
+        &reverse_codecs(),
+    )
+    .await;
+
+    let app = build_app_with_codecs(&pool, true, reverse_codecs());
+    let (status, body) = post_diagnosis(&app, &exec.to_string()).await;
+
+    assert_eq!(status, StatusCode::OK, "body={body}");
+    assert_eq!(
+        body["diagnosis"],
+        json!("clean"),
+        "an encrypted history must decode and replay clean under decode-on; body={body}"
+    );
+    assert!(
+        count_decode_audit_rows(&pool, exec).await >= 1,
+        "decode-on must write a payload.decode_read audit row (issue #608 AC8)"
+    );
+}
+
+#[tokio::test]
+async fn encrypted_history_decode_off_returns_honest_410_and_no_audit_row() {
+    // Encrypted deployment + decode-on-read DISABLED (the default): the endpoint
+    // must NOT decode. It loads with the identity codec (no gate), which
+    // hard-errors on the reverse envelopes, and returns an HONEST 410 pointing at
+    // decode-on-read — never leaking ciphertext into a verdict, never 503-ing —
+    // and writes NO `payload.decode_read` audit row.
+    let (url, _c) = setup_database().await;
+    let pool = build_pool(&url);
+
+    let (input, mut events) = progress_history(&["a"], false);
+    // A real COMPLETED run seals its history; the seal-gate (issue #614) 410s a
+    // terminal execution truncated before its seal, so seed the realistic
+    // terminal history (encoded, like every other event).
+    events.push(WorkflowEvent::WorkflowCompleted {
+        output: Value::Null,
+    });
+    let exec = seed_encoded_execution(
+        &pool,
+        "progress_wf",
+        "COMPLETED",
+        input,
+        events,
+        &reverse_codecs(),
+    )
+    .await;
+
+    // Codecs installed but the ONLY difference from the test above is the flag.
+    let app = build_app_with_codecs(&pool, false, reverse_codecs());
+    let (status, body) = post_diagnosis(&app, &exec.to_string()).await;
+
+    assert_eq!(
+        status,
+        StatusCode::GONE,
+        "encrypted + decode-off must be an honest 410, not a 503 or a leaked verdict; body={body}"
+    );
+    let text = body.to_string();
+    assert!(
+        text.contains("decode-on-read") || text.contains("decoding is required"),
+        "the 410 body must point the operator at decode-on-read; body={body}"
+    );
+    assert_eq!(
+        count_decode_audit_rows(&pool, exec).await,
+        0,
+        "decode-off must NOT write a payload.decode_read audit row"
+    );
 }

--- a/autumn-harvest/src/executor.rs
+++ b/autumn-harvest/src/executor.rs
@@ -810,6 +810,12 @@ pub async fn run_workflow_strict(
     // non-determinism. `workflow_id` is `None` for a raw-events fixture with no id.
     workflow_name: String,
     workflow_id: Option<String>,
+    // Issue #614: the runtime registry's history policy
+    // (`registry.history_policy()`, threaded by the worker), so a strict/diagnosis
+    // replay of a workflow that branches on `ctx.should_continue_as_new()` stays
+    // byte-faithful to the live worker rather than silently using the default
+    // policy. `WorkflowHistoryPolicy::default()` preserves prior behavior.
+    history_policy: WorkflowHistoryPolicy,
 ) -> WorkflowOutcome {
     let ctx = WorkflowContext::for_replay_strict_with_state(exec_id, history, state)
         .with_context_headers(context_headers)
@@ -818,6 +824,7 @@ pub async fn run_workflow_strict(
         .with_parent_execution_id(parent_execution_id)
         .with_workflow_name(workflow_name)
         .with_workflow_id(workflow_id.unwrap_or_default())
+        .with_history_policy(history_policy)
         .with_metrics(metrics);
     run_strict_with_ctx(exec_id, ctx, handler, input).await
 }
@@ -847,6 +854,9 @@ pub(crate) async fn run_workflow_strict_advancing_clock(
     // [`run_workflow_strict`]).
     workflow_name: String,
     workflow_id: Option<String>,
+    // Issue #614: the runtime registry's history policy (see [`run_workflow_strict`]).
+    // `WorkflowHistoryPolicy::default()` preserves prior behavior.
+    history_policy: WorkflowHistoryPolicy,
 ) -> WorkflowOutcome {
     let ctx = WorkflowContext::for_replay_strict_with_state(exec_id, history, state)
         .with_context_headers(context_headers)
@@ -856,6 +866,7 @@ pub(crate) async fn run_workflow_strict_advancing_clock(
         .with_parent_execution_id(parent_execution_id)
         .with_workflow_name(workflow_name)
         .with_workflow_id(workflow_id.unwrap_or_default())
+        .with_history_policy(history_policy)
         .with_metrics(metrics);
     run_strict_with_ctx(exec_id, ctx, handler, input).await
 }

--- a/autumn-harvest/src/testing.rs
+++ b/autumn-harvest/src/testing.rs
@@ -801,6 +801,10 @@ impl WorkflowReplayer {
                 parent_execution_id,
                 workflow_name,
                 workflow_id,
+                // Issue #614: thread the replayer's history policy so a strict
+                // replay of a `should_continue_as_new`-branching workflow stays
+                // faithful to the live worker (which uses `registry.history_policy()`).
+                self.history_policy,
             )
             .await
         } else {
@@ -817,6 +821,10 @@ impl WorkflowReplayer {
                 parent_execution_id,
                 workflow_name,
                 workflow_id,
+                // Issue #614: thread the replayer's history policy so a strict
+                // replay of a `should_continue_as_new`-branching workflow stays
+                // faithful to the live worker (which uses `registry.history_policy()`).
+                self.history_policy,
             )
             .await
         };
@@ -1014,6 +1022,10 @@ impl WorkflowReplayer {
                 self.parent_execution_id,
                 workflow_name,
                 workflow_id,
+                // Issue #614: thread the replayer's history policy so a strict
+                // replay of a `should_continue_as_new`-branching workflow stays
+                // faithful to the live worker (which uses `registry.history_policy()`).
+                self.history_policy,
             )
             .await
         } else {
@@ -1030,6 +1042,10 @@ impl WorkflowReplayer {
                 self.parent_execution_id,
                 workflow_name,
                 workflow_id,
+                // Issue #614: thread the replayer's history policy so a strict
+                // replay of a `should_continue_as_new`-branching workflow stays
+                // faithful to the live worker (which uses `registry.history_policy()`).
+                self.history_policy,
             )
             .await
         };

--- a/autumn-harvest/tests/integration/executor_span_tests.rs
+++ b/autumn-harvest/tests/integration/executor_span_tests.rs
@@ -245,6 +245,8 @@ fn replay_executor_emits_harvest_workflow_execute_with_replay_true() {
             // Issue #698: workflow type name / business workflow_id.
             "echo_workflow".to_string(),
             None,
+            // Issue #614: default history policy for this span test.
+            autumn_harvest::context::WorkflowHistoryPolicy::default(),
         ));
 
     // 1. Span must be named correctly.

--- a/autumn-harvest/tests/integration/replayer_tests.rs
+++ b/autumn-harvest/tests/integration/replayer_tests.rs
@@ -8357,3 +8357,112 @@ async fn interleaved_sibling_child_workflow_terminal_before_timer_replays_succee
          match_child_workflow re-matches after the rewind:\n{report}"
     );
 }
+
+// ─── Issue #614 (PR #1107 Codex review): STRICT replay honors with_history_policy ───
+//
+// The merged #1107 fix threaded the runtime's history policy into the CANARY
+// replay path only; the STRICT paths (`replay_from_events` / `replay_from_snapshot`
+// → `run_workflow_strict` / `_advancing_clock`) still hardcoded
+// `WorkflowHistoryPolicy::default()`, so a caller that set `with_history_policy`
+// and then used a strict path had the setting silently ignored — a
+// `should_continue_as_new`-branching workflow then false-diverged. This block pins
+// the fix on the strict path: the same workflow + history that DIVERGES under the
+// default policy replays CLEAN once `with_history_policy(threshold = 2)` is set.
+
+/// Schedules `checkpoint` when `should_continue_as_new()` trips (via the
+/// history-size threshold), else `keep_going`. The recorded history fixes which
+/// activity was scheduled, so a wrong effective policy schedules the other
+/// activity and diverges — the decision is observable through replay determinism.
+fn history_policy_branch_workflow<'a>(
+    ctx: &'a WorkflowContext,
+    _input: Value,
+) -> Pin<Box<dyn Future<Output = Result<Value, String>> + Send + 'a>> {
+    Box::pin(async move {
+        let activity = if ctx.should_continue_as_new() {
+            "checkpoint"
+        } else {
+            "keep_going"
+        };
+        ctx.execute_activity_raw(activity, Value::Null, "default")
+            .await
+            .map_err(|e| e.to_string())?;
+        Ok(Value::Null)
+    })
+}
+
+/// A 4-event history recorded by the `checkpoint` branch (event count 4 > the
+/// tuned threshold of 2): `WorkflowStarted`, `ActivityScheduled(checkpoint)`,
+/// `ActivityCompleted`, `WorkflowCompleted`. Under the DEFAULT policy (large
+/// threshold) `should_continue_as_new()` never trips for this small history.
+fn history_policy_checkpoint_fixture() -> Vec<WorkflowEvent> {
+    let activity_id = ActivityExecId::new();
+    vec![
+        WorkflowEvent::WorkflowStarted {
+            input: Value::Null,
+            timestamp: Utc::now(),
+            last_completion_result: None,
+            last_error: None,
+            scheduled_time: None,
+        },
+        WorkflowEvent::ActivityScheduled {
+            activity_id,
+            name: "checkpoint".into(),
+            input: Value::Null,
+            queue: "default".into(),
+        },
+        WorkflowEvent::ActivityCompleted {
+            activity_id,
+            output: Value::Null,
+        },
+        WorkflowEvent::WorkflowCompleted {
+            output: Value::Null,
+        },
+    ]
+}
+
+#[tokio::test]
+async fn strict_replay_default_policy_diverges_from_low_threshold_history() {
+    // Negative control: under the DEFAULT history policy (large threshold) the
+    // 4-event history never trips `should_continue_as_new()`, so the workflow
+    // schedules `keep_going` and diverges from the recorded `checkpoint`. Proves
+    // the fixture is discriminating (and that the strict-path default is
+    // unchanged for callers that never set a policy).
+    let report = WorkflowReplayer::new()
+        .register_fn("history_policy_branch", history_policy_branch_workflow)
+        .replay_from_events(history_policy_checkpoint_fixture())
+        .await;
+
+    assert!(
+        matches!(
+            report.status,
+            ReplayStatus::NonDeterminismDetected {
+                kind: NonDeterminismKind::ActivityScheduleMismatch,
+                ..
+            }
+        ),
+        "default policy must diverge (keep_going vs recorded checkpoint):\n{report}"
+    );
+}
+
+#[tokio::test]
+async fn strict_replay_honors_with_history_policy() {
+    // Issue #614 (PR #1107 Codex review): the STRICT `replay_from_events` path
+    // must honor `with_history_policy`. With threshold = 2 the 4-event history
+    // trips `should_continue_as_new()`, so the workflow schedules `checkpoint`,
+    // matching the recorded history → ReplaySucceeded. BEFORE the fix the strict
+    // path hardcoded the default policy, ignored this setter, scheduled
+    // `keep_going`, and reported NonDeterminismDetected (identical to the negative
+    // control above) — so this test is the fix's regression guard.
+    let policy =
+        autumn_harvest::context::WorkflowHistoryPolicy::default().with_continue_as_new_threshold(2);
+    let report = WorkflowReplayer::new()
+        .with_history_policy(policy)
+        .register_fn("history_policy_branch", history_policy_branch_workflow)
+        .replay_from_events(history_policy_checkpoint_fixture())
+        .await;
+
+    assert!(
+        matches!(report.status, ReplayStatus::ReplaySucceeded),
+        "strict replay must honor with_history_policy(threshold=2) and replay clean:\n{report}"
+    );
+}

--- a/autumn-harvest/tests/integration/telemetry_span_tests.rs
+++ b/autumn-harvest/tests/integration/telemetry_span_tests.rs
@@ -554,6 +554,8 @@ fn replay_span_has_replay_true_and_no_activity_execute_span() {
                     // Issue #698: workflow type name / business workflow_id.
                     "telemetry_master_workflow".to_string(),
                     None,
+                    // Issue #614: default history policy for this span test.
+                    autumn_harvest::context::WorkflowHistoryPolicy::default(),
                 )
                 .await;
             });


### PR DESCRIPTION
Follow-up to the merged **#1107** (issue **#614**, on-demand per-execution replay-divergence diagnosis) addressing two findings from the Codex review of that PR. No behavior change for identity-codec deployments or callers that never set a history policy.

## Finding #4 (minor) — history policy honored on ALL replay paths, not just canary

`WorkflowReplayer::with_history_policy(...)` was only consumed by the **canary** path (`replay_canary_snapshot` → `run_workflow_canary`). The **strict** paths — `run_workflow_strict` / `run_workflow_strict_advancing_clock`, used by `replay_from_events`, `replay_from_snapshot`, and `replay_from_db` — hardcoded `WorkflowHistoryPolicy::default()`, so a caller who set `with_history_policy` and then used a strict path had it **silently ignored**. A workflow that branches command-affecting control flow on `ctx.should_continue_as_new()` (which reads `continue_as_new_threshold`) would then replay under the wrong policy and **false-diverge**.

**Fix:** the two strict runners take a `history_policy` param and thread it via `.with_history_policy(...)`, mirroring the canary path. The shared `replay_from_snapshot_effective` helper (used by both `replay_from_snapshot` and `replay_from_db`) passes `self.history_policy` through, so all four public strict entry points honor the setter. Existing direct callers (two span integration tests) pass `WorkflowHistoryPolicy::default()` — **backward compatible, no behavior change**.

**`with_shared_state` verified — no symmetric gap:** all three replay paths (both strict runners + canary) already pass `self.state.clone()`, so shared state was uniformly threaded before this change.

## Finding #5 (security / #608 compliance) — codec decode gated + audited

The `replay_diagnosis` handler loaded history via `store::load_history_inflated(conn, exec_id, &api_state.payload_codecs(), offloader)` **unconditionally**. On an encrypted-codec (#608) deployment this:
- **(a)** decoded payloads even with `decode_payloads_on_read` **OFF** — and decoded content can reach `failure.error` / `divergence.expected` / `divergence.actual` in the response;
- **(b)** dropped the connection **without writing the required `payload.decode_read` audit row**.

The #608 read-path contract is: every request that decodes/marks an envelope must (a) be behind the `decode_payloads_on_read` gate and (b) write a `payload.decode_read` audit row.

**Fix** — mirrors the existing #608 pattern (`read_path_decoder` / `audit_decoded_read`, as used by history-export/describe/`/history`/`/stack`):

| | Before | After |
|---|---|---|
| **decode-on** (opt-in flag + admin) | decoded (unaudited) | decode with runtime codecs (unchanged replay fidelity) **+ write `payload.decode_read` audit row** when ≥1 envelope decoded |
| **decode-off** / non-admin, **identity** deployment | decoded (no-op, no envelopes) | identity load — **byte-identical** (no envelopes exist) |
| **decode-off** / non-admin, **encrypted** deployment | **leaked** decoded plaintext into the verdict | identity load hard-errors `UnknownPayloadCodec` → mapped to an **honest 410** (`HistoryUnavailable`, the endpoint's existing "history not diagnosable" contract) pointing the operator at decode-on-read — never a leak, never a 503 |

The route is already admin-gated (`require_admin`), so the gate resolves to the `decode_payloads_on_read` flag in practice. **Offload inflation (#524) is not a #608 concern** (a storage indirection, not decryption) and is kept in **both** branches so an offloaded history replays faithfully regardless of the decode gate. The audit count is derived from a lossy scan of the raw stored payloads; offloaded-then-encrypted payloads (a rare `PayloadStore` + non-identity-codec combo) are counted conservatively — under-counts, never a leak (documented inline).

## Tests

**Finding #4 (RAN, core `testing` feature — `tests/integration/replayer_tests.rs`):**
- `strict_replay_honors_with_history_policy` — a `should_continue_as_new`-branching workflow + a `checkpoint`-branch history replays **clean** under `with_history_policy(threshold = 2)` on the strict `replay_from_events` path.
- `strict_replay_default_policy_diverges_from_low_threshold_history` — negative control: the same fixture **diverges** under the default policy (proves the fixture discriminates and the strict default is unchanged).
- **Negative control confirmed:** temporarily removing the strict-path `.with_history_policy(...)` threading turns the positive test **red** (`NonDeterminismDetected` instead of `ReplaySucceeded`); restoring it → green.

**Finding #5 (RAN against a local Postgres 16 — `autumn-harvest-plugin/tests/replay_diagnosis_integration.rs`):**
- All **16** existing identity-deployment tests pass **unchanged** (they hit the decode-off identity-load branch, byte-identical to merged behavior).
- `encrypted_history_decode_on_diagnoses_clean_and_writes_audit_row` — a genuine non-identity `ReverseCodec` + `decode_payloads_on_read = true` → 200 `clean` **and** a `payload.decode_read` audit row exists.
- `encrypted_history_decode_off_returns_honest_410_and_no_audit_row` — same encrypted history + flag off → honest **410** pointing at decode-on-read **and** no `payload.decode_read` audit row.
- Full suite: **18 passed, 0 failed**.

## Local CI mirror (all green)

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p autumn-harvest --all-features --tests -- -D warnings` (1.97.0) — clean
- `cargo clippy -p autumn-harvest-plugin --all-targets -- -D warnings` — clean
- `cargo clippy -p autumn-harvest-cli --all-targets -- -D warnings` — clean
- `cargo +1.88.0 check --workspace` — clean
- `replay_diagnosis_integration` — **RAN**, 18/18 pass
- finding #4 strict tests — **RAN**, 2/2 pass

Draft until reviewed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01DukGNsk38gy6ju9BQec9eQ)_