### PR TITLE
chore: fold docs-sweep changelog fragment into 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -225,6 +225,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - De-flake the `nd_blocked_cycle_does_not_emit_signal_unhandled` engine test (Refs #1074). Test-code-only.
 
+- 0.5.0 documentation sweep + migration guide (PR #1130): verified every published doc and runnable example against the shipped source, added the `docs/upgrading/0.5.0.md` upgrade guide covering the 0.4.0 → 0.5.0 transition, filled documentation-coverage gaps for features that landed without a corresponding docs page, and cleaned up stale org-rename links across the docs tree. Docs-only — no code, no `WorkflowEvent` variant, no migration, no test change.
+
 ## [0.4.0] - 2026-06-16
 
 ### Added

--- a/docs/changelog.d/pr-1130-docs-0.5.0-sweep.md
+++ b/docs/changelog.d/pr-1130-docs-0.5.0-sweep.md
@@ -1,3 +1,0 @@
-## Docs — 0.5.0 documentation sweep + migration guide (PR #1130)
-
-Documentation-only sweep for the 0.5.0 release. Verified every published doc and runnable example against the shipped source (no code, no `WorkflowEvent` variant, no migration, no test change). Added the `docs/upgrading/0.5.0.md` upgrade guide covering the 0.4.0 → 0.5.0 transition, filled documentation-coverage gaps for features that landed without a corresponding docs page, and cleaned up stale org-rename links across the docs tree.


### PR DESCRIPTION
Folds the post-#1129 `pr-1130-docs-0.5.0-sweep` changelog fragment into the `## [0.5.0]` section (under `### Internal`), so `docs/changelog.d/` is README-only at the v0.5.0 tag point. Should merge before tagging.

Changelog-only: one bullet added, one fragment removed. No code, no `WorkflowEvent` variant, no migration, no test change.

Gate: `cargo fmt --all --check` clean; no-DB `cargo test -p autumn-harvest --no-default-features --test integration` → 586 passed, 0 failed (hygiene guards green).

---
_Generated by [Claude Code](https://claude.ai/code/session_01UL3NvbCe3mB6uePWQVspTa)_