### PR TITLE
feat(#682): auto-heartbeat guard for long-running activities

### DIFF
--- a/.github/ci/integration-suites.txt
+++ b/.github/ci/integration-suites.txt
@@ -51,6 +51,7 @@ compileonly  autumn-harvest-plugin  status_summary_localpg           -          
 linux        autumn-harvest         integration                      -                          activity_default_floor_tests
 linux        autumn-harvest         integration                      -                          activity_interceptor_tests
 linux        autumn-harvest         integration                      -                          admission_gate_authoritative
+linux        autumn-harvest         integration                      -                          auto_heartbeat_tests
 linux        autumn-harvest         integration                      -                          child_timeout_tests
 linux        autumn-harvest         integration                      -                          completion_callback_tests
 linux        autumn-harvest         integration                      -                          cross_workflow_signal_tests

--- a/autumn-harvest/Cargo.toml
+++ b/autumn-harvest/Cargo.toml
@@ -101,6 +101,9 @@ required-features = ["db"]
 name = "timezone_cron_schedule"
 
 [[example]]
+name = "auto_heartbeat"
+
+[[example]]
 name = "collect_approvals"
 
 [[example]]

--- a/autumn-harvest/examples/auto_heartbeat.rs
+++ b/autumn-harvest/examples/auto_heartbeat.rs
@@ -1,0 +1,78 @@
+#![allow(clippy::all, clippy::pedantic, clippy::nursery)]
+//! Example: auto-heartbeat guard for a long-running activity (issue #682).
+//!
+//! A long-running activity that makes steady progress but does not want to
+//! sprinkle `ctx.heartbeat(..)` calls through its body can install a single
+//! auto-heartbeat guard. The guard spawns a background ticker that re-sends the
+//! activity's last heartbeat payload (or a `null` liveness ping) every
+//! `heartbeat_timeout / 3`, so the heartbeat-timeout scanner never spuriously
+//! reclaims a healthy-but-quiet activity — no hand-rolled `tokio::select!` +
+//! ticker in every activity.
+//!
+//! This example is intentionally compile-friendly: it demonstrates the activity
+//! code and registration shape without requiring a database connection in
+//! `main`. Check it with:
+//!
+//! ```bash
+//! cargo check -p autumn-harvest --example auto_heartbeat --no-default-features
+//! cargo check -p autumn-harvest --example auto_heartbeat
+//! ```
+
+use autumn_harvest::prelude::*;
+use serde_json::{Value, json};
+
+/// A long-running data-crunching activity. It installs the auto-heartbeat guard
+/// on the first line, then does its work without any manual heartbeat calls.
+///
+/// `heartbeat_timeout = "30s"` is what makes `start_auto_heartbeat_default()`
+/// valid — the guard derives a `~10s` tick interval from it. Pair it with a
+/// `start_to_close` when you need a hard upper bound on runtime: auto-heartbeat
+/// keeps a *progressing* activity alive, but the independent `start_to_close`
+/// ceiling still fires for a genuinely wedged one.
+#[activity(heartbeat_timeout = "30s", start_to_close = "10m")]
+#[allow(clippy::missing_errors_doc)]
+pub async fn crunch_dataset(ctx: &ActivityContext, job: Value) -> HarvestResult<Value> {
+    // One line: liveness pings now happen automatically for the whole activity.
+    // Bind to a NAMED local — `let _ = ...` would drop the guard immediately and
+    // stop the auto-heartbeat.
+    let _guard = ctx.start_auto_heartbeat_default()?;
+
+    let rows = job.get("rows").and_then(Value::as_u64).unwrap_or(0);
+    let mut processed = 0u64;
+    while processed < rows {
+        // ... do a chunk of real CPU/IO work here ...
+        processed += 1;
+
+        // Optional: still send a real checkpoint occasionally. The guard's
+        // liveness pings re-send whatever you last passed to `heartbeat`, so a
+        // later retry can resume from it via `ctx.heartbeat_details()`.
+        if processed % 1000 == 0 {
+            ctx.heartbeat(json!({"processed": processed})).await?;
+        }
+
+        // Cooperatively honour cancellation on long loops — the guard never
+        // swallows it (its token is a child of the activity's own token).
+        ctx.check_cancellation().await?;
+    }
+
+    Ok(json!({"processed": processed}))
+}
+
+/// A workflow that dispatches the long-running activity.
+#[workflow]
+#[allow(clippy::missing_errors_doc)]
+pub async fn crunch_workflow(ctx: &WorkflowContext, input: Value) -> HarvestResult<Value> {
+    let result: Value = ctx.execute_activity(&crunch_dataset_info(), input).await?;
+    Ok(result)
+}
+
+fn main() {
+    // Registration shape (no DB needed to illustrate it):
+    let _workflows = workflows![crunch_workflow];
+    let _activities = activities![crunch_dataset];
+    println!(
+        "auto_heartbeat example: register these with HarvestPlugin.\n\
+         The activity installs `let _guard = ctx.start_auto_heartbeat_default()?;`\n\
+         and never manually heartbeats — the guard keeps it alive."
+    );
+}

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -11083,6 +11083,7 @@ mod tests {
     use crate::error::TimeoutType;
     use crate::types::ActivityExecId;
     use chrono::Utc;
+    use std::time::Duration;
 
     // ── Signal handlers (issue #546) ────────────────────────────────────────
 
@@ -12875,6 +12876,246 @@ mod tests {
         assert!(
             matches!(result, Err(HarvestError::ActivityCancelled(_))),
             "check_cancellation should return ActivityCancelled when token is set"
+        );
+    }
+
+    // ── Auto-heartbeat guard (issue #682) ────────────────────────────────────
+
+    /// Build a live-channel activity context with a heartbeat timeout, plus its
+    /// receiver and cancellation token, for auto-heartbeat guard testing.
+    fn auto_heartbeat_ctx(
+        timeout: Duration,
+    ) -> (
+        ActivityContext,
+        tokio::sync::mpsc::Receiver<serde_json::Value>,
+        tokio_util::sync::CancellationToken,
+    ) {
+        let (tx, rx) = tokio::sync::mpsc::channel(64);
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let ctx = ActivityContext::new(empty_shared_state(), Some(tx), cancel.clone())
+            .with_heartbeat_timeout(timeout);
+        (ctx, rx, cancel)
+    }
+
+    /// Deterministically fire `n` ticks of a paused-clock interval, yielding
+    /// after each advance so the spawned ticker task drains its send.
+    async fn advance_ticks(interval: Duration, n: usize) {
+        // The first `interval.tick()` is immediate; let it fire.
+        tokio::task::yield_now().await;
+        for _ in 0..n {
+            tokio::time::advance(interval).await;
+            tokio::task::yield_now().await;
+        }
+    }
+
+    fn drain(rx: &mut tokio::sync::mpsc::Receiver<serde_json::Value>) -> Vec<serde_json::Value> {
+        let mut out = Vec::new();
+        while let Ok(v) = rx.try_recv() {
+            out.push(v);
+        }
+        out
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn auto_heartbeat_ticks_send_payloads() {
+        let (ctx, mut rx, _cancel) = auto_heartbeat_ctx(Duration::from_secs(3));
+        let interval = Duration::from_millis(300);
+        let _guard = ctx
+            .start_auto_heartbeat(interval)
+            .expect("auto-heartbeat should start with a configured timeout");
+
+        advance_ticks(interval, 4).await;
+
+        let pings = drain(&mut rx);
+        assert!(
+            pings.len() >= 3,
+            "expected at least 3 auto-heartbeat pings, got {}",
+            pings.len()
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn auto_heartbeat_guard_drop_stops_ticker() {
+        let (ctx, mut rx, _cancel) = auto_heartbeat_ctx(Duration::from_secs(3));
+        let interval = Duration::from_millis(200);
+        let guard = ctx.start_auto_heartbeat(interval).expect("start guard");
+
+        advance_ticks(interval, 3).await;
+        assert!(!drain(&mut rx).is_empty(), "ticker should have sent pings");
+
+        // Drop stops the ticker (AC#7).
+        drop(guard);
+        tokio::task::yield_now().await;
+        let _ = drain(&mut rx); // clear anything in flight at drop
+
+        advance_ticks(interval, 5).await;
+        assert!(
+            drain(&mut rx).is_empty(),
+            "no pings should arrive after the guard is dropped"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn auto_heartbeat_stops_on_cancellation() {
+        let (ctx, mut rx, cancel) = auto_heartbeat_ctx(Duration::from_secs(3));
+        let interval = Duration::from_millis(200);
+        let _guard = ctx.start_auto_heartbeat(interval).expect("start guard");
+
+        advance_ticks(interval, 3).await;
+        let _ = drain(&mut rx);
+
+        // Cancelling the activity's own token (parent) auto-cancels the ticker's
+        // child token — the ticker stops, but the activity still sees the
+        // cancellation through is_cancelled() (not swallowed by the guard).
+        cancel.cancel();
+        tokio::task::yield_now().await;
+        let _ = drain(&mut rx);
+
+        advance_ticks(interval, 5).await;
+        assert!(
+            drain(&mut rx).is_empty(),
+            "no pings should arrive after cancellation"
+        );
+        assert!(
+            ctx.is_cancelled(),
+            "the activity must still observe cancellation through is_cancelled()"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn auto_heartbeat_closed_channel_no_panic() {
+        let (ctx, rx, _cancel) = auto_heartbeat_ctx(Duration::from_secs(3));
+        let interval = Duration::from_millis(200);
+        let guard = ctx.start_auto_heartbeat(interval).expect("start guard");
+
+        // Close the channel: the flusher's receiver is gone.
+        drop(rx);
+
+        // The next tick's send fails; the ticker must break (never .unwrap()).
+        advance_ticks(interval, 3).await;
+
+        assert!(
+            guard.is_ticker_finished(),
+            "the ticker task must terminate (via break, not panic) once the \
+             heartbeat channel is closed"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn auto_heartbeat_last_write_wins() {
+        let (ctx, mut rx, _cancel) = auto_heartbeat_ctx(Duration::from_secs(3));
+        let interval = Duration::from_millis(200);
+
+        // Seed the checkpoint, then drain the manual send so we observe only
+        // subsequent auto pings.
+        ctx.heartbeat(serde_json::json!({"a": 1}))
+            .await
+            .expect("manual heartbeat");
+        let _guard = ctx.start_auto_heartbeat(interval).expect("start guard");
+        let _ = drain(&mut rx); // clear the manual {a:1}
+
+        advance_ticks(interval, 3).await;
+        let phase1 = drain(&mut rx);
+        assert!(!phase1.is_empty(), "auto pings should have arrived");
+        assert!(
+            phase1.iter().all(|v| v == &serde_json::json!({"a": 1})),
+            "auto pings must re-send the last heartbeat payload, got {phase1:?}"
+        );
+
+        // Update the checkpoint; auto pings must now reflect the new payload.
+        ctx.heartbeat(serde_json::json!({"b": 2}))
+            .await
+            .expect("manual heartbeat");
+        let _ = drain(&mut rx); // clear the manual {b:2}
+        advance_ticks(interval, 3).await;
+        let phase2 = drain(&mut rx);
+        assert!(!phase2.is_empty(), "auto pings should have arrived");
+        assert!(
+            phase2.iter().all(|v| v == &serde_json::json!({"b": 2})),
+            "auto pings must reflect the last-written payload, got {phase2:?}"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn auto_heartbeat_liveness_only_ping() {
+        // No manual heartbeat, no resume snapshot: the liveness ping sends the
+        // initial cell value (JSON null) without panicking.
+        let (ctx, mut rx, _cancel) = auto_heartbeat_ctx(Duration::from_secs(3));
+        let interval = Duration::from_millis(200);
+        let _guard = ctx.start_auto_heartbeat(interval).expect("start guard");
+
+        advance_ticks(interval, 3).await;
+
+        let pings = drain(&mut rx);
+        assert!(!pings.is_empty(), "liveness pings should have arrived");
+        assert!(
+            pings.iter().all(|v| v == &serde_json::Value::Null),
+            "liveness-only pings should be JSON null, got {pings:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn auto_heartbeat_requires_heartbeat_timeout() {
+        // Live flusher, but NO heartbeat_timeout configured: both methods reject
+        // rather than silently spawning a ticker whose pings are never checked.
+        let (tx, _rx) = tokio::sync::mpsc::channel(16);
+        let cancel = tokio_util::sync::CancellationToken::new();
+        let ctx = ActivityContext::new(empty_shared_state(), Some(tx), cancel);
+
+        assert!(
+            matches!(
+                ctx.start_auto_heartbeat(Duration::from_millis(100)),
+                Err(HarvestError::Config(_))
+            ),
+            "start_auto_heartbeat must require a configured heartbeat_timeout"
+        );
+        assert!(
+            matches!(
+                ctx.start_auto_heartbeat_default(),
+                Err(HarvestError::Config(_))
+            ),
+            "start_auto_heartbeat_default must require a configured heartbeat_timeout"
+        );
+    }
+
+    #[tokio::test]
+    async fn auto_heartbeat_rejected_on_local() {
+        // Local activities cannot heartbeat at all — auto-heartbeat must reject
+        // with the unsupported reason, even if a timeout were somehow set.
+        let ctx = ActivityContext::new_local_activity(
+            empty_shared_state(),
+            tokio_util::sync::CancellationToken::new(),
+        )
+        .with_heartbeat_timeout(Duration::from_secs(3));
+
+        assert!(
+            matches!(
+                ctx.start_auto_heartbeat(Duration::from_millis(100)),
+                Err(HarvestError::Config(message)) if message.contains("local activities")
+            ),
+            "auto-heartbeat must be rejected for local activities"
+        );
+        assert!(
+            matches!(
+                ctx.start_auto_heartbeat_default(),
+                Err(HarvestError::Config(message)) if message.contains("local activities")
+            ),
+            "auto-heartbeat (default) must be rejected for local activities"
+        );
+
+        // A no-flusher context is likewise rejected.
+        let no_flusher = ActivityContext::new(
+            empty_shared_state(),
+            None,
+            tokio_util::sync::CancellationToken::new(),
+        )
+        .with_heartbeat_timeout(Duration::from_secs(3));
+        assert!(
+            matches!(
+                no_flusher.start_auto_heartbeat_default(),
+                Err(HarvestError::Config(_))
+            ),
+            "auto-heartbeat must be rejected when no heartbeat flusher is attached"
         );
     }
 

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -10271,13 +10271,28 @@ impl Drop for AutoHeartbeatGuard {
 }
 
 impl AutoHeartbeatGuard {
-    /// Test-only: whether the ticker task has terminated (used to prove the
-    /// ticker exits cleanly via `break` — never a panic — once the heartbeat
-    /// channel is closed).
+    /// Test-only: consume the guard and extract its ticker `JoinHandle`
+    /// **without** running [`Drop`] (which would `abort()` the task).
+    ///
+    /// Used to prove the ticker exits *cleanly* — awaiting the returned handle
+    /// yields `Ok(())` when a closed heartbeat channel makes the loop `break`,
+    /// and a `JoinError` only if it panicked. This is stronger than
+    /// `JoinHandle::is_finished()`, which is also `true` for a task that
+    /// panicked.
     #[cfg(any(test, feature = "testing"))]
     #[must_use]
-    pub fn is_ticker_finished(&self) -> bool {
-        self.handle.is_finished()
+    pub fn into_join_handle(self) -> tokio::task::JoinHandle<()> {
+        let md = std::mem::ManuallyDrop::new(self);
+        // SAFETY: `md` is a `ManuallyDrop`, so `Drop for AutoHeartbeatGuard`
+        // (which would `handle.abort()`) never runs, and each field is moved out
+        // exactly once — no double-free. The abort is deliberately bypassed so
+        // the ticker can terminate on its own via the closed channel.
+        let handle = unsafe { std::ptr::read(&raw const md.handle) };
+        // Dropping the `stop` token does NOT cancel it (only `.cancel()` does),
+        // so the ticker still exits only via the closed channel, as intended.
+        let stop = unsafe { std::ptr::read(&raw const md.stop) };
+        drop(stop);
+        handle
     }
 }
 
@@ -13279,13 +13294,18 @@ mod tests {
         // Close the channel: the flusher's receiver is gone.
         drop(rx);
 
-        // The next tick's send fails; the ticker must break (never .unwrap()).
+        // The next tick's send fails; the ticker must break cleanly (never .unwrap()).
         advance_ticks(interval, 3).await;
 
+        // Extract the handle without running Drop (which would abort the task)
+        // and prove the ticker exited via a clean `break` returning Ok(()) — a
+        // panic would surface as a JoinError. `JoinHandle::is_finished()` alone
+        // is insufficient here (it is also true for a panicked task).
+        let joined = guard.into_join_handle().await;
         assert!(
-            guard.is_ticker_finished(),
-            "the ticker task must terminate (via break, not panic) once the \
-             heartbeat channel is closed"
+            joined.is_ok(),
+            "the ticker must exit cleanly (Ok) via break on a closed channel, \
+             not panic; got {joined:?}"
         );
     }
 
@@ -13342,6 +13362,94 @@ mod tests {
         );
     }
 
+    #[tokio::test(start_paused = true)]
+    async fn auto_heartbeat_default_interval_is_timeout_over_three() {
+        // AC#2: start_auto_heartbeat_default() derives interval = heartbeat_timeout / 3.
+        // With heartbeat_timeout = 9s the interval must be exactly 3s. This
+        // distinguishes /3 (3s) from /2 (4.5s), /1 (9s), and *3 (27s): a second
+        // ping arrives at exactly 3s, not before and not later.
+        let (ctx, mut rx, _cancel) = auto_heartbeat_ctx(Duration::from_secs(9));
+        let _guard = ctx
+            .start_auto_heartbeat_default()
+            .expect("default auto-heartbeat should start with a configured timeout");
+
+        // Let the ticker spawn and fire its immediate first tick.
+        tokio::task::yield_now().await;
+        let first = drain(&mut rx);
+        assert_eq!(
+            first.len(),
+            1,
+            "the immediate first tick should have fired exactly once, got {first:?}"
+        );
+
+        // Advance to just before the derived 3s boundary (2999ms): no second
+        // ping yet (rules out any interval < 3s, e.g. /9=1s or a stray /2).
+        tokio::time::advance(Duration::from_millis(2999)).await;
+        tokio::task::yield_now().await;
+        assert!(
+            drain(&mut rx).is_empty(),
+            "no second ping before the derived 3s interval elapses"
+        );
+
+        // Cross the exact 3s boundary: the second ping fires now (rules out any
+        // interval > 3s, e.g. /2=4.5s or the whole 9s timeout).
+        tokio::time::advance(Duration::from_millis(1)).await;
+        tokio::task::yield_now().await;
+        assert_eq!(
+            drain(&mut rx).len(),
+            1,
+            "the second ping must fire exactly at the derived 3s (= 9s / 3) boundary"
+        );
+    }
+
+    #[cfg(feature = "db")]
+    #[tokio::test(start_paused = true)]
+    async fn auto_heartbeat_first_ping_preserves_resume_checkpoint() {
+        // AC#4 (#151 under #682): the auto-heartbeat cell is seeded from the
+        // previous attempt's resume snapshot in new_with_cancellation_check, so
+        // the FIRST liveness ping (before any manual ctx.heartbeat) re-sends the
+        // resumed checkpoint rather than clobbering it with `null`. A regression
+        // to Mutex::new(None) would silently drop the checkpoint on retry.
+        let (tx, mut rx) = tokio::sync::mpsc::channel(64);
+        let cancel = tokio_util::sync::CancellationToken::new();
+        // Lazily-built pool: never connected (the ticker path never touches the
+        // durable cancellation check), it only satisfies the ctor signature.
+        let manager = diesel_async::pooled_connection::AsyncDieselConnectionManager::<
+            diesel_async::AsyncPgConnection,
+        >::new("postgres://invalid-not-connected/db");
+        let pool = deadpool::managed::Pool::builder(manager)
+            .max_size(1)
+            .build()
+            .expect("lazy pool should build without connecting");
+
+        let ctx = ActivityContext::new_with_cancellation_check(
+            empty_shared_state(),
+            Some(tx),
+            Some(serde_json::json!({"checkpoint": 42})),
+            cancel,
+            uuid::Uuid::new_v4(),
+            pool,
+        )
+        .with_heartbeat_timeout(Duration::from_secs(3));
+
+        // No manual heartbeat: start the ticker and let its first ping fire.
+        let interval = Duration::from_millis(200);
+        let _guard = ctx
+            .start_auto_heartbeat(interval)
+            .expect("auto-heartbeat should start");
+
+        advance_ticks(interval, 1).await;
+
+        let pings = drain(&mut rx);
+        assert!(!pings.is_empty(), "the first auto ping should have fired");
+        assert!(
+            pings
+                .iter()
+                .all(|v| v == &serde_json::json!({"checkpoint": 42})),
+            "the first auto ping must re-send the resumed checkpoint (not null), got {pings:?}"
+        );
+    }
+
     #[tokio::test]
     async fn auto_heartbeat_requires_heartbeat_timeout() {
         // Live flusher, but NO heartbeat_timeout configured: both methods reject
@@ -13353,16 +13461,16 @@ mod tests {
         assert!(
             matches!(
                 ctx.start_auto_heartbeat(Duration::from_millis(100)),
-                Err(HarvestError::Config(_))
+                Err(HarvestError::Config(message)) if message.contains("heartbeat_timeout")
             ),
-            "start_auto_heartbeat must require a configured heartbeat_timeout"
+            "start_auto_heartbeat must reject with a heartbeat_timeout-specific message"
         );
         assert!(
             matches!(
                 ctx.start_auto_heartbeat_default(),
-                Err(HarvestError::Config(_))
+                Err(HarvestError::Config(message)) if message.contains("heartbeat_timeout")
             ),
-            "start_auto_heartbeat_default must require a configured heartbeat_timeout"
+            "start_auto_heartbeat_default must reject with a heartbeat_timeout-specific message"
         );
     }
 

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -10222,6 +10222,63 @@ pub struct ActivityContext {
     /// worker reads afterward, so no `Arc` is required.
     #[cfg(feature = "db")]
     transactional_commit_occurred: std::sync::atomic::AtomicBool,
+    /// Cross-retry heartbeat timeout configured for this activity (issue #682).
+    ///
+    /// Required by [`Self::start_auto_heartbeat`] /
+    /// [`Self::start_auto_heartbeat_default`]: an auto-heartbeat whose liveness
+    /// pings are never checked by the timeout scanner would be a silent no-op,
+    /// so those methods reject when this is `None`. Set by the worker from the
+    /// task row's `heartbeat_timeout`; `None` for test / local / no-flusher
+    /// contexts unless [`Self::with_heartbeat_timeout`] is called.
+    heartbeat_timeout: Option<std::time::Duration>,
+    /// Shared last-heartbeat payload cell for the auto-heartbeat ticker
+    /// (issue #682).
+    ///
+    /// [`Self::heartbeat`] writes the most recent serialized payload here;
+    /// the background ticker started by [`Self::start_auto_heartbeat`] reads
+    /// it so a liveness ping re-sends the current checkpoint (last-write-wins)
+    /// rather than clobbering `harvest_task_queue.heartbeat_details` with a
+    /// sentinel. Seeded from the previous attempt's resume snapshot where one
+    /// is available, so the first liveness ping (before any manual heartbeat)
+    /// preserves the durable checkpoint (issue #151).
+    last_heartbeat_payload: std::sync::Arc<std::sync::Mutex<Option<serde_json::Value>>>,
+}
+
+/// RAII guard returned by [`ActivityContext::start_auto_heartbeat`] /
+/// [`ActivityContext::start_auto_heartbeat_default`] (issue #682).
+///
+/// Owns the background ticker task that periodically re-sends the activity's
+/// last heartbeat payload so a *progressing but not manually pinging* activity
+/// is not spuriously reclaimed by the heartbeat-timeout scanner. Dropping the
+/// guard (typically when the activity handler returns) stops the ticker; the
+/// activity's own cancellation token is a *parent* of the ticker's token, so
+/// cancelling the activity also stops the ticker without the guard swallowing
+/// the cancellation (the handler still observes it through
+/// [`ActivityContext::is_cancelled`] / [`ActivityContext::check_cancellation`]).
+#[must_use = "binding the guard to `_` drops it immediately and stops the auto-heartbeat; bind it to a named local like `let _guard = ...`"]
+pub struct AutoHeartbeatGuard {
+    /// Child of the activity's cancellation token; cancelled on drop.
+    stop: tokio_util::sync::CancellationToken,
+    /// The spawned ticker task.
+    handle: tokio::task::JoinHandle<()>,
+}
+
+impl Drop for AutoHeartbeatGuard {
+    fn drop(&mut self) {
+        self.stop.cancel();
+        self.handle.abort();
+    }
+}
+
+impl AutoHeartbeatGuard {
+    /// Test-only: whether the ticker task has terminated (used to prove the
+    /// ticker exits cleanly via `break` — never a panic — once the heartbeat
+    /// channel is closed).
+    #[cfg(any(test, feature = "testing"))]
+    #[must_use]
+    pub fn is_ticker_finished(&self) -> bool {
+        self.handle.is_finished()
+    }
 }
 
 impl ActivityContext {
@@ -10256,6 +10313,8 @@ impl ActivityContext {
             metrics: std::sync::Arc::new(crate::telemetry::NoOpMetrics),
             #[cfg(feature = "db")]
             transactional_commit_occurred: std::sync::atomic::AtomicBool::new(false),
+            heartbeat_timeout: None,
+            last_heartbeat_payload: std::sync::Arc::new(std::sync::Mutex::new(None)),
         }
     }
 
@@ -10272,6 +10331,12 @@ impl ActivityContext {
         let heartbeat_unsupported_reason = heartbeat_tx
             .is_none()
             .then_some(NO_HEARTBEAT_FLUSHER_REASON);
+
+        // Seed the auto-heartbeat cell from the resume snapshot so the first
+        // liveness ping re-sends the existing checkpoint instead of clobbering
+        // it (issue #151 preservation, issue #682).
+        let last_heartbeat_payload =
+            std::sync::Arc::new(std::sync::Mutex::new(heartbeat_details.clone()));
 
         Self {
             state,
@@ -10293,6 +10358,8 @@ impl ActivityContext {
             context_headers: std::sync::Arc::new(HashMap::new()),
             metrics: std::sync::Arc::new(crate::telemetry::NoOpMetrics),
             transactional_commit_occurred: std::sync::atomic::AtomicBool::new(false),
+            heartbeat_timeout: None,
+            last_heartbeat_payload,
         }
     }
 
@@ -10320,6 +10387,8 @@ impl ActivityContext {
             metrics: std::sync::Arc::new(crate::telemetry::NoOpMetrics),
             #[cfg(feature = "db")]
             transactional_commit_occurred: std::sync::atomic::AtomicBool::new(false),
+            heartbeat_timeout: None,
+            last_heartbeat_payload: std::sync::Arc::new(std::sync::Mutex::new(None)),
         }
     }
 
@@ -10355,6 +10424,31 @@ impl ActivityContext {
         headers: std::sync::Arc<HashMap<String, String>>,
     ) -> Self {
         self.context_headers = headers;
+        self
+    }
+
+    // ── Auto-heartbeat (issue #682) ───────────────────────────────────────────
+
+    /// Attach the activity's configured heartbeat timeout to this context.
+    ///
+    /// Required by [`Self::start_auto_heartbeat`] /
+    /// [`Self::start_auto_heartbeat_default`]. The worker sets this
+    /// automatically from the task row; you only need it when constructing a
+    /// context manually in tests.
+    #[must_use]
+    pub const fn with_heartbeat_timeout(mut self, timeout: std::time::Duration) -> Self {
+        self.heartbeat_timeout = Some(timeout);
+        self
+    }
+
+    /// Attach an optional heartbeat timeout (worker convenience — passes a
+    /// task row's `Option` straight through without a conditional rebind).
+    #[must_use]
+    pub(crate) const fn with_heartbeat_timeout_opt(
+        mut self,
+        timeout: Option<std::time::Duration>,
+    ) -> Self {
+        self.heartbeat_timeout = timeout;
         self
     }
 
@@ -10676,6 +10770,15 @@ impl ActivityContext {
 
         let payload = serde_json::to_value(details)?;
 
+        // Record the latest payload in the shared cell so the auto-heartbeat
+        // ticker (issue #682) re-sends it as a liveness ping (last-write-wins),
+        // regardless of whether an auto-heartbeat guard is active. The std
+        // Mutex is never held across the `.await` below.
+        *self
+            .last_heartbeat_payload
+            .lock()
+            .unwrap_or_else(std::sync::PoisonError::into_inner) = Some(payload.clone());
+
         let Some(ref tx) = self.heartbeat_tx else {
             return Ok(());
         };
@@ -10684,6 +10787,163 @@ impl ActivityContext {
         })?;
 
         Ok(())
+    }
+
+    /// Start a background auto-heartbeat that keeps this activity alive without
+    /// manual `ctx.heartbeat(...)` calls (issue #682).
+    ///
+    /// Spawns a ticker that, every `interval`, re-sends the activity's most
+    /// recent heartbeat payload (or a `null` liveness ping if none was sent
+    /// yet) so a long-running-but-progressing activity is not spuriously
+    /// reclaimed by the heartbeat-timeout scanner. The returned
+    /// [`AutoHeartbeatGuard`] **must be bound to a named local** — binding it to
+    /// `_` drops it immediately and stops the ticker:
+    ///
+    /// ```rust,ignore
+    /// #[activity(heartbeat_timeout = "30s")]
+    /// async fn crunch(ctx: &ActivityContext, job: Job) -> Result<Report, String> {
+    ///     let _guard = ctx.start_auto_heartbeat(std::time::Duration::from_secs(10))
+    ///         .map_err(|e| e.to_string())?;
+    ///     // ... long CPU/IO work; no manual heartbeat needed ...
+    ///     Ok(report)
+    /// }
+    /// ```
+    ///
+    /// The ticker stops when the guard is dropped (typically when the handler
+    /// returns), when the activity's cancellation token fires (the ticker's
+    /// token is a *child* of it), or when the heartbeat channel closes. Because
+    /// the guard cancels only its own child token, cancelling the activity is
+    /// still observable to the handler via [`Self::is_cancelled`] /
+    /// [`Self::check_cancellation`] — the guard never swallows it.
+    ///
+    /// The re-sent payload is last-write-wins: whatever you last passed to
+    /// [`Self::heartbeat`] (or the previous attempt's durable checkpoint) is
+    /// what the liveness ping carries, so an auto-heartbeat never clobbers a
+    /// checkpoint used by [`Self::heartbeat_details`] on a later retry.
+    ///
+    /// # Liveness tradeoff
+    ///
+    /// Auto-heartbeat keeps a *progressing-but-not-manually-pinging* activity
+    /// alive, but it necessarily weakens heartbeat-based wedge detection: a
+    /// live-but-deadlocked future will keep emitting liveness pings too. The
+    /// independent `start_to_close` / `schedule_to_close` timeouts remain the
+    /// hard wedge ceiling and are unaffected by heartbeats, so pair
+    /// auto-heartbeat with a `start_to_close` when you need a guaranteed upper
+    /// bound on activity runtime.
+    ///
+    /// # Errors
+    ///
+    /// - [`HarvestError::Config`] if this context does not support heartbeats
+    ///   (a local activity, or a context with no heartbeat flusher attached).
+    /// - [`HarvestError::Config`] if no `heartbeat_timeout` is configured for
+    ///   the activity: the liveness pings would never be checked by the timeout
+    ///   scanner, so an auto-heartbeat would be a silent no-op. Configure
+    ///   `#[activity(heartbeat_timeout = "..")]` (or remove the auto-heartbeat
+    ///   call).
+    pub fn start_auto_heartbeat(
+        &self,
+        interval: std::time::Duration,
+    ) -> crate::HarvestResult<AutoHeartbeatGuard> {
+        // Reject on local / no-flusher contexts up front (covers both the local
+        // activity reason and the missing-flusher reason).
+        if let Some(reason) = self.heartbeat_unsupported_reason {
+            return Err(HarvestError::Config(reason.into()));
+        }
+
+        if self.heartbeat_timeout.is_none() {
+            return Err(HarvestError::Config(
+                "start_auto_heartbeat requires the activity to have a heartbeat_timeout \
+                 configured; without one the liveness pings are never checked. Configure \
+                 #[activity(heartbeat_timeout = \"..\")] or remove the auto-heartbeat call."
+                    .into(),
+            ));
+        }
+
+        // A zero-period `tokio::time::interval` panics; clamp defensively.
+        let interval = interval.max(std::time::Duration::from_millis(1));
+
+        // The unsupported-reason gate above guarantees a flusher is attached;
+        // guard defensively regardless.
+        let Some(tx) = self.heartbeat_tx.clone() else {
+            return Err(HarvestError::Config(NO_HEARTBEAT_FLUSHER_REASON.into()));
+        };
+
+        let cell = std::sync::Arc::clone(&self.last_heartbeat_payload);
+        let stop = self.cancel.child_token();
+        let ticker_stop = stop.clone();
+
+        let handle = tokio::spawn(async move {
+            let mut ticker = tokio::time::interval(interval);
+            // The first `tick()` completes immediately; an early liveness ping
+            // is harmless.
+            loop {
+                tokio::select! {
+                    biased;
+                    () = ticker_stop.cancelled() => break,
+                    _ = ticker.tick() => {
+                        let payload = {
+                            let guard = cell
+                                .lock()
+                                .unwrap_or_else(std::sync::PoisonError::into_inner);
+                            guard.clone().unwrap_or(serde_json::Value::Null)
+                        };
+                        // Channel closed => the flusher is gone; stop silently
+                        // (never panic).
+                        if tx.send(payload).await.is_err() {
+                            break;
+                        }
+                    }
+                }
+            }
+        });
+
+        Ok(AutoHeartbeatGuard { stop, handle })
+    }
+
+    /// Start a background auto-heartbeat whose tick interval is derived from the
+    /// activity's configured `heartbeat_timeout` (issue #682).
+    ///
+    /// Uses `heartbeat_timeout / 3` as the interval — frequent enough that a
+    /// single missed flush never trips the timeout, without excessive writes.
+    /// Equivalent to `ctx.start_auto_heartbeat(heartbeat_timeout / 3)`; see
+    /// [`Self::start_auto_heartbeat`] for the full contract (cancellation,
+    /// last-write-wins, and the liveness/`start_to_close` tradeoff).
+    ///
+    /// ```rust,ignore
+    /// #[activity(heartbeat_timeout = "30s")]
+    /// async fn crunch(ctx: &ActivityContext, job: Job) -> Result<Report, String> {
+    ///     let _guard = ctx.start_auto_heartbeat_default().map_err(|e| e.to_string())?;
+    ///     // ... long work; heartbeats happen automatically every ~10s ...
+    ///     Ok(report)
+    /// }
+    /// ```
+    ///
+    /// # Errors
+    ///
+    /// - [`HarvestError::Config`] if this context does not support heartbeats
+    ///   (a local activity, or a context with no heartbeat flusher attached).
+    /// - [`HarvestError::Config`] if no `heartbeat_timeout` is configured, so
+    ///   there is nothing to derive the interval from. Use
+    ///   [`Self::start_auto_heartbeat`] with an explicit interval, or configure
+    ///   `#[activity(heartbeat_timeout = "..")]`.
+    pub fn start_auto_heartbeat_default(&self) -> crate::HarvestResult<AutoHeartbeatGuard> {
+        // Reject local / no-flusher contexts first, so the message matches the
+        // heartbeat-unsupported reason rather than the missing-timeout reason.
+        if let Some(reason) = self.heartbeat_unsupported_reason {
+            return Err(HarvestError::Config(reason.into()));
+        }
+
+        let Some(timeout) = self.heartbeat_timeout else {
+            return Err(HarvestError::Config(
+                "start_auto_heartbeat_default requires a configured heartbeat_timeout to \
+                 derive the tick interval; none is set. Use start_auto_heartbeat(interval) \
+                 with an explicit interval, or configure #[activity(heartbeat_timeout=\"..\")]."
+                    .into(),
+            ));
+        };
+
+        let interval = (timeout / 3).max(std::time::Duration::from_millis(1));
+        self.start_auto_heartbeat(interval)
     }
 
     /// Check whether the owning workflow has been cancelled.

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -10843,6 +10843,22 @@ impl ActivityContext {
     /// what the liveness ping carries, so an auto-heartbeat never clobbers a
     /// checkpoint used by [`Self::heartbeat_details`] on a later retry.
     ///
+    /// Choose an `interval` **strictly less than** the configured
+    /// `heartbeat_timeout` — an `interval >= heartbeat_timeout` lets the window
+    /// elapse between pings and silently fails to protect the activity. Prefer
+    /// [`Self::start_auto_heartbeat_default`], which derives a safe
+    /// `heartbeat_timeout / 3`.
+    ///
+    /// Calling this more than once on the same context spawns multiple
+    /// independent tickers; that is harmless (the extra pings are redundant,
+    /// idempotent liveness signals) and each returned guard stops only its own
+    /// ticker.
+    ///
+    /// Even a leaked or forgotten guard cannot outlive the activity dispatch:
+    /// the ticker runs on a *child* of the activity's cancellation token, so the
+    /// worker's own activity-completion cancellation stops it regardless of
+    /// whether the guard was dropped.
+    ///
     /// # Liveness tradeoff
     ///
     /// Auto-heartbeat keeps a *progressing-but-not-manually-pinging* activity
@@ -10929,7 +10945,9 @@ impl ActivityContext {
     /// single missed flush never trips the timeout, without excessive writes.
     /// Equivalent to `ctx.start_auto_heartbeat(heartbeat_timeout / 3)`; see
     /// [`Self::start_auto_heartbeat`] for the full contract (cancellation,
-    /// last-write-wins, and the liveness/`start_to_close` tradeoff).
+    /// last-write-wins, and the [`Liveness tradeoff`](Self::start_auto_heartbeat#liveness-tradeoff)
+    /// — auto-heartbeat weakens heartbeat-based wedge detection, so pair it with
+    /// a `start_to_close` ceiling for a guaranteed runtime upper bound).
     ///
     /// ```rust,ignore
     /// #[activity(heartbeat_timeout = "30s")]

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -10696,6 +10696,11 @@ impl ActivityContext {
     /// sent by the current attempt become visible only to a later retry attempt,
     /// after the heartbeat flusher successfully writes them to Postgres.
     ///
+    /// A stored JSON `null` checkpoint is treated as no checkpoint (`Ok(None)`)
+    /// — a liveness-only auto-heartbeat (issue #682) that pings before any manual
+    /// `ctx.heartbeat(..)` persists `null`, and that must never mask or corrupt a
+    /// real checkpoint on a later retry (issue #151).
+    ///
     /// # Errors
     ///
     /// - [`HarvestError::Serialization`] if the stored payload does not
@@ -10709,11 +10714,12 @@ impl ActivityContext {
             return Err(HarvestError::Config(reason.into()));
         }
 
-        self.heartbeat_details
-            .clone()
-            .map(serde_json::from_value)
-            .transpose()
-            .map_err(HarvestError::from)
+        match self.heartbeat_details.clone() {
+            None | Some(serde_json::Value::Null) => Ok(None),
+            Some(v) => serde_json::from_value(v)
+                .map(Some)
+                .map_err(HarvestError::from),
+        }
     }
 
     /// Send a heartbeat to signal the activity is still running.
@@ -13040,6 +13046,27 @@ mod tests {
         let result = ctx.heartbeat_details::<TestHeartbeatDetails>();
 
         assert!(matches!(result, Err(HarvestError::Serialization(_))));
+    }
+
+    #[test]
+    fn heartbeat_details_treats_stored_null_as_absent() {
+        // A liveness-only auto-heartbeat (issue #682) persists JSON `null`; it
+        // must read back as no checkpoint (`Ok(None)`), never a hard
+        // deserialization error, preserving the issue #151 resume contract.
+        let ctx = activity_context_with_heartbeat_details(Some(serde_json::Value::Null));
+        let details = ctx
+            .heartbeat_details::<TestHeartbeatDetails>()
+            .expect("stored JSON null must read as Ok(None)");
+        assert_eq!(details, None);
+
+        // A real checkpoint still deserializes normally.
+        let ctx = activity_context_with_heartbeat_details(Some(serde_json::json!({
+            "progress": 7,
+        })));
+        let details = ctx
+            .heartbeat_details::<TestHeartbeatDetails>()
+            .expect("real checkpoint should deserialize");
+        assert_eq!(details, Some(TestHeartbeatDetails { progress: 7 }));
     }
 
     #[tokio::test]

--- a/autumn-harvest/src/context.rs
+++ b/autumn-harvest/src/context.rs
@@ -10443,6 +10443,7 @@ impl ActivityContext {
 
     /// Attach an optional heartbeat timeout (worker convenience — passes a
     /// task row's `Option` straight through without a conditional rebind).
+    #[cfg_attr(not(feature = "db"), allow(dead_code))]
     #[must_use]
     pub(crate) const fn with_heartbeat_timeout_opt(
         mut self,

--- a/autumn-harvest/src/lib.rs
+++ b/autumn-harvest/src/lib.rs
@@ -288,7 +288,7 @@ pub use completion_trigger::{
     MAX_CONDITION_NODES, TerminalState, TriggerCondition, gate_stored_condition,
 };
 pub use context::{
-    ActivityContext, DEFAULT_CONTINUE_AS_NEW_DEADLINE_FRACTION,
+    ActivityContext, AutoHeartbeatGuard, DEFAULT_CONTINUE_AS_NEW_DEADLINE_FRACTION,
     DEFAULT_HISTORY_CONTINUE_AS_NEW_THRESHOLD, DEFAULT_SESSION_ACQUISITION_TIMEOUT, RaceBuilder,
     RaceWinner, Session, SessionOptions, TimerHandle, TimerOutcome, WorkflowCommand,
     WorkflowContext, WorkflowExecutionInfo, WorkflowHistoryPolicy,

--- a/autumn-harvest/src/prelude.rs
+++ b/autumn-harvest/src/prelude.rs
@@ -13,8 +13,8 @@ pub use crate::circuit_breaker::{
     DispatchDecision, DispatchToken,
 };
 pub use crate::context::{
-    ActivityContext, DEFAULT_SESSION_ACQUISITION_TIMEOUT, Session, SessionOptions, TimerHandle,
-    TimerOutcome, WorkflowContext, WorkflowExecutionInfo,
+    ActivityContext, AutoHeartbeatGuard, DEFAULT_SESSION_ACQUISITION_TIMEOUT, Session,
+    SessionOptions, TimerHandle, TimerOutcome, WorkflowContext, WorkflowExecutionInfo,
 };
 pub use crate::dag::{
     DagBuildError, DagBuilder, DagCondition, DagDefinition, DagDispatchDecision, DagMapTaskRef,

--- a/autumn-harvest/src/worker.rs
+++ b/autumn-harvest/src/worker.rs
@@ -7790,6 +7790,9 @@ async fn process_activity_task(
     )
     .with_trace_context(trace_carrier.clone())
     .with_context_headers(activity_context_headers)
+    // Issue #682: surface the activity's heartbeat timeout so a handler can
+    // opt into `ctx.start_auto_heartbeat_default()`.
+    .with_heartbeat_timeout_opt(task.heartbeat_timeout.and_then(|d| d.to_std().ok()))
     .with_metrics(registry.telemetry().metrics.clone())
     .with_idempotency_key(IdempotencyKey::from_activity_exec_id(activity_id))
     .with_attempt(task_attempt(task))

--- a/autumn-harvest/tests/integration/auto_heartbeat_tests.rs
+++ b/autumn-harvest/tests/integration/auto_heartbeat_tests.rs
@@ -420,23 +420,17 @@ async fn auto_heartbeat_prevents_spurious_heartbeat_reclaim() {
 
     assert_eq!(execution.state, "COMPLETED");
 
-    // No heartbeat (nor any) ActivityTimedOut event was ever appended — the
+    // No heartbeat ActivityTimedOut event was ever appended — the
     // auto-heartbeat kept `last_heartbeat_at` fresh throughout.
     let history = load_history(&url, exec_id).await;
-    let heartbeat_timeouts: Vec<_> = history
-        .iter()
-        .filter(|e| {
-            matches!(
-                e,
-                WorkflowEvent::ActivityTimedOut {
-                    timeout_type: autumn_harvest::error::TimeoutType::Heartbeat,
-                    ..
-                }
-            )
-        })
-        .collect();
     assert!(
-        heartbeat_timeouts.is_empty(),
+        !history.iter().any(|e| matches!(
+            e,
+            WorkflowEvent::ActivityTimedOut {
+                timeout_type: autumn_harvest::error::TimeoutType::Heartbeat,
+                ..
+            }
+        )),
         "auto-heartbeat must prevent any Heartbeat reclaim; history={history:?}"
     );
     assert!(
@@ -477,12 +471,12 @@ async fn seed_running_activity(
     diesel::sql_query(format!(
         "UPDATE harvest_task_queue \
          SET state = 'RUNNING', worker_id = 'w-1', \
-             started_at = NOW() - make_interval(secs => $2), \
+             started_at = NOW() - ($2 * INTERVAL '1 second'), \
              last_heartbeat_at = {hb_sql} \
          WHERE id = $1"
     ))
     .bind::<diesel::sql_types::Uuid, _>(task_id)
-    .bind::<diesel::sql_types::Double, _>(started_secs_ago as f64)
+    .bind::<diesel::sql_types::BigInt, _>(started_secs_ago)
     .execute(conn)
     .await
     .expect("drive task into RUNNING");
@@ -491,7 +485,10 @@ async fn seed_running_activity(
 }
 
 fn reason_for(tasks: &[(TaskQueueItem, TimeoutReason)], id: Uuid) -> Option<TimeoutReason> {
-    tasks.iter().find(|(t, _)| t.id == id).map(|(_, r)| r.clone())
+    tasks
+        .iter()
+        .find(|(t, _)| t.id == id)
+        .map(|(_, r)| r.clone())
 }
 
 #[tokio::test]

--- a/autumn-harvest/tests/integration/auto_heartbeat_tests.rs
+++ b/autumn-harvest/tests/integration/auto_heartbeat_tests.rs
@@ -1,0 +1,558 @@
+#![cfg(feature = "db")]
+//! Auto-heartbeat guard behavioural tests — issue #682.
+//!
+//! Two complementary proofs:
+//!
+//! * TEST A (`auto_heartbeat_prevents_spurious_heartbeat_reclaim`): the value of
+//!   the feature. A long-running activity that never manually heartbeats but
+//!   installs `ctx.start_auto_heartbeat_default()` runs for well over 3× its
+//!   `heartbeat_timeout` while a background timeout scanner sweeps repeatedly.
+//!   The activity is **never** reclaimed via `TimeoutReason::Heartbeat` and the
+//!   workflow completes — the auto-heartbeat's liveness pings keep
+//!   `last_heartbeat_at` fresh (AC#8, success metric).
+//!
+//! * TEST B (`fresh_heartbeat_does_not_defeat_start_to_close`): the wedge
+//!   safety-net proof, deterministic and pure (no wedged future needed). Seeds
+//!   `harvest_task_queue` rows directly with a **fresh** `last_heartbeat_at`
+//!   (what auto-heartbeat produces) and inspects the pure `find_timed_out_tasks`
+//!   scanner. A fresh heartbeat protects from the *heartbeat* timeout but does
+//!   NOT protect a wedged activity from the independent `start_to_close`
+//!   ceiling. Also asserts the converse: a stale heartbeat IS reclaimed as
+//!   `Heartbeat`, so the fresh-heartbeat protection is real, not vacuous.
+//!
+//! Execution: set `HARVEST_TEST_DATABASE_URL` to a migrated Postgres to run
+//! against it directly; otherwise a fresh testcontainers Postgres is booted
+//! with the full migration bundle.
+
+use std::collections::HashMap;
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::Duration;
+
+use autumn_harvest::event::WorkflowEvent;
+use autumn_harvest::info::{ActivityInfo, WorkflowInfo};
+use autumn_harvest::models::{NewWorkflowExecution, TaskQueueItem, WorkflowExecution};
+use autumn_harvest::queue::{self, EnqueueParams, TaskType};
+use autumn_harvest::schema::{harvest_task_queue, harvest_workflow_executions};
+use autumn_harvest::telemetry::{MetricsRecorder, NoOpMetrics, TelemetryConfig};
+use autumn_harvest::timeout::{self, TimeoutReason, find_timed_out_tasks};
+use autumn_harvest::types::{ExecutionId, ShardId};
+use autumn_harvest::worker::{DbPool, HandlerRegistry, Worker, WorkerRuntimeConfig};
+use autumn_harvest::{WorkflowContext, store};
+
+use chrono::Utc;
+use diesel::prelude::*;
+use diesel_async::pooled_connection::AsyncDieselConnectionManager;
+use diesel_async::{AsyncConnection, AsyncPgConnection, RunQueryDsl};
+use testcontainers::ContainerAsync;
+use testcontainers::ImageExt;
+use testcontainers_modules::postgres::Postgres;
+use testcontainers_modules::testcontainers::runners::AsyncRunner;
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// DB setup — env-var-redirectable, otherwise testcontainers.
+// ---------------------------------------------------------------------------
+
+fn init_sql() -> Vec<u8> {
+    autumn_harvest::full_migrations_sql().as_bytes().to_vec()
+}
+
+async fn setup_db() -> (String, Option<ContainerAsync<Postgres>>) {
+    if let Ok(url) = std::env::var("HARVEST_TEST_DATABASE_URL") {
+        return (url, None);
+    }
+    let container = Postgres::default()
+        .with_init_sql(init_sql())
+        .with_tag("16")
+        .start()
+        .await
+        .expect("failed to start Postgres container");
+    let host = container.get_host().await.expect("host");
+    let port = container.get_host_port_ipv4(5432).await.expect("port");
+    let url = format!("postgres://postgres:postgres@{host}:{port}/postgres");
+    (url, Some(container))
+}
+
+fn build_pool(url: &str) -> DbPool {
+    let manager = AsyncDieselConnectionManager::<AsyncPgConnection>::new(url);
+    deadpool::managed::Pool::builder(manager)
+        .max_size(8)
+        .build()
+        .expect("pool build failed")
+}
+
+async fn connect(url: &str) -> AsyncPgConnection {
+    <AsyncPgConnection as AsyncConnection>::establish(url)
+        .await
+        .expect("failed to connect to Postgres")
+}
+
+// ---------------------------------------------------------------------------
+// Worker + registry construction.
+// ---------------------------------------------------------------------------
+
+fn build_registry(
+    workflows: Vec<WorkflowInfo>,
+    activities: Vec<ActivityInfo>,
+) -> Arc<HandlerRegistry> {
+    let telemetry = Arc::new(
+        TelemetryConfig::builder()
+            .metrics(Arc::new(NoOpMetrics) as Arc<dyn MetricsRecorder>)
+            .build(),
+    );
+    Arc::new(HandlerRegistry::with_state_and_telemetry(
+        workflows,
+        activities,
+        autumn_harvest::context::empty_shared_state(),
+        telemetry,
+    ))
+}
+
+fn build_worker(worker_id: &str, registry: Arc<HandlerRegistry>) -> Arc<Worker> {
+    Arc::new(
+        Worker::new(
+            WorkerRuntimeConfig {
+                worker_id: worker_id.to_string(),
+                queues: vec!["default".to_string()],
+                notification_database_url: None,
+                max_concurrent_workflows: 2,
+                max_concurrent_activities: 2,
+                poll_interval: Duration::from_millis(25),
+                shutdown_timeout: Duration::from_secs(1),
+                cancellation_grace_period: Duration::from_secs(1),
+                sticky_timeout: Duration::from_secs(5),
+                max_local_activity_start_to_close: Duration::from_secs(60),
+                shard_assignments: vec![ShardId::new(0)],
+                worker_heartbeat_interval: Duration::from_secs(5),
+                build_id: String::new(),
+                deployment_name: None,
+                workflow_cache_size: 1000,
+                priority_aging_secs: None,
+                unknown_target_grace_window: Duration::from_secs(5),
+                poison_pill_threshold: 3,
+                workflow_task_timeout: Duration::from_secs(10),
+                workflow_panic_max_attempts: 3,
+                labels: HashMap::new(),
+                queue_weights: HashMap::new(),
+                max_workflow_pause_duration: Duration::from_secs(24 * 3600),
+                max_workflow_history_events: None,
+                shard_notification_database_urls: Vec::new(),
+                sharded_pool: None,
+                slot_tuner: None,
+                max_concurrent_sessions: 0,
+            },
+            registry,
+        )
+        .expect("worker should build"),
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Seeding + read helpers.
+// ---------------------------------------------------------------------------
+
+async fn seed_workflow(
+    conn: &mut AsyncPgConnection,
+    workflow_name: &'static str,
+    input: serde_json::Value,
+) -> ExecutionId {
+    let exec_id = ExecutionId::new_for_shard(ShardId::new(0));
+    let row = NewWorkflowExecution {
+        id: exec_id.as_uuid(),
+        workflow_name,
+        workflow_id: &format!("wf-{}", exec_id.as_uuid()),
+        run_id: Uuid::new_v4(),
+        shard_id: 0,
+        input: input.clone(),
+        parent_id: None,
+        queue_name: "default",
+        execution_timeout: None,
+        deadline_at: None,
+        memo: None,
+        search_attrs: None,
+        assigned_build_id: None,
+        parent_close_policy: None,
+        owner: None,
+        runbook_url: None,
+        severity: None,
+        context_headers: None,
+        sla: None,
+        sla_deadline_at: None,
+        schedule_id: None,
+        scheduled_for: None,
+        workflow_attempt: 1,
+        workflow_retry_policy: None,
+        retry_of_exec_id: None,
+        origin: None,
+        completion_callbacks: None,
+        continued_from_exec_id: None,
+        first_exec_id: None,
+        start_source: None,
+        start_source_ref: None,
+        started_by: None,
+    };
+    diesel::insert_into(harvest_workflow_executions::table)
+        .values(&row)
+        .execute(conn)
+        .await
+        .expect("insert workflow execution");
+
+    store::append_events(
+        conn,
+        exec_id,
+        &[WorkflowEvent::WorkflowStarted {
+            input: input.clone(),
+            timestamp: Utc::now(),
+            last_completion_result: None,
+            last_error: None,
+            scheduled_time: None,
+        }],
+        0,
+    )
+    .await
+    .expect("append WorkflowStarted");
+
+    let mut params = EnqueueParams::new("default", TaskType::Workflow, input);
+    params.workflow_exec_id = Some(exec_id.as_uuid());
+    params.scheduled_at = Utc::now() - chrono::Duration::seconds(5);
+    queue::enqueue(conn, &params)
+        .await
+        .expect("enqueue workflow task");
+
+    exec_id
+}
+
+async fn load_execution(url: &str, exec_id: ExecutionId) -> WorkflowExecution {
+    let mut conn = connect(url).await;
+    harvest_workflow_executions::table
+        .find(exec_id.as_uuid())
+        .select(WorkflowExecution::as_select())
+        .first(&mut conn)
+        .await
+        .expect("reload workflow execution")
+}
+
+async fn load_history(url: &str, exec_id: ExecutionId) -> Vec<WorkflowEvent> {
+    let mut conn = connect(url).await;
+    store::load_history(&mut conn, exec_id)
+        .await
+        .expect("load_history")
+        .events
+}
+
+async fn wait_for_state(
+    url: &str,
+    exec_id: ExecutionId,
+    want: &str,
+    timeout: Duration,
+) -> WorkflowExecution {
+    tokio::time::timeout(timeout, async {
+        loop {
+            let e = load_execution(url, exec_id).await;
+            if e.state == want {
+                break e;
+            }
+            tokio::time::sleep(Duration::from_millis(50)).await;
+        }
+    })
+    .await
+    .unwrap_or_else(|_| panic!("execution did not reach state {want} within {timeout:?}"))
+}
+
+// ---------------------------------------------------------------------------
+// Handlers.
+// ---------------------------------------------------------------------------
+
+type BoxFut<'a> =
+    Pin<Box<dyn std::future::Future<Output = Result<serde_json::Value, String>> + Send + 'a>>;
+
+/// Workflow that calls a single long-running activity and returns its output.
+fn workflow_calls_long_activity(ctx: &WorkflowContext, input: serde_json::Value) -> BoxFut<'_> {
+    Box::pin(async move {
+        ctx.execute_activity_raw("long_auto_hb_activity", input, "default")
+            .await
+            .map_err(|e| e.to_string())
+    })
+}
+
+/// Long-running activity that installs an auto-heartbeat guard and then runs
+/// (checking cancellation) for well over 3× its `heartbeat_timeout` WITHOUT
+/// ever manually heartbeating. Only the auto-heartbeat keeps it alive.
+fn long_auto_hb_activity(
+    ctx: &autumn_harvest::ActivityContext,
+    _input: serde_json::Value,
+) -> BoxFut<'_> {
+    Box::pin(async move {
+        let _guard = ctx
+            .start_auto_heartbeat_default()
+            .map_err(|e| e.to_string())?;
+        // heartbeat_timeout is 3s (see ActivityInfo); run for ~11s (>3×).
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(11);
+        while tokio::time::Instant::now() < deadline {
+            tokio::time::sleep(Duration::from_millis(150)).await;
+            ctx.check_cancellation().await.map_err(|e| e.to_string())?;
+        }
+        Ok(serde_json::json!({"done": true}))
+    })
+}
+
+fn workflow_info(name: &'static str, handler: autumn_harvest::info::WorkflowHandlerFn) -> WorkflowInfo {
+    WorkflowInfo {
+        mcp: false,
+        name,
+        module: "auto_heartbeat_tests",
+        handler,
+        execution_timeout: None,
+        sla: None,
+        concurrency: None,
+        debounce: None,
+        batch: None,
+        throttle: None,
+        max_input_bytes: None,
+        owner: None,
+        runbook_url: None,
+        severity: None,
+        description: None,
+        input_schema: None,
+        output_schema: None,
+        error_schema: None,
+        retry_policy: None,
+    }
+}
+
+fn activity_info(
+    name: &'static str,
+    handler: autumn_harvest::info::ActivityHandlerFn,
+    heartbeat_timeout: Option<Duration>,
+    start_to_close: Option<Duration>,
+) -> ActivityInfo {
+    ActivityInfo {
+        name,
+        module: "auto_heartbeat_tests",
+        default_retry_policy: None,
+        default_start_to_close: start_to_close,
+        default_heartbeat_timeout: heartbeat_timeout,
+        default_schedule_to_start: None,
+        default_schedule_to_close: None,
+        default_queue: Some("default"),
+        max_concurrent: None,
+        concurrency_key: None,
+        rate_limit_rps: None,
+        rate_limit_burst: None,
+        rate_limit_key: None,
+        rate_limit_key_expr: None,
+        circuit_breaker: None,
+        is_local: false,
+        max_input_bytes: None,
+        max_result_bytes: None,
+        requires: None,
+        handler,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// TEST A — auto-heartbeat prevents spurious heartbeat reclaim (AC#8).
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn auto_heartbeat_prevents_spurious_heartbeat_reclaim() {
+    let (url, _container) = setup_db().await;
+    let mut conn = connect(&url).await;
+
+    let exec_id = seed_workflow(&mut conn, "long_wf", serde_json::json!({"n": 1})).await;
+
+    let registry = build_registry(
+        vec![workflow_info("long_wf", workflow_calls_long_activity)],
+        // heartbeat_timeout = 3s, NO start_to_close (so only heartbeat
+        // enforcement is active). Default auto interval = 3s / 3 = 1s.
+        vec![activity_info(
+            "long_auto_hb_activity",
+            long_auto_hb_activity,
+            Some(Duration::from_secs(3)),
+            None,
+        )],
+    );
+    let worker = build_worker("worker-auto-hb", Arc::clone(&registry));
+    let pool = build_pool(&url);
+    let runner = Arc::clone(&worker);
+    let pool_for_run = pool.clone();
+    let run_handle = tokio::spawn(async move { runner.run(&pool_for_run).await });
+
+    // Background timeout scanner: sweep every 500ms for the whole test. Without
+    // auto-heartbeat, this would reclaim the activity (Heartbeat) once it has
+    // been RUNNING for > heartbeat_timeout.
+    let scanner_pool = pool.clone();
+    let scanner_stop = Arc::new(tokio::sync::Notify::new());
+    let scanner_stop_for_task = Arc::clone(&scanner_stop);
+    let scanner_handle = tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                () = scanner_stop_for_task.notified() => break,
+                () = tokio::time::sleep(Duration::from_millis(500)) => {
+                    let mut c = scanner_pool.get().await.expect("scanner conn");
+                    let _ = timeout::enforce_timeouts_once(
+                        &mut c,
+                        &[ShardId::new(0)],
+                        &NoOpMetrics,
+                    )
+                    .await;
+                }
+            }
+        }
+    });
+
+    // The activity runs ~11s; give a generous ceiling for CI.
+    let execution = wait_for_state(&url, exec_id, "COMPLETED", Duration::from_secs(40)).await;
+
+    scanner_stop.notify_one();
+    let _ = scanner_handle.await;
+    worker.shutdown();
+    let _ = run_handle.await;
+
+    assert_eq!(execution.state, "COMPLETED");
+
+    // No heartbeat (nor any) ActivityTimedOut event was ever appended — the
+    // auto-heartbeat kept `last_heartbeat_at` fresh throughout.
+    let history = load_history(&url, exec_id).await;
+    let heartbeat_timeouts: Vec<_> = history
+        .iter()
+        .filter(|e| {
+            matches!(
+                e,
+                WorkflowEvent::ActivityTimedOut {
+                    timeout_type: autumn_harvest::error::TimeoutType::Heartbeat,
+                    ..
+                }
+            )
+        })
+        .collect();
+    assert!(
+        heartbeat_timeouts.is_empty(),
+        "auto-heartbeat must prevent any Heartbeat reclaim; history={history:?}"
+    );
+    assert!(
+        history
+            .iter()
+            .any(|e| matches!(e, WorkflowEvent::ActivityCompleted { .. })),
+        "the long-running activity must complete normally; history={history:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// TEST B — a fresh heartbeat does not defeat start_to_close (wedge safety net).
+// ---------------------------------------------------------------------------
+
+/// Enqueue an activity task and drive it into `RUNNING` with explicit
+/// `started_at` / `last_heartbeat_at`, mirroring the state auto-heartbeat leaves
+/// behind (or, for the stale case, does not).
+async fn seed_running_activity(
+    conn: &mut AsyncPgConnection,
+    exec_id: ExecutionId,
+    heartbeat_timeout: Option<Duration>,
+    start_to_close: Option<Duration>,
+    started_secs_ago: i64,
+    fresh_heartbeat: bool,
+) -> Uuid {
+    let mut params = EnqueueParams::new("default", TaskType::Activity, serde_json::json!(null));
+    params.workflow_exec_id = Some(exec_id.as_uuid());
+    params.activity_name = Some("wedge_activity".to_string());
+    params.heartbeat_timeout = heartbeat_timeout;
+    params.start_to_close = start_to_close;
+    let task_id = queue::enqueue(conn, &params).await.expect("enqueue activity");
+
+    let hb_sql = if fresh_heartbeat {
+        "NOW()"
+    } else {
+        "NULL"
+    };
+    diesel::sql_query(format!(
+        "UPDATE harvest_task_queue \
+         SET state = 'RUNNING', worker_id = 'w-1', \
+             started_at = NOW() - make_interval(secs => $2), \
+             last_heartbeat_at = {hb_sql} \
+         WHERE id = $1"
+    ))
+    .bind::<diesel::sql_types::Uuid, _>(task_id)
+    .bind::<diesel::sql_types::Double, _>(started_secs_ago as f64)
+    .execute(conn)
+    .await
+    .expect("drive task into RUNNING");
+
+    task_id
+}
+
+fn reason_for(tasks: &[(TaskQueueItem, TimeoutReason)], id: Uuid) -> Option<TimeoutReason> {
+    tasks.iter().find(|(t, _)| t.id == id).map(|(_, r)| *r)
+}
+
+#[tokio::test]
+async fn fresh_heartbeat_does_not_defeat_start_to_close() {
+    let (url, _container) = setup_db().await;
+    let mut conn = connect(&url).await;
+
+    let exec_id = seed_workflow(&mut conn, "wedge_wf", serde_json::json!(null)).await;
+
+    // Row 1 — FRESH heartbeat + start_to_close (started 10s ago, s2c 1s):
+    // a fresh heartbeat (what auto-heartbeat produces) must NOT shield a wedged
+    // activity from the independent start_to_close ceiling.
+    let fresh_with_s2c = seed_running_activity(
+        &mut conn,
+        exec_id,
+        Some(Duration::from_secs(1)), // heartbeat_timeout 1s
+        Some(Duration::from_secs(1)), // start_to_close 1s
+        10,                           // started 10s ago
+        true,                         // fresh last_heartbeat_at = NOW()
+    )
+    .await;
+
+    // Row 2 — FRESH heartbeat, short heartbeat_timeout, NO start_to_close:
+    // the fresh heartbeat DOES protect from the heartbeat timeout — not reclaimed.
+    let fresh_no_s2c = seed_running_activity(
+        &mut conn,
+        exec_id,
+        Some(Duration::from_secs(1)),
+        None,
+        10,
+        true,
+    )
+    .await;
+
+    // Row 3 — STALE heartbeat (NULL), short heartbeat_timeout, NO start_to_close:
+    // proves the protection is real — without a fresh heartbeat it IS reclaimed
+    // as Heartbeat.
+    let stale_no_s2c = seed_running_activity(
+        &mut conn,
+        exec_id,
+        Some(Duration::from_secs(1)),
+        None,
+        10,
+        false,
+    )
+    .await;
+
+    let timed_out = find_timed_out_tasks(&mut conn)
+        .await
+        .expect("scanner should succeed");
+
+    // Row 1: reclaimed, and by StartToClose (NOT Heartbeat).
+    assert_eq!(
+        reason_for(&timed_out, fresh_with_s2c),
+        Some(TimeoutReason::StartToClose),
+        "a fresh heartbeat must not shield a wedged activity from start_to_close"
+    );
+
+    // Row 2: fresh heartbeat + no start_to_close → not reclaimed at all.
+    assert_eq!(
+        reason_for(&timed_out, fresh_no_s2c),
+        None,
+        "a fresh heartbeat must protect from the heartbeat timeout"
+    );
+
+    // Row 3: stale heartbeat → reclaimed as Heartbeat (protection is not vacuous).
+    assert_eq!(
+        reason_for(&timed_out, stale_no_s2c),
+        Some(TimeoutReason::Heartbeat),
+        "a stale heartbeat with an elapsed heartbeat_timeout must be reclaimed"
+    );
+}

--- a/autumn-harvest/tests/integration/auto_heartbeat_tests.rs
+++ b/autumn-harvest/tests/integration/auto_heartbeat_tests.rs
@@ -33,7 +33,7 @@ use autumn_harvest::event::WorkflowEvent;
 use autumn_harvest::info::{ActivityInfo, WorkflowInfo};
 use autumn_harvest::models::{NewWorkflowExecution, TaskQueueItem, WorkflowExecution};
 use autumn_harvest::queue::{self, EnqueueParams, TaskType};
-use autumn_harvest::schema::{harvest_task_queue, harvest_workflow_executions};
+use autumn_harvest::schema::harvest_workflow_executions;
 use autumn_harvest::telemetry::{MetricsRecorder, NoOpMetrics, TelemetryConfig};
 use autumn_harvest::timeout::{self, TimeoutReason, find_timed_out_tasks};
 use autumn_harvest::types::{ExecutionId, ShardId};
@@ -297,7 +297,10 @@ fn long_auto_hb_activity(
     })
 }
 
-fn workflow_info(name: &'static str, handler: autumn_harvest::info::WorkflowHandlerFn) -> WorkflowInfo {
+fn workflow_info(
+    name: &'static str,
+    handler: autumn_harvest::info::WorkflowHandlerFn,
+) -> WorkflowInfo {
     WorkflowInfo {
         mcp: false,
         name,
@@ -393,8 +396,13 @@ async fn auto_heartbeat_prevents_spurious_heartbeat_reclaim() {
                     let mut c = scanner_pool.get().await.expect("scanner conn");
                     let _ = timeout::enforce_timeouts_once(
                         &mut c,
-                        &[ShardId::new(0)],
                         &NoOpMetrics,
+                        Duration::from_secs(60),
+                        &None,
+                        &[ShardId::new(0)],
+                        None,
+                        None,
+                        60,
                     )
                     .await;
                 }
@@ -457,15 +465,15 @@ async fn seed_running_activity(
     let mut params = EnqueueParams::new("default", TaskType::Activity, serde_json::json!(null));
     params.workflow_exec_id = Some(exec_id.as_uuid());
     params.activity_name = Some("wedge_activity".to_string());
-    params.heartbeat_timeout = heartbeat_timeout;
-    params.start_to_close = start_to_close;
-    let task_id = queue::enqueue(conn, &params).await.expect("enqueue activity");
+    params.heartbeat_timeout =
+        heartbeat_timeout.map(|d| chrono::Duration::from_std(d).expect("hb interval"));
+    params.start_to_close =
+        start_to_close.map(|d| chrono::Duration::from_std(d).expect("s2c interval"));
+    let task_id = queue::enqueue(conn, &params)
+        .await
+        .expect("enqueue activity");
 
-    let hb_sql = if fresh_heartbeat {
-        "NOW()"
-    } else {
-        "NULL"
-    };
+    let hb_sql = if fresh_heartbeat { "NOW()" } else { "NULL" };
     diesel::sql_query(format!(
         "UPDATE harvest_task_queue \
          SET state = 'RUNNING', worker_id = 'w-1', \
@@ -483,7 +491,7 @@ async fn seed_running_activity(
 }
 
 fn reason_for(tasks: &[(TaskQueueItem, TimeoutReason)], id: Uuid) -> Option<TimeoutReason> {
-    tasks.iter().find(|(t, _)| t.id == id).map(|(_, r)| *r)
+    tasks.iter().find(|(t, _)| t.id == id).map(|(_, r)| r.clone())
 }
 
 #[tokio::test]

--- a/autumn-harvest/tests/integration/auto_heartbeat_tests.rs
+++ b/autumn-harvest/tests/integration/auto_heartbeat_tests.rs
@@ -1,7 +1,7 @@
 #![cfg(feature = "db")]
 //! Auto-heartbeat guard behavioural tests — issue #682.
 //!
-//! Two complementary proofs:
+//! Three complementary proofs:
 //!
 //! * TEST A (`auto_heartbeat_prevents_spurious_heartbeat_reclaim`): the value of
 //!   the feature. A long-running activity that never manually heartbeats but
@@ -19,6 +19,14 @@
 //!   NOT protect a wedged activity from the independent `start_to_close`
 //!   ceiling. Also asserts the converse: a stale heartbeat IS reclaimed as
 //!   `Heartbeat`, so the fresh-heartbeat protection is real, not vacuous.
+//!
+//! * TEST C (`auto_heartbeat_activity_still_reclaimed_by_start_to_close`): the
+//!   end-to-end complement to TEST B. A real activity installs
+//!   `ctx.start_auto_heartbeat_default()` and then wedges by sleeping past a
+//!   tight `start_to_close`; driven through the worker with a live scanner, it
+//!   IS reclaimed as `StartToClose` (never `Heartbeat`) and the workflow fails —
+//!   proving auto-heartbeat defeats only the heartbeat timeout, never the hard
+//!   `start_to_close` ceiling.
 //!
 //! Execution: set `HARVEST_TEST_DATABASE_URL` to a migrated Postgres to run
 //! against it directly; otherwise a fresh testcontainers Postgres is booted
@@ -287,12 +295,44 @@ fn long_auto_hb_activity(
         let _guard = ctx
             .start_auto_heartbeat_default()
             .map_err(|e| e.to_string())?;
-        // heartbeat_timeout is 3s (see ActivityInfo); run for ~11s (>3×).
-        let deadline = tokio::time::Instant::now() + Duration::from_secs(11);
+        // heartbeat_timeout is 6s (see ActivityInfo); auto interval is 2s, so
+        // the freshness margin is ~3s of leeway against the 6s window even on a
+        // loaded CI runner. Run for ~19s (> 3× the window).
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(19);
         while tokio::time::Instant::now() < deadline {
             tokio::time::sleep(Duration::from_millis(150)).await;
             ctx.check_cancellation().await.map_err(|e| e.to_string())?;
         }
+        Ok(serde_json::json!({"done": true}))
+    })
+}
+
+/// Workflow that calls the wedging auto-heartbeat activity (TEST C).
+fn workflow_calls_wedge_activity(ctx: &WorkflowContext, input: serde_json::Value) -> BoxFut<'_> {
+    Box::pin(async move {
+        ctx.execute_activity_raw("wedge_auto_hb_activity", input, "default")
+            .await
+            .map_err(|e| e.to_string())
+    })
+}
+
+/// Activity that installs an auto-heartbeat guard (keeping `last_heartbeat_at`
+/// fresh) and then *wedges* by sleeping well past its tight `start_to_close`
+/// ceiling without cooperating. Proves the full composition: auto-heartbeat
+/// defeats only the heartbeat timeout, NEVER the independent `start_to_close`
+/// ceiling — the wedge is still reclaimed.
+fn wedge_auto_hb_activity(
+    ctx: &autumn_harvest::ActivityContext,
+    _input: serde_json::Value,
+) -> BoxFut<'_> {
+    Box::pin(async move {
+        let _guard = ctx
+            .start_auto_heartbeat_default()
+            .map_err(|e| e.to_string())?;
+        // heartbeat_timeout is 3s (auto interval 1s keeps last_heartbeat_at
+        // fresh); start_to_close is 2s. Sleep ~8s so the scanner reclaims via
+        // start_to_close while the activity is still "running" and pinging.
+        tokio::time::sleep(Duration::from_secs(8)).await;
         Ok(serde_json::json!({"done": true}))
     })
 }
@@ -367,12 +407,13 @@ async fn auto_heartbeat_prevents_spurious_heartbeat_reclaim() {
 
     let registry = build_registry(
         vec![workflow_info("long_wf", workflow_calls_long_activity)],
-        // heartbeat_timeout = 3s, NO start_to_close (so only heartbeat
-        // enforcement is active). Default auto interval = 3s / 3 = 1s.
+        // heartbeat_timeout = 6s, NO start_to_close (so only heartbeat
+        // enforcement is active). Default auto interval = 6s / 3 = 2s, giving a
+        // ~3s freshness margin against the 6s window (widened for CI headroom).
         vec![activity_info(
             "long_auto_hb_activity",
             long_auto_hb_activity,
-            Some(Duration::from_secs(3)),
+            Some(Duration::from_secs(6)),
             None,
         )],
     );
@@ -410,8 +451,8 @@ async fn auto_heartbeat_prevents_spurious_heartbeat_reclaim() {
         }
     });
 
-    // The activity runs ~11s; give a generous ceiling for CI.
-    let execution = wait_for_state(&url, exec_id, "COMPLETED", Duration::from_secs(40)).await;
+    // The activity runs ~19s; give a generous ceiling for CI.
+    let execution = wait_for_state(&url, exec_id, "COMPLETED", Duration::from_secs(60)).await;
 
     scanner_stop.notify_one();
     let _ = scanner_handle.await;
@@ -559,5 +600,100 @@ async fn fresh_heartbeat_does_not_defeat_start_to_close() {
         reason_for(&timed_out, stale_no_s2c),
         Some(TimeoutReason::Heartbeat),
         "a stale heartbeat with an elapsed heartbeat_timeout must be reclaimed"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// TEST C — end-to-end: an auto-heartbeat activity is still reclaimed by
+// start_to_close (the airtight full-composition wedge proof, AC).
+// ---------------------------------------------------------------------------
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn auto_heartbeat_activity_still_reclaimed_by_start_to_close() {
+    let (url, _container) = setup_db().await;
+    let mut conn = connect(&url).await;
+
+    let exec_id = seed_workflow(&mut conn, "wedge_wf_e2e", serde_json::json!({"n": 1})).await;
+
+    let registry = build_registry(
+        vec![workflow_info("wedge_wf_e2e", workflow_calls_wedge_activity)],
+        // heartbeat_timeout = 3s (auto interval 1s keeps last_heartbeat_at
+        // fresh), start_to_close = 2s (the tight ceiling the wedge cannot
+        // escape). Default auto interval = 3s / 3 = 1s.
+        vec![activity_info(
+            "wedge_auto_hb_activity",
+            wedge_auto_hb_activity,
+            Some(Duration::from_secs(3)),
+            Some(Duration::from_secs(2)),
+        )],
+    );
+    let worker = build_worker("worker-wedge-hb", Arc::clone(&registry));
+    let pool = build_pool(&url);
+    let runner = Arc::clone(&worker);
+    let pool_for_run = pool.clone();
+    let run_handle = tokio::spawn(async move { runner.run(&pool_for_run).await });
+
+    // Background timeout scanner sweeping every 250ms — enforces start_to_close
+    // even though the auto-heartbeat keeps `last_heartbeat_at` fresh.
+    let scanner_pool = pool.clone();
+    let scanner_stop = Arc::new(tokio::sync::Notify::new());
+    let scanner_stop_for_task = Arc::clone(&scanner_stop);
+    let scanner_handle = tokio::spawn(async move {
+        loop {
+            tokio::select! {
+                () = scanner_stop_for_task.notified() => break,
+                () = tokio::time::sleep(Duration::from_millis(250)) => {
+                    let mut c = scanner_pool.get().await.expect("scanner conn");
+                    let _ = timeout::enforce_timeouts_once(
+                        &mut c,
+                        &NoOpMetrics,
+                        Duration::from_secs(60),
+                        &None,
+                        &[ShardId::new(0)],
+                        None,
+                        None,
+                        60,
+                    )
+                    .await;
+                }
+            }
+        }
+    });
+
+    // The wedge is reclaimed by start_to_close (~2s) and the workflow fails; a
+    // generous ceiling for CI.
+    let execution = wait_for_state(&url, exec_id, "FAILED", Duration::from_secs(30)).await;
+
+    scanner_stop.notify_one();
+    let _ = scanner_handle.await;
+    worker.shutdown();
+    let _ = run_handle.await;
+
+    assert_eq!(execution.state, "FAILED");
+
+    // The wedge was reclaimed by StartToClose, NOT Heartbeat: the auto-heartbeat
+    // kept `last_heartbeat_at` fresh, so the ONLY thing that could reclaim it is
+    // the independent start_to_close ceiling. This is the airtight
+    // full-composition proof requested by the coordinator.
+    let history = load_history(&url, exec_id).await;
+    assert!(
+        history.iter().any(|e| matches!(
+            e,
+            WorkflowEvent::ActivityTimedOut {
+                timeout_type: autumn_harvest::error::TimeoutType::StartToClose,
+                ..
+            }
+        )),
+        "the wedged auto-heartbeat activity must be reclaimed by start_to_close; history={history:?}"
+    );
+    assert!(
+        !history.iter().any(|e| matches!(
+            e,
+            WorkflowEvent::ActivityTimedOut {
+                timeout_type: autumn_harvest::error::TimeoutType::Heartbeat,
+                ..
+            }
+        )),
+        "auto-heartbeat must keep last_heartbeat_at fresh — no Heartbeat reclaim; history={history:?}"
     );
 }

--- a/autumn-harvest/tests/integration/mod.rs
+++ b/autumn-harvest/tests/integration/mod.rs
@@ -9,6 +9,8 @@ mod admission_gate_tests;
 mod alert_pack_docs;
 mod audit_tests;
 #[cfg(feature = "db")]
+mod auto_heartbeat_tests;
+#[cfg(feature = "db")]
 mod build_routing_tests;
 mod cache_delta_load_tests;
 mod cancellation_tests;

--- a/docs/changelog.d/pr-1116-auto-heartbeat-guard.md
+++ b/docs/changelog.d/pr-1116-auto-heartbeat-guard.md
@@ -11,11 +11,21 @@ guard lives.
 
 New `ActivityContext` surface: `start_auto_heartbeat(interval)` and
 `start_auto_heartbeat_default()` (derives `interval = heartbeat_timeout / 3`),
-both returning a `#[must_use]` RAII `AutoHeartbeatGuard`; plus a
-`with_heartbeat_timeout(Duration)` builder and a `heartbeat_timeout` field the
-worker populates from the task row via the internal
-`with_heartbeat_timeout_opt` (the single worker.rs edit, on the
+both returning a `#[must_use]` RAII `AutoHeartbeatGuard` (re-exported from
+`lib.rs` and the prelude alongside the sibling RAII handles `TimerHandle` /
+`Session` / `RaceWinner`); plus a `with_heartbeat_timeout(Duration)` builder and
+a `heartbeat_timeout` field the worker populates from the task row via the
+internal `with_heartbeat_timeout_opt` (the single worker.rs edit, on the
 `new_with_cancellation_check(..)` dispatch builder chain).
+
+**#151 read-path preservation.** A liveness-only auto-heartbeat that pings
+before any manual `ctx.heartbeat(..)` persists a JSON `null` into
+`harvest_task_queue.heartbeat_details`; a `start_to_close`/crash reclaim that
+preserves that column (the #151 contract) would then feed `null` back to the
+retry. `heartbeat_details::<T>()` now treats a stored JSON `null` as *no
+checkpoint* (`Ok(None)`) rather than a hard `Serialization` error — so a
+liveness ping never flips the documented `Ok(None)` resume API into a failure
+(and potential DLQ) or masks a real checkpoint.
 
 **Design.** The guard spawns a ticker on `self.cancel.child_token()`, so
 cancelling the activity's own token auto-stops the ticker while the handler
@@ -49,18 +59,30 @@ surface, no scanner/flusher/schema change. The timeout scanner (`timeout.rs`)
 and the batched heartbeat flusher (`heartbeat.rs`) are untouched — the guard
 simply feeds the existing flusher channel.
 
-**Tests.** 8 pure unit tests in `context.rs` under paused-clock time
+**Tests.** Pure unit tests in `context.rs` under paused-clock time
 (`start_paused = true`): ticking sends payloads, guard-drop stops the ticker,
 cancellation stops it while `is_cancelled()` stays true, closed-channel exits
-without panic, last-write-wins re-send, liveness-only `null` ping, the
-require-`heartbeat_timeout` rejection, and the local/no-flusher rejection. Two
+cleanly (`AutoHeartbeatGuard::into_join_handle().await` returns `Ok(())` — a
+stronger no-panic proof than `is_finished()`, which is also true for a panicked
+task), last-write-wins re-send, liveness-only `null` ping, the
+require-`heartbeat_timeout` rejection (message-pinned) and the local/no-flusher
+rejection, the AC#2 `heartbeat_timeout / 3` interval derivation (a 9s timeout
+pings at exactly 3s — distinguishing `/3` from `/2`, `/1`, `*3`), the AC#4 #151
+seed-from-resume-snapshot (the first liveness ping re-sends the resumed
+checkpoint, not `null`), and the stored-`null`→`Ok(None)` read-path.
+
 DB integration tests in `tests/integration/auto_heartbeat_tests.rs`:
 `auto_heartbeat_prevents_spurious_heartbeat_reclaim` drives a real worker +
 background timeout scanner and proves a long-running activity that only
 auto-heartbeats is never reclaimed via `TimeoutReason::Heartbeat` and completes
-(AC#8, success metric); `fresh_heartbeat_does_not_defeat_start_to_close` is a
-pure, deterministic scanner proof that a fresh `last_heartbeat_at` (what
+(AC#8, success metric; widened freshness margin — 6s window, 2s interval — for
+CI headroom); `fresh_heartbeat_does_not_defeat_start_to_close` is a pure,
+deterministic scanner proof that a fresh `last_heartbeat_at` (what
 auto-heartbeat produces) shields the heartbeat timeout but NOT the independent
 `start_to_close` ceiling — and that a stale heartbeat IS reclaimed as
-`Heartbeat`, so the protection is real. Example:
+`Heartbeat`, so the protection is real;
+`auto_heartbeat_activity_still_reclaimed_by_start_to_close` is the end-to-end
+complement — a real auto-heartbeating activity that wedges past a tight
+`start_to_close` is still reclaimed as `StartToClose` (never `Heartbeat`) and
+the workflow fails, the airtight full-composition proof. Example:
 `autumn-harvest/examples/auto_heartbeat.rs`.

--- a/docs/changelog.d/pr-1116-auto-heartbeat-guard.md
+++ b/docs/changelog.d/pr-1116-auto-heartbeat-guard.md
@@ -1,0 +1,66 @@
+## Phase 3.53 — Auto-heartbeat guard for long-running activities (issue #682)
+
+**Before:** an activity that runs longer than its `heartbeat_timeout` but makes
+steady progress (a long transcode, a big batch job) had to either sprinkle
+`ctx.heartbeat(..)` calls through its body or hand-roll a `tokio::select!` +
+ticker in every such activity, or risk being spuriously reclaimed by the
+heartbeat-timeout scanner and dead-lettered. **After:** one line —
+`let _guard = ctx.start_auto_heartbeat_default()?;` — installs a background
+ticker that keeps the activity's `last_heartbeat_at` fresh for as long as the
+guard lives.
+
+New `ActivityContext` surface: `start_auto_heartbeat(interval)` and
+`start_auto_heartbeat_default()` (derives `interval = heartbeat_timeout / 3`),
+both returning a `#[must_use]` RAII `AutoHeartbeatGuard`; plus a
+`with_heartbeat_timeout(Duration)` builder and a `heartbeat_timeout` field the
+worker populates from the task row via the internal
+`with_heartbeat_timeout_opt` (the single worker.rs edit, on the
+`new_with_cancellation_check(..)` dispatch builder chain).
+
+**Design.** The guard spawns a ticker on `self.cancel.child_token()`, so
+cancelling the activity's own token auto-stops the ticker while the handler
+still observes cancellation through `is_cancelled()` / `check_cancellation()`
+(the guard never swallows it). Dropping the guard — typically when the handler
+returns — cancels the child token and aborts the ticker. Each tick re-sends the
+activity's most recent heartbeat payload from a shared last-payload cell that
+`heartbeat()` now writes on every call (last-write-wins); the cell is seeded
+from the previous attempt's resume snapshot (`heartbeat_details`) so the first
+liveness ping preserves — rather than clobbers — the durable checkpoint used by
+`heartbeat_details()` on a later retry (issue #151 contract). With no manual
+heartbeat and no resume snapshot the liveness ping is a JSON `null`. A closed
+heartbeat channel makes the ticker `break` (never `.unwrap()`/panic); a
+zero-period interval is clamped to 1ms (a zero `tokio::time::interval` panics).
+
+**Guardrails.** Both methods reject with `HarvestError::Config` on a local
+activity or a no-flusher context (heartbeats are unsupported there), and reject
+when no `heartbeat_timeout` is configured — an auto-heartbeat whose liveness
+pings are never checked by the scanner would be a silent no-op, so the caller
+is told to configure `#[activity(heartbeat_timeout = "..")]`.
+
+**Liveness tradeoff (documented on both methods):** auto-heartbeat keeps a
+*progressing-but-not-manually-pinging* activity alive, but necessarily weakens
+heartbeat-based wedge detection for a live-but-deadlocked future. The
+independent `start_to_close` / `schedule_to_close` timeouts remain the hard
+wedge ceiling and are unaffected by heartbeats — pair auto-heartbeat with a
+`start_to_close` for a guaranteed runtime upper bound.
+
+**Invariants:** no new `WorkflowEvent` variant, no migration, no management-API
+surface, no scanner/flusher/schema change. The timeout scanner (`timeout.rs`)
+and the batched heartbeat flusher (`heartbeat.rs`) are untouched — the guard
+simply feeds the existing flusher channel.
+
+**Tests.** 8 pure unit tests in `context.rs` under paused-clock time
+(`start_paused = true`): ticking sends payloads, guard-drop stops the ticker,
+cancellation stops it while `is_cancelled()` stays true, closed-channel exits
+without panic, last-write-wins re-send, liveness-only `null` ping, the
+require-`heartbeat_timeout` rejection, and the local/no-flusher rejection. Two
+DB integration tests in `tests/integration/auto_heartbeat_tests.rs`:
+`auto_heartbeat_prevents_spurious_heartbeat_reclaim` drives a real worker +
+background timeout scanner and proves a long-running activity that only
+auto-heartbeats is never reclaimed via `TimeoutReason::Heartbeat` and completes
+(AC#8, success metric); `fresh_heartbeat_does_not_defeat_start_to_close` is a
+pure, deterministic scanner proof that a fresh `last_heartbeat_at` (what
+auto-heartbeat produces) shields the heartbeat timeout but NOT the independent
+`start_to_close` ceiling — and that a stale heartbeat IS reclaimed as
+`Heartbeat`, so the protection is real. Example:
+`autumn-harvest/examples/auto_heartbeat.rs`.


### PR DESCRIPTION
## Before / After

**Before.** An activity that runs longer than its `heartbeat_timeout` but makes steady progress (a long transcode, a large batch job) had to either sprinkle `ctx.heartbeat(..)` calls through its body, or hand-roll a `tokio::select!` + ticker in *every* such activity — otherwise the heartbeat-timeout scanner spuriously reclaims a healthy-but-quiet activity and dead-letters it.

**After.** One line keeps liveness ticking for the whole activity, and it stops automatically when the handler returns:

```rust
#[activity(heartbeat_timeout = "30s", start_to_close = "10m")]
async fn crunch(ctx: &ActivityContext, job: Job) -> Result<Report, String> {
    let _guard = ctx.start_auto_heartbeat_default()?; // ~10s tick, derived from heartbeat_timeout
    // ... long CPU/IO work; no manual heartbeat needed ...
    Ok(report)
}
```

## How

- New `ActivityContext::start_auto_heartbeat(interval)` and `start_auto_heartbeat_default()` (interval = `heartbeat_timeout / 3`) return a `#[must_use]` RAII `AutoHeartbeatGuard`.
- The guard spawns a ticker on `self.cancel.child_token()`: cancelling the activity's own token auto-stops the ticker, while the handler still observes cancellation through `is_cancelled()` / `check_cancellation()` (the guard never swallows it). Dropping the guard stops the ticker.
- `heartbeat()` writes every payload to a shared last-payload cell (last-write-wins); each tick re-sends that payload. The cell is seeded from the previous attempt's resume snapshot so the first liveness ping **preserves** the durable checkpoint used by `heartbeat_details()` on a retry (issue #151) rather than clobbering it with a sentinel. With no manual heartbeat and no snapshot, the liveness ping is JSON `null`.
- A closed heartbeat channel makes the ticker `break` (never panic); a zero interval is clamped to 1ms.
- The worker threads the task row's `heartbeat_timeout` in via `with_heartbeat_timeout_opt` on the activity-dispatch builder chain (the single `worker.rs` edit).
- Both methods reject with `HarvestError::Config` on a local/no-flusher context, and when no `heartbeat_timeout` is configured (the pings would never be checked → a silent no-op).

## Liveness tradeoff

Auto-heartbeat keeps a *progressing-but-not-manually-pinging* activity alive, but necessarily weakens heartbeat-based wedge detection for a live-but-deadlocked future. The independent `start_to_close` / `schedule_to_close` timeouts remain the hard wedge ceiling and are unaffected by heartbeats — pair auto-heartbeat with a `start_to_close` when you need a guaranteed runtime upper bound. This is proven directly by `fresh_heartbeat_does_not_defeat_start_to_close`.

## Invariants

- **No new `WorkflowEvent` variant, no migration, no management-API surface, no scanner/flusher/schema change.** The timeout scanner and batched heartbeat flusher are untouched — the guard simply feeds the existing flusher channel.

## Tests

- 8 pure unit tests in `context.rs` under a paused clock (`start_paused = true`): ticking, guard-drop-stops, cancellation-stops (`is_cancelled()` preserved), closed-channel-no-panic, last-write-wins re-send, liveness-only `null` ping, require-`heartbeat_timeout` rejection, local/no-flusher rejection.
- 2 DB integration tests (`tests/integration/auto_heartbeat_tests.rs`): `auto_heartbeat_prevents_spurious_heartbeat_reclaim` (end-to-end worker + background scanner: the activity is never reclaimed via `TimeoutReason::Heartbeat` and completes) and `fresh_heartbeat_does_not_defeat_start_to_close` (deterministic pure-scanner wedge proof + the converse that a stale heartbeat *is* reclaimed).
- Example: `autumn-harvest/examples/auto_heartbeat.rs`.

Closes #682.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HfUR478sb2PcZEvvjhUhjc)_